### PR TITLE
fix #16736 const proc in let array causes invalid codegen

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -354,10 +354,13 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
   of tyProc:
     if containsGarbageCollectedRef(dest.t):
       # optimize closure assignment:
-      let a = optAsgnLoc(dest, dest.t, "ClE_0".rope)
-      let b = optAsgnLoc(src, dest.t, "ClE_0".rope)
-      genRefAssign(p, a, b)
-      linefmt(p, cpsStmts, "$1.ClP_0 = $2.ClP_0;$n", [rdLoc(dest), rdLoc(src)])
+      if containsGarbageCollectedRef(src.t):
+        let a = optAsgnLoc(dest, dest.t, "ClE_0".rope)
+        let b = optAsgnLoc(src, dest.t, "ClE_0".rope)
+        genRefAssign(p, a, b)
+        linefmt(p, cpsStmts, "$1.ClP_0 = $2.ClP_0;$n", [rdLoc(dest), rdLoc(src)])
+      else:
+        linefmt(p, cpsStmts, "$1.ClP_0 = $2;$n", [rdLoc(dest), rdLoc(src)])
     else:
       linefmt(p, cpsStmts, "$1 = $2;$n", [rdLoc(dest), rdLoc(src)])
   of tyTuple:

--- a/tests/closure/t16736.nim
+++ b/tests/closure/t16736.nim
@@ -1,0 +1,7 @@
+type ProcType = proc():int
+let a: ProcType = proc():int = 1
+let b: array[1, ProcType] = [a]
+
+const something: ProcType = proc():int = 2
+let arr: array[1, ProcType] = [something]
+doAssert arr[0]() == 2


### PR DESCRIPTION
fix #16736

this doesn't fix #20544, so I think better introduce new PType flag, so to distinguish proc and a real closure that has env.