### PR TITLE
FIX #20400

### DIFF
--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -63,7 +63,7 @@ func len*[T](c: CritBitTree[T]): int {.inline.} =
 
   result = c.count
 
-proc rawGet[T](c: CritBitTree[T], key: string): Node[T] =
+proc rawGet[T](c: CritBitTree[T], key: string): Node[T]=
   var it = c.root
   while it != nil:
     if not it.isLeaf:
@@ -71,7 +71,11 @@ proc rawGet[T](c: CritBitTree[T], key: string): Node[T] =
       let dir = (1 + (ch.ord or it.otherBits.ord)) shr 8
       it = it.child[dir]
     else:
-      return if it.key == key: it else: nil
+      let itKey = it.key
+      if itKey == key:
+        return it
+      else:
+        nil
 
 func contains*[T](c: CritBitTree[T], key: string): bool {.inline.} =
   ## Returns true if `c` contains the given `key`.

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -75,7 +75,7 @@ proc rawGet[T](c: CritBitTree[T], key: string): Node[T]=
       if itKey == key:
         return it
       else:
-        nil
+        return nil
 
 func contains*[T](c: CritBitTree[T], key: string): bool {.inline.} =
   ## Returns true if `c` contains the given `key`.


### PR DESCRIPTION
Reduces the complexity of a statement in `rawGet`. It appears that that statement causes issues when run with `-mm:orc`, as `hasKey` invokes this proc and this can lead to the error `Exception message: field 'key' is not accessible for type 'NodeObj' using 'isLeaf = 255'.

Applying this change has shown that the error no longer occurs.

Please note: This code is 100% completely stolen from @ringabout as we troubleshooted it together and they figured out the solution, so ideally questions should also include them.