### PR TITLE
fix #12938 index type of array in type section without static

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -589,6 +589,7 @@ type
     tfEffectSystemWorkaround
     tfIsOutParam
     tfSendable
+    tfImplicitStatic
 
   TTypeFlags* = set[TTypeFlag]
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -352,7 +352,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
           "Array length can't be negative, but was " & $e.intVal)
       result = makeRangeType(c, 0, e.intVal-1, n.info, e.typ)
     elif e.kind == nkSym:
-      if  e.typ.kind == tyStatic:
+      if e.typ.kind == tyStatic:
         if e.sym.ast != nil:
           return semArrayIndex(c, e.sym.ast)
         if e.typ.lastSon.kind != tyGenericParam and not isOrdinalType(e.typ.lastSon):
@@ -361,7 +361,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
         result = makeRangeWithStaticExpr(c, e)
       else:
         result = e.typ.skipTypes({tyTypeDesc})
-        result.flags.incl tfInferrableStatic
+        result.flags.incl tfImplicitStatic
       if c.inGenericContext > 0: result.flags.incl tfUnresolved
     elif e.kind in (nkCallKinds + {nkBracketExpr}) and hasUnresolvedArgs(c, e):
       if not isOrdinalType(e.typ.skipTypes({tyStatic, tyAlias, tyGenericInst, tySink})):
@@ -1546,7 +1546,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
         typ = typ.skipTypes({tyTypeDesc})
         if containsGenericType(typ): isConcrete = false
         var skip = true
-        if isArray and i == 1 and tfInferrableStatic in m.call[0].typ[0].flags and isIntLit(typ):
+        if isArray and i == 1 and tfImplicitStatic in m.call[0].typ[0].flags and isIntLit(typ):
           skip = false
         addToResult(typ, skip)
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -351,13 +351,17 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
         localError(c.config, n.info,
           "Array length can't be negative, but was " & $e.intVal)
       result = makeRangeType(c, 0, e.intVal-1, n.info, e.typ)
-    elif e.kind == nkSym and e.typ.kind == tyStatic:
-      if e.sym.ast != nil:
-        return semArrayIndex(c, e.sym.ast)
-      if e.typ.lastSon.kind != tyGenericParam and not isOrdinalType(e.typ.lastSon):
-        let info = if n.safeLen > 1: n[1].info else: n.info
-        localError(c.config, info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
-      result = makeRangeWithStaticExpr(c, e)
+    elif e.kind == nkSym:
+      if  e.typ.kind == tyStatic:
+        if e.sym.ast != nil:
+          return semArrayIndex(c, e.sym.ast)
+        if e.typ.lastSon.kind != tyGenericParam and not isOrdinalType(e.typ.lastSon):
+          let info = if n.safeLen > 1: n[1].info else: n.info
+          localError(c.config, info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
+        result = makeRangeWithStaticExpr(c, e)
+      else:
+        result = e.typ.skipTypes({tyTypeDesc})
+        result.flags.incl tfInferrableStatic
       if c.inGenericContext > 0: result.flags.incl tfUnresolved
     elif e.kind in (nkCallKinds + {nkBracketExpr}) and hasUnresolvedArgs(c, e):
       if not isOrdinalType(e.typ.skipTypes({tyStatic, tyAlias, tyGenericInst, tySink})):
@@ -1492,20 +1496,24 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   var t = s.typ.skipTypes({tyAlias})
   if t.kind == tyCompositeTypeClass and t.base.kind == tyGenericBody:
     t = t.base
-
   result = newOrPrevType(tyGenericInvocation, prev, c)
   addSonSkipIntLit(result, t, c.idgen)
 
-  template addToResult(typ) =
+  template addToResult(typ, skip) =
+    
     if typ.isNil:
       internalAssert c.config, false
       rawAddSon(result, typ)
-    else: addSonSkipIntLit(result, typ, c.idgen)
+    else:
+      if skip:
+        addSonSkipIntLit(result, typ, c.idgen)
+      else:
+        rawAddSon(result, makeRangeWithStaticExpr(c, typ.n))
 
   if t.kind == tyForward:
     for i in 1..<n.len:
       var elem = semGenericParamInInvocation(c, n[i])
-      addToResult(elem)
+      addToResult(elem, true)
     return
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
@@ -1525,7 +1533,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       return newOrPrevType(tyError, prev, c)
 
     var isConcrete = true
-
+    let isArray = m.call[0].typ.lastSon.kind == tyArray
     for i in 1..<m.call.len:
       var typ = m.call[i].typ
       # is this a 'typedesc' *parameter*? If so, use the typedesc type,
@@ -1533,11 +1541,14 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       if m.call[i].kind == nkSym and m.call[i].sym.kind == skParam and
           typ.kind == tyTypeDesc and containsGenericType(typ):
         isConcrete = false
-        addToResult(typ)
+        addToResult(typ, true)
       else:
         typ = typ.skipTypes({tyTypeDesc})
         if containsGenericType(typ): isConcrete = false
-        addToResult(typ)
+        var skip = true
+        if isArray and i == 1 and tfInferrableStatic in m.call[0].typ[0].flags and isIntLit(typ):
+          skip = false
+        addToResult(typ, skip)
 
     if isConcrete:
       if s.ast == nil and s.typ.kind != tyCompositeTypeClass:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1536,7 +1536,8 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       return newOrPrevType(tyError, prev, c)
 
     var isConcrete = true
-    let isArray = m.call[0].typ != nil and m.call[0].typ.lastSon.kind == tyArray
+    let rType = m.call[0].typ
+    let mIndex = if rType != nil: rType.len - 1 else: -1
     for i in 1..<m.call.len:
       var typ = m.call[i].typ
       # is this a 'typedesc' *parameter*? If so, use the typedesc type,
@@ -1549,7 +1550,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
         typ = typ.skipTypes({tyTypeDesc})
         if containsGenericType(typ): isConcrete = false
         var skip = true
-        if isArray and i == 1 and tfImplicitStatic in m.call[0].typ[0].flags and isIntLit(typ):
+        if mIndex >= i - 1 and tfImplicitStatic in rType[i - 1].flags and isIntLit(typ):
           skip = false
         addToResult(typ, skip)
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -367,10 +367,10 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
           let info = if n.safeLen > 1: n[1].info else: n.info
           localError(c.config, info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
         result = makeRangeWithStaticExpr(c, e)
+        if c.inGenericContext > 0: result.flags.incl tfUnresolved
       else:
         result = e.typ.skipTypes({tyTypeDesc})
         result.flags.incl tfImplicitStatic
-      if c.inGenericContext > 0: result.flags.incl tfUnresolved
     elif e.kind in (nkCallKinds + {nkBracketExpr}) and hasUnresolvedArgs(c, e):
       if not isOrdinalType(e.typ.skipTypes({tyStatic, tyAlias, tyGenericInst, tySink})):
         localError(c.config, n[1].info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))

--- a/tests/generics/t12938.nim
+++ b/tests/generics/t12938.nim
@@ -1,0 +1,9 @@
+type
+  ExampleArray[Size, T] = array[Size, T]
+
+var integerArray: ExampleArray[32, int]  # Compiler crash!
+doAssert integerArray.len == 32
+
+const Size = 2
+var integerArray2: ExampleArray[Size, int]
+doAssert integerArray2.len == 2

--- a/tests/generics/t14193.nim
+++ b/tests/generics/t14193.nim
@@ -1,9 +1,5 @@
 type
   Task*[N: int] = object
-    ## Tasks are simple closures that are sent by shared-memory channels
-    ## In the future, if Nim built-in closures become threadsafe
-    ## they can be used directly instead.
-    fn*: proc(env: pointer) {.nimcall.}
     env*: array[N, byte]
 
 var task14193: Task[20]

--- a/tests/generics/t14193.nim
+++ b/tests/generics/t14193.nim
@@ -1,0 +1,10 @@
+type
+  Task*[N: int] = object
+    ## Tasks are simple closures that are sent by shared-memory channels
+    ## In the future, if Nim built-in closures become threadsafe
+    ## they can be used directly instead.
+    fn*: proc(env: pointer) {.nimcall.}
+    env*: array[N, byte]
+
+var task14193: Task[20]
+doAssert task14193.env.len == 20


### PR DESCRIPTION
… as template argument for array size  

fix #12938  
fix https://github.com/nim-lang/Nim/issues/14193
fix https://github.com/nim-lang/Nim/issues/15862
fix https://github.com/nim-lang/Nim/issues/17362
fix https://github.com/nim-lang/Nim/issues/11643

refs: https://github.com/nim-lang/Nim/issues/17163 type as index

refs: https://github.com/nim-lang/Nim/issues/10185

refs: https://github.com/nim-lang/Nim/issues/9326

refs: https://github.com/nim-lang/Nim/issues/5780

refs: https://github.com/nim-lang/Nim/issues/17423

refs: https://github.com/nim-lang/Nim/issues/7359

need re-check some issues list in https://github.com/nim-lang/Nim/issues/14989  

TODO:
disallow below code, use `typeAllowedCheck`
``` nim
type
  ExampleArray[Size, T] = array[Size, T]

let s = 3
var integerArray3: ExampleArray[s, int]
```

make code more understandable and flexiable to other type(eg. `set`) as well, see https://github.com/nim-lang/Nim/issues/5881