### PR TITLE
borrowed procs can have a body now for documentation generation

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2130,10 +2130,11 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
         localError(c.config, n.info, "the overloaded " & s.name.s &
           " operator has to be enabled with {.experimental: \"callOperator\".}")
 
+  if sfBorrow in s.flags and c.config.cmd notin cmdDocLike:
+    result[bodyPos] = c.graph.emptyNode
+
   if n[bodyPos].kind != nkEmpty and sfError notin s.flags:
     # for DLL generation we allow sfImportc to have a body, for use in VM
-    if sfBorrow in s.flags:
-      localError(c.config, n[bodyPos].info, errImplOfXNotAllowed % s.name.s)
     if c.config.ideCmd in {ideSug, ideCon} and s.kind notin {skMacro, skTemplate} and not
         cursorInProc(c.config, n[bodyPos]):
       # speed up nimsuggest

--- a/tests/borrow/typeclassborrow.nim
+++ b/tests/borrow/typeclassborrow.nim
@@ -32,13 +32,17 @@ assert $seq[int](bar) == $bar
 assert $seq[int](baz) == $baz
 
 type
-  Fine = distinct string
+  Fine* = distinct string
 
 proc `==`*(x, y: Fine): bool {.borrow.} =
   ## Here is the documentation
+  runnableExamples:
+    var x = Fine("1234")
+    var y = Fine("1234")
+    doAssert x == y
   doAssert false
 
 
 var x = Fine("1234")
-var y = Fine("8765")
+var y = Fine("1234")
 doAssert x == y

--- a/tests/borrow/typeclassborrow.nim
+++ b/tests/borrow/typeclassborrow.nim
@@ -30,3 +30,15 @@ baz.doThing()
 assert $seq[int](foo) == $foo
 assert $seq[int](bar) == $bar
 assert $seq[int](baz) == $baz
+
+type
+  Fine = distinct string
+
+proc `==`*(x, y: Fine): bool {.borrow.} =
+  ## Here is the documentation
+  doAssert false
+
+
+var x = Fine("1234")
+var y = Fine("8765")
+doAssert x == y


### PR DESCRIPTION
Borrowed functions should work as well as magic functions, I hope.

**Preview**

![image](https://user-images.githubusercontent.com/43030857/197322456-dfb36206-e121-4afe-a0e2-635ba0d1235c.png)

Otherwise, our new `std/paths` module won't look very good.

![image](https://user-images.githubusercontent.com/43030857/197322665-1dc6825b-e712-4b44-a4e9-fa6da8118360.png)
