### PR TITLE
fix #6407 SomeFloat and SomeInteger types fails to differentiate in a…

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1874,7 +1874,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
           rhsTyp = rhsTyp.lastSon
         if lhs.sym.typ.kind == tyAnything:
           rhsTyp = rhsTyp.skipIntLit(c.idgen)
-        if cmpTypes(c, lhs.typ, rhsTyp) in {isGeneric, isEqual}:
+        if cmpTypes(c, lhs.typ, rhsTyp) in {isGeneric, isEqual, isTypeClass}:
           internalAssert c.config, c.p.resultSym != nil
           # Make sure the type is valid for the result variable
           typeAllowedCheck(c, n.info, rhsTyp, skResult)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -42,6 +42,7 @@ type
     isInferred,              # generic proc was matched against a concrete type
     isInferredConvertible,   # same as above, but requiring proc CC conversion
     isGeneric,
+    isTypeClass,
     isFromIntLit,            # conversion *from* int literal; proven safe
     isEqual
 

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -390,6 +390,11 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
   assert(obj.kind == JObject)
   obj.fields[key] = val
 
+proc `%`*(o: enum): JsonNode =
+  ## Construct a JsonNode that represents the specified enum value as a
+  ## string. Creates a new `JString JsonNode`.
+  result = %($o)
+
 proc `%`*[T: object](o: T): JsonNode =
   ## Construct JsonNode from tuples and objects.
   result = newJObject()
@@ -401,11 +406,6 @@ proc `%`*(o: ref object): JsonNode =
     result = newJNull()
   else:
     result = %(o[])
-
-proc `%`*(o: enum): JsonNode =
-  ## Construct a JsonNode that represents the specified enum value as a
-  ## string. Creates a new `JString JsonNode`.
-  result = %($o)
 
 proc toJsonImpl(x: NimNode): NimNode =
   case x.kind

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -567,7 +567,7 @@ proc formatValue*(result: var string; value: string; specifier: string) =
       setLen(value, runeOffset(value, spec.precision))
   result.add alignString(value, spec.minimumWidth, spec.align, spec.fill)
 
-proc formatValue[T: not SomeInteger](result: var string; value: T; specifier: string) =
+proc formatValue[T: not SomeNumber](result: var string; value: T; specifier: string) =
   mixin `$`
   formatValue(result, $value, specifier)
 

--- a/tests/generics/t13549.nim
+++ b/tests/generics/t13549.nim
@@ -1,0 +1,10 @@
+
+proc foo[T](x: T):int = 1
+
+proc foo[T: tuple](x: T):int = 2
+
+doAssert foo((1, 2, 3)) == 2
+
+type Obj = object
+proc foo(x: object):int = 3
+doAssert foo(Obj()) == 3

--- a/tests/generics/t18314.nim
+++ b/tests/generics/t18314.nim
@@ -1,0 +1,14 @@
+discard """
+  disabled: true
+"""
+
+type
+  A = ref object of RootObj
+  B = ref object of A
+  C = ref object of B
+
+proc foo[T: A](a: T):int = 1
+proc foo[T: B](b: T):int = 2
+
+var c = C()
+doAssert foo(c) == 2

--- a/tests/generics/t4084.nim
+++ b/tests/generics/t4084.nim
@@ -1,0 +1,13 @@
+discard """
+  disabled: true
+"""
+
+type
+  Image[T: int32|int64] = object
+    data: seq[T]
+
+proc newImage[T](w, h: int): ref Image[T] =
+  new(result)
+  result.data = newSeq[T](w * h)
+
+var i = newImage[string](320, 200)

--- a/tests/generics/t6407.nim
+++ b/tests/generics/t6407.nim
@@ -1,0 +1,12 @@
+discard """
+action: compile
+"""
+
+proc foo[T6407: SomeFloat](y: T6407):int = 0
+
+proc foo[T6407: SomeInteger](y: T6407):int = 1
+
+proc boo[T6407](x: T6407):int =
+  foo[T6407](x)
+
+doAssert boo(1) == 1

--- a/tests/generics/t6407_2.nim
+++ b/tests/generics/t6407_2.nim
@@ -1,0 +1,10 @@
+discard """
+action: compile
+"""
+
+proc sort[T: uint8|char|byte](c: T) = discard
+proc sort[T: bool](c: T) = discard
+
+proc sorted[T](c: T): T = sort[T](c)
+
+doAssert sorted(true) == false


### PR DESCRIPTION
… generic call from other generic

fix #6407  
fix https://github.com/nim-lang/Nim/issues/13549 type class

refs: https://github.com/nim-lang/Nim/issues/12787

refs: https://github.com/nim-lang/Nim/issues/10739 `type Obj[A; B: not A] = object`

refs: https://github.com/nim-lang/Nim/issues/19999 this call doesn't turn to a container of enum, so wil not compare f.base and a.base

refs: https://github.com/nim-lang/Nim/issues/6840 this does not seems be a issue.

refs: https://github.com/nim-lang/Nim/issues/4084 proc generic doesn't have constrained as return type

refs: https://github.com/nim-lang/Nim/issues/18314 Objects subtype generics are bound using the most broad type and not the most specific type 
