### PR TITLE
[sugar] handle HiddenDeref in capture, error at CT if unsupported nnk

### DIFF
--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -99,7 +99,6 @@ template main() =
     block: # issue #20679
       # this should compile. Previously was broken as `var int` is an `nnkHiddenDeref`
       # which was not handled correctly
-      from sugar import capture
       proc function(data: var int) =
         capture data:
           discard

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -103,6 +103,29 @@ template main() =
         capture data:
           discard
 
+      proc functionS(data: var seq[int]) =
+        capture data:
+          discard
+
+      proc functionT[T](data: var T) =
+        capture data:
+          discard
+
+      block:
+        var x = 1.1
+        functionT(x)
+      block:
+        var x = "hello"
+        functionT(x)
+
+      type
+        Foo = ref object
+          x: int
+
+      block:
+        var f = Foo(x: 5)
+        functionT(f)
+
   block: # dup
     block dup_with_field:
       type

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -96,6 +96,14 @@ template main() =
         let foo = i + 1
         doAssert p() == foo
 
+    block: # issue #20679
+      # this should compile. Previously was broken as `var int` is an `nnkHiddenDeref`
+      # which was not handled correctly
+      from sugar import capture
+      proc function(data: var int) =
+        capture data:
+          discard
+
   block: # dup
     block dup_with_field:
       type


### PR DESCRIPTION
Instead of running into trouble of the `.strVal` access failing, it's better to error at CT.

Personally, I'd add the node kind that was encountered to the error message, but afaik we typically try to avoid "leaking" such implementation details to the user?

Fixes #20679.