### PR TITLE
int128.nim fix warnings

### DIFF
--- a/compiler/int128.nim
+++ b/compiler/int128.nim
@@ -345,12 +345,10 @@ proc low64(a: Int128): uint64 =
   bitconcat(a.udata[1], a.udata[0])
 
 proc `*`*(lhs, rhs: Int128): Int128 =
-  {.push warnings: off.}  # Warning: target type is larger than source type.
-  let a32 = cast[uint64](lhs.udata[1])
-  let a00 = cast[uint64](lhs.udata[0])
-  let b32 = cast[uint64](rhs.udata[1])
-  let b00 = cast[uint64](rhs.udata[0])
-  {.pop.}
+  let a32 = uint64(lhs.udata[1])
+  let a00 = uint64(lhs.udata[0])
+  let b32 = uint64(rhs.udata[1])
+  let b00 = uint64(rhs.udata[0])
   result = makeInt128(high64(lhs) * low64(rhs) + low64(lhs) * high64(rhs) + a32 * b32, a00 * b00)
   result += toInt128(a32 * b00) shl 32
   result += toInt128(a00 * b32) shl 32

--- a/compiler/int128.nim
+++ b/compiler/int128.nim
@@ -345,11 +345,12 @@ proc low64(a: Int128): uint64 =
   bitconcat(a.udata[1], a.udata[0])
 
 proc `*`*(lhs, rhs: Int128): Int128 =
+  {.push warning[CastSizes]: off.}
   let a32 = cast[uint64](lhs.udata[1])
   let a00 = cast[uint64](lhs.udata[0])
   let b32 = cast[uint64](rhs.udata[1])
   let b00 = cast[uint64](rhs.udata[0])
-
+  {.pop.}
   result = makeInt128(high64(lhs) * low64(rhs) + low64(lhs) * high64(rhs) + a32 * b32, a00 * b00)
   result += toInt128(a32 * b00) shl 32
   result += toInt128(a00 * b32) shl 32

--- a/compiler/int128.nim
+++ b/compiler/int128.nim
@@ -345,7 +345,7 @@ proc low64(a: Int128): uint64 =
   bitconcat(a.udata[1], a.udata[0])
 
 proc `*`*(lhs, rhs: Int128): Int128 =
-  {.push warning[CastSizes]: off.}
+  {.push warnings: off.}  # Warning: target type is larger than source type.
   let a32 = cast[uint64](lhs.udata[1])
   let a00 = cast[uint64](lhs.udata[0])
   let b32 = cast[uint64](rhs.udata[1])


### PR DESCRIPTION
Silence warning (false positive) for `int128.nim` complains `Warning: target type is larger than source type` but it is Ok.

![Screenshot_20221026_160141](https://user-images.githubusercontent.com/1189414/198113938-490ca917-61fe-420d-880f-96cefadc06e1.png)
