### PR TITLE
fix #20148 implicit compile time conversion int to ranged float cause…

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -460,8 +460,11 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
           else: int(src.intVal != 0)
     of tyFloat..tyFloat64:
       dest.ensureKind(rkFloat)
-      case skipTypes(srctyp, abstractRange).kind
+      let srcKind = skipTypes(srctyp, abstractRange).kind
+      case srcKind
       of tyInt..tyInt64, tyUInt..tyUInt64, tyEnum, tyBool, tyChar:
+        dest.floatVal = toBiggestFloat(src.intVal)
+      elif src.kind == rkInt:
         dest.floatVal = toBiggestFloat(src.intVal)
       else:
         dest.floatVal = src.floatVal

--- a/tests/statictypes/t20148.nim
+++ b/tests/statictypes/t20148.nim
@@ -1,0 +1,8 @@
+type Percent = range[0.0 .. 1.0]
+# type Percent = float # using unlimited `float` works fine
+
+proc initColor*(alpha: Percent): bool =
+  echo alpha
+
+const moduleInstanceStyle = initColor(1)
+# let moduleInstanceStyle = initColor(1) # using runtime conversion works fine


### PR DESCRIPTION
…s compiler fatal error
fix #20148

it passed sigmatch and runs well at runtime, so I guess there's no extro semcheck needed, just do the conversion 