### PR TITLE
macOS use SecRandomCopyBytes instead of getentropy

### DIFF
--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -232,7 +232,7 @@ elif defined(freebsd):
     result = getrandom(p, csize_t(size), 0)
 
 elif defined(ios) or defined(macosx):
-  {.passL: "-framework Security".}
+  {.passl: "-framework Security".}
 
   const errSecSuccess = 0 ## No error.
 

--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -20,7 +20,7 @@
 ## | :---                 | ----:                 |
 ## | Windows              | `BCryptGenRandom`_    |
 ## | Linux                | `getrandom`_          |
-## | MacOSX               | `getentropy`_         |
+## | MacOSX               | `SecRandomCopyBytes`_ |
 ## | iOS                  | `SecRandomCopyBytes`_ |
 ## | OpenBSD              | `getentropy openbsd`_ |
 ## | FreeBSD              | `getrandom freebsd`_  |
@@ -66,7 +66,7 @@ when defined(nimPreviewSlimSystem):
   import std/assertions
 
 const
-  batchImplOS = defined(freebsd) or defined(openbsd) or defined(zephyr) or (defined(macosx) and not defined(ios))
+  batchImplOS = defined(freebsd) or defined(openbsd) or defined(zephyr)
   batchSize {.used.} = 256
 
 when batchImplOS:
@@ -231,7 +231,7 @@ elif defined(freebsd):
   proc getRandomImpl(p: pointer, size: int): int {.inline.} =
     result = getrandom(p, csize_t(size), 0)
 
-elif defined(ios):
+elif defined(ios) or defined(macosx):
   {.passL: "-framework Security".}
 
   const errSecSuccess = 0 ## No error.
@@ -253,19 +253,6 @@ elif defined(ios):
       return
 
     result = secRandomCopyBytes(nil, csize_t(size), addr dest[0])
-
-elif defined(macosx):
-  const sysrandomHeader = """#include <Availability.h>
-#include <sys/random.h>
-"""
-
-  proc getentropy(p: pointer, size: csize_t): cint {.importc: "getentropy", header: sysrandomHeader.}
-    # getentropy() fills a buffer with random data, which can be used as input
-    # for process-context pseudorandom generators like arc4random(3).
-    # The maximum buffer size permitted is 256 bytes.
-
-  proc getRandomImpl(p: pointer, size: int): int {.inline.} =
-    result = getentropy(p, csize_t(size)).int
 
 else:
   template urandomImpl(result: var int, dest: var openArray[byte]) =


### PR DESCRIPTION
This changes the `urandom` proc to use `SecRandomCopyBytes` on macOS instead of `getentropy` because:

- `SecRandomCopyBytes` is available on iOS 2.0+ and macOS 10.7+ https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?language=objc
- `getentropy` is only available on macOS 10.12+

This fixes my application that I currently build for a macOS 10.10 machine after upgrading to Nim 1.6 from Nim 1.4. This supersedes and closes #20460