### PR TITLE
openssl 3 support no longer opt in + some 1.0 support

### DIFF
--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -46,8 +46,7 @@ jobs:
               valgrind libc6-dbg libblas-dev xorg-dev
       - name: 'Install dependencies (macOS)'
         if: runner.os == 'macOS'
-        run: |
-          brew install boehmgc make sfml gtk+3
+        run: brew install boehmgc make sfml gtk+3
       - name: 'Install dependencies (Windows)'
         if: runner.os == 'Windows'
         shell: bash
@@ -71,5 +70,4 @@ jobs:
 
       - name: 'koch, Run CI'
         shell: bash
-        run: |
-          . ci/funs.sh && nimInternalBuildKochAndRunCI
+        run: . ci/funs.sh && nimInternalBuildKochAndRunCI

--- a/changelog.md
+++ b/changelog.md
@@ -78,9 +78,6 @@
 
 - Removed the `nimIncrSeqV3` define.
 
-- Static linking against OpenSSL versions below 1.1, previously done by
-  setting `-d:openssl10`, is no longer supported.
-
 - `macros.getImpl` for `const` symbols now returns the full definition node
   (as `nnkConstDef`) rather than the AST of the constant value.
 
@@ -98,6 +95,7 @@
 ## Standard library additions and changes
 
 [//]: # "Changes:"
+- OpenSSL 3 is now supported.
 - `macros.parseExpr` and `macros.parseStmt` now accept an optional
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.

--- a/changelog.md
+++ b/changelog.md
@@ -98,7 +98,6 @@
 ## Standard library additions and changes
 
 [//]: # "Changes:"
-- OpenSSL version 3 is now supported by setting either `-d:sslVersion=3` or `-d:useOpenssl3`.
 - `macros.parseExpr` and `macros.parseStmt` now accept an optional
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -546,18 +546,20 @@ proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
   fromSockAddrAux(cast[ptr Sockaddr_storage](unsafeAddr sa), sl, address, port)
 
 when defineSsl:
-  CRYPTO_malloc_init()
-  doAssert SslLibraryInit() == 1
-  SSL_load_error_strings()
-  ERR_load_BIO_strings()
-  OpenSSL_add_all_algorithms()
+  # OpenSSL >= 1.1.0 does not need explicit init.
+  when not opensslNoInit:
+    CRYPTO_malloc_init()
+    doAssert SslLibraryInit() == 1
+    SSL_load_error_strings()
+    ERR_load_BIO_strings()
+    OpenSSL_add_all_algorithms()
 
   proc sslHandle*(self: Socket): SslPtr =
     ## Retrieve the ssl pointer of `socket`.
     ## Useful for interfacing with `openssl`.
     self.sslHandle
 
-  proc raiseSSLError*(s = "") =
+  proc raiseSSLError*(s = "") {.raises: [SslError].}=
     ## Raises a new SSL error.
     if s != "":
       raise newException(SslError, s)
@@ -622,9 +624,8 @@ when defineSsl:
                    caDir = "", caFile = ""): SslContext =
     ## Creates an SSL context.
     ##
-    ## Protocol version specifies the protocol to use. SSLv2, SSLv3, TLSv1
-    ## are available with the addition of `protSSLv23` which allows for
-    ## compatibility with all of them.
+    ## Protocol version is currently ignored by default and TLS is used.
+    ## With `-d:openssl10`, only SSLv23 and TLSv1 may be used.
     ##
     ## There are three options for verify mode:
     ## `CVerifyNone`: certificates are not verified;
@@ -651,16 +652,24 @@ when defineSsl:
     ## or using ECDSA:
     ## - `openssl ecparam -out mykey.pem -name secp256k1 -genkey`
     ## - `openssl req -new -key mykey.pem -x509 -nodes -days 365 -out mycert.pem`
-    var newCTX: SslCtx
-    case protVersion
-    of protSSLv23:
-      newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
-    of protSSLv2:
-      raiseSSLError("SSLv2 is no longer secure and has been deprecated, use protSSLv23")
-    of protSSLv3:
-      raiseSSLError("SSLv3 is no longer secure and has been deprecated, use protSSLv23")
-    of protTLSv1:
-      newCTX = SSL_CTX_new(TLSv1_method())
+    var mtd: PSSL_METHOD
+    when defined(openssl10):
+      case protVersion
+      of protSSLv23:
+        mtd = SSLv23_method()
+      of protSSLv2:
+        raiseSSLError("SSLv2 is no longer secure and has been deprecated, use protSSLv23")
+      of protSSLv3:
+        raiseSSLError("SSLv3 is no longer secure and has been deprecated, use protSSLv23")
+      of protTLSv1:
+        mtd = TLSv1_method()
+    else:
+      mtd = TLS_method()
+    if mtd == nil:
+      raiseSSLError("Failed to create TLS context")
+    var newCTX = SSL_CTX_new(mtd)
+    if newCTX == nil:
+      raiseSSLError("Failed to create TLS context")
 
     if newCTX.SSL_CTX_set_cipher_list(cipherList) != 1:
       raiseSSLError()
@@ -819,24 +828,28 @@ when defineSsl:
     if SSL_set_fd(socket.sslHandle, socket.fd) != 1:
       raiseSSLError()
 
-  proc checkCertName(socket: Socket, hostname: string) =
+  proc checkCertName(socket: Socket, hostname: string) {.raises: [SslError], tags:[RootEffect].} =
     ## Check if the certificate Subject Alternative Name (SAN) or Subject CommonName (CN) matches hostname.
     ## Wildcards match only in the left-most label.
     ## When name starts with a dot it will be matched by a certificate valid for any subdomain
     when not defined(nimDisableCertificateValidation) and not defined(windows):
       assert socket.isSsl
-      let certificate = socket.sslHandle.SSL_get_peer_certificate()
-      if certificate.isNil:
-        raiseSSLError("No SSL certificate found.")
+      try:
+        let certificate = socket.sslHandle.SSL_get_peer_certificate()
+        if certificate.isNil:
+          raiseSSLError("No SSL certificate found.")
 
-      const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = 0x1.cuint
-      # https://www.openssl.org/docs/man1.1.1/man3/X509_check_host.html
-      let match = certificate.X509_check_host(hostname.cstring, hostname.len.cint,
-        X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, nil)
-      # https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_certificate.html
-      X509_free(certificate)
-      if match != 1:
-        raiseSSLError("SSL Certificate check failed.")
+        const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = 0x1.cuint
+        # https://www.openssl.org/docs/man1.1.1/man3/X509_check_host.html
+        let match = certificate.X509_check_host(hostname.cstring, hostname.len.cint,
+          X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, nil)
+        # https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_certificate.html
+        X509_free(certificate)
+        if match != 1:
+          raiseSSLError("SSL Certificate check failed.")
+
+      except LibraryError:
+        raiseSSLError("SSL import failed")
 
   proc wrapConnectedSocket*(ctx: SslContext, socket: Socket,
                             handshake: SslHandshakeType,
@@ -863,6 +876,7 @@ when defineSsl:
       let ret = SSL_connect(socket.sslHandle)
       socketError(socket, ret)
       when not defined(nimDisableCertificateValidation) and not defined(windows):
+        # FIXME: this should be skipped on CVerifyNone
         if hostname.len > 0 and not isIpAddress(hostname):
           socket.checkCertName(hostname)
     of handshakeAsServer:
@@ -1318,7 +1332,7 @@ when defined(nimdoc) or (defined(posix) and not useNimNetLite):
           (sizeof(socketAddr.sun_family) + path.len).SockLen) != 0'i32:
         raiseOSError(osLastError())
 
-when defined(ssl):
+when defineSsl:
   proc gotHandshake*(socket: Socket): bool =
     ## Determines whether a handshake has occurred between a client (`socket`)
     ## and the server that `socket` is connected to.
@@ -2005,7 +2019,7 @@ proc dial*(address: string, port: Port,
     raise newException(IOError, "Couldn't resolve address: " & address)
 
 proc connect*(socket: Socket, address: string,
-    port = Port(0)) {.tags: [ReadIOEffect].} =
+    port = Port(0)) {.tags: [ReadIOEffect, RootEffect].} =
   ## Connects socket to `address`:`port`. `Address` can be an IP address or a
   ## host name. If `address` is a host name, this function will try each IP
   ## of that host name. `htons` is already performed on `port` so you must
@@ -2080,7 +2094,7 @@ proc connectAsync(socket: Socket, name: string, port = Port(0),
   if not success: raiseOSError(lastError)
 
 proc connect*(socket: Socket, address: string, port = Port(0),
-    timeout: int) {.tags: [ReadIOEffect, WriteIOEffect].} =
+    timeout: int) {.tags: [ReadIOEffect, WriteIOEffect, RootEffect].} =
   ## Connects to server as specified by `address` on port specified by `port`.
   ##
   ## The `timeout` parameter specifies the time in milliseconds to allow for

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -547,7 +547,7 @@ proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
 
 when defineSsl:
   # OpenSSL >= 1.1.0 does not need explicit init.
-  when not opensslNoInit:
+  when not useOpenssl3:
     CRYPTO_malloc_init()
     doAssert SslLibraryInit() == 1
     SSL_load_error_strings()

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -546,20 +546,18 @@ proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
   fromSockAddrAux(cast[ptr Sockaddr_storage](unsafeAddr sa), sl, address, port)
 
 when defineSsl:
-  # OpenSSL >= 1.1.0 does not need explicit init.
-  when not useOpenssl3:
-    CRYPTO_malloc_init()
-    doAssert SslLibraryInit() == 1
-    SSL_load_error_strings()
-    ERR_load_BIO_strings()
-    OpenSSL_add_all_algorithms()
+  CRYPTO_malloc_init()
+  doAssert SslLibraryInit() == 1
+  SSL_load_error_strings()
+  ERR_load_BIO_strings()
+  OpenSSL_add_all_algorithms()
 
   proc sslHandle*(self: Socket): SslPtr =
     ## Retrieve the ssl pointer of `socket`.
     ## Useful for interfacing with `openssl`.
     self.sslHandle
 
-  proc raiseSSLError*(s = "") {.raises: [SslError].}=
+  proc raiseSSLError*(s = "") =
     ## Raises a new SSL error.
     if s != "":
       raise newException(SslError, s)
@@ -624,7 +622,9 @@ when defineSsl:
                    caDir = "", caFile = ""): SslContext =
     ## Creates an SSL context.
     ##
-    ## protVersion is currently unsed.
+    ## Protocol version specifies the protocol to use. SSLv2, SSLv3, TLSv1
+    ## are available with the addition of `protSSLv23` which allows for
+    ## compatibility with all of them.
     ##
     ## There are three options for verify mode:
     ## `CVerifyNone`: certificates are not verified;
@@ -651,12 +651,16 @@ when defineSsl:
     ## or using ECDSA:
     ## - `openssl ecparam -out mykey.pem -name secp256k1 -genkey`
     ## - `openssl req -new -key mykey.pem -x509 -nodes -days 365 -out mycert.pem`
-    let mtd = TLS_method()
-    if mtd == nil:
-      raiseSSLError("Failed to create TLS context")
-    var newCTX = SSL_CTX_new(mtd)
-    if newCTX == nil:
-      raiseSSLError("Failed to create TLS context")
+    var newCTX: SslCtx
+    case protVersion
+    of protSSLv23:
+      newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
+    of protSSLv2:
+      raiseSSLError("SSLv2 is no longer secure and has been deprecated, use protSSLv23")
+    of protSSLv3:
+      raiseSSLError("SSLv3 is no longer secure and has been deprecated, use protSSLv23")
+    of protTLSv1:
+      newCTX = SSL_CTX_new(TLSv1_method())
 
     if newCTX.SSL_CTX_set_cipher_list(cipherList) != 1:
       raiseSSLError()
@@ -815,28 +819,24 @@ when defineSsl:
     if SSL_set_fd(socket.sslHandle, socket.fd) != 1:
       raiseSSLError()
 
-  proc checkCertName(socket: Socket, hostname: string) {.raises: [SslError], tags:[RootEffect].} =
+  proc checkCertName(socket: Socket, hostname: string) =
     ## Check if the certificate Subject Alternative Name (SAN) or Subject CommonName (CN) matches hostname.
     ## Wildcards match only in the left-most label.
     ## When name starts with a dot it will be matched by a certificate valid for any subdomain
     when not defined(nimDisableCertificateValidation) and not defined(windows):
       assert socket.isSsl
-      try:
-        let certificate = socket.sslHandle.SSL_get_peer_certificate()
-        if certificate.isNil:
-          raiseSSLError("No SSL certificate found.")
+      let certificate = socket.sslHandle.SSL_get_peer_certificate()
+      if certificate.isNil:
+        raiseSSLError("No SSL certificate found.")
 
-        const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = 0x1.cuint
-        # https://www.openssl.org/docs/man1.1.1/man3/X509_check_host.html
-        let match = certificate.X509_check_host(hostname.cstring, hostname.len.cint,
-          X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, nil)
-        # https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_certificate.html
-        X509_free(certificate)
-        if match != 1:
-          raiseSSLError("SSL Certificate check failed.")
-
-      except LibraryError:
-        raiseSSLError("SSL import failed")
+      const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = 0x1.cuint
+      # https://www.openssl.org/docs/man1.1.1/man3/X509_check_host.html
+      let match = certificate.X509_check_host(hostname.cstring, hostname.len.cint,
+        X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, nil)
+      # https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_certificate.html
+      X509_free(certificate)
+      if match != 1:
+        raiseSSLError("SSL Certificate check failed.")
 
   proc wrapConnectedSocket*(ctx: SslContext, socket: Socket,
                             handshake: SslHandshakeType,
@@ -863,7 +863,6 @@ when defineSsl:
       let ret = SSL_connect(socket.sslHandle)
       socketError(socket, ret)
       when not defined(nimDisableCertificateValidation) and not defined(windows):
-        # FIXME: this should be skipped on CVerifyNone
         if hostname.len > 0 and not isIpAddress(hostname):
           socket.checkCertName(hostname)
     of handshakeAsServer:
@@ -1319,7 +1318,7 @@ when defined(nimdoc) or (defined(posix) and not useNimNetLite):
           (sizeof(socketAddr.sun_family) + path.len).SockLen) != 0'i32:
         raiseOSError(osLastError())
 
-when defineSsl:
+when defined(ssl):
   proc gotHandshake*(socket: Socket): bool =
     ## Determines whether a handshake has occurred between a client (`socket`)
     ## and the server that `socket` is connected to.
@@ -2006,7 +2005,7 @@ proc dial*(address: string, port: Port,
     raise newException(IOError, "Couldn't resolve address: " & address)
 
 proc connect*(socket: Socket, address: string,
-    port = Port(0)) {.tags: [ReadIOEffect, RootEffect].} =
+    port = Port(0)) {.tags: [ReadIOEffect].} =
   ## Connects socket to `address`:`port`. `Address` can be an IP address or a
   ## host name. If `address` is a host name, this function will try each IP
   ## of that host name. `htons` is already performed on `port` so you must
@@ -2081,7 +2080,7 @@ proc connectAsync(socket: Socket, name: string, port = Port(0),
   if not success: raiseOSError(lastError)
 
 proc connect*(socket: Socket, address: string, port = Port(0),
-    timeout: int) {.tags: [ReadIOEffect, WriteIOEffect, RootEffect].} =
+    timeout: int) {.tags: [ReadIOEffect, WriteIOEffect].} =
   ## Connects to server as specified by `address` on port specified by `port`.
   ##
   ## The `timeout` parameter specifies the time in milliseconds to allow for

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -44,11 +44,7 @@ const useWinVersion = defined(windows) or defined(nimdoc)
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
-const useOpenssl3 {.booldefine, used.} = sslVersion.startsWith('3')
-const opensslNoInit* {.booldefine.} = useOpenssl3
-  ## Do not attempt to call openssl init functions.
-  ## 
-  ## True if openssl 3 is set. Otherwise set with `-d:opensslNoInit`.
+const useOpenssl3* {.booldefine, used.} = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -295,6 +291,8 @@ when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
 
     proc getOpenSSLVersion*(): culong =
       SSLeay()
+
+    proc ERR_load_BIO_strings*() {.cdecl, dynlib: DLLUtilName, importc.}
   else:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =
@@ -317,10 +315,13 @@ when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
       # Static linking against OpenSSL < 1.1.0 is not supported
       discard
 
+    proc ERR_load_BIO_strings*() =
+      discard
+
   when defined(libressl) or defined(openssl10):
     proc SSL_state(ssl: SslPtr): cint {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSL_in_init*(ssl: SslPtr): cint {.inline.} =
-      SSl_state(ssl) and SSL_ST_INIT
+      SSL_state(ssl) and SSL_ST_INIT
   else:
     proc SSL_in_init*(ssl: SslPtr): cint {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSL_CTX_set_ciphersuites*(ctx: SslCtx, str: cstring): cint {.cdecl, dynlib: DLLSSLName, importc.}
@@ -390,28 +391,25 @@ else:
     let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
     return method2Proc()
 
-  when opensslNoInit:
-    proc SSL_library_init*(): cint {.discardable.} =
-      result = 1
+  proc SSL_library_init*(): cint {.discardable.} =
+    ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
+    ## SSL_library_init
+    let newInitSym = sslSymNullable("OPENSSL_init_ssl")
+    if not newInitSym.isNil:
+      let newInitProc =
+        cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
+      return newInitProc(0, 0)
+    let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
+    if not olderProc.isNil: result = olderProc()
 
-    proc SSL_load_error_strings*() =
-      discard
-  else:
-    proc SSL_library_init*(): cint {.discardable.} =
-      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
-      ## SSL_library_init
-      let newInitSym = sslSymNullable("OPENSSL_init_ssl")
-      if not newInitSym.isNil:
-        let newInitProc =
-          cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
-        return newInitProc(0, 0)
-      let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
-      if not olderProc.isNil: result = olderProc()
+  proc SSL_load_error_strings*() =
+    # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
+    let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
+    if not theProc.isNil: theProc()
 
-    proc SSL_load_error_strings*() =
-      # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
-      let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
-      if not theProc.isNil: theProc()
+  proc ERR_load_BIO_strings*() =
+    let theProc = cast[proc() {.cdecl.}](utilModule().symNullable("ERR_load_BIO_strings"))
+    if not theProc.isNil: theProc()
 
   proc SSLv23_client_method*(): PSSL_METHOD =
     loadPSSLMethod("SSLv23_client_method", "TLS_client_method")
@@ -466,10 +464,6 @@ else:
     if theProc.isNil:
       theProc = cast[typeof(theProc)](sslSymThrows("SSL_CTX_set_ciphersuites"))
     theProc(ctx, str)
-
-proc ERR_load_BIO_strings*() =
-  let theProc = cast[proc() {.cdecl.}](utilModule().symNullable("ERR_load_BIO_strings"))
-  if not theProc.isNil: theProc()
 
 proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
@@ -577,8 +571,8 @@ proc i2d_X509*(cert: PX509): string =
 const
   useNimsAlloc = not defined(nimNoAllocForSSL) and not defined(gcDestructors)
 
-when not opensslNoInit and not useWinVersion and not defined(macosx) and
-    not defined(android) and useNimsAlloc:
+when not useWinVersion and not defined(macosx) and not defined(android) and
+    useNimsAlloc:
   proc CRYPTO_set_mem_functions(a,b,c: pointer) =
     let theProc = cast[proc(a,b,c: pointer) {.cdecl.}](utilModule().symNullable("CRYPTO_set_mem_functions"))
     if not theProc.isNil: theProc(a, b, c)

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -843,8 +843,8 @@ when not defined(nimDisableCertificateValidation) and not defined(windows):
       let methodSym = sslSymNullable("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
       if methodSym.isNil:
         raise newException(LibraryError, "Could not load SSL_get_peer_certificate or SSL_get1_peer_certificate")
-      let method2Proc = cast[proc(): PX509 {.cdecl, gcsafe, raises: [].}](methodSym)
-      return method2Proc()
+      let method2Proc = cast[proc(ssl: SslCtx): PX509 {.cdecl, gcsafe, raises: [].}](methodSym)
+      return method2Proc(ssl)
 
   proc X509_get_subject_name*(a: PX509): PX509_NAME{.cdecl, dynlib: DLLSSLName, importc.}
 

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -7,23 +7,20 @@
 #    distribution, for details about the copyright.
 #
 
-## OpenSSL wrapper. Supports OpenSSL >= 1.1.0 dynamically (as default) or statically linked
-## using `--dynlibOverride:ssl`.
+## OpenSSL support
 ##
-## To use openSSL 3, either set `-d:sslVersion=3` or `-d:useOpenssl3`.
+## When OpenSSL is dynamically linked, the wrapper provides partial forward and backward
+## compatibility for OpenSSL versions above and below 1.1.0
+##
+## OpenSSL can also be statically linked using `--dynlibOverride:ssl` for OpenSSL >= 1.1.0.
+## If you want to statically link against OpenSSL 1.0.x, you now have to
+## define the `openssl10` symbol via `-d:openssl10`.
 ##
 ## Build and test examples:
 ##
 ## .. code-block::
-##   ./bin/nim c -d:ssl -p:. -r tests/stdlib/tssl.nim
-##   ./bin/nim c -d:ssl --threads:on -p:. -r tests/stdlib/thttpclient_ssl.nim
 ##   ./bin/nim c -d:ssl -p:. -r tests/untestable/tssl.nim
 ##   ./bin/nim c -d:ssl -p:. --dynlibOverride:ssl --passl:-lcrypto --passl:-lssl -r tests/untestable/tssl.nim
-##   ./bin/nim r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:ssl -p:testament/lib --threads:on tests/untestable/thttpclient_ssl_remotenetwork.nim
-
-# https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html
-#
-from strutils import startsWith
 
 when defined(nimPreviewSlimSystem):
   import std/syncio
@@ -33,14 +30,13 @@ when defined(nimHasStyleChecks):
 
 const useWinVersion = defined(windows) or defined(nimdoc)
 
-# To force openSSL version use -d:sslVersion=1.2.3
+# To force openSSL version use -d:sslVersion=1.0.0
 # See: #10281, #10230
 # General issue:
 # Other dynamic libraries (like libpg) load different openSSL version then what nim loads.
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
-const useOpenssl3* {.booldefine.} = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -59,7 +55,7 @@ when sslVersion != "":
     from posix import SocketHandle
 
 elif useWinVersion:
-  when defined(nimOldDlls):
+  when defined(openssl10) or defined(nimOldDlls):
     when defined(cpu64):
       const
         DLLSSLName* = "(ssleay32|ssleay64).dll"
@@ -79,11 +75,10 @@ elif useWinVersion:
 
   from winlean import SocketHandle
 else:
-  # same list of versions but ordered differently?
   when defined(osx):
-    const versions = "(.3|.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+    const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
   else:
-    const versions = "(.3|.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
+    const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const
@@ -276,29 +271,40 @@ proc TLSv1_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 # and support SSLv3, TLSv1, TLSv1.1 and TLSv1.2
 # SSLv23_method(), SSLv23_server_method(), SSLv23_client_method() are removed in 1.1.0
 
-when compileOption("dynlibOverride", "ssl"):
+when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
   # Static linking
-  when not useOpenssl3:
+
+  when defined(openssl10):
+    proc SSL_library_init*(): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
+    proc SSL_load_error_strings*() {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSLv23_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSLeay(): culong {.cdecl, dynlib: DLLUtilName, importc.}
+
+    proc getOpenSSLVersion*(): culong =
+      SSLeay()
+  else:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =
       ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
       return OPENSSL_init_ssl(0.uint64, 0.uint8)
 
-  proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+    proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSLv23_method*(): PSSL_METHOD =
+      TLS_method()
 
-  proc OpenSSL_version_num(): culong {.cdecl, dynlib: DLLUtilName, importc.}
+    proc OpenSSL_version_num(): culong {.cdecl, dynlib: DLLUtilName, importc.}
 
-  proc getOpenSSLVersion*(): culong =
-    ## Return OpenSSL version as unsigned long
-    OpenSSL_version_num()
+    proc getOpenSSLVersion*(): culong =
+      ## Return OpenSSL version as unsigned long
+      OpenSSL_version_num()
 
-  proc SSL_load_error_strings*() =
-    ## Removed from OpenSSL 1.1.0
-    # This proc prevents breaking existing code calling SslLoadErrorStrings
-    # Static linking against OpenSSL < 1.1.0 is not supported
-    discard
+    proc SSL_load_error_strings*() =
+      ## Removed from OpenSSL 1.1.0
+      # This proc prevents breaking existing code calling SslLoadErrorStrings
+      # Static linking against OpenSSL < 1.1.0 is not supported
+      discard
 
-  when defined(libressl):
+  when defined(libressl) or defined(openssl10):
     proc SSL_state(ssl: SslPtr): cint {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSL_in_init*(ssl: SslPtr): cint {.inline.} =
       SSl_state(ssl) and SSL_ST_INIT
@@ -308,8 +314,12 @@ when compileOption("dynlibOverride", "ssl"):
 
   template OpenSSL_add_all_algorithms*() = discard
 
+  proc SSLv23_client_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+  proc SSLv2_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+  proc SSLv3_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+
 else:
-  # Here we're trying to stay compatible with openssl 1.1.*. Some
+  # Here we're trying to stay compatible with openssl 1.0.* and 1.1.*. Some
   # symbols are loaded dynamically and we don't use them if not found.
   proc thisModule(): LibHandle {.inline.} =
     var thisMod {.global.}: LibHandle
@@ -317,12 +327,9 @@ else:
 
     result = thisMod
 
-  proc sslModule(): LibHandle {.inline, raises: [LibraryError], tags:[RootEffect].} =
+  proc sslModule(): LibHandle {.inline.} =
     var sslMod {.global.}: LibHandle
-    try:
-      if sslMod.isNil: sslMod = loadLibPattern(DLLSSLName)
-    except:
-      raise newException(LibraryError, "Could not load SSL using " & DLLSSLName)
+    if sslMod.isNil: sslMod = loadLibPattern(DLLSSLName)
 
     result = sslMod
 
@@ -347,48 +354,62 @@ else:
       if result.isNil and alternativeName.len > 0:
         result = symAddr(thisDynlib, alternativeName)
 
-  proc sslSymNullable(name: string, alternativeName = ""): pointer {.raises: [LibraryError], tags:[RootEffect].} =
+  proc sslSymNullable(name: string, alternativeName = ""): pointer =
     sslModule().symNullable(name, alternativeName)
 
-  proc sslSymThrows(name: string, alternativeName = ""): pointer {.raises: [LibraryError].} =
+  proc sslSymThrows(name: string, alternativeName = ""): pointer =
     result = sslSymNullable(name, alternativeName)
     if result.isNil: raiseInvalidLibrary(name)
 
   proc utilSymNullable(name: string, alternativeName = ""): pointer =
     utilModule().symNullable(name, alternativeName)
 
-  proc loadPSSLMethod(method1, method2: string): PSSL_METHOD {.raises: [LibraryError], tags:[RootEffect].} =
+  proc loadPSSLMethod(method1, method2: string): PSSL_METHOD =
     ## Load <method1> from OpenSSL if available, otherwise <method2>
     ##
     let methodSym = sslSymNullable(method1, method2)
     if methodSym.isNil:
       raise newException(LibraryError, "Could not load " & method1 & " nor " & method2)
 
-    let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
+    let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe.}](methodSym)
     return method2Proc()
 
-  when not useOpenssl3:
-    proc SSL_library_init*(): cint {.discardable.} =
-      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
-      ## SSL_library_init
-      let newInitSym = sslSymNullable("OPENSSL_init_ssl")
-      if not newInitSym.isNil:
-        let newInitProc =
-          cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
-        return newInitProc(0, 0)
-      let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
-      if not olderProc.isNil: result = olderProc()
+  proc SSL_library_init*(): cint {.discardable.} =
+    ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
+    ## SSL_library_init
+    let newInitSym = sslSymNullable("OPENSSL_init_ssl")
+    if not newInitSym.isNil:
+      let newInitProc =
+        cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
+      return newInitProc(0, 0)
+    let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
+    if not olderProc.isNil: result = olderProc()
 
   proc SSL_load_error_strings*() =
     # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
     let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
     if not theProc.isNil: theProc()
 
+  proc SSLv23_client_method*(): PSSL_METHOD =
+    loadPSSLMethod("SSLv23_client_method", "TLS_client_method")
+
+  proc SSLv23_method*(): PSSL_METHOD =
+    loadPSSLMethod("SSLv23_method", "TLS_method")
+
+  proc SSLv2_method*(): PSSL_METHOD =
+    loadPSSLMethod("SSLv2_method", "TLS_method")
+
   proc SSLv3_method*(): PSSL_METHOD =
     loadPSSLMethod("SSLv3_method", "TLS_method")
 
   proc TLS_method*(): PSSL_METHOD =
     loadPSSLMethod("TLS_method", "SSLv23_method")
+
+  proc TLS_client_method*(): PSSL_METHOD =
+    loadPSSLMethod("TLS_client_method", "SSLv23_client_method")
+
+  proc TLS_server_method*(): PSSL_METHOD =
+    loadPSSLMethod("TLS_server_method", "SSLv23_server_method")
 
   proc OpenSSL_add_all_algorithms*() =
     # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
@@ -424,9 +445,6 @@ else:
     theProc(ctx, str)
 
 proc ERR_load_BIO_strings*(){.cdecl, dynlib: DLLUtilName, importc.}
-
-proc TLS_client_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
-
 
 proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
@@ -792,17 +810,8 @@ when defined(nimHasStyleChecks):
 # On old openSSL version some of these symbols are not available
 when not defined(nimDisableCertificateValidation) and not defined(windows):
 
-  # proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
-  #  loadPSSLMethod("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
-
-  when useOpenssl3:
-    proc SSL_get1_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc.}
-    proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
-      SSL_get1_peer_certificate(ssl)
-
-  else:
-    proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc.}
-
+  proc SSL_get_peer_certificate*(ssl: SslCtx): PX509{.cdecl, dynlib: DLLSSLName,
+      importc.}
 
   proc X509_get_subject_name*(a: PX509): PX509_NAME{.cdecl, dynlib: DLLSSLName, importc.}
 

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -7,20 +7,27 @@
 #    distribution, for details about the copyright.
 #
 
-## OpenSSL support
+## OpenSSL wrapper. Supports OpenSSL >= 1.1.0 dynamically (as default) or statically linked
+## using `--dynlibOverride:ssl`.
 ##
-## When OpenSSL is dynamically linked, the wrapper provides partial forward and backward
-## compatibility for OpenSSL versions above and below 1.1.0
-##
-## OpenSSL can also be statically linked using `--dynlibOverride:ssl` for OpenSSL >= 1.1.0.
-## If you want to statically link against OpenSSL 1.0.x, you now have to
-## define the `openssl10` symbol via `-d:openssl10`.
+## `-d:sslVersion=1.2.3` can be used to force an SSL version. 
+## This version must be included in the library name.
+## `-d:useOpenssl3` may be set for OpenSSL 3 instead.
+## 
+## There is also limited support for OpenSSL 1.0.x which may require `-d:openssl10`.
 ##
 ## Build and test examples:
 ##
 ## .. code-block::
+##   ./bin/nim c -d:ssl -p:. -r tests/stdlib/tssl.nim
+##   ./bin/nim c -d:ssl --threads:on -p:. -r tests/stdlib/thttpclient_ssl.nim
 ##   ./bin/nim c -d:ssl -p:. -r tests/untestable/tssl.nim
 ##   ./bin/nim c -d:ssl -p:. --dynlibOverride:ssl --passl:-lcrypto --passl:-lssl -r tests/untestable/tssl.nim
+##   ./bin/nim r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:ssl -p:testament/lib --threads:on tests/untestable/thttpclient_ssl_remotenetwork.nim
+
+# https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html
+#
+from strutils import startsWith
 
 when defined(nimPreviewSlimSystem):
   import std/syncio
@@ -30,13 +37,18 @@ when defined(nimHasStyleChecks):
 
 const useWinVersion = defined(windows) or defined(nimdoc)
 
-# To force openSSL version use -d:sslVersion=1.0.0
+# To force openSSL version use -d:sslVersion=1.2.3
 # See: #10281, #10230
 # General issue:
 # Other dynamic libraries (like libpg) load different openSSL version then what nim loads.
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
+const useOpenssl3 {.booldefine, used.} = sslVersion.startsWith('3')
+const opensslNoInit* {.booldefine.} = useOpenssl3
+  ## Do not attempt to call openssl init functions.
+  ## 
+  ## True if openssl 3 is set. Otherwise set with `-d:opensslNoInit`.
 when sslVersion != "":
   when defined(macosx):
     const
@@ -75,10 +87,11 @@ elif useWinVersion:
 
   from winlean import SocketHandle
 else:
+  # same list of versions but ordered differently?
   when defined(osx):
-    const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+    const versions = "(.3|.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
   else:
-    const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
+    const versions = "(.3|.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const
@@ -285,8 +298,8 @@ when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
   else:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =
-      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
-      return OPENSSL_init_ssl(0.uint64, 0.uint8)
+      ## Removed from OpenSSL 1.1.0
+      result = 1
 
     proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSLv23_method*(): PSSL_METHOD =
@@ -319,7 +332,7 @@ when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
   proc SSLv3_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
 
 else:
-  # Here we're trying to stay compatible with openssl 1.0.* and 1.1.*. Some
+  # Here we're trying to stay compatible between openssl versions. Some
   # symbols are loaded dynamically and we don't use them if not found.
   proc thisModule(): LibHandle {.inline.} =
     var thisMod {.global.}: LibHandle
@@ -327,9 +340,12 @@ else:
 
     result = thisMod
 
-  proc sslModule(): LibHandle {.inline.} =
+  proc sslModule(): LibHandle {.inline, raises: [LibraryError], tags:[RootEffect].} =
     var sslMod {.global.}: LibHandle
-    if sslMod.isNil: sslMod = loadLibPattern(DLLSSLName)
+    try:
+      if sslMod.isNil: sslMod = loadLibPattern(DLLSSLName)
+    except:
+      raise newException(LibraryError, "Could not load SSL using " & DLLSSLName)
 
     result = sslMod
 
@@ -354,41 +370,48 @@ else:
       if result.isNil and alternativeName.len > 0:
         result = symAddr(thisDynlib, alternativeName)
 
-  proc sslSymNullable(name: string, alternativeName = ""): pointer =
+  proc sslSymNullable(name: string, alternativeName = ""): pointer {.raises: [LibraryError], tags:[RootEffect].} =
     sslModule().symNullable(name, alternativeName)
 
-  proc sslSymThrows(name: string, alternativeName = ""): pointer =
+  proc sslSymThrows(name: string, alternativeName = ""): pointer {.raises: [LibraryError].} =
     result = sslSymNullable(name, alternativeName)
     if result.isNil: raiseInvalidLibrary(name)
 
   proc utilSymNullable(name: string, alternativeName = ""): pointer =
     utilModule().symNullable(name, alternativeName)
 
-  proc loadPSSLMethod(method1, method2: string): PSSL_METHOD =
+  proc loadPSSLMethod(method1, method2: string): PSSL_METHOD {.raises: [LibraryError], tags:[RootEffect].} =
     ## Load <method1> from OpenSSL if available, otherwise <method2>
     ##
     let methodSym = sslSymNullable(method1, method2)
     if methodSym.isNil:
       raise newException(LibraryError, "Could not load " & method1 & " nor " & method2)
 
-    let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe.}](methodSym)
+    let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
     return method2Proc()
 
-  proc SSL_library_init*(): cint {.discardable.} =
-    ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
-    ## SSL_library_init
-    let newInitSym = sslSymNullable("OPENSSL_init_ssl")
-    if not newInitSym.isNil:
-      let newInitProc =
-        cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
-      return newInitProc(0, 0)
-    let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
-    if not olderProc.isNil: result = olderProc()
+  when opensslNoInit:
+    proc SSL_library_init*(): cint {.discardable.} =
+      result = 1
 
-  proc SSL_load_error_strings*() =
-    # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
-    let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
-    if not theProc.isNil: theProc()
+    proc SSL_load_error_strings*() =
+      discard
+  else:
+    proc SSL_library_init*(): cint {.discardable.} =
+      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0 otherwise
+      ## SSL_library_init
+      let newInitSym = sslSymNullable("OPENSSL_init_ssl")
+      if not newInitSym.isNil:
+        let newInitProc =
+          cast[proc(opts: uint64, settings: uint8): cint {.cdecl.}](newInitSym)
+        return newInitProc(0, 0)
+      let olderProc = cast[proc(): cint {.cdecl.}](sslSymThrows("SSL_library_init"))
+      if not olderProc.isNil: result = olderProc()
+
+    proc SSL_load_error_strings*() =
+      # TODO: Are we ignoring this on purpose? SSL GitHub CI fails otherwise.
+      let theProc = cast[proc() {.cdecl.}](sslSymNullable("SSL_load_error_strings"))
+      if not theProc.isNil: theProc()
 
   proc SSLv23_client_method*(): PSSL_METHOD =
     loadPSSLMethod("SSLv23_client_method", "TLS_client_method")
@@ -444,7 +467,9 @@ else:
       theProc = cast[typeof(theProc)](sslSymThrows("SSL_CTX_set_ciphersuites"))
     theProc(ctx, str)
 
-proc ERR_load_BIO_strings*(){.cdecl, dynlib: DLLUtilName, importc.}
+proc ERR_load_BIO_strings*() =
+  let theProc = cast[proc() {.cdecl.}](utilModule().symNullable("ERR_load_BIO_strings"))
+  if not theProc.isNil: theProc()
 
 proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
@@ -552,9 +577,11 @@ proc i2d_X509*(cert: PX509): string =
 const
   useNimsAlloc = not defined(nimNoAllocForSSL) and not defined(gcDestructors)
 
-when not useWinVersion and not defined(macosx) and not defined(android) and useNimsAlloc:
-  proc CRYPTO_set_mem_functions(a,b,c: pointer){.cdecl,
-    dynlib: DLLUtilName, importc.}
+when not opensslNoInit and not useWinVersion and not defined(macosx) and
+    not defined(android) and useNimsAlloc:
+  proc CRYPTO_set_mem_functions(a,b,c: pointer) =
+    let theProc = cast[proc(a,b,c: pointer) {.cdecl.}](utilModule().symNullable("CRYPTO_set_mem_functions"))
+    if not theProc.isNil: theProc(a, b, c)
 
   proc allocWrapper(size: int): pointer {.cdecl.} = allocShared(size)
   proc reallocWrapper(p: pointer; newSize: int): pointer {.cdecl.} =
@@ -565,9 +592,11 @@ when not useWinVersion and not defined(macosx) and not defined(android) and useN
   proc deallocWrapper(p: pointer) {.cdecl.} =
     if p != nil: deallocShared(p)
 
-proc CRYPTO_malloc_init*() =
-  when not useWinVersion and not defined(macosx) and not defined(android) and useNimsAlloc:
+  proc CRYPTO_malloc_init*() =
     CRYPTO_set_mem_functions(allocWrapper, reallocWrapper, deallocWrapper)
+else:
+  proc CRYPTO_malloc_init*() =
+    discard
 
 proc SSL_CTX_ctrl*(ctx: SslCtx, cmd: cint, larg: clong, parg: pointer): clong{.
   cdecl, dynlib: DLLSSLName, importc.}
@@ -810,8 +839,19 @@ when defined(nimHasStyleChecks):
 # On old openSSL version some of these symbols are not available
 when not defined(nimDisableCertificateValidation) and not defined(windows):
 
-  proc SSL_get_peer_certificate*(ssl: SslCtx): PX509{.cdecl, dynlib: DLLSSLName,
-      importc.}
+  # SSL_get_peer_certificate removed in 3.0
+  # SSL_get1_peer_certificate added in 3.0
+  when useOpenssl3:
+    proc SSL_get1_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
+      SSL_get1_peer_certificate(ssl)
+  else:
+    proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 =
+      let methodSym = sslSymNullable("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
+      if methodSym.isNil:
+        raise newException(LibraryError, "Could not load SSL_get_peer_certificate or SSL_get1_peer_certificate")
+      let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
+      return method2Proc()
 
   proc X509_get_subject_name*(a: PX509): PX509_NAME{.cdecl, dynlib: DLLSSLName, importc.}
 

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -44,7 +44,7 @@ const useWinVersion = defined(windows) or defined(nimdoc)
 # Having two different openSSL loaded version causes a crash.
 # Use this compile time define to force the openSSL version that your other dynamic libraries want.
 const sslVersion {.strdefine.}: string = ""
-const useOpenssl3* {.booldefine, used.} = sslVersion.startsWith('3')
+const useOpenssl3* {.booldefine.} = sslVersion.startsWith('3')
 when sslVersion != "":
   when defined(macosx):
     const
@@ -296,8 +296,8 @@ when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
   else:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =
-      ## Removed from OpenSSL 1.1.0
-      result = 1
+      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
+      return OPENSSL_init_ssl(0.uint64, 0.uint8)
 
     proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSLv23_method*(): PSSL_METHOD =
@@ -571,8 +571,7 @@ proc i2d_X509*(cert: PX509): string =
 const
   useNimsAlloc = not defined(nimNoAllocForSSL) and not defined(gcDestructors)
 
-when not useWinVersion and not defined(macosx) and not defined(android) and
-    useNimsAlloc:
+when not useWinVersion and not defined(macosx) and not defined(android) and useNimsAlloc:
   proc CRYPTO_set_mem_functions(a,b,c: pointer) =
     let theProc = cast[proc(a,b,c: pointer) {.cdecl.}](utilModule().symNullable("CRYPTO_set_mem_functions"))
     if not theProc.isNil: theProc(a, b, c)

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -850,7 +850,7 @@ when not defined(nimDisableCertificateValidation) and not defined(windows):
       let methodSym = sslSymNullable("SSL_get_peer_certificate", "SSL_get1_peer_certificate")
       if methodSym.isNil:
         raise newException(LibraryError, "Could not load SSL_get_peer_certificate or SSL_get1_peer_certificate")
-      let method2Proc = cast[proc(): PSSL_METHOD {.cdecl, gcsafe, raises: [].}](methodSym)
+      let method2Proc = cast[proc(): PX509 {.cdecl, gcsafe, raises: [].}](methodSym)
       return method2Proc()
 
   proc X509_get_subject_name*(a: PX509): PX509_NAME{.cdecl, dynlib: DLLSSLName, importc.}


### PR DESCRIPTION
Followup to #19814, #20324, #20341.

Openssl 3 support no longer needs a define. Openssl 1.0 support is added back.

The first commit is a revert of those PRs to make the backport (#20669) easier.