### PR TITLE
fix sighashes for generic ref

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -185,7 +185,8 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
       hashType c, t[0], flags
   of tyRef, tyPtr, tyGenericBody, tyVar:
     c &= char(t.kind)
-    c.hashType t.lastSon, flags
+    if t.sons.len > 0:
+      c.hashType t.lastSon, flags
     if tfVarIsPtr in t.flags: c &= ".varisptr"
   of tyFromExpr:
     c &= char(t.kind)


### PR DESCRIPTION
the `hashType` issue in #12229 was never really fixed - it just stopped being called in that context