### PR TITLE
Fix #18079 Illegal storage access compiling call with nested ref/deref 

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -775,7 +775,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
     expr(p, e[0], d)
     if e[0].typ.skipTypes(abstractInstOwned).kind == tyRef:
       d.storage = OnHeap
-  else: 
+  else:
     var a: TLoc
     var typ = e[0].typ
     if typ.kind in {tyUserTypeClass, tyUserTypeClassInst} and typ.isResolvedUserTypeClass:

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1420,8 +1420,15 @@ proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
         else: internalError(p.config, n[0].info, "expr(nkBracketExpr, " & $kindOfIndexedExpr & ')')
     of nkObjDownConv:
       gen(p, n[0], r)
-    of nkHiddenDeref, nkDerefExpr:
+    of nkHiddenDeref:
       gen(p, n[0], r)
+    of nkDerefExpr:
+      var x = n[0]
+      if n.kind == nkHiddenAddr:
+        x = n[0][0]
+        if n.typ.skipTypes(abstractVar).kind != tyOpenArray:
+          x.typ = n.typ
+      gen(p, x, r)
     of nkHiddenAddr:
       gen(p, n[0], r)
     of nkConv:

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1420,7 +1420,7 @@ proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
         else: internalError(p.config, n[0].info, "expr(nkBracketExpr, " & $kindOfIndexedExpr & ')')
     of nkObjDownConv:
       gen(p, n[0], r)
-    of nkHiddenDeref:
+    of nkHiddenDeref, nkDerefExpr:
       gen(p, n[0], r)
     of nkHiddenAddr:
       gen(p, n[0], r)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -90,7 +90,11 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add newAsgnStmt(x, call)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  if x.kind in {nkHiddenDeref, nkDerefExpr}:
+  let kinds = if c.g.config.backend == backendCpp: 
+      {nkHiddenDeref} 
+    else: 
+      {nkDerefExpr, nkHiddenDeref}
+  if x.kind in kinds:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -90,7 +90,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add newAsgnStmt(x, call)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  if x.kind == nkHiddenDeref:
+  if x.kind in {nkHiddenDeref, nkDerefExpr}:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -90,11 +90,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add newAsgnStmt(x, call)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  let kinds = if c.g.config.backend == backendCpp: 
-      {nkHiddenDeref} 
-    else: 
-      {nkDerefExpr, nkHiddenDeref}
-  if x.kind in kinds:
+  if x.kind == nkHiddenDeref:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/tests/misc/t18079.nim
+++ b/tests/misc/t18079.nim
@@ -1,0 +1,11 @@
+type
+  Foo = object
+    y: int
+
+  Bar = object
+    x: Foo
+
+proc baz(state: var Bar):int = 
+  state.x.y = 2
+  state.x.y
+doAssert baz((ref Bar)(x: (new Foo)[])[]) == 2


### PR DESCRIPTION
after https://github.com/nim-lang/Nim/commit/58f79e7c3e1bfc227efaaf20f34593cb3fb3ddeb is cgen error ` error: ‘T3_’ is a pointer; did you mean to use ‘->’?
  169 |   T3_.x = (*colontmpD_);`

Fix #18079