### PR TITLE
Fix #20628 for Windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1031,7 +1031,10 @@ type
     blockSize*: int                   ## Preferred I/O block size for this object.
                                       ## In some filesystems, this may vary from file to file.
     isRegular*: bool                  ## Is file regular? (on Unix some "files"
-                                      ## can be non-regular like FIFOs, devices)
+                                      ## can be non-regular like FIFOs,
+                                      ## devices); for directories `isRegular`
+                                      ## is always `true`, for symlinks it is
+                                      ## the same as for the link's target.
 
 template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
   ## Transforms the native file info structure into the one nim uses.
@@ -1059,6 +1062,7 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
     else:
       formalInfo.permissions = {fpUserExec..fpOthersRead}
 
+    formalInfo.isRegular = true
     # Retrieve basic file kind
     if (rawInfo.dwFileAttributes and FILE_ATTRIBUTE_DIRECTORY) != 0'i32:
       formalInfo.kind = pcDir

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1030,10 +1030,10 @@ type
     creationTime*: times.Time         ## Time file was created. Not supported on all systems!
     blockSize*: int                   ## Preferred I/O block size for this object.
                                       ## In some filesystems, this may vary from file to file.
-    isRegular*: bool                  ## Is file regular? (on Unix some "files"
-                                      ## can be non-regular like FIFOs,
-                                      ## devices); for directories `isRegular`
-                                      ## is always `true`, for symlinks it is
+    isSpecial*: bool                  ## Is file special? (on Unix some "files"
+                                      ## can be special=non-regular like FIFOs,
+                                      ## devices); for directories `isSpecial`
+                                      ## is always `false`, for symlinks it is
                                       ## the same as for the link's target.
 
 template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
@@ -1062,7 +1062,6 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
     else:
       formalInfo.permissions = {fpUserExec..fpOthersRead}
 
-    formalInfo.isRegular = true
     # Retrieve basic file kind
     if (rawInfo.dwFileAttributes and FILE_ATTRIBUTE_DIRECTORY) != 0'i32:
       formalInfo.kind = pcDir
@@ -1096,14 +1095,14 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
     checkAndIncludeMode(S_IWOTH, fpOthersWrite)
     checkAndIncludeMode(S_IXOTH, fpOthersExec)
 
-    (formalInfo.kind, formalInfo.isRegular) =
+    (formalInfo.kind, formalInfo.isSpecial) =
       if S_ISDIR(rawInfo.st_mode):
-        (pcDir, true)
+        (pcDir, false)
       elif S_ISLNK(rawInfo.st_mode):
         assert(path != "") # symlinks can't occur for file handles
         getSymlinkFileKind(path)
       else:
-        (pcFile, S_ISREG(rawInfo.st_mode))
+        (pcFile, not S_ISREG(rawInfo.st_mode))
 
 when defined(js):
   when not declared(FileHandle):
@@ -1157,7 +1156,7 @@ proc getFileInfo*(path: string, followSymlink = true): FileInfo {.noWeirdTarget.
   ## When `followSymlink` is true (default), symlinks are followed and the
   ## information retrieved is information related to the symlink's target.
   ## Otherwise, information on the symlink itself is retrieved (however,
-  ## field `isRegular` is still determined from the target on Unix).
+  ## field `isSpecial` is still determined from the target on Unix).
   ##
   ## If the information cannot be retrieved, such as when the path doesn't
   ## exist, or when permission restrictions prevent the program from retrieving

--- a/lib/std/dirs.nim
+++ b/lib/std/dirs.nim
@@ -77,7 +77,7 @@ proc moveDir*(source, dest: Path) {.inline, tags: [ReadIOEffect, WriteIOEffect].
   moveDir(source.string, dest.string)
 
 iterator walkDir*(dir: Path; relative = false, checkDir = false,
-                 onlyRegular = false):
+                 skipSpecial = false):
     tuple[kind: PathComponent, path: Path] {.tags: [ReadDirEffect].} =
   ## Walks over the directory `dir` and yields for each directory or file in
   ## `dir`. The component type and full path for each item are returned.
@@ -88,20 +88,20 @@ iterator walkDir*(dir: Path; relative = false, checkDir = false,
   ##   otherwise the full path is returned.
   ## * If `checkDir` is true, `OSError` is raised when `dir`
   ##   doesn't exist.
-  ## * If `onlyRegular` is true, then (besides all directories) only *regular*
+  ## * If `skipSpecial` is true, then (besides all directories) only *regular*
   ##   files (**without** special "file" objects like FIFOs, device files,
   ##   etc) will be yielded on Unix.
-  for (k, p) in walkDir(dir.string, relative, checkDir, onlyRegular):
+  for (k, p) in walkDir(dir.string, relative, checkDir, skipSpecial):
     yield (k, Path(p))
 
 iterator walkDirRec*(dir: Path,
                      yieldFilter = {pcFile}, followFilter = {pcDir},
-                     relative = false, checkDir = false, onlyRegular = false):
+                     relative = false, checkDir = false, skipSpecial = false):
                     Path {.tags: [ReadDirEffect].} =
   ## Recursively walks over the directory `dir` and yields for each file
   ## or directory in `dir`.
   ##
-  ## Options `relative`, `checkdir`, `onlyRegular` are explained in
+  ## Options `relative`, `checkdir`, `skipSpecial` are explained in
   ## [walkDir iterator] description.
   ##
   ## .. warning:: Modifying the directory structure while the iterator
@@ -132,7 +132,7 @@ iterator walkDirRec*(dir: Path,
   ## * `walkDirs iterator`_
   ## * `walkDir iterator`_
   for p in walkDirRec(dir.string, yieldFilter, followFilter, relative,
-                      checkDir, onlyRegular):
+                      checkDir, skipSpecial):
     yield Path(p)
 
 proc setCurrentDir*(newDir: Path) {.inline, tags: [].} =

--- a/lib/std/private/oscommon.nim
+++ b/lib/std/private/oscommon.nim
@@ -86,16 +86,16 @@ type
 
 when defined(posix) and not weirdTarget:
   proc getSymlinkFileKind*(path: string):
-      tuple[pc: PathComponent, isRegular: bool] =
+      tuple[pc: PathComponent, isSpecial: bool] =
     # Helper function.
     var s: Stat
     assert(path != "")
-    result = (pcLinkToFile, true)
+    result = (pcLinkToFile, false)
     if stat(path, s) == 0'i32:
       if S_ISDIR(s.st_mode):
-        result = (pcLinkToDir, true)
+        result = (pcLinkToDir, false)
       elif not S_ISREG(s.st_mode):
-        result = (pcLinkToFile, false)
+        result = (pcLinkToFile, true)
 
 proc tryMoveFSObject*(source, dest: string, isDir: bool): bool {.noWeirdTarget.} =
   ## Moves a file (or directory if `isDir` is true) from `source` to `dest`.

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -240,9 +240,9 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
             var k = pcFile
 
             template resolveSymlink() =
-              var isRegular: bool
-              (k, isRegular) = getSymlinkFileKind(path)
-              if skipSpecial and not isRegular: continue
+              var isSpecial: bool
+              (k, isSpecial) = getSymlinkFileKind(path)
+              if skipSpecial and isSpecial: continue
 
             template kSetGeneric() =  # pure Posix component `k` resolution
               if lstat(path.cstring, s) < 0'i32: continue  # don't yield

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -155,7 +155,7 @@ proc staticWalkDir(dir: string; relative: bool): seq[
   discard
 
 iterator walkDir*(dir: string; relative = false, checkDir = false,
-                  onlyRegular = false):
+                  skipSpecial = false):
   tuple[kind: PathComponent, path: string] {.tags: [ReadDirEffect].} =
   ## Walks over the directory `dir` and yields for each directory or file in
   ## `dir`. The component type and full path for each item are returned.
@@ -166,7 +166,7 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
   ##   otherwise the full path is returned.
   ## * If `checkDir` is true, `OSError` is raised when `dir`
   ##   doesn't exist.
-  ## * If `onlyRegular` is true, then (besides all directories) only *regular*
+  ## * If `skipSpecial` is true, then (besides all directories) only *regular*
   ##   files (**without** special "file" objects like FIFOs, device files,
   ##   etc) will be yielded on Unix.
   ##
@@ -242,7 +242,7 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
             template resolveSymlink() =
               var isRegular: bool
               (k, isRegular) = getSymlinkFileKind(path)
-              if onlyRegular and not isRegular: continue
+              if skipSpecial and not isRegular: continue
 
             template kSetGeneric() =  # pure Posix component `k` resolution
               if lstat(path.cstring, s) < 0'i32: continue  # don't yield
@@ -250,7 +250,7 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
                 k = pcDir
               elif S_ISLNK(s.st_mode):
                 resolveSymlink()
-              elif onlyRegular and not S_ISREG(s.st_mode): continue
+              elif skipSpecial and not S_ISREG(s.st_mode): continue
 
             when defined(linux) or defined(macosx) or
                  defined(bsd) or defined(genode) or defined(nintendoswitch):
@@ -261,7 +261,7 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
               of DT_UNKNOWN:
                 kSetGeneric()
               else: # DT_REG or special "files" like FIFOs
-                if onlyRegular and x.d_type != DT_REG: continue
+                if skipSpecial and x.d_type != DT_REG: continue
                 else: discard # leave it as pcFile
             else:  # assuming that field `d_type` is not present
               kSetGeneric()
@@ -270,12 +270,12 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
 
 iterator walkDirRec*(dir: string,
                      yieldFilter = {pcFile}, followFilter = {pcDir},
-                     relative = false, checkDir = false, onlyRegular = false):
+                     relative = false, checkDir = false, skipSpecial = false):
                     string {.tags: [ReadDirEffect].} =
   ## Recursively walks over the directory `dir` and yields for each file
   ## or directory in `dir`.
   ##
-  ## Options `relative`, `checkdir`, `onlyRegular` are explained in
+  ## Options `relative`, `checkdir`, `skipSpecial` are explained in
   ## [walkDir iterator] description.
   ##
   ## .. warning:: Modifying the directory structure while the iterator
@@ -311,7 +311,7 @@ iterator walkDirRec*(dir: string,
   while stack.len > 0:
     let d = stack.pop()
     for k, p in walkDir(dir / d, relative = true, checkDir = checkDir,
-                        onlyRegular = onlyRegular):
+                        skipSpecial = skipSpecial):
       let rel = d / p
       if k in {pcDir, pcLinkToDir} and k in followFilter:
         stack.add rel

--- a/tests/stdlib/tgetfileinfo.nim
+++ b/tests/stdlib/tgetfileinfo.nim
@@ -127,11 +127,11 @@ proc testGetFileInfo =
       echo pcLinkToDir
       echo pcLinkToFile
 
-    doAssert dirInfo.isRegular == true
-    doAssert fileInfo.isRegular == true
+    doAssert dirInfo.isSpecial == false
+    doAssert fileInfo.isSpecial == false
     when defined(posix):
-      doAssert linkDirInfo.isRegular == true
-      doAssert linkFileInfo.isRegular == true
+      doAssert linkDirInfo.isSpecial == false
+      doAssert linkFileInfo.isSpecial == false
 
     removeDir(dirPath)
     removeFile(filePath)
@@ -139,7 +139,7 @@ proc testGetFileInfo =
       removeFile(linkDirPath)
       removeFile(linkFilePath)
 
-  # Test that `isRegular` is set correctly
+  # Test that `isSpecial` is set correctly
   block:
     when defined(posix):
       let
@@ -154,8 +154,8 @@ proc testGetFileInfo =
         fifoInfo = getFileInfo(fifoPath)
         linkFifoInfo = getFileInfo(linkFifoPath)
 
-      doAssert fifoInfo.isRegular == false
-      doAssert linkFifoInfo.isRegular == false
+      doAssert fifoInfo.isSpecial == true
+      doAssert linkFifoInfo.isSpecial == true
 
       removeFile(fifoPath)
       removeFile(linkFifoPath)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -361,7 +361,7 @@ block: # walkDir
       removeDir("walkdir_test")
 
   when defined(posix):
-    block walkDirRegular:
+    block walkDirSpecial:
       createDir("walkdir_test")
       doAssert execShellCmd("mkfifo walkdir_test/fifo") == 0
       createSymlink("fifo", "walkdir_test/fifo_link")
@@ -370,9 +370,9 @@ block: # walkDir
                 (pcFile, "fifo") in withSpecialFiles and
                 (pcLinkToFile, "fifo_link") in withSpecialFiles)
       # now Unix special files are excluded from walkdir output:
-      let onlyRegularFiles = toSeq(walkDir("walkdir_test", relative = true,
-                                           onlyRegular = true))
-      doAssert onlyRegularFiles.len == 0
+      let skipSpecialFiles = toSeq(walkDir("walkdir_test", relative = true,
+                                           skipSpecial = true))
+      doAssert skipSpecialFiles.len == 0
       removeDir("walkdir_test")
 
 block normalizedPath:

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -989,7 +989,7 @@ iterator walkDirBasic(dir: string, walkOptC: WalkOptComp[Pattern]): string
     let rightDirForFiles = d.isRightDirectory(walkOptC)
     var files = newSeq[string]()
     var dirs = newSeq[string]()
-    for kind, path in walkDir(d, onlyRegular = true):
+    for kind, path in walkDir(d, skipSpecial = true):
       case kind
       of pcFile:
         if path.hasRightPath(walkOptC) and rightDirForFiles:


### PR DESCRIPTION
Fix a mistake found by @Varriount .

There was already a test assert added but [it was not run](https://dev.azure.com/nim-lang/255dfe86-e590-40bb-a8a2-3c0295ebdeb1/_apis/build/builds/24172/logs/75) ?!
```
2022-10-24T19:40:17.9426018Z NOTINBATCH: tests/stdlib/tgetfileinfo.nim c
```
I'm not sure what "NOTINBATCH" is.

