### PR TITLE
closed ambiguous enum defaults to first overload

### DIFF
--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -143,3 +143,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasTopDownInference")
   defineSymbol("nimHasTemplateRedefinitionPragma")
   defineSymbol("nimHasCstringCase")
+  defineSymbol("nimHasAmbiguousEnumHint")

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -82,7 +82,6 @@ type
     warnEffect = "Effect",
     warnCastSizes = "CastSizes"
     warnTemplateRedefinition = "TemplateRedefinition",
-    warnAmbiguousEnum = "AmbiguousEnum",
     warnUser = "User",
     # hints
     hintSuccess = "Success", hintSuccessX = "SuccessX",
@@ -97,6 +96,7 @@ type
     hintPattern = "Pattern", hintExecuting = "Exec", hintLinking = "Link", hintDependency = "Dependency",
     hintSource = "Source", hintPerformance = "Performance", hintStackTrace = "StackTrace",
     hintGCStats = "GCStats", hintGlobalVar = "GlobalVar", hintExpandMacro = "ExpandMacro",
+    hintAmbiguousEnum = "AmbiguousEnum",
     hintUser = "User", hintUserRaw = "UserRaw", hintExtendedContext = "ExtendedContext",
     hintMsgOrigin = "MsgOrigin", # since 1.3.5
     hintDeclaredLoc = "DeclaredLoc", # since 1.5.1
@@ -178,7 +178,6 @@ const
     warnEffect: "$1",
     warnCastSizes: "$1",
     warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding an explicit .redefine pragma",
-    warnAmbiguousEnum: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`
@@ -211,6 +210,7 @@ const
     hintGCStats: "$1",
     hintGlobalVar: "global variable declared here",
     hintExpandMacro: "expanded macro: $1",
+    hintAmbiguousEnum: "$1",
     hintUser: "$1",
     hintUserRaw: "$1",
     hintExtendedContext: "$1",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -82,6 +82,7 @@ type
     warnEffect = "Effect",
     warnCastSizes = "CastSizes"
     warnTemplateRedefinition = "TemplateRedefinition",
+    warnAmbiguousEnum = "AmbiguousEnum",
     warnUser = "User",
     # hints
     hintSuccess = "Success", hintSuccessX = "SuccessX",
@@ -177,6 +178,7 @@ const
     warnEffect: "$1",
     warnCastSizes: "$1",
     warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding an explicit .redefine pragma",
+    warnAmbiguousEnum: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -87,6 +87,12 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
   result = semExprCheck(c, n, flags, expectedType)
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
+  elif (result.typ == nil or result.typ.kind == tyNone) and
+      result.kind == nkClosedSymChoice and result.len != 0 and
+      result[0].sym.kind == skEnumField:
+    # if overloaded enum field could not choose a type from a closed list,
+    # choose the first resolved enum field, i.e. the latest in scope
+    result = result[0]
   elif result.typ == nil or result.typ == c.enforceVoidContext:
     localError(c.config, n.info, errExprXHasNoType %
                 renderTree(result, {renderNoComments}))

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -88,10 +88,12 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
   elif (result.typ == nil or result.typ.kind == tyNone) and
-      result.kind == nkClosedSymChoice and result.len != 0 and
+      result.kind == nkClosedSymChoice and
       result[0].sym.kind == skEnumField:
     # if overloaded enum field could not choose a type from a closed list,
     # choose the first resolved enum field, i.e. the latest in scope
+    # to mirror old behavior
+    msgSymChoiceUseQualifier(c, result, warnAmbiguousEnum)
     result = result[0]
   elif result.typ == nil or result.typ == c.enforceVoidContext:
     localError(c.config, n.info, errExprXHasNoType %

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -93,7 +93,7 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
     # if overloaded enum field could not choose a type from a closed list,
     # choose the first resolved enum field, i.e. the latest in scope
     # to mirror old behavior
-    msgSymChoiceUseQualifier(c, result, warnAmbiguousEnum)
+    msgSymChoiceUseQualifier(c, result, hintAmbiguousEnum)
     result = result[0]
   elif result.typ == nil or result.typ == c.enforceVoidContext:
     localError(c.config, n.info, errExprXHasNoType %

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -577,7 +577,7 @@ proc semVarMacroPragma(c: PContext, a: PNode, n: PNode): PNode =
 proc msgSymChoiceUseQualifier(c: PContext; n: PNode; note = errGenerated) =
   assert n.kind in nkSymChoices
   var err =
-    if note == warnAmbiguousEnum:
+    if note == hintAmbiguousEnum:
       "ambiguous enum field '$1' assumed to be of type $2, this will become an error in the future" % [$n[0], typeToString(n[0].typ)]
     else:
       "ambiguous identifier: '" & $n[0] & "'"

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -591,7 +591,9 @@ proc semCaseBranch(c: PContext, t, branch: PNode, branchIndex: int,
       branch[i] = semCaseBranchRange(c, t, b, covered)
     else:
       # constant sets and arrays are allowed:
-      var r = semConstExpr(c, b)
+      # set expected type to selector type for type inference
+      # even if it can be a different type like a set or array
+      var r = semConstExpr(c, b, expectedType = t[0].typ)
       if r.kind in {nkCurly, nkBracket} and r.len == 0 and branch.len == 2:
         # discarding ``{}`` and ``[]`` branches silently
         delSon(branch, 0)

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -15,7 +15,10 @@ cc = gcc
 --parallel_build: "0" # 0 to auto-detect number of processors
 
 hint[LineTooLong]=off
-hint[AmbiguousEnum]=off
+@if nimHasAmbiguousEnumHint:
+  # not needed if hint is a style check
+  hint[AmbiguousEnum]=off
+@end
 #hint[XDeclaredButNotUsed]=off
 
 threads:on

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -15,6 +15,7 @@ cc = gcc
 --parallel_build: "0" # 0 to auto-detect number of processors
 
 hint[LineTooLong]=off
+hint[AmbiguousEnum]=off
 #hint[XDeclaredButNotUsed]=off
 
 threads:on

--- a/tests/ambsym/tambsym3.nim
+++ b/tests/ambsym/tambsym3.nim
@@ -1,11 +1,13 @@
 discard """
-  errormsg: "ambiguous identifier"
+  errormsg: "ambiguous enum field"
   file: "tambsym3.nim"
-  line: 11
+  line: 13
 """
 # Test ambiguous symbols
 
 import mambsym1, times
+
+{.warningAsError[AmbiguousEnum]: on.}
 
 var
   v = mDec #ERROR_MSG ambiguous identifier

--- a/tests/ambsym/tambsym3.nim
+++ b/tests/ambsym/tambsym3.nim
@@ -1,13 +1,14 @@
 discard """
   errormsg: "ambiguous enum field"
   file: "tambsym3.nim"
-  line: 13
+  line: 14
 """
 # Test ambiguous symbols
 
 import mambsym1, times
 
-{.warningAsError[AmbiguousEnum]: on.}
+{.hint[AmbiguousEnum]: on.}
+{.hintAsError[AmbiguousEnum]: on.}
 
 var
   v = mDec #ERROR_MSG ambiguous identifier

--- a/tests/enum/tcrossmodule.nim
+++ b/tests/enum/tcrossmodule.nim
@@ -8,3 +8,8 @@ template t =
   doAssert some(Success)
 
 t()
+
+block: # behavior before overloadableEnums
+  # in case of ambiguity in closed environment, pick latest enum in scope
+  let x = {Success}
+  doAssert x is set[MyEnum]

--- a/tests/enum/tcrossmodule.nim
+++ b/tests/enum/tcrossmodule.nim
@@ -9,7 +9,7 @@ template t =
 
 t()
 
-block: # behavior before overloadableEnums
-  # in case of ambiguity in closed environment, pick latest enum in scope
+block: # legacy support for behavior before overloadableEnums
+  # warning: ambiguous enum field 'Success' assumed to be of type MyEnum
   let x = {Success}
   doAssert x is set[MyEnum]


### PR DESCRIPTION
In the case where a closed enum field symchoice cannot collapse to a type, assume it has the type of the first overload in the symchoice. From what I understand this is also the closest overload in scope.

Unfortunately this also applies to enum types in the same scope, as disallowing this would require iterating over the overloads again. But this was not possible without overloadableEnums, and the type system should point out issues.

This allows some code that didn't use overloadableEnums to work. Specifically, this should make code that broke with #20298, namely the regression in the comments https://github.com/nim-lang/Nim/pull/20298#issuecomment-1239903341 and later reported on the forum https://forum.nim-lang.org/t/9474#62224 work.

This gives a warning that can be turned into an error with `--warningAsError:AmbiguousEnum`.