### PR TITLE
[docs] add back discard as a way to do multiline comments, see #12352

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -257,6 +257,18 @@ Multiline documentation comments also exist and support nesting too:
     ]##
   ```
 
+You can also use the [discard statement](#statements-and-expressions-discard-statement) together with
+[triple quoted string literals](#lexical-analysis-triple-quoted-string-literals) to create multiline comments:
+
+  ```nim
+  discard """ You can have any Nim code text commented
+  out inside this with no indentation restrictions.
+        yes("May I ask a pointless question?") """
+  ```
+
+This was how multiline comments were done before version 0.13.0,
+and it is used to provide specifications to [testament](testament.html#writing-unitests) test framework.
+
 
 Identifiers & Keywords
 ----------------------


### PR DESCRIPTION
in https://github.com/nim-lang/Nim/pull/12352 (more than three years ago), I did my first PR to Nim repo with a very simple fix to the tutorial: removing mention of discard as a way to do multiline comments (too early for beginners).

Back then @planetis-m remarked correctly that I could have add this remark in the manual.

Sorry that I did not follow up promptly 🙃, but I ran for some reason in that old PR of my own and thought I could fix my own mistake.

Also noticed that manual will be mostly markdown for 2.0 (and I do not think this should be backported, since we should be almost there), nice!

I also added a link to testament, since as @Araq remarked back then, this syntax is indeed used there.

...and I think this text is now way longer than the fix. :) Have a nice day everyone!
