### PR TITLE
fix #18128 rfind on empty needle returns rightmost index

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2022,7 +2022,8 @@ func rfind*(s, sub: string, start: Natural = 0, last = -1): int {.rtl,
   ## See also:
   ## * `find func<#find,string,string,Natural,int>`_
   if sub.len == 0:
-    return -1
+    let rightIndex: Natural = if last < 0: s.len else: last
+    return max(start, rightIndex)
   if sub.len > s.len - start:
     return -1
   let last = if last == -1: s.high else: last

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -360,19 +360,23 @@ template main() =
     doAssert "///".rfind("//", start=3) == -1
 
     # searching for empty string
-    doAssert "".rfind("") == -1
-    doAssert "abc".rfind("") == -1
-    doAssert "abc".rfind("", start=1) == -1
-    doAssert "abc".rfind("", start=2) == -1
-    doAssert "abc".rfind("", start=3) == -1
-    doAssert "abc".rfind("", start=4) == -1
-    doAssert "abc".rfind("", start=400) == -1
+    doAssert "".rfind("") == 0
+    doAssert "abc".rfind("") == 3
+    doAssert "abc".rfind("", start=1) == 3
+    doAssert "abc".rfind("", start=2) == 3
+    doAssert "abc".rfind("", start=3) == 3
+    doAssert "abc".rfind("", start=4) == 4
+    doAssert "abc".rfind("", start=400) == 400
 
-    doAssert "abc".rfind("", start=1, last=3) == -1
-    doAssert "abc".rfind("", start=1, last=2) == -1
-    doAssert "abc".rfind("", start=1, last=1) == -1
-    doAssert "abc".rfind("", start=1, last=0) == -1
-    doAssert "abc".rfind("", start=1, last = -1) == -1
+    doAssert "abc".rfind("", start=1, last=3) == 3
+    doAssert "abc".rfind("", start=1, last=2) == 2
+    doAssert "abc".rfind("", start=1, last=1) == 1
+    # This returns the start index instead of the last index
+    # because start > last
+    doAssert "abc".rfind("", start=1, last=0) == 1
+    doAssert "abc".rfind("", start=1, last = -1) == 3
+    
+    doAssert "abc".rfind("", start=0, last=0) == 0
 
     # when last <= start, searching for non-empty string
     block:


### PR DESCRIPTION
Fix #18128

All the relevant test cases discussed in the linked issue pass now
```nim
import strutils

doAssert "abc".find("") == 0
doAssert "abc".rfind("") == 3

doAssert "abc".find("") == 0
doAssert "abc".rfind("") == 3
doAssert "abc".rfind("c") == 2
doAssert "abc".rfind("bc") == 1
doAssert "abc".rfind("abc") == 0

doAssert "abc".find("") == 0
doAssert "abc".find("a") == 0
doAssert "abc".find("ab") == 0
doAssert "abc".find("abc") == 0
```