### PR TITLE
fix #7446 Generics: type mismatch 'SomeunsignedInt or Natural'

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1595,10 +1595,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         c.inheritancePenalty = 0
         let x = typeRel(c, branch, aOrig, flags)
         maxInheritance = max(maxInheritance, c.inheritancePenalty)
-
         # 'or' implies maximum matching result:
         if x > result: result = x
-      if result >= isSubtype:
+      if result >= isConvertible:
         if result > isGeneric: result = isGeneric
         bindingRet result
       else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1597,7 +1597,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         maxInheritance = max(maxInheritance, c.inheritancePenalty)
         # 'or' implies maximum matching result:
         if x > result: result = x
-      if result >= isConvertible:
+      if result >= isIntConv:
         if result > isGeneric: result = isGeneric
         bindingRet result
       else:

--- a/tests/generics/t7446.nim
+++ b/tests/generics/t7446.nim
@@ -1,0 +1,10 @@
+proc foo(x: Natural or SomeUnsignedInt):int = 
+  when x is int:
+    result = 1
+  else:
+    result = 2
+let a = 10
+doAssert foo(a) == 1
+
+let b = 10'u8
+doAssert foo(b) == 2


### PR DESCRIPTION
fix #7446

note for myself: `isConvertible` is used for sequence, array, string and proc callconv.
`isIntConv` is used for interger and range of interger 