### PR TITLE
clean up `std/os` related modules

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -485,7 +485,11 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
     var hasDefaultField = a[^1].kind != nkEmpty
     if hasDefaultField:
       a[^1] = semConstExpr(c, a[^1])
-      typ = a[^1].typ
+      if a[^2].kind != nkEmpty:
+        typ = semTypeNode(c, a[^2], nil)
+        typ = fitNodeConsiderViewType(c, typ, a[^1], a[^1].info).typ
+      else:
+        typ = a[^1].typ
     elif a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       if c.graph.config.isDefined("nimPreviewRangeDefault") and typ.skipTypes(abstractInst).kind == tyRange:
@@ -820,7 +824,11 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
     var hasDefaultField = n[^1].kind != nkEmpty
     if hasDefaultField:
       n[^1] = semConstExpr(c, n[^1])
-      typ = n[^1].typ
+      if n[^2].kind != nkEmpty:
+        typ = semTypeNode(c, n[^2], nil)
+        typ = fitNodeConsiderViewType(c, typ, n[^1], n[^1].info).typ
+      else:
+        typ = n[^1].typ
       propagateToOwner(rectype, typ)
     elif n[^2].kind == nkEmpty:
       localError(c.config, n.info, errTypeExpected)

--- a/lib/std/dirs.nim
+++ b/lib/std/dirs.nim
@@ -1,7 +1,7 @@
 from paths import Path, ReadDirEffect, WriteDirEffect
 
 from std/private/osdirs import dirExists, createDir, existsOrCreateDir, removeDir,
-                               moveDir, walkPattern, walkFiles, walkDirs, walkDir,
+                               moveDir, walkDir, setCurrentDir,
                                walkDirRec, PathComponent
 
 export PathComponent
@@ -76,51 +76,6 @@ proc moveDir*(source, dest: Path) {.inline, tags: [ReadIOEffect, WriteIOEffect].
   ## * `createDir proc`_
   moveDir(source.string, dest.string)
 
-iterator walkPattern*(pattern: Path): Path {.tags: [ReadDirEffect].} =
-  ## Iterate over all the files and directories that match the `pattern`.
-  ##
-  ## On POSIX this uses the `glob`:idx: call.
-  ## `pattern` is OS dependent, but at least the `"*.ext"`
-  ## notation is supported.
-  ##
-  ## See also:
-  ## * `walkFiles iterator`_
-  ## * `walkDirs iterator`_
-  ## * `walkDir iterator`_
-  ## * `walkDirRec iterator`_
-  for p in walkPattern(pattern.string):
-    yield Path(p)
-
-iterator walkFiles*(pattern: Path): Path {.tags: [ReadDirEffect].} =
-  ## Iterate over all the files that match the `pattern`.
-  ##
-  ## On POSIX this uses the `glob`:idx: call.
-  ## `pattern` is OS dependent, but at least the `"*.ext"`
-  ## notation is supported.
-  ##
-  ## See also:
-  ## * `walkPattern iterator`_
-  ## * `walkDirs iterator`_
-  ## * `walkDir iterator`_
-  ## * `walkDirRec iterator`_
-  for p in walkFiles(pattern.string):
-    yield Path(p)
-
-iterator walkDirs*(pattern: Path): Path {.tags: [ReadDirEffect].} =
-  ## Iterate over all the directories that match the `pattern`.
-  ##
-  ## On POSIX this uses the `glob`:idx: call.
-  ## `pattern` is OS dependent, but at least the `"*.ext"`
-  ## notation is supported.
-  ##
-  ## See also:
-  ## * `walkPattern iterator`_
-  ## * `walkFiles iterator`_
-  ## * `walkDir iterator`_
-  ## * `walkDirRec iterator`_
-  for p in walkDirs(pattern.string):
-    yield Path(p)
-
 iterator walkDir*(dir: Path; relative = false, checkDir = false):
     tuple[kind: PathComponent, path: Path] {.tags: [ReadDirEffect].} =
   ## Walks over the directory `dir` and yields for each directory or file in
@@ -175,3 +130,11 @@ iterator walkDirRec*(dir: Path,
   ## * `walkDir iterator`_
   for p in walkDirRec(dir.string, yieldFilter, followFilter, relative, checkDir):
     yield Path(p)
+
+proc setCurrentDir*(newDir: Path) {.inline, tags: [].} =
+  ## Sets the `current working directory`:idx:; `OSError`
+  ## is raised if `newDir` cannot been set.
+  ##
+  ## See also:
+  ## * `getCurrentDir proc`_
+  osdirs.setCurrentDir(newDir.string)

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -24,7 +24,7 @@ func `==`*(x, y: Path): bool {.inline.} =
   ## Compares two paths.
   ##
   ## On a case-sensitive filesystem this is done
-  ## case-sensitively otherwise case-insensitively. Returns:
+  ## case-sensitively otherwise case-insensitively.
   result = cmpPaths(x.string, y.string) == 0
 
 template endsWith(a: string, b: set[char]): bool =

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -21,7 +21,11 @@ type
   Path* = distinct string
 
 func `==`*(x, y: Path): bool {.inline.} =
-  x.string == y.string
+  ## Compares two paths.
+  ##
+  ## On a case-sensitive filesystem this is done
+  ## case-sensitively otherwise case-insensitively. Returns:
+  result = cmpPaths(x.string, y.string) == 0
 
 template endsWith(a: string, b: set[char]): bool =
   a.len > 0 and a[^1] in b
@@ -213,17 +217,6 @@ func addFileExt*(filename: Path, ext: string): Path {.inline.} =
   ## * `lastPathPart proc`_
   ## * `changeFileExt proc`_
   result = Path(addFileExt(filename.string, ext))
-
-func cmpPaths*(pathA, pathB: Path): int {.inline.} =
-  ## Compares two paths.
-  ##
-  ## On a case-sensitive filesystem this is done
-  ## case-sensitively otherwise case-insensitively. Returns:
-  ##
-  ## | 0 if pathA == pathB
-  ## | < 0 if pathA < pathB
-  ## | > 0 if pathA > pathB
-  result = cmpPaths(pathA.string, pathB.string)
 
 func unixToNativePath*(path: Path, drive=Path("")): Path {.inline.} =
   ## Converts an UNIX-like path to a native one.

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -1,6 +1,9 @@
 import std/private/osseps
 export osseps
 
+import std/envvars
+import std/private/osappdirs
+
 import pathnorm
 
 from std/private/ospaths2 import  joinPath, splitPath,
@@ -16,6 +19,9 @@ export ReadDirEffect, WriteDirEffect
 
 type
   Path* = distinct string
+
+func `==`*(x, y: Path): bool {.inline.} =
+  x.string == y.string
 
 template endsWith(a: string, b: set[char]): bool =
   a.len > 0 and a[^1] in b
@@ -246,14 +252,6 @@ proc getCurrentDir*(): Path {.inline, tags: [].} =
   ## * `getProjectPath proc <macros.html#getProjectPath>`_
   result = Path(ospaths2.getCurrentDir())
 
-proc setCurrentDir*(newDir: Path) {.inline, tags: [].} =
-  ## Sets the `current working directory`:idx:; `OSError`
-  ## is raised if `newDir` cannot been set.
-  ##
-  ## See also:
-  ## * `getCurrentDir proc`_
-  ospaths2.setCurrentDir(newDir.string)
-
 proc normalizeExe*(file: var Path) {.borrow.}
 
 proc normalizePath*(path: var Path) {.borrow.}
@@ -268,3 +266,29 @@ proc absolutePath*(path: Path, root = getCurrentDir()): Path =
   ## See also:
   ## * `normalizePath proc`_
   result = Path(absolutePath(path.string, root.string))
+
+proc expandTildeImpl(path: string): string {.
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  if len(path) == 0 or path[0] != '~':
+    result = path
+  elif len(path) == 1:
+    result = getHomeDir()
+  elif (path[1] in {DirSep, AltSep}):
+    result = joinPath(getHomeDir(), path.substr(2))
+  else:
+    # TODO: handle `~bob` and `~bob/` which means home of bob
+    result = path
+
+proc expandTilde*(path: Path): Path {.inline,
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Expands ``~`` or a path starting with ``~/`` to a full path, replacing
+  ## ``~`` with `getHomeDir()`_ (otherwise returns ``path`` unmodified).
+  ##
+  ## Windows: this is still supported despite the Windows platform not having this
+  ## convention; also, both ``~/`` and ``~\`` are handled.
+  runnableExamples:
+    import std/appdirs
+    assert expandTilde(Path("~") / Path("appname.cfg")) == getHomeDir() / Path("appname.cfg")
+    assert expandTilde(Path("~/foo/bar")) == getHomeDir() / Path("foo/bar")
+    assert expandTilde(Path("/foo/bar")) == Path("/foo/bar")
+  result = Path(expandTildeImpl(path.string))

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -538,3 +538,21 @@ proc moveDir*(source, dest: string) {.tags: [ReadIOEffect, WriteIOEffect], noWei
     # Fallback to copy & del
     copyDir(source, dest)
     removeDir(source)
+
+proc setCurrentDir*(newDir: string) {.inline, tags: [], noWeirdTarget.} =
+  ## Sets the `current working directory`:idx:; `OSError`
+  ## is raised if `newDir` cannot been set.
+  ##
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `getCurrentDir proc`_
+  when defined(windows):
+    when useWinUnicode:
+      if setCurrentDirectoryW(newWideCString(newDir)) == 0'i32:
+        raiseOSError(osLastError(), newDir)
+    else:
+      if setCurrentDirectoryA(newDir) == 0'i32: raiseOSError(osLastError(), newDir)
+  else:
+    if chdir(newDir) != 0'i32: raiseOSError(osLastError(), newDir)


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/20582

**API changes**
- remove `walkFiles`, `walkPattern`, `walkDirs` from `std/dirs` ref https://github.com/nim-lang/Nim/pull/20628#issuecomment-1289450060
- move `setCurrentDir` to `std/dirs` ref https://dlang.org/phobos/std_file.html
- implements `expandTilde` in `std/paths`