### PR TITLE
Fix double defer with break in closureiterators [backport]

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -1372,6 +1372,7 @@ proc preprocess(c: var PreprocessContext; n: PNode): PNode =
   # detect: 'finally: raises X' which is currently not supported. We produce
   # an error for this case for now. All this will be done properly with Yuriy's
   # patch.
+
   result = n
   case n.kind
   of nkTryStmt:
@@ -1388,6 +1389,7 @@ proc preprocess(c: var PreprocessContext; n: PNode): PNode =
       discard c.finallys.pop()
 
   of nkWhileStmt, nkBlockStmt:
+    if n.hasYields == false: return n
     c.blocks.add((n, c.finallys.len))
     for i in 0 ..< n.len:
       result[i] = preprocess(c, n[i])

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -38,6 +38,10 @@ nested finally
 outer finally
 nested finally
 outer finally
+In defer
+trying
+exception caught
+finally block
 '''
 """
 
@@ -362,3 +366,29 @@ block:
 
   for _ in p4():
     discard
+
+# bug #18824
+iterator poc_iterator: int {.closure.}  =
+  block:
+    try:
+      break
+    finally:
+      echo "In defer"
+
+for _ in poc_iterator():
+  discard
+
+# bug #20624
+iterator tryFinally() {.closure.} =
+  block route:
+    try:
+      echo "trying"
+      raise
+    except:
+      echo "exception caught"
+      break route
+    finally:
+      echo "finally block"
+
+var x = tryFinally
+x()


### PR DESCRIPTION
fixes #18824
fixes #20624
alternative to #20626

I did this fix a few months ago, but didn't push it as I wanted to refactor the closure iterator exception handling. Didn't have time to do it so far, so pushing this in the meantime