### PR TITLE
strutils, rstgen: avoid deprecated `strutils.delete`

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -763,7 +763,7 @@ proc stripTocHtml(s: string): string =
     if last < 0:
       # Abort, since we didn't found a closing angled bracket.
       return
-    result.delete(first, last)
+    result.delete(first..last)
     first = result.find('<', first)
 
 proc renderHeadline(d: PDoc, n: PRstNode, result: var string) =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1648,7 +1648,7 @@ func removePrefix*(s: var string, chars: set[char] = Newlines) {.rtl,
 
   var start = 0
   while start < s.len and s[start] in chars: start += 1
-  if start > 0: s.delete(0, start - 1)
+  if start > 0: s.delete(0..start - 1)
 
 func removePrefix*(s: var string, c: char) {.rtl,
     extern: "nsuRemovePrefixChar".} =
@@ -1675,8 +1675,8 @@ func removePrefix*(s: var string, prefix: string) {.rtl,
     var answers = "yesyes"
     answers.removePrefix("yes")
     doAssert answers == "yes"
-  if s.startsWith(prefix):
-    s.delete(0, prefix.len - 1)
+  if s.startsWith(prefix) and prefix.len > 0:
+    s.delete(0..prefix.len - 1)
 
 func removeSuffix*(s: var string, chars: set[char] = Newlines) {.rtl,
     extern: "nsuRemoveSuffixCharSet".} =
@@ -2469,7 +2469,8 @@ func trimZeros*(x: var string; decimalSep = '.') =
     var pos = last
     while pos >= 0 and x[pos] == '0': dec(pos)
     if pos > sPos: inc(pos)
-    x.delete(pos, last)
+    if last >= pos:
+      x.delete(pos..last)
 
 type
   BinaryPrefixMode* = enum ## The different names for binary prefixes.

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -433,6 +433,9 @@ template main() =
     x = "1e0"
     x.trimZeros()
     doAssert x == "1e0"
+    x = "1.23"
+    x.trimZeros()
+    doAssert x == "1.23"
 
   block: # countLines
     proc assertCountLines(s: string) = doAssert s.countLines == s.splitLines.len


### PR DESCRIPTION
The strutils `delete` func with signature

```nim
func delete*(s: var string, first, last: int)
```

was deprecated in https://github.com/nim-lang/Nim/commit/adba5eb45e0ae0d370aea4d653a4f00a4c075695, in favor of one with signature

```
func delete*(s: var string, slice: Slice[int])
```

However, a few procedures still used the deprecated form. This commit updates them, resolving these deprecation warnings:

```text
rstgen.nim(766, 12) Warning: use `delete(s, first..last)`; delete is deprecated [Deprecated]
strutils.nim(1651, 19) Warning: use `delete(s, first..last)`; delete is deprecated [Deprecated]
strutils.nim(1679, 7) Warning: use `delete(s, first..last)`; delete is deprecated [Deprecated]
strutils.nim(2472, 7) Warning: use `delete(s, first..last)`; delete is deprecated [Deprecated]
```

Before this commit:

- `trimZeros` called `s.delete(i+1, i)` for an input that lacks a trailing zero (like "1.23").

- `removePrefix*(s: var string, prefix: string)` called `s.delete(0, -1)` when the prefix was the empty string.

which did not modify `s`, nor raise an error. But the newer slice `delete` raises an `IndexDefect` when the start of the slice is greater than the end, so we avoid calling the new `delete` for such a case.

Recall that exceptions inheriting from `system.Defect` [are not tracked](https://github.com/nim-lang/Nim/blob/2dec69fe5aa6/doc/manual.md#exception-tracking) with the `.raises: []` exception tracking mechanism, so this commit does not break existing code like:

```nim
proc foo {.raises: [].} =
  var s = "abc1.20"
  s.removePrefix("abc")
  s.trimZeros()
  doAssert s == "1.2"
```

The `strutils.delete` deprecation was motivated by a problem with `system.delete` (addressed in https://github.com/nim-lang/Nim/commit/92cb765714325703d1a8e1b0409bfcd1b17af103). From the [Nim 1.6.0 changelog](https://github.com/nim-lang/Nim/blob/2dec69fe5aa6/changelogs/changelog_1_6_0.md#system):

> `system.delete` had surprising behavior when the index passed to it was out of bounds (it would delete the last entry then). Compile with `-d:nimStrictDelete` so that an index error is produced instead.
>
> Be aware however that your code might depend on this quirky behavior so a review process is required on your part before you can use `-d:nimStrictDelete`. To make this review easier, use the `-d:nimAuditDelete` switch, which pretends that `system.delete` is deprecated so that it is easier to see where it was used in your code.
>
> `-d:nimStrictDelete` will become the default in upcoming versions.

A [similar deprecation happened with `sequtils.delete`](https://github.com/nim-lang/Nim/commit/1d6863a7899fd87fd9eb017ae370ef37db18ad32), but that deprecated form is already not used in this repo.