### PR TITLE
REMOVE usage of deprecated alias `unsafeAddr`

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -140,7 +140,7 @@ template encodeImpl() {.dirty.} =
       encodeInternal(s, lookupTableVM)
   else:
     block:
-      let lookupTable = if safe: unsafeAddr(cb64safe) else: unsafeAddr(cb64)
+      let lookupTable = if safe: addr(cb64safe) else: addr(cb64)
       encodeInternal(s, lookupTable)
 
 proc encode*[T: byte|char](s: openArray[T], safe = false): string =


### PR DESCRIPTION
Removes a couple usages of unsafeAddr to comply with the following compiler warning:

/.../.choosenim/toolchains/nim-#devel/lib/pure/base64.nim(141, 44) Warning: 'unsafeAddr' is a deprecated alias for 'addr'; unsafeAddr is deprecated [Deprecated]
/.../.choosenim/toolchains/nim-#devel/lib/pure/base64.nim(141, 71) Warning: 'unsafeAddr' is a deprecated alias for 'addr'; unsafeAddr is deprecated [Deprecated]

I've been staring at this compiler-warning for months now popping up when compiling with nim-devel, so might as well.