### PR TITLE
Fix #20139 gcc error when constructing an object that has the same name in the same file name in 2 different directories

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -179,6 +179,8 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
           # make the hash different from the one we produce by hashing only the
           # type name.
           c &= ".empty"
+      else:
+        c &= t.id
     else:
       c &= t.id
     if t.len > 0 and t[0] != nil:

--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -180,7 +180,8 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
           # type name.
           c &= ".empty"
       else:
-        c &= t.id
+        if sfCompilerProc notin t.sym.flags:
+          c &= t.id
     else:
       c &= t.id
     if t.len > 0 and t[0] != nil:

--- a/tests/modules/module1/defs.nim
+++ b/tests/modules/module1/defs.nim
@@ -1,0 +1,2 @@
+type MyObj* = object
+  field1*: int

--- a/tests/modules/module2/defs.nim
+++ b/tests/modules/module2/defs.nim
@@ -1,0 +1,2 @@
+type MyObj* = object
+  field2*: int

--- a/tests/modules/tmoduleconflict.nim
+++ b/tests/modules/tmoduleconflict.nim
@@ -1,0 +1,6 @@
+import module1/defs as md1
+import module2/defs as md2
+
+let x = md1.MyObj(field1: 1)
+let y = md2.MyObj(field2: 1)
+doAssert x.field1 == y.field2


### PR DESCRIPTION
Fix #20139

cause by `hashType`  `of tyObject` not cover all branch.