### PR TITLE
revert #19891; `nimRawSetjmp` causes problems for mingw 32 bits too [backport]

### DIFF
--- a/config/config.nims
+++ b/config/config.nims
@@ -20,10 +20,5 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
-when defined(windows) and not defined(booting):
-  # Avoid some rare stack corruption while using exceptions with a SEH-enabled
-  # toolchain: https://github.com/nim-lang/Nim/pull/19197
-  switch("define", "nimRawSetjmp")
-
 switch("define", "nimVersion:" & NimVersion)
 


### PR DESCRIPTION
revert https://github.com/nim-lang/Nim/pull/19891
ref https://github.com/nim-lang/Nim/issues/19957


It causes regression on 1.6.8 for mingw 32-bit + clang (msvc) on Windows

I'm looking into it.

cc @Menduist 

> In parallel, we've been running nimbus with this flag enabled since it was merged without issues

It seems to cause problems for stew; ref https://github.com/status-im/nim-stew/issues/133

