### PR TITLE
fixes #20422; prepareStrMutation for toOpenArray (extend to more types)

### DIFF
--- a/tests/views/tviews1.nim
+++ b/tests/views/tviews1.nim
@@ -77,3 +77,22 @@ type Inner = object
 var o = Outer(value: 1234)
 var v = Inner(owner: o).owner.value
 doAssert v == 1234
+
+
+block:
+  proc f(a: var string) =
+    var v = a.toOpenArray(1, 3)
+    v[0] = 'a'  # <--
+  var a = "Hello"
+  f(a)
+
+block:
+  proc f(a: string) =
+    var v = a.toOpenArray(1, 3)
+    doAssert v[0] == 'H'
+  f("Hello")
+
+block:
+  var a = "Hello"
+  var v = a.toOpenArray(1, 3)
+  v[0] = 'a'  # <--


### PR DESCRIPTION
`toOpenArray` always return `tyOpenArray` type. `prepareStrMutation` is not called in this case:

```nim
block:
  proc f(a: var string) =
    var v = a.toOpenArray(1, 3)
    v[0] = 'a'  # <--
  var a = "Hello"
  f(a)
```
`a` is a string literal, so we need to call `prepareStrMutation` before modification. 

However, we shouldn't call `prepareStrMutation` for immutable strings, otherwise it causes segfault.

```nim
block:
  proc f(a: string) =
    var v = a.toOpenArray(1, 3)
    doAssert v[0] == 'H'
  f("Hello")
```

In order to differentiate these two cases, only parameters from `skVar` or `skParam` with a `tyVar` type
are considered.