### PR TITLE
remove unused `userVersion:1.6` which is succeeded by `nimPreviewSlimSystem` in this case

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -142,7 +142,7 @@ proc csource(args: string) =
 proc bundleC2nim(args: string) =
   cloneDependency(distDir, "https://github.com/nim-lang/c2nim.git")
   nimCompile("dist/c2nim/c2nim",
-             options = "--noNimblePath --useVersion:1.6 --path:. " & args)
+             options = "--noNimblePath --path:. " & args)
 
 proc bundleNimbleExe(latest: bool, args: string) =
   let commit = if latest: "HEAD" else: NimbleStableCommit
@@ -150,7 +150,7 @@ proc bundleNimbleExe(latest: bool, args: string) =
                   commit = commit, allowBundled = true)
   # installer.ini expects it under $nim/bin
   nimCompile("dist/nimble/src/nimble.nim",
-             options = "-d:release --mm:refc --useVersion:1.6 --noNimblePath " & args)
+             options = "-d:release --mm:refc --noNimblePath " & args)
 
 proc bundleNimsuggest(args: string) =
   nimCompileFold("Compile nimsuggest", "nimsuggest/nimsuggest.nim",


### PR DESCRIPTION
It is succeeded by `nimPreviewSlimSystem` for its usage in this case.