### PR TITLE
Export trace member of exception type to allow custom stack trace entries

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -493,9 +493,9 @@ type
                                         ## providing an exception message
                                         ## is bad style.
     when defined(js):
-      trace: string
+      trace*: string
     else:
-      trace: seq[StackTraceEntry]
+      trace*: seq[StackTraceEntry]
     up: ref Exception # used for stacking exceptions. Not exported!
 
   Defect* = object of Exception ## \


### PR DESCRIPTION
Add the proc insertStackTraceEntry() to allow code to insert custom stack trace entries in an exception.

My particular use case is providing a better user experience for NPeg, but this can be of value for any code that adds flow control on top of the Nim language.

For the NPeg use case: when an exception is raised during the parsing of an grammar, the stack trace is augmented with the call stack frames of the NPeg parser virtual machine, giving the user a nice overview of where in the grammar the exception happened. 

The resulting stack trace looks something like this: the last 5 entries in the trace are added by Npeg and refer to the grammar rules in which the exception happened:

```
/home/ico/sandbox/prjs/npeg/main.nim(30) main
/home/ico/sandbox/prjs/npeg/main.nim(27) flap
/home/ico/sandbox/prjs/npeg/src/npeg.nim(135) match
/home/ico/sandbox/prjs/npeg/src/npeg/patt.nim(90) fn`gensym46
/home/ico/sandbox/prjs/npeg/src/npeg/patt.nim(90) fn
/home/ico/sandbox/prjs/npeg/main.nim(11) nodes <- *(node * (' ' | !1))
/home/ico/sandbox/prjs/npeg/main.nim(12) node <- extraWord | word
/home/ico/sandbox/prjs/npeg/main.nim(13) extraWord <- word * extra * dash
/home/ico/sandbox/prjs/npeg/main.nim(19) extra <- number | dot
/home/ico/sandbox/prjs/npeg/main.nim(20) number <- +Digit
```