### PR TITLE
Uri.isIpv6 exported

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,7 @@
 - Undeprecated `os.isvalidfilename`.
 - `std/oids` now uses `int64` to store time internally (before it was int32).
 - `std/uri.Uri` dollar `$` improved, precalculates the `string` result length from the `Uri`.
+- `std/uri.Uri.isIpv6` is now exported.
 
 
 [//]: # "Additions:"

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -50,7 +50,7 @@ type
     scheme*, username*, password*: string
     hostname*, port*, path*, query*, anchor*: string
     opaque*: bool
-    isIpv6: bool # not expose it for compatibility.
+    isIpv6*: bool
 
   UriParseError* = object of ValueError
 


### PR DESCRIPTION
- `std/uri.Uri.isIpv6` is now exported, was private.
