### PR TITLE
fix #6472 Typed template arguments are substituted directly if they a…

### DIFF
--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -129,6 +129,9 @@ proc evalTemplateArgs(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode 
 
   result = newNodeI(nkArgList, n.info)
   for i in 1..givenRegularParams:
+    if s.typ != nil and n[i].typ != nil:
+      if n[i].kind in nkIntLit..nkUInt64Lit and skipTypes(s.typ[i], abstractVarRange).kind in {tyInt..tyInt64} + {tyUInt..tyUInt64}:
+        n[i] = newIntTypeNode(n[i].intVal,s.typ[i])
     result.add n[i]
 
   # handle parameters with default values, which were

--- a/tests/template/t6427.nim
+++ b/tests/template/t6427.nim
@@ -1,0 +1,9 @@
+discard """
+  action: compile
+"""
+import typetraits
+
+template bar(name: untyped; b1, b2: int8) =
+  let name: array[2, int8] = [b1, b2]
+
+bar(y, 0x11, 0x22)


### PR DESCRIPTION
…re compatible with parameter type

fix #6472  

after CI fails it seems need fix exists code for this.