### PR TITLE
add environment variable NIM_CACHE_HOME on win

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -764,7 +764,8 @@ proc getOsCacheDir(): string =
   when defined(posix):
     result = getEnv("XDG_CACHE_HOME", getHomeDir() / ".cache") / "nim"
   else:
-    result = getHomeDir() / genSubDir.string
+    let nimCacheHome = getEnv("NIM_CACHE_HOME")
+    result = if nimCacheHome == "": (getHomeDir() / genSubDir.string) else: nimCacheHome
 
 proc getNimcacheDir*(conf: ConfigRef): AbsoluteDir =
   proc nimcacheSuffix(conf: ConfigRef): string =

--- a/doc/nimc.md
+++ b/doc/nimc.md
@@ -261,7 +261,7 @@ The generated files that Nim produces all go into a subdirectory called
 
 - ``$XDG_CACHE_HOME/nim/$projectname(_r|_d)`` or ``~/.cache/nim/$projectname(_r|_d)``
   on Posix
-- ``$NIM_CACHE_HOME/$projectname(_r|_d)`` or ``$HOME\nimcache\$projectname(_r|_d)`` on Windows.
+- ``$NIM_CACHE_HOME\$projectname(_r|_d)`` or ``$HOME\nimcache\$projectname(_r|_d)`` on Windows.
 
 The `_r` suffix is used for release builds, `_d` is for debug builds.
 

--- a/doc/nimc.md
+++ b/doc/nimc.md
@@ -261,7 +261,7 @@ The generated files that Nim produces all go into a subdirectory called
 
 - ``$XDG_CACHE_HOME/nim/$projectname(_r|_d)`` or ``~/.cache/nim/$projectname(_r|_d)``
   on Posix
-- ``$HOME\nimcache\$projectname(_r|_d)`` on Windows.
+- ``$NIM_CACHE_HOME/$projectname(_r|_d)`` or ``$HOME\nimcache\$projectname(_r|_d)`` on Windows.
 
 The `_r` suffix is used for release builds, `_d` is for debug builds.
 


### PR DESCRIPTION
The default nim cache saving path is over `C:\` where the default $HOME is located.

So I wonder could we make this more configurable? Like choosing where we think is just right for that.

I think I've made this, feel free to comment if there's anything goes wrong or againsts the language principles. 😃 
