### PR TITLE
Add no-signed-zeros for GCC when build for Release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -119,7 +119,7 @@
   - Added `getIsoWeeksInYear` to return the number of weeks in a week-based year.
 - Added new modules which were part of `std/os`:
   - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
-  - Added `std/paths`, `std/dirs`, `std/files`, `std/symlinks` and `std/appdirs`. 
+  - Added `std/paths`, `std/dirs`, `std/files`, `std/symlinks` and `std/appdirs`.
 - Added `sep` parameter in `std/uri` to specify the query separator.
 - Added bindings to [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
   and [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
@@ -238,7 +238,8 @@
   related functions produced on the backend. This prevents conflicts with other Nim
   static libraries.
 
-- When compiling for Release the flag `-fno-math-errno` is used for GCC.
+- When compiling with `-d:release` the flag `-fno-math-errno` is used for GCC.
+- When compiling with `-d:danger`  the flag `-fno-signed-zeros` is used for GCC and Clang.
 
 
 ## Tool changes

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -349,3 +349,13 @@ tcc.options.always = "-w"
   clang.options.linker %= "${clang.options.linker} -s"
   clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
 @end
+
+
+# Options used for -d:danger
+# -fno-signed-zeros the -0.0 is replaced by 0.0
+@if danger:
+  gcc.options.speed       %= "-fno-signed-zeros"
+  gcc.cpp.options.speed   %= "-fno-signed-zeros"
+  clang.options.speed     %= "-fno-signed-zeros"
+  clang.cpp.options.speed %= "-fno-signed-zeros"
+@end


### PR DESCRIPTION
- Add `no-signed-zeros` when `-d:danger` (makes `-0.0` be `0.0` in the ASM).
- Continuation of https://github.com/nim-lang/Nim/pull/20503 and https://github.com/nim-lang/Nim/pull/12454
