### PR TITLE
allow deferred close of nil stream

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -180,8 +180,10 @@ proc close*(s: Stream) =
       
     block:
       let strm = newFileStream("amissingfile.txt")
+      # deferring works even if newFileStream fails
       defer: strm.close()
-      ## do something...
+      if not isNil(strm):
+        ## do something...
 
   if not isNil(s) and not isNil(s.closeImpl):
     s.closeImpl(s)

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -173,10 +173,18 @@ proc close*(s: Stream) =
   ## See also:
   ## * `flush proc <#flush,Stream>`_
   runnableExamples:
-    var strm = newStringStream("The first line\nthe second line\nthe third line")
-    ## do something...
-    strm.close()
-  if not isNil(s.closeImpl): s.closeImpl(s)
+    block:
+      let strm = newStringStream("The first line\nthe second line\nthe third line")
+      ## do something...
+      strm.close()
+      
+    block:
+      let strm = newFileStream("amissingfile.txt")
+      defer: strm.close()
+      ## do something...
+
+  if not isNil(s) and not isNil(s.closeImpl):
+    s.closeImpl(s)
 
 proc atEnd*(s: Stream): bool =
   ## Checks if more data can be read from `s`. Returns ``true`` if all data has

--- a/tests/stdlib/tstreams.nim
+++ b/tests/stdlib/tstreams.nim
@@ -50,6 +50,12 @@ block tstreams3:
       echo line
     s.close
 
+
+block:
+  let fs = newFileStream("amissingfile.txt")
+  defer: fs.close()
+  doAssert isNil(fs)
+
 # bug #12410
 
 var a = newStringStream "hehohihahuhyh"


### PR DESCRIPTION
Allows a [`defer`](https://nim-lang.github.io/Nim/manual.html#exception-handling-defer-statement) statement to close an opened stream, even if opening the stream failed.

Example:
https://github.com/nim-lang/Nim/blob/c51ab31f673493d8c8cf176ef658b9e05bbc0693/tests/stdlib/tstreams.nim#L55-L57