### PR TITLE
fixes pre-existing `quit` documentation regression [backport]

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2258,6 +2258,9 @@ when defined(js):
 
 when defined(nimNoQuit):
   proc quit*(errorcode: int = QuitSuccess) = discard "ignoring quit"
+
+elif defined(nimdoc):
+  proc quit*(errorcode: int = QuitSuccess) {.magic: "Exit", noreturn.}
     ## Stops the program immediately with an exit code.
     ##
     ## Before stopping the program the "exit procedures" are called in the
@@ -2285,9 +2288,6 @@ when defined(nimNoQuit):
     ##   raised by an `addExitProc` proc, as well as cleanup code in other threads.
     ##   It does *not* call the garbage collector to free all the memory,
     ##   unless an `addExitProc` proc calls `GC_fullCollect <#GC_fullCollect>`_.
-
-elif defined(nimdoc):
-  proc quit*(errorcode: int = QuitSuccess) {.magic: "Exit", noreturn.}
 
 elif defined(genode):
   proc quit*(errorcode: int = QuitSuccess) {.inline, noreturn.} =


### PR DESCRIPTION
It is a regression caused by https://github.com/nim-lang/Nim/commit/ce44cf03cc4a78741c423b2b3963b48b6d9e6755

Before:
![image](https://user-images.githubusercontent.com/43030857/200118109-3f70110a-8ade-49dd-9ce0-100d3cb65591.png)

After:
![image](https://user-images.githubusercontent.com/43030857/200118134-cfbc42c3-28c1-4f10-96f9-e91eb0efa112.png)
