### PR TITLE
Optimize `base64.encodeMime`

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -202,7 +202,7 @@ proc encodeMime*(s: string, lineLen = 75.Positive, newLine = "\r\n"): string =
   let e = encode(s)
   if e.len <= lineLen or newLine.len == 0:
     return e
-  result = newString(e.len + newLine.len * (e.len div lineLen))
+  result = newString(e.len + newLine.len * ((e.len div lineLen) - int(e.len mod lineLen == 0)))
   var i, j, k, b: int
   let nd = e.len - lineLen
   while j < nd:


### PR DESCRIPTION
* 5x faster for common scenarios, 13x faster if `lineLen` <= encoded string's length or `newLine` is empty.
* Changed `lineLen`'s type to `Positive` to disallow `0`.
```
name ............................... min time      avg time    std dv   runs
* `lineLen` >= encoded string's length:
new ................................ 0.001 ms      0.001 ms    ±0.000  x1000
old ................................ 0.013 ms      0.013 ms    ±0.000  x1000
* empty `newLine`:
new ................................ 0.001 ms      0.001 ms    ±0.000  x1000
old ................................ 0.014 ms      0.014 ms    ±0.001  x1000
* none of the above:
new ................................ 0.003 ms      0.003 ms    ±0.001  x1000
old ................................ 0.014 ms      0.015 ms    ±0.001  x1000
```