### PR TITLE
[backport] Handle nkOpenSymChoice for nkAccQuoted in considerQuotedIdent

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -48,7 +48,7 @@ proc considerQuotedIdent*(c: PContext; n: PNode, origin: PNode = nil): PIdent =
         case x.kind
         of nkIdent: id.add(x.ident.s)
         of nkSym: id.add(x.sym.name.s)
-        of nkOpenSymChoice:
+        of nkSymChoices:
           if x[0].kind == nkSym:
             id.add(x[0].sym.name.s)
           else:

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -48,6 +48,11 @@ proc considerQuotedIdent*(c: PContext; n: PNode, origin: PNode = nil): PIdent =
         case x.kind
         of nkIdent: id.add(x.ident.s)
         of nkSym: id.add(x.sym.name.s)
+        of nkOpenSymChoice:
+          if x[0].kind == nkSym:
+            id.add(x[0].sym.name.s)
+          else:
+            handleError(n, origin)
         of nkLiterals - nkFloatLiterals: id.add(x.renderTree)
         else: handleError(n, origin)
       result = getIdent(c.cache, id)

--- a/tests/template/template_various.nim
+++ b/tests/template/template_various.nim
@@ -353,3 +353,18 @@ block gensym3:
   echo a ! b ! c ! d
   echo a ! b ! c ! d ! e
   echo x,y,z
+
+
+block identifier_construction_with_overridden_symbol:
+  # could use add, but wanna make sure it's an override no matter what
+  func examplefn = discard
+  func examplefn(x: int) = discard
+
+  # the function our template wants to use
+  func examplefn1 = discard
+
+  template exampletempl(n) =
+    # attempt to build a name using the overridden symbol "examplefn"
+    `examplefn n`()
+
+  exampletempl(1)


### PR DESCRIPTION
Fixes #20591

Makes stuff like this work 

```nim
proc adda = discard

template example(f: untyped) =
  `add f`()

example(a) 
```