### PR TITLE
Add fno-spell-checking for GCC/Clang

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -188,14 +188,14 @@ gcc.maxerrorsimpl = "-fmax-errors=3"
 
 @if macosx or freebsd or openbsd:
   cc = clang
-  gcc.options.always %= "-w ${gcc.maxerrorsimpl}"
-  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl} -fno-checking"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive -fno-checking"
 @elif windows:
-  gcc.options.always %= "-w ${gcc.maxerrorsimpl} -mno-ms-bitfields"
-  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive -mno-ms-bitfields"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl} -mno-ms-bitfields -fno-checking"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive -mno-ms-bitfields -fno-checking"
 @else:
-  gcc.options.always %= "-w ${gcc.maxerrorsimpl}"
-  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl} -fno-checking"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive -fno-checking"
 @end
 
 # Configuration for Objective-C compiler:
@@ -272,9 +272,10 @@ llvm_gcc.options.speed = "-O2"
 llvm_gcc.options.size = "-Os"
 
 # Configuration for the LLVM CLang compiler:
+# -fno-spell-checking disables CLI arg spell-checker in GCC and Clang, see `clang --help-hidden | grep spell`.
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-clang.options.always = "-w -ferror-limit=3"
+clang.options.always = "-w -ferror-limit=3 -fno-spell-checking"
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 


### PR DESCRIPTION
GCC and Clang have a built-in CLI arguments spell-checker enabled by default,
that runs some Levenshtein-distance suggestions before each compilation,
because it is meant to be run by humans on the CLI typing the arguments.

- Check it yourself runing `clang --help-hidden | grep spell`.
- Continuation of https://github.com/nim-lang/Nim/pull/20503 and https://github.com/nim-lang/Nim/pull/12454

```console
$ gcc -ffast-meth a.c
gcc: error: unrecognized command-line option ‘-ffast-meth’;  did you mean ‘-ffast-math’?
```
