### PR TITLE
fixes the typical (not a == b) bug in the documentation

### DIFF
--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -15,16 +15,15 @@ from algorithm import binarySearch
 type
   Color* = distinct int ## A color stored as RGB, e.g. `0xff00cc`.
 
-proc `==` *(a, b: Color): bool {.borrow.}
+proc `==`*(a, b: Color): bool {.borrow.} =
   ## Compares two colors.
-  ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0xff_00_ff)
-  ##     b = colFuchsia
-  ##     c = Color(0x00_ff_cc)
-  ##   assert a == b
-  ##   assert not a == c
+  runnableExamples:
+    var
+      a = Color(0xff_00_ff)
+      b = colFuchsia
+      c = Color(0x00_ff_cc)
+    assert a == b
+    assert not (a == c)
 
 template extract(a: Color, r, g, b: untyped) =
   var r = a.int shr 16 and 0xff

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -15,15 +15,16 @@ from algorithm import binarySearch
 type
   Color* = distinct int ## A color stored as RGB, e.g. `0xff00cc`.
 
-proc `==`*(a, b: Color): bool {.borrow.} =
+proc `==`*(a, b: Color): bool {.borrow.}
   ## Compares two colors.
-  runnableExamples:
-    var
-      a = Color(0xff_00_ff)
-      b = colFuchsia
-      c = Color(0x00_ff_cc)
-    assert a == b
-    assert not (a == c)
+  ##
+  ## .. code-block::
+  ##   var
+  ##     a = Color(0xff_00_ff)
+  ##     b = colFuchsia
+  ##     c = Color(0x00_ff_cc)
+  ##   assert a == b
+  ##   assert not (a == c)
 
 template extract(a: Color, r, g, b: untyped) =
   var r = a.int shr 16 and 0xff


### PR DESCRIPTION
`(not a == b)` => `not (a == b)`