### PR TITLE
fix closure iter state table init type [backport]

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -1155,7 +1155,7 @@ proc newArrayType(g: ModuleGraph; n: int, t: PType; idgen: IdGenerator; owner: P
   result = newType(tyArray, nextTypeId(idgen), owner)
 
   let rng = newType(tyRange, nextTypeId(idgen), owner)
-  rng.n = newTree(nkRange, g.newIntLit(owner.info, 0), g.newIntLit(owner.info, n))
+  rng.n = newTree(nkRange, g.newIntLit(owner.info, 0), g.newIntLit(owner.info, n - 1))
   rng.rawAddSon(t)
 
   result.rawAddSon(rng)


### PR DESCRIPTION
It is a well-known fact that using closed intervals for ranges is logically, objectively and eternally wrong, as evidenced by this off-by-one.