### PR TITLE
fix arc global variable issues

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -490,7 +490,7 @@ proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
       res.add newTree(nkFastAsgn, v, genDefaultCall(v.typ, c, v.info))
   elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
-    if sfGlobal in v.sym.flags and s.parent == nil: #XXX: Rethink this logic (see tarcmisc.test2)
+    if sfGlobal in v.sym.flags: #XXX: Rethink this logic (see tarcmisc.test2)
       c.graph.globalDestructors.add c.genDestroy(v)
     else:
       s.final.add c.genDestroy(v)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -491,7 +491,10 @@ proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
   elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
     if sfGlobal in v.sym.flags: #XXX: Rethink this logic (see tarcmisc.test2)
-      c.graph.globalDestructors.add c.genDestroy(v)
+      if c.inLoop > 0:
+        s.final.add c.genDestroy(v)
+      else:
+        c.graph.globalDestructors.add c.genDestroy(v)
     else:
       s.final.add c.genDestroy(v)
 

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -124,7 +124,7 @@ proc test(count: int) =
 test(3)
 
 proc test2(count: int) =
-  #block: #XXX: Fails with block currently
+  block: #XXX: Fails with block currently
     var v {.global.} = newVariable(20)
 
     var count = count - 1


### PR DESCRIPTION
this fix minimal example in https://github.com/nim-lang/Nim/issues/15005#issuecomment-663320909

but not in https://github.com/nim-lang/Nim/issues/15005#issuecomment-717239441 since it use `once` that changes branch. solution is avoiding use that and delcare variable with initialization is fine.

this doesn't help https://github.com/nim-lang/Nim/issues/17552