### PR TITLE
fixes #20699; object variants with void fields crash with ORC

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3242,9 +3242,11 @@ proc getNullValueAux(p: BProc; t: PType; obj, constOrNil: PNode,
           break
 
     let selectedBranch = caseObjDefaultBranch(obj, branch)
-    result.add "{"
     var countB = 0
     let b = lastSon(obj[selectedBranch])
+    if isEmptyType(b.typ): # the type of field is void
+      return
+    result.add "{"
     # designated initilization is the only way to init non first element of unions
     # branches are allowed to have no members (b.len == 0), in this case they don't need initializer
     if b.kind == nkRecList and b.len > 0:

--- a/tests/objects/tobjects_various.nim
+++ b/tests/objects/tobjects_various.nim
@@ -105,3 +105,20 @@ block t7244:
 
   proc test(foo: var Foo) = discard
   proc test(bar: var Bar) = test(Foo(bar))
+
+block: # bug #20699
+  type
+    Either[A,B] = object
+      case kind:bool
+      of false:
+        b: B
+      of true:
+        a: A
+
+    O = object of RootRef
+
+  proc oToEither(o:O):Either[O,void] =
+    Either[O,void](kind:true,a: o)
+
+  let x = oToEither(O())
+  doAssert typeof(x.a) is O


### PR DESCRIPTION
fixes nim-lang/Nim#20699

Different from refc, ORC initializes object variants. If an object variant has void fields, it will get a wrong initial value. In fact, it shouldn't be assigned with a default value since the void field is eliminated from types.

