### PR TITLE
Use same defaults as JS for fetch options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -118,7 +118,7 @@
 
 
 - `std/net.IpAddress` dollar `$` improved, uses a fixed capacity for the `string` result based from the `IpAddressFamily`.
-
+- `std/jsfetch.newFetchOptions` now has default values for all parameters
 
 [//]: # "Additions:"
 - Added ISO 8601 week date utilities in `times`:

--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -84,9 +84,9 @@ proc unsafeNewFetchOptions*(metod, body, mode, credentials, cache, referrerPolic
     "{method: #, body: #, mode: #, credentials: #, cache: #, referrerPolicy: #, keepalive: #, redirect: #, referrer: #, integrity: #, headers: #}".}
   ## .. warning:: Unsafe `newfetchOptions`.
 
-func newfetchOptions*(metod: HttpMethod; body: cstring;
-    mode: FetchModes; credentials: FetchCredentials; cache: FetchCaches; referrerPolicy: FetchReferrerPolicies;
-    keepalive: bool; redirect = frFollow; referrer = "client".cstring; integrity = "".cstring,
+func newfetchOptions*(metod = HttpGet; body: cstring = nil;
+    mode = fmCors; credentials = fcSameOrigin; cache = fchDefault; referrerPolicy = frpNoReferrerWhenDowngrade;
+    keepalive = false; redirect = frFollow; referrer = "client".cstring; integrity = "".cstring,
     headers: Headers = newHeaders()): FetchOptions =
   ## Constructor for `FetchOptions`.
   result = FetchOptions(


### PR DESCRIPTION
Uses default values for all parameters. Parameter positions have stayed the same so shouldn't break existing code

Values are mostly from [Mozilla's docs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options) with a few from [javascript.info](https://javascript.info/fetch-api)

Means fetch options work similar to how they normally work in JS where you only provide the options you need e.g. Why should I care about cache when I'm just trying to make  POST request with a body? 