### PR TITLE
Support doc comments in new-styled concepts

### DIFF
--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -61,6 +61,8 @@ proc semConceptDecl(c: PContext; n: PNode): PNode =
     for i in 0..<n.len-1:
       result[i] = n[i]
     result[^1] = semConceptDecl(c, n[^1])
+  of nkCommentStmt:
+    discard
   else:
     localError(c.config, n.info, "unexpected construct in the new-styled concept: " & renderTree(n))
     result = n

--- a/tests/concepts/t20237.nim
+++ b/tests/concepts/t20237.nim
@@ -1,0 +1,3 @@
+type Foo = concept
+  ## doc comment
+  proc foo(x: Self)


### PR DESCRIPTION
Fixes #20237.

This is just the suggested fix from #20237, I'm not sure if this is the right way to handle doc comments (I tried to figure out how `enum`/`object` handle doc comments, but didn't find anything).