### PR TITLE
Add basic fuzz

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -146,6 +146,7 @@
 - Added `openArray[char]` overloads for `std/parseutils` allowing more code reuse.
 - Added `openArray[char]` overloads for `std/unicode` allowing more code reuse.
 - Added `safe` parameter to `base64.encodeMime`.
+- Added basic fuzzing for unittests in `std/unittest`.
 
 [//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.


### PR DESCRIPTION
- This modules is for "boilerplate to make unit testing easy" as its documentation says, so I was wondering if we can have a basic string fuzz for unittests.
- Most of the code is actually `runnableExamples`. Works with cpp and js.
- I know llvm libfuzzer but thats huge and complicated and wont run in all targets whatsoever.
