### PR TITLE
partial revert and redesign of #19814, changelog

### DIFF
--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -43,9 +43,7 @@ jobs:
       - name: 'Install dependencies (macOS)'
         if: runner.os == 'macOS'
         run: |
-          brew install boehmgc make sfml gtk+3 openssl@1.1
-          ln -s $(brew --prefix)/opt/openssl/lib/libcrypto.1.1.dylib /usr/local/lib
-          ln -s $(brew --prefix)/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/
+          brew install boehmgc make sfml gtk+3
       - name: 'Install dependencies (Windows)'
         if: runner.os == 'Windows'
         shell: bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,13 @@ jobs:
       condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
 
     - bash: |
+        brew install openssl@1.1
+        ln -s $(brew --prefix)/opt/openssl/lib/libcrypto.1.1.dylib /usr/local/lib
+        ln -s $(brew --prefix)/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/
+      displayName: 'Install OpenSSL (OSX)'
+      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
+
+    - bash: |
         set -e
         . ci/funs.sh
         nimInternalInstallDepsWindows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,13 +131,6 @@ jobs:
       condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
 
     - bash: |
-        brew install openssl@1.1
-        ln -s $(brew --prefix)/opt/openssl/lib/libcrypto.1.1.dylib /usr/local/lib
-        ln -s $(brew --prefix)/opt/openssl/lib/libssl.1.1.dylib /usr/local/lib/
-      displayName: 'Install OpenSSL (OSX)'
-      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
-
-    - bash: |
         set -e
         . ci/funs.sh
         nimInternalInstallDepsWindows

--- a/changelog.md
+++ b/changelog.md
@@ -42,7 +42,7 @@
 ## Standard library additions and changes
 
 [//]: # "Changes:"
-- OpenSSL version 3 is now supported by setting `-d:sslVersion=3`.
+- OpenSSL version 3 is now supported by setting either `-d:sslVersion=3` or `-d:useOpenssl3`.
 - `macros.parseExpr` and `macros.parseStmt` now accept an optional
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.

--- a/changelog.md
+++ b/changelog.md
@@ -36,9 +36,13 @@
 - [Overloadable enums](https://nim-lang.github.io/Nim/manual_experimental.html#overloadable-enum-value-names)
   are no longer experimental.
 
+- Static linking against OpenSSL versions below 1.1, previously done by
+  setting `-d:openssl10`, is no longer supported.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"
+- OpenSSL version 3 is now supported by setting `-d:sslVersion=3`.
 - `macros.parseExpr` and `macros.parseStmt` now accept an optional
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -544,7 +544,7 @@ proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
 
 when defineSsl:
   # OpenSSL >= 1.1.0 does not need explicit init.
-  when not openssl3:
+  when not useOpenssl3:
     CRYPTO_malloc_init()
     doAssert SslLibraryInit() == 1
     SSL_load_error_strings()

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -544,6 +544,12 @@ proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
 
 when defineSsl:
   # OpenSSL >= 1.1.0 does not need explicit init.
+  when not openssl3:
+    CRYPTO_malloc_init()
+    doAssert SslLibraryInit() == 1
+    SSL_load_error_strings()
+    ERR_load_BIO_strings()
+    OpenSSL_add_all_algorithms()
 
   proc sslHandle*(self: Socket): SslPtr =
     ## Retrieve the ssl pointer of `socket`.

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -10,7 +10,7 @@
 ## OpenSSL wrapper. Supports OpenSSL >= 1.1.0 dynamically (as default) or statically linked
 ## using `--dynlibOverride:ssl`.
 ##
-## To use openSSL 3 set the symbol: -d:sslVersion=3
+## To use openSSL 3, either set `-d:sslVersion=3` or `-d:useOpenssl3`.
 ##
 ## Build and test examples:
 ##
@@ -37,7 +37,7 @@ const useWinVersion = defined(windows) or defined(nimdoc)
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
-const useOpenssl3* = sslVersion.startsWith('3')
+const useOpenssl3* {.booldefine.} = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -78,9 +78,9 @@ elif useWinVersion:
 else:
   # same list of versions but ordered differently?
   when defined(osx):
-    const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+    const versions = "(.3|.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
   else:
-    const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
+    const versions = "(.3|.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -76,7 +76,11 @@ elif useWinVersion:
 
   from winlean import SocketHandle
 else:
-  const versions = "(.1.1|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
+  # same list of versions but ordered differently?
+  when defined(osx):
+    const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+  else:
+    const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -37,6 +37,7 @@ const useWinVersion = defined(windows) or defined(nimdoc)
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
+const openssl3 = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -270,6 +271,11 @@ proc TLSv1_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 
 when compileOption("dynlibOverride", "ssl"):
   # Static linking
+  when not openssl3:
+    proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
+    proc SSL_library_init*(): cint {.discardable.} =
+      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
+      return OPENSSL_init_ssl(0.uint64, 0.uint8)
 
   proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
 
@@ -354,6 +360,18 @@ else:
     let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
     return method2Proc()
 
+  when not openssl3:
+    proc SSL_library_init*(): cint {.discardable.} =
+      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
+      ## SSL_library_init
+      let newInitSym = sslSymNullable("OPENSSL_init_ssl")
+      if not newInitSym.isNil:
+        let newInitProc =
+          cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
+        return newInitProc(0, 0)
+      let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
+      if not olderProc.isNil: result = olderProc()
+
   proc SSL_load_error_strings*() =
     # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
     let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
@@ -398,8 +416,7 @@ else:
       theProc = cast[typeof(theProc)](sslSymThrows("SSL_CTX_set_ciphersuites"))
     theProc(ctx, str)
 
-
-proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc.}
+proc ERR_load_BIO_strings*(){.cdecl, dynlib: DLLUtilName, importc.}
 
 proc TLS_client_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
 
@@ -768,7 +785,7 @@ when not defined(nimDisableCertificateValidation) and not defined(windows):
   # proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
   #  loadPSSLMethod("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
 
-  when sslVersion.startsWith('3'):
+  when openssl3:
     proc SSL_get1_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
       SSL_get1_peer_certificate(ssl)

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -37,7 +37,7 @@ const useWinVersion = defined(windows) or defined(nimdoc)
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
-const openssl3 = sslVersion.startsWith('3')
+const useOpenssl3* = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -271,7 +271,7 @@ proc TLSv1_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 
 when compileOption("dynlibOverride", "ssl"):
   # Static linking
-  when not openssl3:
+  when not useOpenssl3:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =
       ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
@@ -360,7 +360,7 @@ else:
     let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
     return method2Proc()
 
-  when not openssl3:
+  when not useOpenssl3:
     proc SSL_library_init*(): cint {.discardable.} =
       ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
       ## SSL_library_init
@@ -785,7 +785,7 @@ when not defined(nimDisableCertificateValidation) and not defined(windows):
   # proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
   #  loadPSSLMethod("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
 
-  when openssl3:
+  when useOpenssl3:
     proc SSL_get1_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
       SSL_get1_peer_certificate(ssl)


### PR DESCRIPTION
refs #19814

The openssl 1.1 install on macos seems to have been the issue. An issue can be opened for why, but this could be something that doesn't affect users/isn't a problem with the codebase.

`-d:useOpenssl3` has been added to separate from `-d:sslVersion`, although `useOpenssl3` can be enabled by setting `sslVersion`. The version range for the automatic dynlibs has been reverted as well, and `.3` has been added as another possible suffix (setting sslVersion makes this suffix required). Changelog entry has also been added.

The `tssl` refactor and certain changes to remove compatibility with 1.0 have also been reverted. These are for the sake of making the original PR harmless.

Will run CI 3 times in a row to make sure it works.

`useOpenssl3` + `tssl` revert -> 1 passed, 1 failed
`useOpenssl3` + `tssl` revert + version range revert -> 1 failed
(current) `useOpenssl3` + `tssl` revert + CI openssl 1.1 install revert -> 3 passed
