### PR TITLE
fixes Thread initializer for ARC/ORC on Macos

### DIFF
--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -141,7 +141,7 @@ else:
                      header: "<pthread.h>".} = cint
   else:
     type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = distinct pointer
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = int
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<sys/types.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -139,16 +139,9 @@ else:
                        header: "<pthread.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",
                      header: "<pthread.h>".} = cint
-  elif defined(macos):
-    type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = pointer
-      Pthread_attr {.importc: "pthread_attr_t",
-                       header: "<sys/types.h>".} = object
-      ThreadVarSlot {.importc: "pthread_key_t",
-                     header: "<sys/types.h>".} = object
   else:
     type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = object
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = distinct pointer
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<sys/types.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -134,14 +134,21 @@ else:
                     header: "<sys/types.h>".} = distinct cuint
   elif defined(openbsd) and defined(amd64):
     type
-      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = ptr object
+      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = object
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<pthread.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",
                      header: "<pthread.h>".} = cint
+  elif defined(macos):
+    type
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = pointer
+      Pthread_attr {.importc: "pthread_attr_t",
+                       header: "<sys/types.h>".} = object
+      ThreadVarSlot {.importc: "pthread_key_t",
+                     header: "<sys/types.h>".} = object
   else:
     type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = ptr object
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = object
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<sys/types.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -134,14 +134,14 @@ else:
                     header: "<sys/types.h>".} = distinct cuint
   elif defined(openbsd) and defined(amd64):
     type
-      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = object
+      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = ptr object
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<pthread.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",
                      header: "<pthread.h>".} = cint
   else:
     type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = object
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = ptr object
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<sys/types.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",

--- a/tests/generics/tthread_generic.nim
+++ b/tests/generics/tthread_generic.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: "nim $target --hints:on --threads:on $options $file"
+  matrix: "--mm:refc; --mm:orc"
   action: compile
 """
 


### PR DESCRIPTION
Otherwise 

```
2022-09-15T22:14:56.9592680Z /Users/runner/work/1/s/nimcache/tests/generics/tthread_generic.nim_4a8a08f09d37b73795649038408b5f33/@mtthread_generic.nim.c:100:101: error: scalar initializer cannot be empty
2022-09-15T22:14:56.9593710Z static NIM_CONST tyObject_Thread__zHU2p4cP5TKE0P9cAAcLY8g TM__4S7kGJlWA60L39cvweIkHuA_2 = {NIM_NIL, {}, NIM_NIL, {{(&NTIv2__Hlf80yaLZNgwpkXrygtUDA_)}, NIM_NIL, NIM_NIL}}
```