### PR TITLE
Remove side-effects from sysFatal with panics on

### DIFF
--- a/lib/system/fatal.nim
+++ b/lib/system/fatal.nim
@@ -17,42 +17,43 @@ else:
 when hostOS == "standalone":
   include "$projectpath/panicoverride"
 
-  proc sysFatal(exceptn: typedesc, message: string) {.inline.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline.} =
     panic(message)
 
-  proc sysFatal(exceptn: typedesc, message, arg: string) {.inline.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline.} =
     rawoutput(message)
     panic(arg)
 
 elif (defined(nimQuirky) or defined(nimPanics)) and not defined(nimscript):
   import ansi_c
 
-  proc name(t: typedesc): string {.magic: "TypeTrait".}
+  func name(t: typedesc): string {.magic: "TypeTrait".}
 
-  proc sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
     when nimvm:
       # TODO when doAssertRaises works in CT, add a test for it
       raise (ref exceptn)(msg: message & arg)
     else:
-      writeStackTrace()
-      var buf = newStringOfCap(200)
-      add(buf, "Error: unhandled exception: ")
-      add(buf, message)
-      add(buf, arg)
-      add(buf, " [")
-      add(buf, name exceptn)
-      add(buf, "]\n")
-      cstderr.rawWrite buf
+      {.noSideEffect.}:
+        writeStackTrace()
+        var buf = newStringOfCap(200)
+        add(buf, "Error: unhandled exception: ")
+        add(buf, message)
+        add(buf, arg)
+        add(buf, " [")
+        add(buf, name exceptn)
+        add(buf, "]\n")
+        cstderr.rawWrite buf
       quit 1
 
-  proc sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
     sysFatal(exceptn, message, "")
 
 else:
-  proc sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
     raise (ref exceptn)(msg: message)
 
-  proc sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
     raise (ref exceptn)(msg: message & arg)
 
 {.pop.}

--- a/tests/exception/t20613.nim
+++ b/tests/exception/t20613.nim
@@ -1,0 +1,8 @@
+discard """
+  matrix: "; --panics:on"
+"""
+
+func test =
+  if 0 > 10:
+    raiseAssert "hey"
+test()


### PR DESCRIPTION
fix #20613

We could instead always have side effects on sysFatal, but it would make it hard to use `raiseAssert` in funcs
`assert` already swallows the side effects (ie you can use `assert` in a `func`) [here](https://github.com/nim-lang/Nim/blob/684a862526847c39597e345d00b8323353012c07/lib/std/assertions.nim#L43-L44)

We could also tell users to use `failedAssertImpl` in func, but that doesn't seem elegant. Merging this would also allow to do as the comment wants:
https://github.com/nim-lang/Nim/blob/684a862526847c39597e345d00b8323353012c07/lib/std/assertions.nim#L41-L44