### PR TITLE
Change both code snippets to use the same test URL

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -33,7 +33,7 @@
 ##   proc asyncProc(): Future[string] {.async.} =
 ##     var client = newAsyncHttpClient()
 ##     try:
-##       return await client.getContent("http://example.com")
+##       return await client.getContent("http://google.com")
 ##     finally:
 ##       client.close()
 ##


### PR DESCRIPTION
I thought I'd update the documentation for both of the code snippets to use the same testing URL. For some strange reason example.com doesn't work on my local machine, but google.com does. However at first since I didn't realize that the URLs were different, I assumed something wrong was going on with using async vs not using it. Seems like this doc update might be a bit more consistent. 

Thanks!