### PR TITLE
Improve dollar LineInfo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,7 @@
 - Undeprecated `os.isvalidfilename`.
 - `std/oids` now uses `int64` to store time internally (before it was int32).
 - `std/uri.Uri` dollar `$` improved, precalculates the `string` result length from the `Uri`.
+- `std/macros.LineInfo` dollar `$` improved, precalculates the `string` result length from the `LineInfo`.
 
 
 [//]: # "Additions:"

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -520,7 +520,16 @@ type
 proc `$`*(arg: LineInfo): string =
   ## Return a string representation in the form `filepath(line, column)`.
   # BUG: without `result = `, gives compile error
-  result = arg.filename & "(" & $arg.line & ", " & $arg.column & ")"
+  # ( "(".len + ", ".len + ")".len + "0".len + "0".len) == 6
+  result = newStringOfCap(6 + arg.filename.len)
+  result.add arg.filename
+  result.add '('
+  result.addInt arg.line   # 1 char at least.
+  result.add ','
+  result.add ' '
+  result.addInt arg.column # 1 char at least.
+  result.add ')'
+
 
 #proc lineinfo*(n: NimNode): LineInfo {.magic: "NLineInfo", noSideEffect.}
 #  ## returns the position the node appears in the original source file


### PR DESCRIPTION
- Improve dollar for `std/macros.LineInfo`.
- Continuation of https://github.com/nim-lang/Nim/pull/20672 and https://github.com/nim-lang/Nim/pull/20670
