### PR TITLE
fixes #20515; base `method` requires explicit `{.gcsafe.}` to be GC-safe

### DIFF
--- a/tests/method/t20515.nim
+++ b/tests/method/t20515.nim
@@ -1,0 +1,20 @@
+discard """
+  errormsg: "Base method 'zzz' requires explicit '{.gcsafe.}' to be GC-safe"
+  line: 10
+"""
+
+type
+  A = ref object of RootObj
+  B = ref object of A
+
+method zzz(a: A) {.base.} =
+  discard
+
+var s: seq[int]
+method zzz(a: B) =
+  echo s
+
+proc xxx(someObj: A) {.gcsafe.} =
+  someObj.zzz()
+
+xxx(B())


### PR DESCRIPTION
fixes #20515

Methods need runtime information to do dynamic dispatch. We cannot check the GC safety of methods at compile time because it will check the base method instead of the polymorphism one for dynamic dispatch. One solution is to require base methods to have explicit `gcsafe` pragmas so that the Nim compiler can check children methods at the compile time. 