### PR TITLE
fix #10833 type expected error for proc resolution with static[int]]

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -641,7 +641,7 @@ proc explicitGenericInstError(c: PContext; n: PNode): PNode =
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   # binding has to stay 'nil' for this to work!
   var m = newCandidate(c, s, nil)
-
+  inc c.inExplicitGenericSym
   for i in 1..<n.len:
     let formal = s.ast[genericParamsPos][i-1].typ
     var arg = n[i].typ
@@ -660,6 +660,7 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   let info = getCallLineInfo(n)
   markUsed(c, info, s)
   onUse(info, s)
+  dec c.inExplicitGenericSym
   result = newSymNode(newInst, info)
 
 proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -118,6 +118,7 @@ type
     compilesContextId*: int    # > 0 if we are in a ``compiles`` magic
     compilesContextIdGenerator*: int
     inGenericInst*: int        # > 0 if we are instantiating a generic
+    inExplicitGenericSym*: int
     converters*: seq[PSym]
     patterns*: seq[PSym]       # sequence of pattern matchers
     optionStack*: seq[POptionEntry]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1294,7 +1294,7 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       else: result = newSymNode(s, n.info)
     of tyStatic:
       let staticDuringGenericInst = (c.inStaticContext > 0 and c.inGenericInst > 0)
-      if (c.inExplicitGenericSym <= 0 or staticDuringGenericInst) and typ.n != nil:
+      if (c.inExplicitGenericSym <= 0 or staticDuringGenericInst or efInTypeof in flags) and typ.n != nil:
         result = typ.n
         result.typ = typ.base
       else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1293,7 +1293,8 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       if s.astdef.safeLen == 0: result = inlineConst(c, n, s)
       else: result = newSymNode(s, n.info)
     of tyStatic:
-      if typ.n != nil:
+      let staticDuringGenericInst = (c.inStaticContext > 0 and c.inGenericInst > 0)
+      if (c.inExplicitGenericSym <= 0 or staticDuringGenericInst) and typ.n != nil:
         result = typ.n
         result.typ = typ.base
       else:

--- a/tests/generics/t10833.nim
+++ b/tests/generics/t10833.nim
@@ -1,10 +1,12 @@
 type Foo*[A; B; C: static[int]] = object
   s: string
-#   d: typeof(C)
+  f: typeof(C)
 
 proc build*[A; B; C: static[int]](s: string;): Foo[A, B, C] =
   const d = C
+  doAssert d == 1
   result.s = s
+  result.f = C
 
 proc build*[A; B; C: static[int]](): Foo[A, B, C] =
   build[A, B, C]("foo")
@@ -14,3 +16,4 @@ type
   Baz = object
 let r = build[Bar, Baz, 1]()
 doAssert r.s == "foo"
+doAssert r.f == 1

--- a/tests/generics/t10833.nim
+++ b/tests/generics/t10833.nim
@@ -1,0 +1,16 @@
+type Foo*[A; B; C: static[int]] = object
+  s: string
+#   d: typeof(C)
+
+proc build*[A; B; C: static[int]](s: string;): Foo[A, B, C] =
+  const d = C
+  result.s = s
+
+proc build*[A; B; C: static[int]](): Foo[A, B, C] =
+  build[A, B, C]("foo")
+
+type
+  Bar = object
+  Baz = object
+let r = build[Bar, Baz, 1]()
+doAssert r.s == "foo"

--- a/tests/generics/t10833_2.nim
+++ b/tests/generics/t10833_2.nim
@@ -1,0 +1,27 @@
+type MyObject = object
+  x, y: int
+  s: string
+
+const c = MyObject(x: 1, y: 2, s: "")
+
+type Foo[A, B; C: static MyObject] = object
+  s: string
+  f: typeof(C)
+
+proc build*[A; B; C: static MyObject](s: string;): Foo[A, B, C] =
+  const d = C
+  doAssert d.x == c.x
+  doAssert d.x == 1
+  result.f = d
+  result.s = s
+
+proc build*[A; B; C: static MyObject](): Foo[A, B, C] =
+  build[A, B, C]("foo")
+
+type
+  Bar = object
+  Baz = object
+
+let r = build[Bar, Baz, c]()
+doAssert r.s == "foo"
+doAssert r.f == c

--- a/tests/generics/t10833_3.nim
+++ b/tests/generics/t10833_3.nim
@@ -1,0 +1,27 @@
+type MyObject = object
+  x, y: int
+  s: string
+
+const c = @[MyObject(x: 1, y: 2, s: "")]
+
+type Foo[A, B; C: static seq[MyObject]] = object
+  s: string
+  f: typeof(C)
+
+proc build*[A; B; C: static seq[MyObject]](s: string;): Foo[A, B, C] =
+  const d = C
+  doAssert d[0].x == c[0].x
+  doAssert d[0].x == 1
+  result.f = d
+  result.s = s
+
+proc build*[A; B; C: static seq[MyObject]](): Foo[A, B, C] =
+  build[A, B, C]("foo")
+
+type
+  Bar = object
+  Baz = object
+
+let r = build[Bar, Baz, c]()
+doAssert r.s == "foo"
+doAssert r.f == c


### PR DESCRIPTION
fix #10833

related: https://github.com/nim-lang/Nim/issues/4990
https://github.com/nim-lang/Nim/issues/6522

<s>uncomment `typeMismatch(c.config, info, formal, arg.typ, arg)` still get
`t10833.nim(7, 19) Error: type mismatch: got <Foo[t10833.Bar, t10833.Baz, system.int]> but expected 'Foo[t10833.Bar, t10833.Baz, 1]'`  

type info loss, however I debugging in serveral steps all type check passed, in the end the `int` is compare in `handleRange` in first case  `f.kind == a.kind` , even it loss literal info.   </s>

this may related to https://github.com/nim-lang/Nim/pull/20417, if merge, merge this one first.