### PR TITLE
revert #20719; relieve `std/assertions` of the `sysFatal` dep

### DIFF
--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -9,7 +9,8 @@
 
 ## This module implements assertion handling.
 
-import system/fatal
+when not declared(sysFatal):
+  include "system/fatal"
 
 import std/private/miscdollars
 # ---------------------------------------------------------------------------

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -9,9 +9,6 @@
 
 ## This module implements assertion handling.
 
-when not declared(sysFatal):
-  include "system/fatal"
-
 import std/private/miscdollars
 # ---------------------------------------------------------------------------
 # helpers
@@ -31,7 +28,7 @@ when not defined(nimHasSinkInference):
 
 proc raiseAssert*(msg: string) {.noinline, noreturn, nosinks.} =
   ## Raises an `AssertionDefect` with `msg`.
-  sysFatal(AssertionDefect, msg)
+  raise newException(AssertionDefect, msg)
 
 proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
   ## Raises an `AssertionDefect` with `msg`, but this is hidden

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1637,13 +1637,8 @@ when not defined(nimscript):
     ## for debug builds. Since it's usually used for debugging, this
     ## is proclaimed to have no IO effect!
 
-
-when defined(nimHasExceptionsQuery):
-  const gotoBasedExceptions = compileOption("exceptions", "goto")
-else:
-  const gotoBasedExceptions = false
-
-import system/fatal
+when not declared(sysFatal):
+  include "system/fatal"
 
 when not defined(nimscript):
   {.push stackTrace: off, profiler: off.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1651,6 +1651,12 @@ when not defined(nimscript):
 when defined(nimV2):
   include system/arc
 
+template newException*(exceptn: typedesc, message: string;
+                       parentException: ref Exception = nil): untyped =
+  ## Creates an exception object of type `exceptn` and sets its `msg` field
+  ## to `message`. Returns the new exception object.
+  (ref exceptn)(msg: message, parent: parentException)
+
 when not defined(nimPreviewSlimSystem):
   {.deprecated: "assertions is about to move out of system; use `-d:nimPreviewSlimSystem` and import `std/assertions`".}
   import std/assertions
@@ -1857,12 +1863,6 @@ proc debugEcho*(x: varargs[typed, `$`]) {.magic: "Echo", noSideEffect,
   ## `debugEcho` pretends to be free of side effects, so that it can be used
   ## for debugging routines marked as `noSideEffect
   ## <manual.html#pragmas-nosideeffect-pragma>`_.
-
-template newException*(exceptn: typedesc, message: string;
-                       parentException: ref Exception = nil): untyped =
-  ## Creates an exception object of type `exceptn` and sets its `msg` field
-  ## to `message`. Returns the new exception object.
-  (ref exceptn)(msg: message, parent: parentException)
 
 when hostOS == "standalone" and defined(nogc):
   proc nimToCStringConv(s: NimString): cstring {.compilerproc, inline.} =

--- a/lib/system/fatal.nim
+++ b/lib/system/fatal.nim
@@ -9,22 +9,27 @@
 
 {.push profiler: off.}
 
+when defined(nimHasExceptionsQuery):
+  const gotoBasedExceptions = compileOption("exceptions", "goto")
+else:
+  const gotoBasedExceptions = false
+
 when hostOS == "standalone":
   include "$projectpath/panicoverride"
 
-  func sysFatal*(exceptn: typedesc, message: string) {.inline.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline.} =
     panic(message)
 
-  func sysFatal*(exceptn: typedesc, message, arg: string) {.inline.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline.} =
     rawoutput(message)
     panic(arg)
 
 elif (defined(nimQuirky) or defined(nimPanics)) and not defined(nimscript):
-  import system/ansi_c
+  import ansi_c
 
   func name(t: typedesc): string {.magic: "TypeTrait".}
 
-  func sysFatal*(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
     when nimvm:
       # TODO when doAssertRaises works in CT, add a test for it
       raise (ref exceptn)(msg: message & arg)
@@ -41,14 +46,14 @@ elif (defined(nimQuirky) or defined(nimPanics)) and not defined(nimscript):
         cstderr.rawWrite buf
       quit 1
 
-  func sysFatal*(exceptn: typedesc, message: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
     sysFatal(exceptn, message, "")
 
 else:
-  func sysFatal*(exceptn: typedesc, message: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =
     raise (ref exceptn)(msg: message)
 
-  func sysFatal*(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
+  func sysFatal(exceptn: typedesc, message, arg: string) {.inline, noreturn.} =
     raise (ref exceptn)(msg: message & arg)
 
 {.pop.}

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -8,7 +8,7 @@ tassert_c.nim(35)        tassert_c
 tassert_c.nim(34)        foo
 assertions.nim(*)       failedAssertImpl
 assertions.nim(*)       raiseAssert
-fatal.nim(*)            sysFatal"""
+"""
 
 proc tmatch(x, p: string): bool =
   var i = 0

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -1,12 +1,13 @@
 discard """
-  errormsg: "unhandled exception:"
-  file: "system/fatal.nim"
+  errormsg: "unhandled exception: t9768.nim(24, 12) `a < 4`  [AssertionDefect]"
+  file: "std/assertions.nim"
   nimout: '''
 stack trace: (most recent call last)
-t9768.nim(28, 33)        main
-t9768.nim(23, 11)        foo1
+t9768.nim(29, 33)        main
+t9768.nim(24, 11)        foo1
 '''
 """
+
 
 
 


### PR DESCRIPTION
revert #20719

ref https://github.com/nim-lang/Nim/pull/20718/files#r1010607801

I'm not sure whether `import system/sysFatal` works and the leaking is just a flaky when investigating https://github.com/nim-lang/Nim/pull/20718 . Better safe than sorry. I revert that PR and relieve `std/assertions` of the sysFatal dep following [Nim/lib/std/syncio.nim](https://github.com/nim-lang/Nim/blob/59083e2e48bbf49daaa8d29e233c6f57f33a05ef/lib/std/syncio.nim#L154)  
```nim
template sysFatal(exc, msg) =
  raise newException(exc, msg)
```

For the record, the leak was and I can reproduce it on wsl2.

```
==99591== HEAP SUMMARY:
==99591==     in use at exit: 10 bytes in 1 blocks
==99591==   total heap usage: 32 allocs, 31 frees, 5,113 bytes allocated
==99591== 
==99591== 10 bytes in 1 blocks are definitely lost in loss record 1 of 1
==99591==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==99591==    by 0x10CE14: alloc0Impl__system_1765 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10CE42: allocShared0Impl__system_1778 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10F091: prepareAdd (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10F3F3: setLengthStrV2 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10ACD9: addChars__stdZprivateZdigitsutils_100 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10B31B: addIntImpl__stdZprivateZdigitsutils_59 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10B3C7: addInt__stdZprivateZdigitsutils_150 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10B637: addInt__stdZprivateZdigitsutils_153 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10C608: addInt__stdZprivateZdigitsutils_175 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x10C6A9: dollar___systemZdollars_8 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591==    by 0x111608: raiseFieldError2 (in /home/vsts/work/1/s/tests/arc/tcaseobj)
==99591== 
==99591== LEAK SUMMARY:
==99591==    definitely lost: 10 bytes in 1 blocks
==99591==    indirectly lost: 0 bytes in 0 blocks
==99591==      possibly lost: 0 bytes in 0 blocks
==99591==    still reachable: 0 bytes in 0 blocks
==99591==         suppressed: 0 bytes in 0 blocks
==99591== 
==99591== For lists of detected and suppressed errors, rerun with: -s
==99591== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```