### PR TITLE
test disable do: block lambda lifting

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2161,7 +2161,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       inc(m.genericMatches)
       m.fauxMatch = a.kind
       return arg
-    elif a.kind == tyVoid and f.matchesVoidProc and argOrig.kind == nkStmtList:
+    elif false and a.kind == tyVoid and f.matchesVoidProc and argOrig.kind == nkStmtList:
       # lift do blocks without params to lambdas
       let p = c.graph
       let lifted = c.semExpr(c, newProcNode(nkDo, argOrig.info, body = argOrig,

--- a/tests/closure/tclosure.nim
+++ b/tests/closure/tclosure.nim
@@ -239,7 +239,7 @@ block doNotation:
   b.onClick do (e: Event):
     echo "click at ", e.x, ",", e.y
 
-  b.onFocusLost:
+  b.onFocusLost do ():
     echo "lost focus 1"
 
   b.onFocusLost do ():
@@ -248,10 +248,10 @@ block doNotation:
   b.onUserEvent("UserEvent 1") do ():
     discard
 
-  b.onUserEvent "UserEvent 2":
+  onUserEvent(b, "UserEvent 2") do ():
     discard
 
-  b.onUserEvent("UserEvent 3"):
+  b.onUserEvent("UserEvent 3") do ():
     discard
 
   b.onUserEvent("UserEvent 4", () => echo "event 4")

--- a/tests/closure/tclosure.nim
+++ b/tests/closure/tclosure.nim
@@ -242,10 +242,10 @@ block doNotation:
   b.onFocusLost:
     echo "lost focus 1"
 
-  b.onFocusLost do:
+  b.onFocusLost do ():
     echo "lost focus 2"
 
-  b.onUserEvent("UserEvent 1") do:
+  b.onUserEvent("UserEvent 1") do ():
     discard
 
   b.onUserEvent "UserEvent 2":

--- a/tests/closure/tclosure_issues.nim
+++ b/tests/closure/tclosure_issues.nim
@@ -77,6 +77,6 @@ block tissue7104:
       sp():
           inc i
           echo "ok ", i
-          sp do:
+          sp do ():
               inc i
               echo "ok ", i

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -217,7 +217,7 @@ block:
   on("click") do (e: Event):
     console.log e
 
-  jslib.on("reloaded") do:
+  jslib.on("reloaded") do ():
     console.log jsarguments[0]
 
   # this test case is different from the above, because

--- a/tests/js/tjsffi_old.nim
+++ b/tests/js/tjsffi_old.nim
@@ -321,7 +321,7 @@ block:
   on("click") do (e: Event):
     console.log e
 
-  jslib.on("reloaded") do:
+  jslib.on("reloaded") do ():
     console.log jsarguments[0]
 
   # this test case is different from the above, because

--- a/tests/misc/tlambdadonotation.nim
+++ b/tests/misc/tlambdadonotation.nim
@@ -67,7 +67,7 @@ proc main2() =
   proc foo() =
     subscriber.consume()
 
-  emitter.on_event() do:
+  emitter.on_event() do ():
     subscriber.consume()
 
   # this works


### PR DESCRIPTION
There's no RFC for removing this or anything (there is some really old discussion), just wanted to see how common this is, maybe this can be made a style check or warning or something.

Only important package that uses this: [argparse](https://github.com/iffy/nim-argparse/blob/4048a76b24919807b0871dd145ba93a48c2688e7/src/argparse.nim#L308)