### PR TITLE
Add `scope` template to `sugar` module

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -416,3 +416,38 @@ macro collect*(body: untyped): untyped {.since: (1, 5).} =
     assert m == {0: "bird", 1: "word"}.toTable
 
   result = collectImpl(nil, body)
+
+proc neverhappens {.noreturn, inline.} =
+  discard
+
+template scope*(body): untyped =
+  ## Can be used instead of `block` to introduce a new scoped block of code,
+  ## without influencing any `break` statements in the code.
+  ##
+  ## .. warning:: An invocation of `scope` is parsed slightly different than a
+  ##    `block`. For instance if you add parentheses `(scope: ...)` the compiler
+  ##    will try to parse a named tuple instead of a scoped block.
+  runnableExamples:
+
+    # introduce a new scope for variables:
+    let x = 42
+    scope:
+      let x = "some string"
+      assert x == "some string" # x is a string in the inner scope
+    assert x == 42 # x is an integer in the outer scope
+
+    # a scope can have a resulting value:
+    let xy = scope:
+      let x = "x"
+      let y = "y"
+      x & y
+    assert xy == "xy"
+
+  if true:
+    body
+  else:
+    # add a discard statement to work around a compiler bug in the unit test:
+    discard
+    # call {.noreturn.} proc here to ensure that the compiler uses `body` for
+    # the result value of the if-statement:
+    neverhappens()

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -209,6 +209,19 @@ template main() =
         discard collect(newSeq, for i in 1..3: i)
       foo()
 
+  block: # scope
+    let x = 42
+    scope:
+      let x = "some string"
+      doAssert x == "some string"
+    doAssert x == 42
+
+    let xy = scope:
+      let x = "x"
+      let y = "y"
+      x & y
+    doAssert xy == "xy"
+
 proc mainProc() =
   block: # dump
     # symbols in templates are gensym'd


### PR DESCRIPTION
Adds a `scope` template that can be used instead of a `block`. Because `block`s have the side-effect of influencing `break` statements, they are not always suitable for introducing a scoped block, especially in templates and macros. See this [RFC](https://github.com/nim-lang/RFCs/issues/451) for a more thorough discussion.

This PR introduces a `scope` template as [suggested by Araq](https://github.com/nim-lang/RFCs/issues/451#issuecomment-1062576542). It also takes into account the case where a scoped block has a resulting value.

Examples:

```nim
# introduce a new scope for variables:
let x = 42
scope:
  let x = "some string"
  assert x == "some string" # x is a string in the inner scope
assert x == 42 # x is an integer in the outer scope

# a scope can have a resulting value:
let xy = scope:
  let x = "x"
  let y = "y"
  x & y
assert xy == "xy"
```

I'd like to get some feedback on this implementation, especially on the `{.noreturn.}` trick in the `else` part. If there's a better way to achieve a `block` like construct without influencing `break` statements then I'd love to hear about it.

Also, I'm a bit puzzled by the need of having an additional `discard` statement in the else part. If I omit it, then the test will fail because it seems that a part of the `x & y` expression from the test is ignored by the compiler?