### PR TITLE
fix #20152 Illegal capture of closure iterator, when should be legal

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -458,7 +458,7 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
             else:
               discard addField(obj, s, c.graph.cache, c.idgen)
     # direct or indirect dependency:
-    elif (innerProc and s.typ.callConv == ccClosure) or interestingVar(s):
+    elif (innerProc and s.typ.callConv == ccClosure and tfCapturesEnv in s.owner.typ.flags) or interestingVar(s):
       discard """
         proc outer() =
           var x: int

--- a/koch.nim
+++ b/koch.nim
@@ -142,7 +142,7 @@ proc csource(args: string) =
 proc bundleC2nim(args: string) =
   cloneDependency(distDir, "https://github.com/nim-lang/c2nim.git")
   nimCompile("dist/c2nim/c2nim",
-             options = "--noNimblePath --useVersion:1.6 --path:. " & args)
+             options = "--noNimblePath --path:. " & args)
 
 proc bundleNimbleExe(latest: bool, args: string) =
   let commit = if latest: "HEAD" else: NimbleStableCommit
@@ -150,7 +150,7 @@ proc bundleNimbleExe(latest: bool, args: string) =
                   commit = commit, allowBundled = true)
   # installer.ini expects it under $nim/bin
   nimCompile("dist/nimble/src/nimble.nim",
-             options = "-d:release --mm:refc --useVersion:1.6 --noNimblePath " & args)
+             options = "-d:release --mm:refc --noNimblePath " & args)
 
 proc bundleNimsuggest(args: string) =
   nimCompileFold("Compile nimsuggest", "nimsuggest/nimsuggest.nim",

--- a/tests/proc/t20152.nim
+++ b/tests/proc/t20152.nim
@@ -1,0 +1,8 @@
+proc foo() =
+  iterator it():int {.closure.} =
+    yield 1
+  proc useIter() {.nimcall.} =
+    var iii = it # <-- illegal capture
+    doAssert iii() == 1
+  useIter()
+foo()


### PR DESCRIPTION
fix #20152

it seems it changed by acident after multiple times refactoring,  `notin ccDefault` ->  `notin {ccClosure, ccDefault}:`