### PR TITLE
replace localErrorNode with `nkError`

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -17,7 +17,8 @@ import
   intsets, transf, vmdef, vm, aliases, cgmeth, lambdalifting,
   evaltempl, patterns, parampatterns, sempass2, linter, semmacrosanity,
   lowerings, plugins/active, lineinfos, strtabs, int128,
-  isolation_check, typeallowed, modulegraphs, enumtostr, concepts, astmsgs
+  isolation_check, typeallowed, modulegraphs, enumtostr, concepts, astmsgs,
+  errorhandling
 
 when defined(nimfix):
   import nimfix/prettybase
@@ -322,7 +323,7 @@ proc fixupTypeAfterEval(c: PContext, evaluated, eOrig: PNode): PNode =
       result = evaluated
       let expectedType = eOrig.typ.skipTypes({tyStatic})
       if hasCycle(result):
-        result = localErrorNode(c, eOrig, "the resulting AST is cyclic and cannot be processed further")
+        result = reportError(c.config, eOrig, eOrig.info, "the resulting AST is cyclic and cannot be processed further")
       else:
         semmacrosanity.annotateType(result, expectedType, c.config)
   else:

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -508,25 +508,6 @@ proc errorNode*(c: PContext, n: PNode): PNode =
   result = newNodeI(nkEmpty, n.info)
   result.typ = errorType(c)
 
-# These mimic localError
-template localErrorNode*(c: PContext, n: PNode, info: TLineInfo, msg: TMsgKind, arg: string): PNode =
-  liMessage(c.config, info, msg, arg, doNothing, instLoc())
-  errorNode(c, n)
-
-template localErrorNode*(c: PContext, n: PNode, info: TLineInfo, arg: string): PNode =
-  liMessage(c.config, info, errGenerated, arg, doNothing, instLoc())
-  errorNode(c, n)
-
-template localErrorNode*(c: PContext, n: PNode, msg: TMsgKind, arg: string): PNode =
-  let n2 = n
-  liMessage(c.config, n2.info, msg, arg, doNothing, instLoc())
-  errorNode(c, n2)
-
-template localErrorNode*(c: PContext, n: PNode, arg: string): PNode =
-  let n2 = n
-  liMessage(c.config, n2.info, errGenerated, arg, doNothing, instLoc())
-  errorNode(c, n2)
-
 proc fillTypeS*(dest: PType, kind: TTypeKind, c: PContext) =
   dest.kind = kind
   dest.owner = getCurrOwner(c)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1077,7 +1077,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   if e != nil:
     result.add(newSymNode(e))
   else:
-    result.add localErrorNode(c, n, "system needs: echo")
+    result.add reportError(c.graph.config, n, n.info, "system needs: echo")
   result.add(n)
   result.add(newStrNode(nkStrLit, ": " & n.typ.typeToString))
   result = semExpr(c, result)
@@ -2330,14 +2330,14 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags; expectedType: P
   of mSpawn:
     markUsed(c, n.info, s)
     when defined(leanCompiler):
-      result = localErrorNode(c, n, "compiler was built without 'spawn' support")
+      result = reportError(c.graph.config, n, n.info, "compiler was built without 'spawn' support")
     else:
       result = setMs(n, s)
       for i in 1..<n.len:
         result[i] = semExpr(c, n[i])
 
       if n.len > 1 and n[1].kind notin nkCallKinds:
-        return localErrorNode(c, n, n[1].info, "'spawn' takes a call expression; got: " & $n[1])
+        return reportError(c.graph.config, n, n[1].info, "'spawn' takes a call expression; got: " & $n[1])
 
       let typ = result[^1].typ
       if not typ.isEmptyType:
@@ -2709,7 +2709,7 @@ proc semTupleConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
     # check if either everything or nothing is tyTypeDesc
     for i in 1..<tupexp.len:
       if isTupleType != (tupexp[i].typ.kind == tyTypeDesc):
-        return localErrorNode(c, n, tupexp[i].info, "Mixing types and values in tuples is not allowed.")
+        return reportError(c.graph.config, n, tupexp[i].info, "Mixing types and values in tuples is not allowed.")
   if isTupleType: # expressions as ``(int, string)`` are reinterpret as type expressions
     result = n
     var typ = semTypeNode(c, n, nil).skipTypes({tyTypeDesc})

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -221,12 +221,12 @@ proc semBindSym(c: PContext, n: PNode): PNode =
 
   let sl = semConstExpr(c, n[1])
   if sl.kind notin {nkStrLit, nkRStrLit, nkTripleStrLit}:
-    return localErrorNode(c, n, n[1].info, errStringLiteralExpected)
+    return reportError(c.graph.config, n, n[1].info, errStringLiteralExpected)
 
   let isMixin = semConstExpr(c, n[2])
   if isMixin.kind != nkIntLit or isMixin.intVal < 0 or
       isMixin.intVal > high(TSymChoiceRule).int:
-    return localErrorNode(c, n, n[2].info, errConstExprExpected)
+    return reportError(c.graph.config, n, n[2].info, errConstExprExpected)
 
   let id = newIdentNode(getIdent(c.cache, sl.strVal), n.info)
   let s = qualifiedLookUp(c, id, {checkUndeclared})
@@ -243,10 +243,10 @@ proc semBindSym(c: PContext, n: PNode): PNode =
 
 proc opBindSym(c: PContext, scope: PScope, n: PNode, isMixin: int, info: PNode): PNode =
   if n.kind notin {nkStrLit, nkRStrLit, nkTripleStrLit, nkIdent}:
-    return localErrorNode(c, n, info.info, errStringOrIdentNodeExpected)
+    return reportError(c.graph.config, n, info.info, errStringOrIdentNodeExpected)
 
   if isMixin < 0 or isMixin > high(TSymChoiceRule).int:
-    return localErrorNode(c, n, info.info, errConstExprExpected)
+    return reportError(c.graph.config, n, info.info, errConstExprExpected)
 
   let id = if n.kind == nkIdent: n
     else: newIdentNode(getIdent(c.cache, n.strVal), info.info)

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -381,7 +381,7 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType 
   for child in n: result.add child
 
   if t == nil:
-    return localErrorNode(c, result, "object constructor needs an object type")
+    return reportError(c.graph.config, result, result.info, "object constructor needs an object type")
   
   if t.skipTypes({tyGenericInst,
       tyAlias, tySink, tyOwned, tyRef}).kind != tyObject and
@@ -398,7 +398,7 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType 
       # multiple times as long as they don't have closures.
       result.typ.flags.incl tfHasOwned
   if t.kind != tyObject:
-    return localErrorNode(c, result, if t.kind != tyGenericBody:
+    return reportError(c.graph.config, result, result.info, if t.kind != tyGenericBody:
       "object constructor needs an object type".dup(addDeclaredLoc(c.config, t))
       else: "cannot instantiate: '" &
         typeToString(t, preferDesc) &

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -847,7 +847,7 @@ proc semForVars(c: PContext, n: PNode; flags: TExprFlags): PNode =
     if n.len == 3:
       if n[0].kind == nkVarTuple:
         if n[0].len-1 != iterAfterVarLent.len:
-          return localErrorNode(c, n, n[0].info, errWrongNumberOfVariables)
+          return reportError(c.graph.config, n, n[0].info, errWrongNumberOfVariables)
 
         for i in 0..<n[0].len-1:
           var v = symForVar(c, n[0][i])


### PR DESCRIPTION
I'm not sure whether `nkError` must be handled at sempass2. Instead, we could report the errors at once and return the error node just like what the `localErrorNode` did. Then we can turn the `localError` call into the `reportError` call gradually and handle `nkError` in order to continue the compilation.