### PR TITLE
fixes #20391; make of operator work with generics for ORC

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1280,7 +1280,7 @@ proc genTypeInfo2Name(m: BModule; t: PType): Rope =
   var it = t
   while it != nil:
     it = it.skipTypes(skipPtrs)
-    if it.sym != nil:
+    if it.sym != nil and tfFromGeneric notin it.flags:
       var m = it.sym.owner
       while m != nil and m.kind != skModule: m = m.owner
       if m == nil or sfSystemModule in m.flags:

--- a/tests/method/tmethod_issues.nim
+++ b/tests/method/tmethod_issues.nim
@@ -160,3 +160,11 @@ proc main() =
 
 main()
 
+block: # bug #20391
+  type Container[T] = ref object of RootRef
+    item: T
+
+  let a = Container[int]()
+
+  doAssert a of Container[int]
+  doAssert not (a of Container[string])


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/20391

For a generic type, it should consider its fields. Otherwise different instances of the generic types might have the same name but shouldn't.