### PR TITLE
fixes #8301; disallow typedesc being assigned to result

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1806,7 +1806,8 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     let rhs = semExprWithType(c, n[1], {}, le)
     if lhs.kind == nkSym and lhs.sym.kind == skResult:
       if rhs.typ == nil or rhs.typ.kind == tyTypeDesc:
-        localError(c.config, a.info, errXVoidCannotBeAssignedToResult)
+        localError(c.config, a.info, errXTypedescCannotBeAssignedToResult %
+                  renderTree(rhs, {renderNoComments}))
       n.typ = c.enforceVoidContext
       if c.p.owner.kind != skMacro and resultTypeIsInferrable(lhs.sym.typ):
         var rhsTyp = rhs.typ

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1874,9 +1874,6 @@ proc semProcBody(c: PContext, n: PNode; expectedType: PType = nil): PNode =
       a[0] = newSymNode(c.p.resultSym)
       a[1] = result
       result = semAsgn(c, a)
-      if result.typ != nil and result.typ.kind == tyVoid:
-        localError(c.config, c.p.resultSym.info, errCannotInferReturnType %
-          c.p.owner.name.s)
   else:
     discardCheck(c, result, {})
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1805,7 +1805,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     let lhs = n[0]
     let rhs = semExprWithType(c, n[1], {}, le)
     if lhs.kind == nkSym and lhs.sym.kind == skResult:
-      if rhs.typ == nil or rhs.typ.kind == tyTypeDesc:
+      if rhs.typ != nil and rhs.typ.kind == tyTypeDesc:
         localError(c.config, a.info, errXTypedescCannotBeAssignedToResult %
                   renderTree(rhs, {renderNoComments}))
       n.typ = c.enforceVoidContext

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1805,7 +1805,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     let lhs = n[0]
     let rhs = semExprWithType(c, n[1], {}, le)
     if lhs.kind == nkSym and lhs.sym.kind == skResult:
-      if rhs.typ == nil or rhs.typ.skipTypes({tyTypeDesc}).kind == tyVoid:
+      if rhs.typ == nil or rhs.typ.kind == tyTypeDesc:
         localError(c.config, a.info, errXVoidCannotBeAssignedToResult)
       n.typ = c.enforceVoidContext
       if c.p.owner.kind != skMacro and resultTypeIsInferrable(lhs.sym.typ):

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -24,7 +24,7 @@ const
   errArrayExpectsTwoTypeParams = "array expects two type parameters"
   errInvalidVisibilityX = "invalid visibility: '$1'"
   errXCannotBeAssignedTo = "'$1' cannot be assigned to"
-  errXVoidCannotBeAssignedToResult = "'void' cannot be assigned to 'result'"
+  errXTypedescCannotBeAssignedToResult = "'$1' cannot be assigned to 'result'"
   errIteratorNotAllowed = "iterators can only be defined at the module's top level"
   errXNeedsReturnType = "$1 needs a return type"
   errNoReturnTypeDeclared = "no return type declared"

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -24,6 +24,7 @@ const
   errArrayExpectsTwoTypeParams = "array expects two type parameters"
   errInvalidVisibilityX = "invalid visibility: '$1'"
   errXCannotBeAssignedTo = "'$1' cannot be assigned to"
+  errXVoidCannotBeAssignedToResult = "'void' cannot be assigned to 'result'"
   errIteratorNotAllowed = "iterators can only be defined at the module's top level"
   errXNeedsReturnType = "$1 needs a return type"
   errNoReturnTypeDeclared = "no return type declared"

--- a/tests/errmsgs/t8301.nim
+++ b/tests/errmsgs/t8301.nim
@@ -1,0 +1,11 @@
+discard """
+  errormsg: "'void' cannot be assigned to 'result'"
+"""
+
+# bug #8301
+proc foo_1():auto=
+  void
+
+when true:
+  # Error: internal error: expr: var not init result_115006
+  foo_p1()


### PR DESCRIPTION
fixes #8301

`tyVoid` matches `tyAnthing`; the same thing goes for `fitNode`; 

```nim
# bug #8301
proc foo_1():auto=
  void

when true:
  # Error: internal error: expr: var not init result_115006
  foo_p1()
```