### PR TITLE
remove hack for deprecated csize in compiler

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2252,8 +2252,7 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc) =
       cgsym(p.module, raiser)
 
       let boundaryCast =
-        if n0t.skipTypes(abstractVarRange).kind in {tyUInt, tyUInt32, tyUInt64} or
-            (n0t.sym != nil and sfSystemModule in n0t.sym.owner.flags and n0t.sym.name.s == "csize"):
+        if n0t.skipTypes(abstractVarRange).kind in {tyUInt, tyUInt32, tyUInt64}:
           "(NI64)"
         else:
           ""

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -56,11 +56,7 @@ discard $x0
 const x1 = cast[uint](-1)
 discard $(x1,)
 
-when not defined(nimPreviewSlimSystem):
-  # bug #13698
-  let n: csize = 1 # xxx should that be csize_t or is that essential here?
-  doAssert $n.int32 == "1"
-
+# bug #13698
 let n2: csize_t = 1
 doAssert $n2.int32 == "1"
 


### PR DESCRIPTION
csize is removed with nimPreviewSlimSystem as of #20355