### PR TITLE
fixes #20740; fixes pre-existing field visibility issues and removes `efSkipFieldVisibilityCheck`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1075,7 +1075,7 @@ const
                                       nfIsRef, nfIsPtr, nfPreventCg, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam,
                                       nfExecuteOnReload, nfLastRead,
-                                      nfFirstWrite}
+                                      nfFirstWrite, nfUseDefaultField}
   namePos* = 0
   patternPos* = 1    # empty except for term rewriting macros
   genericParamsPos* = 2

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -69,8 +69,7 @@ type
     efWantStmt, efAllowStmt, efDetermineType, efExplain,
     efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo, efNoSem2Check,
-    efNoUndeclared, efIsDotCall, efCannotBeDotCall,
-    efSkipFieldVisibilityCheck
+    efNoUndeclared, efIsDotCall, efCannotBeDotCall
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
 

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -76,8 +76,7 @@ proc semConstrField(c: PContext, flags: TExprFlags,
   let assignment = locateFieldInInitExpr(c, field, initExpr)
   if assignment != nil:
     if nfSem in assignment.flags: return assignment[1]
-    if nfUseDefaultField in assignment[1].flags or
-       efSkipFieldVisibilityCheck in flags:
+    if nfUseDefaultField in assignment[1].flags:
       discard
     elif not fieldVisible(c, field):
       localError(c.config, initExpr.info,
@@ -416,10 +415,7 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType 
   # field (if this is a case object, initialized fields in two different
   # branches will be reported as an error):
   var constrCtx = initConstrContext(t, result)
-  let (initResult, defaults) = if nfUseDefaultField in n.flags:
-        semConstructTypeAux(c, constrCtx, flags + {efSkipFieldVisibilityCheck})
-      else:
-        semConstructTypeAux(c, constrCtx, flags)
+  let (initResult, defaults) = semConstructTypeAux(c, constrCtx, flags)
   result[0].sons.add defaults
   var hasError = false # needed to split error detect/report for better msgs
 

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1810,7 +1810,9 @@ proc getNullValueAux(t: PType; obj: PNode, result: PNode; conf: ConfigRef; currP
   of nkSym:
     let field = newNodeI(nkExprColonExpr, result.info)
     field.add(obj)
-    field.add(getNullValue(obj.sym.typ, result.info, conf))
+    let value = getNullValue(obj.sym.typ, result.info, conf)
+    value.flags.incl nfUseDefaultField
+    field.add(value)
     result.add field
     doAssert obj.sym.position == currPosition
     inc currPosition

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -3,7 +3,7 @@ discard """
   targets: "c cpp js"
 """
 
-import std/[times, tables]
+import std/[times, tables, macros]
 
 type
   Guess = object
@@ -456,6 +456,26 @@ template main {.dirty.} =
 
       var d = default(Bar)
       doAssert d.t == 0
+
+    block: # bug #20740
+      block:
+        proc foo(x: static DateTime = Datetime()) =
+          discard
+
+        foo()
+
+      block:
+        macro foo(x: static DateTime) =
+          discard x
+
+        macro foo2: untyped =
+          var x = DateTime()
+
+          result = quote do:
+            foo(`x`)
+
+        foo2()
+
 
 static: main()
 main()


### PR DESCRIPTION
fixes #20740
ref https://github.com/nim-lang/Nim/issues/20695

Probably I will rename it to `nfSkipFieldVisibilityCheck` later.