### PR TITLE
fixes #20681; add efSkipFieldVisibilityCheck to skip check

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -69,7 +69,8 @@ type
     efWantStmt, efAllowStmt, efDetermineType, efExplain,
     efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo, efNoSem2Check,
-    efNoUndeclared, efIsDotCall, efCannotBeDotCall
+    efNoUndeclared, efIsDotCall, efCannotBeDotCall,
+    efSkipFieldVisibilityCheck
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3077,8 +3077,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
   of nkCurly: result = semSetConstr(c, n, expectedType)
   of nkBracket:
     result = semArrayConstr(c, n, flags, expectedType)
-    if n.typ != nil and n.typ.skipTypes(abstractRange).kind == tySequence:
-      result.typ = n.typ # keeps tySequence type for []
   of nkObjConstr: result = semObjConstr(c, n, flags, expectedType)
   of nkLambdaKinds: result = semProcAux(c, n, skProc, lambdaPragmas, flags)
   of nkDerefExpr: result = semDeref(c, n)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3075,7 +3075,10 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
     of paTupleFields: result = semTupleFieldsConstr(c, n, flags, expectedType)
     of paSingle: result = semExpr(c, n[0], flags, expectedType)
   of nkCurly: result = semSetConstr(c, n, expectedType)
-  of nkBracket: result = semArrayConstr(c, n, flags, expectedType)
+  of nkBracket:
+    result = semArrayConstr(c, n, flags, expectedType)
+    if n.typ != nil and n.typ.skipTypes(abstractRange).kind == tySequence:
+      result.typ = n.typ # keeps tySequence type for []
   of nkObjConstr: result = semObjConstr(c, n, flags, expectedType)
   of nkLambdaKinds: result = semProcAux(c, n, skProc, lambdaPragmas, flags)
   of nkDerefExpr: result = semDeref(c, n)

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -380,6 +380,8 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
     assert false, "Must not enter here."
 
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
+  if nfUseDefaultField in n.flags:
+    return n
   var t = semTypeNode(c, n[0], nil)
   result = newNodeIT(nkObjConstr, n.info, t)
   result.add newNodeIT(nkType, n.info, t) #This will contain the default values to be added in transf

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -220,6 +220,16 @@ proc isRecursiveType(t: PType, cycleDetector: var IntSet): bool =
   else:
     return false
 
+proc fitDefaultNode(c: PContext, n: PNode): PType =
+  let expectedType = if n[^2].kind != nkEmpty: semTypeNode(c, n[^2], nil) else: nil
+  n[^1] = semConstExpr(c, n[^1], expectedType = expectedType)
+  if n[^2].kind != nkEmpty:
+    if expectedType != nil:
+      n[^1] = fitNodeConsiderViewType(c, expectedType, n[^1], n[^1].info)
+    result = n[^1].typ
+  else:
+    result = n[^1].typ
+
 proc isRecursiveType*(t: PType): bool =
   # handle simple recusive types before typeFinalPass
   var cycleDetector = initIntSet()
@@ -484,13 +494,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
     checkMinSonsLen(a, 3, c.config)
     var hasDefaultField = a[^1].kind != nkEmpty
     if hasDefaultField:
-      a[^1] = semConstExpr(c, a[^1])
-      if a[^2].kind != nkEmpty:
-        typ = semTypeNode(c, a[^2], nil)
-        let def = semExprWithType(c, a[^1], {}, typ)
-        typ = fitNodeConsiderViewType(c, typ, def, def.info).typ
-      else:
-        typ = a[^1].typ
+      typ = fitDefaultNode(c, a)
     elif a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       if c.graph.config.isDefined("nimPreviewRangeDefault") and typ.skipTypes(abstractInst).kind == tyRange:
@@ -824,13 +828,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
     var typ: PType
     var hasDefaultField = n[^1].kind != nkEmpty
     if hasDefaultField:
-      n[^1] = semConstExpr(c, n[^1])
-      if n[^2].kind != nkEmpty:
-        typ = semTypeNode(c, n[^2], nil)
-        let def = semExprWithType(c, n[^1], {}, typ)
-        typ = fitNodeConsiderViewType(c, typ, def, def.info).typ
-      else:
-        typ = n[^1].typ
+      typ = fitDefaultNode(c, n)
       propagateToOwner(rectype, typ)
     elif n[^2].kind == nkEmpty:
       localError(c.config, n.info, errTypeExpected)

--- a/tests/objects/tdefaultfieldscheck.nim
+++ b/tests/objects/tdefaultfieldscheck.nim
@@ -3,12 +3,9 @@ discard """
   errormsg: ""
   nimout:
 '''
-tdefaultfieldscheck.nim(17, 17) Error: type mismatch: got <string> but expected 'int'
-tdefaultfieldscheck.nim(18, 20) Error: type mismatch: got <int literal(12)> but expected 'string'
-tdefaultfieldscheck.nim(20, 16) Error: type mismatch: got <float64> but expected 'int'
-tdefaultfieldscheck.nim(17, 5) Error: type mismatch: got <string> but expected 'int'
-tdefaultfieldscheck.nim(18, 5) Error: type mismatch: got <int literal(12)> but expected 'string'
-tdefaultfieldscheck.nim(20, 5) Error: type mismatch: got <float64> but expected 'int'
+tdefaultfieldscheck.nim(14, 17) Error: type mismatch: got <string> but expected 'int'
+tdefaultfieldscheck.nim(15, 20) Error: type mismatch: got <int literal(12)> but expected 'string'
+tdefaultfieldscheck.nim(17, 16) Error: type mismatch: got <float64> but expected 'int'
 '''
 """
 

--- a/tests/objects/tdefaultrangetypescheck.nim
+++ b/tests/objects/tdefaultrangetypescheck.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "conversion from int literal(0) to range 1..5(int) is invalid"
+  errormsg: "cannot convert 0 to range 1..5(int)"
   line: 9
 """
 

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -206,32 +206,33 @@ template main {.dirty.} =
   when nimvm:
     discard "fixme"
   else:
-    block: #seq
-      var x = newSeq[Object](10)
-      let y = x[0]
-      doAssert y.value == 12
-      doAssert y.time == 1.2
-      doAssert y.scale == 1
+    when defined(gcArc) or defined(gcOrc):
+      block: #seq
+        var x = newSeq[Object](10)
+        let y = x[0]
+        doAssert y.value == 12
+        doAssert y.time == 1.2
+        doAssert y.scale == 1
 
-    block:
-      var x: seq[Object]
-      setLen(x, 5)
-      let y = x[^1]
-      doAssert y.value == 12
-      doAssert y.time == 1.2
-      doAssert y.scale == 1
+      block:
+        var x: seq[Object]
+        setLen(x, 5)
+        let y = x[^1]
+        doAssert y.value == 12
+        doAssert y.time == 1.2
+        doAssert y.scale == 1
 
-    block:
-      var my = @[1, 2, 3, 4, 5]
-      my.setLen(0)
-      my.setLen(5)
-      doAssert my == @[0, 0, 0, 0, 0]
+      block:
+        var my = @[1, 2, 3, 4, 5]
+        my.setLen(0)
+        my.setLen(5)
+        doAssert my == @[0, 0, 0, 0, 0]
 
-    block:
-      var my = "hello"
-      my.setLen(0)
-      my.setLen(5)
-      doAssert $(@my) == """@['\x00', '\x00', '\x00', '\x00', '\x00']"""
+      block:
+        var my = "hello"
+        my.setLen(0)
+        my.setLen(5)
+        doAssert $(@my) == """@['\x00', '\x00', '\x00', '\x00', '\x00']"""
 
   block: # array
     var x: array[10, Object] = arrayWith(default(Object), 10)

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -418,21 +418,12 @@ template main {.dirty.} =
     var z {.noinit.}: Pure = Pure(id: 77)
     doAssert z.id == 77
 
+  block: # bug #20681
+    type A = object
+      d: DateTime = DateTime()
 
-  block:
-    type TokenData = object
-      campaignMemberships = Table[string, string]()
-
-    let x = default(TokenData)
-    doAssert x.campaignMemberships.len == 0
-
-  when false: # todo fixme
-    block:
-      type TokenData = object
-        campaignMemberships = newTable[string, string]()
-
-      let x = default(TokenData)
-      doAssert x.campaignMemberships.len == 0
+    let x = default(A)
+    doAssert $x == "(d: Uninitialized DateTime)"
 
 
 static: main()

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -426,12 +426,13 @@ template main {.dirty.} =
     let x = default(TokenData)
     doAssert x.campaignMemberships.len == 0
 
-  block:
-    type TokenData = object
-      campaignMemberships = newTable[string, string]()
+  when false: # todo fixme
+    block:
+      type TokenData = object
+        campaignMemberships = newTable[string, string]()
 
-    let x = default(TokenData)
-    doAssert x.campaignMemberships.len == 0
+      let x = default(TokenData)
+      doAssert x.campaignMemberships.len == 0
 
 
 static: main()

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -421,14 +421,14 @@ template main {.dirty.} =
 
   block:
     type TokenData = object
-      campaignMemberships: Table = Table[string, string]()
+      campaignMemberships = Table[string, string]()
 
     let x = default(TokenData)
     doAssert x.campaignMemberships.len == 0
 
   block:
     type TokenData = object
-      campaignMemberships: Table = newTable[string, string]()
+      campaignMemberships = newTable[string, string]()
 
     let x = default(TokenData)
     doAssert x.campaignMemberships.len == 0

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -3,7 +3,7 @@ discard """
   targets: "c cpp js"
 """
 
-import times
+import std/[times, tables]
 
 type
   Guess = object
@@ -206,21 +206,32 @@ template main {.dirty.} =
   when nimvm:
     discard "fixme"
   else:
-    when defined(gcArc) or defined(gcOrc):
-      block: #seq
-        var x = newSeq[Object](10)
-        let y = x[0]
-        doAssert y.value == 12
-        doAssert y.time == 1.2
-        doAssert y.scale == 1
+    block: #seq
+      var x = newSeq[Object](10)
+      let y = x[0]
+      doAssert y.value == 12
+      doAssert y.time == 1.2
+      doAssert y.scale == 1
 
-      block:
-        var x: seq[Object]
-        setLen(x, 5)
-        let y = x[^1]
-        doAssert y.value == 12
-        doAssert y.time == 1.2
-        doAssert y.scale == 1
+    block:
+      var x: seq[Object]
+      setLen(x, 5)
+      let y = x[^1]
+      doAssert y.value == 12
+      doAssert y.time == 1.2
+      doAssert y.scale == 1
+
+    block:
+      var my = @[1, 2, 3, 4, 5]
+      my.setLen(0)
+      my.setLen(5)
+      doAssert my == @[0, 0, 0, 0, 0]
+
+    block:
+      var my = "hello"
+      my.setLen(0)
+      my.setLen(5)
+      doAssert $(@my) == """@['\x00', '\x00', '\x00', '\x00', '\x00']"""
 
   block: # array
     var x: array[10, Object] = arrayWith(default(Object), 10)
@@ -379,7 +390,7 @@ template main {.dirty.} =
       doAssert x.id == 1
       doAssert x.obj == default(ObjectBase)
       doAssert x.name == ""
-    
+
     block:
       var x = default(Class)
       doAssert x.def == default(Default)
@@ -387,12 +398,11 @@ template main {.dirty.} =
       doAssert x.def.obj == default(ObjectBase)
       doAssert x.def.name == ""
 
-    when not defined(cpp):
-      block:
-        var x = default(Member)
-        doAssert x.def.id == 777
-        doAssert x.def.obj == default(ObjectBase)
-        doAssert x.def.name == "fine"
+    block:
+      var x = default(Member)
+      doAssert x.def.id == 777
+      doAssert x.def.obj == default(ObjectBase)
+      doAssert x.def.name == "fine"
 
   block:
     var x {.noinit.} = 12
@@ -409,21 +419,20 @@ template main {.dirty.} =
     doAssert z.id == 77
 
 
-proc main1 =
-  var my = @[1, 2, 3, 4, 5]
-  my.setLen(0)
-  my.setLen(5)
-  doAssert my == @[0, 0, 0, 0, 0]
+  block:
+    type TokenData = object
+      campaignMemberships: Table = Table[string, string]()
 
-proc main2 =
-  var my = "hello"
-  my.setLen(0)
-  my.setLen(5)
-  doAssert $(@my) == """@['\x00', '\x00', '\x00', '\x00', '\x00']"""
+    let x = default(TokenData)
+    doAssert x.campaignMemberships.len == 0
 
-when defined(gcArc) or defined(gcOrc):
-  main1()
-  main2()
+  block:
+    type TokenData = object
+      campaignMemberships: Table = newTable[string, string]()
+
+    let x = default(TokenData)
+    doAssert x.campaignMemberships.len == 0
+
 
 static: main()
 main()


### PR DESCRIPTION
fixes #20681

Constant object construction has been checked and `inlined` already, there is no need to `sem` it again, especially for default fields.

fixes
```nim
import std/tables
block:
  type TokenData = object
    campaignMemberships = Table[string, string]()

  let x = default(TokenData)
  doAssert x.campaignMemberships.len == 0
```