### PR TITLE
removes channels_builtin when enabling `nimPreviewSlimSystem`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@
   - `PInt32`, `PInt64`, `PFloat32`, `PFloat64`, aliases to
     `ptr int32`, `ptr int64`, `ptr float32`, `ptr float64`
 
+- Enabling `-d:nimPreviewSlimSystem` removes the import of `channels_builtin` in
+  in the `system` module.
+
 - The `gc:v2` option is removed.
 
 - The `mainmodule` and `m` options are removed.

--- a/doc/lib.md
+++ b/doc/lib.md
@@ -41,10 +41,6 @@ Automatic imports
   Basic Nim thread support. **Note:** This is part of the system module. Do not
   import it explicitly. Enabled with `--threads:on`:option:.
 
-* [channels_builtin](channels_builtin.html)
-  Nim message passing support for threads. **Note:** This is part of the
-  system module. Do not import it explicitly. Enabled with `--threads:on`:option:.
-
 
 Core
 ----

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -22,6 +22,9 @@ runnableExamples("-r:off"):
     if line.len > 0: echo line
   echo "exiting"
 
+when defined(nimPreviewSlimSystem):
+  import std/syncio
+
 when defined(windows):
   proc readLineFromStdin*(prompt: string): string {.
                           tags: [ReadIOEffect, WriteIOEffect].} =

--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -47,7 +47,6 @@ runnableExamples:
 ## See also
 ## ========
 ## * `lists module <lists.html>`_ for singly and doubly linked lists and rings
-## * `channels module <channels_builtin.html>`_ for inter-thread communication
 
 import std/private/since
 

--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -14,7 +14,6 @@
 ## See also
 ## ========
 ## * `threads module <threads.html>`_ for basic thread support
-## * `channels module <channels_builtin.html>`_ for message passing support
 ## * `locks module <locks.html>`_ for locks and condition variables
 ## * `asyncdispatch module <asyncdispatch.html>`_ for asynchronous IO
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2206,7 +2206,8 @@ when notJSnotNims and hasAlloc:
     include "system/repr"
 
 when notJSnotNims and hasThreadSupport and hostOS != "standalone":
-  include "system/channels_builtin"
+  when not defined(nimPreviewSlimSystem):
+    include "system/channels_builtin"
 
 
 when notJSnotNims and hostOS != "standalone":

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -137,10 +137,6 @@ niminst.md
 mm.md
 """.splitWhitespace().mapIt("doc" / it)
 
-  doc0 = """
-lib/system/channels_builtin.nim
-""".splitWhitespace() # ran by `nim doc0` instead of `nim doc`
-
   withoutIndex = """
 lib/wrappers/mysql.nim
 lib/wrappers/sqlite3.nim
@@ -185,7 +181,6 @@ when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
 
 proc getDocList(): seq[string] =
   var docIgnore: HashSet[string]
-  for a in doc0: docIgnore.incl a
   for a in withoutIndex: docIgnore.incl a
   for a in ignoredModules: docIgnore.incl a
 
@@ -260,16 +255,11 @@ proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
   let rst2html = getMd2html()
   var
-    commands = newSeq[string](rst2html.len + len(doc0) + len(doc) + withoutIndex.len)
+    commands = newSeq[string](rst2html.len + len(doc) + withoutIndex.len)
     i = 0
   let nim = findNim().quoteShell()
   for d in items(rst2html):
     commands[i] = nim & " md2html $# --git.url:$# -o:$# --index:on $#" %
-      [nimArgs, gitUrl,
-      destPath / changeFileExt(splitFile(d).name, "html"), d]
-    i.inc
-  for d in items(doc0):
-    commands[i] = nim & " doc0 $# --git.url:$# -o:$# --index:on $#" %
       [nimArgs, gitUrl,
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc


### PR DESCRIPTION
It is not worth making `channels_builtin` importable at the cost of exposing numerous functions in the system since it is less useful for ARC/ORC. https://github.com/nim-lang/Nim/issues/20526 will be addressed later by accepting `nimPreviewSlimSystem` for `koch doc`.