### PR TITLE
Export FileMode

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -98,6 +98,7 @@ import std/private/since
 
 when defined(nimPreviewSlimSystem):
   import std/syncio
+  export FileMode
 
 proc newEIO(msg: string): owned(ref IOError) =
   new(result)


### PR DESCRIPTION
Streams exposes FileMode in its public API but you need to import std/syncio? Seems a little clunky.