### PR TITLE
Pass json options to hooks

### DIFF
--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -430,7 +430,7 @@ proc fromJsonHook*[T](self: var Option[T], jsonNode: JsonNode, opt = Joptions())
   ## Enables `fromJson` for `Option` types.
   ##
   ## See also:
-  ## * `toJsonHook proc<#toJsonHook,Option[T],ToJsonOptions>`_
+  ## * `toJsonHook proc<#toJsonHook,Option[T]>`_
   runnableExamples:
     import std/[options, json]
     var opt: Option[string]
@@ -448,7 +448,7 @@ proc toJsonHook*[T](self: Option[T], opt = initToJsonOptions()): JsonNode =
   ## Enables `toJson` for `Option` types.
   ##
   ## See also:
-  ## * `fromJsonHook proc<#fromJsonHook,Option[T],JsonNode,Joptions>`_
+  ## * `fromJsonHook proc<#fromJsonHook,Option[T],JsonNode>`_
   runnableExamples:
     import std/[options, json]
     let optSome = some("test")

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -350,7 +350,7 @@ proc toJson*[T](a: T, opt = initToJsonOptions()): JsonNode =
   else: result = %a
 
 proc fromJsonHook*[K: string|cstring, V](t: var (Table[K, V] | OrderedTable[K, V]),
-                         jsonNode: JsonNode) =
+                         jsonNode: JsonNode, opt = Joptions()) =
   ## Enables `fromJson` for `Table` and `OrderedTable` types.
   ##
   ## See also:
@@ -368,9 +368,9 @@ proc fromJsonHook*[K: string|cstring, V](t: var (Table[K, V] | OrderedTable[K, V
           "type is `" & $jsonNode.kind & "`."
   clear(t)
   for k, v in jsonNode:
-    t[k] = jsonTo(v, V)
+    t[k] = jsonTo(v, V, opt)
 
-proc toJsonHook*[K: string|cstring, V](t: (Table[K, V] | OrderedTable[K, V])): JsonNode =
+proc toJsonHook*[K: string|cstring, V](t: (Table[K, V] | OrderedTable[K, V]), opt = initToJsonOptions()): JsonNode =
   ## Enables `toJson` for `Table` and `OrderedTable` types.
   ##
   ## See also:
@@ -390,9 +390,9 @@ proc toJsonHook*[K: string|cstring, V](t: (Table[K, V] | OrderedTable[K, V])): J
   result = newJObject()
   for k, v in pairs(t):
     # not sure if $k has overhead for string
-    result[(when K is string: k else: $k)] = toJson(v)
+    result[(when K is string: k else: $k)] = toJson(v, opt)
 
-proc fromJsonHook*[A](s: var SomeSet[A], jsonNode: JsonNode) =
+proc fromJsonHook*[A](s: var SomeSet[A], jsonNode: JsonNode, opt = Joptions()) =
   ## Enables `fromJson` for `HashSet` and `OrderedSet` types.
   ##
   ## See also:
@@ -410,9 +410,9 @@ proc fromJsonHook*[A](s: var SomeSet[A], jsonNode: JsonNode) =
           "type is `" & $jsonNode.kind & "`."
   clear(s)
   for v in jsonNode:
-    incl(s, jsonTo(v, A))
+    incl(s, jsonTo(v, A, opt))
 
-proc toJsonHook*[A](s: SomeSet[A]): JsonNode =
+proc toJsonHook*[A](s: SomeSet[A], opt = initToJsonOptions()): JsonNode =
   ## Enables `toJson` for `HashSet` and `OrderedSet` types.
   ##
   ## See also:
@@ -424,7 +424,7 @@ proc toJsonHook*[A](s: SomeSet[A]): JsonNode =
 
   result = newJArray()
   for k in s:
-    add(result, toJson(k))
+    add(result, toJson(k, opt))
 
 proc fromJsonHook*[T](self: var Option[T], jsonNode: JsonNode, opt = Joptions()) =
   ## Enables `fromJson` for `Option` types.

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -410,6 +410,28 @@ template fn() =
       doAssert foo.c == 0
       doAssert foo.c0 == 42
 
+    type
+      InnerEnum = enum
+        A
+        B
+        C
+      InnerObject = object
+        x: string
+        y: InnerEnum
+
+    block testOptionsArePassedWhenDeserialising:
+      let json = parseJson("""{"x": "hello"}""")
+      let inner = json.jsonTo(Option[InnerObject], Joptions(allowMissingKeys: true))
+      doAssert inner.isSome()
+      doAssert inner.get().x == "hello"
+      doAssert inner.get().y == A
+
+    block testOptionsArePassedWhenSerialising:
+      let inner = some InnerObject(x: "hello", y: A)
+      let json = inner.toJson(ToJsonOptions(enumMode: joptEnumSymbol))
+      doAssert $json == """{"x": "hello", "y": "A"}"""
+
+
     when false:
       ## TODO: Implement support for nested variant objects allowing the tests
       ## bellow to pass.

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -429,7 +429,7 @@ template fn() =
     block testOptionsArePassedWhenSerialising:
       let inner = some InnerObject(x: "hello", y: A)
       let json = inner.toJson(ToJsonOptions(enumMode: joptEnumSymbol))
-      doAssert $json == """{"x": "hello", "y": "A"}"""
+      doAssert $json == """{"x":"hello","y":"A"}"""
 
 
     when false:


### PR DESCRIPTION
`jsonutils` now passes options when serialising/deserialising hooks that accept it. Makes builtin hooks for generic types (e.g. `Option[T]`, `Table[K, V]`) accept options so they can be passed along

This would fail before since the options were not passed to the `Option[T]` hook and would fail because of the missing `y` key in the optional `Foo` object (but would work if `Foo` wasn't optional) 

```nim
import std/[jsonutils, json, options]

type
  Foo = object
    x: int
    y: string
  Bar = object
    foo: Option[Foo]

let bar = """
  {
    "foo": {
      "x": 9 
    }
  }
""".parseJson().jsonTo(Bar, JOptions(allowMissingKeys: true))
```

Default parameters are added so that old hook signatures can be used and won't break old code