### PR TITLE
report expression has no type other than has to be used (or discarded…

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -139,6 +139,9 @@ proc discardCheck(c: PContext, result: PNode, flags: TExprFlags) =
       var n = newNodeI(nkDiscardStmt, result.info, 1)
       n[0] = result
     elif result.typ.kind != tyError and c.config.cmd != cmdInteractive:
+      if result.typ.kind == tyNone:
+        localError(c.config, result.info, "expression has no type: " &
+               renderTree(result, {renderNoComments}))
       var n = result
       while n.kind in skipForDiscardable:
         if n.kind == nkTryStmt: n = n[0]

--- a/tests/errmsgs/t8064.nim
+++ b/tests/errmsgs/t8064.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "expression has no type: values"
+"""
+import tables
+
+values


### PR DESCRIPTION
…) when typ is tyNone in discardCheck

related: https://github.com/nim-lang/Nim/issues/8064