### PR TITLE
fixes semExpr wrongly erases the seq type of nkbracket

### DIFF
--- a/tests/macros/tmacros1.nim
+++ b/tests/macros/tmacros1.nim
@@ -79,3 +79,15 @@ block:
   ## one
   ## two
   ## three"""
+
+block:
+  macro foo(x: static seq[int]) =
+    discard x
+
+  macro foo2: untyped =
+    var x: seq[int] = @[]
+
+    result = quote do:
+      foo(`x`)
+
+  foo2()


### PR DESCRIPTION
After the call of `semArrayConstr`, the type of `nkBracket` becomes `nkArray` even though its original type is `tySequence`.