### PR TITLE
Implemented `mSlice` on the VM allowing `toOpenArray` to work at compile time.

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -227,8 +227,7 @@ type
     nkError               # erroneous AST node
     nkModuleRef           # for .rod file support: A (moduleId, itemId) pair
     nkReplayAction        # for .rod file support: A replay action
-    nkNilRodNode,          # for .rod file support: a 'nil' PNode
-    nkOpenArray # For VM support of `toOpenArray`, should never leak to user code.
+    nkNilRodNode          # for .rod file support: a 'nil' PNode
 
 
   TNodeKinds* = set[TNodeKind]

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -227,7 +227,9 @@ type
     nkError               # erroneous AST node
     nkModuleRef           # for .rod file support: A (moduleId, itemId) pair
     nkReplayAction        # for .rod file support: A replay action
-    nkNilRodNode          # for .rod file support: a 'nil' PNode
+    nkNilRodNode,          # for .rod file support: a 'nil' PNode
+    nkOpenArray # For VM support of `toOpenArray`, should never leak to user code.
+
 
   TNodeKinds* = set[TNodeKind]
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -229,7 +229,6 @@ type
     nkReplayAction        # for .rod file support: A replay action
     nkNilRodNode          # for .rod file support: a 'nil' PNode
 
-
   TNodeKinds* = set[TNodeKind]
 
 type

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -703,7 +703,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           left = src[1].intVal
           right = src[2].intVal
           realIndex = left + idx
-        if realIndex > right or realIndex < 0:
+        if idx in 0..(right - left):
           stackTrace(c, tos, pc, formatErrorIndexBound(idx, int right))
         else:
           regs[ra].node = src[0][int realIndex]

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -768,7 +768,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           realIndex = left + idx
         if idx in 0..(right - left): # Refer to `opcSlice`
           case src[0].kind
-          of nkStrLit:
+          of nkStrKinds:
             regs[ra] = takeCharAddress(c, src[0], realIndex, pc)
           of nkBracket:
             takeAddress regs[ra], src.sons[0].sons[realIndex]

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -704,9 +704,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           right = src[2].intVal
           realIndex = left + idx
         if idx in 0..(right - left):
-          stackTrace(c, tos, pc, formatErrorIndexBound(idx, int right))
-        else:
           regs[ra].node = src[0][int realIndex]
+        else:
+          stackTrace(c, tos, pc, formatErrorIndexBound(idx, int right))
+
       of nkStrLit..nkTripleStrLit:
         if idx <% src.strVal.len:
           regs[ra].node = newNodeI(nkCharLit, c.debug[pc])

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -81,6 +81,7 @@ type
     opcWrStrIdx,
     opcLdStrIdx, # a = b[c]
     opcLdStrIdxAddr,  # a = addr(b[c])
+    opcSlice, # toOpenArray(collection, left, right)
 
     opcAddInt,
     opcAddImmInt,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1057,10 +1057,10 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mSlice:
     var
       d = c.genx(n[1])
-      left = c.genx(n[2])
-      right = c.genx(n[3])
+      left = c.genIndex(n[2], n[1].typ)
+      right = c.genIndex(n[3], n[1].typ)
     if dest < 0: dest = c.getTemp(n.typ)
-    c.gABx(n, opcNodeToReg, dest, d)
+    c.gABC(n, opcNodeToReg, dest, d)
     c.gABC(n, opcSlice, dest, left, right)
     c.freeTemp(left)
     c.freeTemp(right)
@@ -1191,7 +1191,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     var d = c.genx(n[1])
     # XXX use ldNullOpcode() here?
     c.gABx(n, opcLdNull, d, c.genType(n[1].typ))
-    c.gABx(n, opcNodeToReg, d, d)
+    c.gABC(n, opcNodeToReg, d, d)
     c.genAsgnPatch(n[1], d)
   of mDefault, mZeroDefault:
     if dest < 0: dest = c.getTemp(n.typ)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1054,6 +1054,21 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     of tyString: genUnaryABI(c, n, dest, opcLenStr)
     of tyCstring: genUnaryABI(c, n, dest, opcLenCstring)
     else: doAssert false, $n[1].typ.kind
+  of mSlice:
+    var
+      d = c.genx(n[1])
+      left = c.genx(n[2])
+      right = c.genx(n[3])
+    if dest < 0: dest = c.getTemp(n.typ)
+    c.gABC(n, opcSlice, d, d, left)
+    c.gABC(n, opcSlice, d, d, right)
+    c.gABx(n, opcNodeToReg, dest, d)
+    c.freeTemp(left)
+    c.freeTemp(right)
+    c.freeTemp(d)
+
+
+
   of mIncl, mExcl:
     unused(c, n, dest)
     var d = c.genx(n[1])

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -12,5 +12,3 @@ static:
   assert a.toOpenArray(0, 2) == [0, 1, 2]
   assert a.toOpenArray(0, 0) == [0]
   assert a.toOpenArray(1, 2) == [1, 2]
-
-

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -1,0 +1,16 @@
+proc mutate(a: var openarray[int]) =
+  var i = 0
+  for x in a.mitems:
+    x = i
+    inc i
+
+static:
+  var a = [10, 20, 30]
+  assert a.toOpenArray(1, 2).len == 2
+
+  mutate(a)
+  assert a.toOpenArray(0, 2) == [0, 1, 2]
+  assert a.toOpenArray(0, 0) == [0]
+  assert a.toOpenArray(1, 2) == [1, 2]
+
+

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -27,5 +27,12 @@ static:
   assert str == "Heaaa"
   assert str.toOpenArray(0, 4) == "Heaaa"
 
+  var arr: array[3..4, int] = [1, 2]
+  assert arr.toOpenArray(3, 4) == [1, 2]
+  assert arr.toOpenArray(3, 4).len == 2
+  assert arr.toOpenArray(3, 3).high == 0
+
+  assert arr.toOpenArray(3, 4).toOpenArray(0, 0) == [1]
+
 
 

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -4,6 +4,11 @@ proc mutate(a: var openarray[int]) =
     x = i
     inc i
 
+proc mutate(a: var openarray[char]) =
+  var i = 1
+  for ch in a.mitems:
+    ch = 'a'
+
 static:
   var a = [10, 20, 30]
   assert a.toOpenArray(1, 2).len == 2
@@ -12,3 +17,11 @@ static:
   assert a.toOpenArray(0, 2) == [0, 1, 2]
   assert a.toOpenArray(0, 0) == [0]
   assert a.toOpenArray(1, 2) == [1, 2]
+  assert "Hello".toOpenArray(1, 4) == "ello"
+  var str = "Hello"
+  str.toOpenArray(2, 4).mutate()
+  assert str == "Heaaa"
+  assert str.toOpenArray(0, 4) == "Heaaa"
+  assert str.toOpenArray(0, 4).len == 5
+  assert str.toOpenArray(0, 0).len == 1
+  assert str.toOpenArray(0, 0).high == 0

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -9,6 +9,7 @@ proc mutate(a: var openarray[char]) =
   for ch in a.mitems:
     ch = 'a'
 
+
 static:
   var a = [10, 20, 30]
   assert a.toOpenArray(1, 2).len == 2
@@ -20,8 +21,11 @@ static:
   assert "Hello".toOpenArray(1, 4) == "ello"
   var str = "Hello"
   str.toOpenArray(2, 4).mutate()
-  assert str == "Heaaa"
-  assert str.toOpenArray(0, 4) == "Heaaa"
   assert str.toOpenArray(0, 4).len == 5
   assert str.toOpenArray(0, 0).len == 1
   assert str.toOpenArray(0, 0).high == 0
+  assert str == "Heaaa"
+  assert str.toOpenArray(0, 4) == "Heaaa"
+
+
+


### PR DESCRIPTION
This is requisite for changes to the stdlib to use `openArray[char]` more. There is an issue with `static openArray[T]`, but `oa[a..b]` does work so can be used in place.