### PR TITLE
fixes variable initialization of `concept` types with ORC on Macos and Linux i386

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -482,8 +482,9 @@ proc inferWithMetatype(c: PContext, formal: PType,
     # This almost exactly replicates the steps taken by the compiler during
     # param matching. It performs an embarrassing amount of back-and-forth
     # type jugling, but it's the price to pay for consistency and correctness
-    result.typ = generateTypeInstance(c, m.bindings, arg.info,
-                                      formal.skipTypes({tyCompositeTypeClass}))
+    # result.typ = generateTypeInstance(c, m.bindings, arg.info,
+    #                                   formal.skipTypes({tyCompositeTypeClass}))
+    result.typ = arg.typ
   else:
     typeMismatch(c.config, arg.info, formal, arg.typ, arg)
     # error correction:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -482,9 +482,11 @@ proc inferWithMetatype(c: PContext, formal: PType,
     # This almost exactly replicates the steps taken by the compiler during
     # param matching. It performs an embarrassing amount of back-and-forth
     # type jugling, but it's the price to pay for consistency and correctness
-    # result.typ = generateTypeInstance(c, m.bindings, arg.info,
-    #                                   formal.skipTypes({tyCompositeTypeClass}))
-    result.typ = arg.typ
+    if formal.kind == tyUserTypeClass:
+      result.typ = arg.typ
+    else:
+      result.typ = generateTypeInstance(c, m.bindings, arg.info,
+                                      formal.skipTypes({tyCompositeTypeClass}))
   else:
     typeMismatch(c.config, arg.info, formal, arg.typ, arg)
     # error correction:

--- a/tests/concepts/tusertypeclasses.nim
+++ b/tests/concepts/tusertypeclasses.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''Sortable
 Sortable
 Container


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/19972#issuecomment-1250199557

given a small test case

```nim
type
  stringTest = concept x
    x is string

let usedToFail: stringTest = "111"
echo usedToFail
```

After matching the concept type and the type of argument using `paramTypesMatch`, we can infer the type of `usedToFail` with `string` instead of keeping using `tyConcept` type. We don't need to use `typeAllowed` to check whether the concept is properly constructed because it is checked at the concept definition.

