### PR TITLE
oids sticks to 24 length strings; fixes breaking changes

### DIFF
--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -41,9 +41,9 @@ proc hexbyte*(hex: char): int {.inline.} =
 
 proc parseOid*(str: cstring): Oid =
   ## Parses an OID.
-  var bytes = cast[cstring](addr(result.time))
+  var bytes = cast[cstring](cast[pointer](cast[ByteAddress](addr(result.time)) + 4))
   var i = 0
-  while i < 16:
+  while i < 12:
     bytes[i] = chr((hexbyte(str[2 * i]) shl 4) or hexbyte(str[2 * i + 1]))
     inc(i)
 
@@ -51,12 +51,12 @@ proc `$`*(oid: Oid): string =
   ## Converts an OID to a string.
   const hex = "0123456789abcdef"
 
-  result.setLen 32
+  result.setLen 24
 
   var o = oid
-  var bytes = cast[cstring](addr(o))
+  var bytes = cast[cstring](cast[pointer](cast[ByteAddress](addr(o)) + 4))
   var i = 0
-  while i < 16:
+  while i < 12:
     let b = bytes[i].ord
     result[2 * i] = hex[(b and 0xF0) shr 4]
     result[2 * i + 1] = hex[b and 0xF]
@@ -83,9 +83,9 @@ template genOid(result: var Oid, incr: var int, fuzz: int32) =
 proc genOid*(): Oid =
   ## Generates a new OID.
   runnableExamples:
-    doAssert ($genOid()).len == 32
+    doAssert ($genOid()).len == 24
   runnableExamples("-r:off"):
-    echo $genOid() # for example, "00000000632c452db08c3d19ee9073e5"
+    echo $genOid() # for example, "5fc7f546ddbbc84800006aaf"
   genOid(result, incr, fuzz)
 
 proc generatedTime*(oid: Oid): Time =

--- a/tests/stdlib/toids.nim
+++ b/tests/stdlib/toids.nim
@@ -7,7 +7,7 @@ import std/assertions
 
 block: # genOid
   let x = genOid()
-  doAssert ($x).len == 32
+  doAssert ($x).len == 24
 
 block:
   let x = genOid()


### PR DESCRIPTION
ref https://github.com/ringabout/Nim/issues/26

follow up https://github.com/nim-lang/Nim/pull/20338

fixes breaking changes. (though cast[int32] may work better)