### PR TITLE
fixes nightlies regression; patches for freebsd

### DIFF
--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -366,6 +366,18 @@ when hasSpawnH:
     Tposix_spawn_file_actions* {.importc: "posix_spawn_file_actions_t",
                                  header: "<spawn.h>", final, pure.} = object
 
+
+when not defined(macos) and not defined(macosx): # freebsd
+  type
+    Mqd* {.importc: "mqd_t", header: "<mqueue.h>", final, pure.} = object
+    MqAttr* {.importc: "struct mq_attr",
+              header: "<mqueue.h>",
+              final, pure.} = object ## message queue attribute
+      mq_flags*: int   ## Message queue flags.
+      mq_maxmsg*: int  ## Maximum number of messages.
+      mq_msgsize*: int ## Maximum message size.
+      mq_curmsgs*: int ## Number of messages currently queued.
+
 when defined(linux):
   # from sys/un.h
   const Sockaddr_un_path_length* = 108


### PR DESCRIPTION
followup https://github.com/nim-lang/Nim/pull/20710
ref https://github.com/nim-lang/nightlies/actions/runs/3415378685

```
2022-11-07T00:57:37.4252251Z nim compile -f --symbolfiles:off --compileonly --gen_mapping --cc:gcc --skipUserCfg --os:freebsd --cpu:amd64 -d:danger -d:gitHash:a228e331f30def00d4369d4e792c7454963d8c4e compiler/nim.nim
/home/runner/work/nightlies/nightlies/nim/lib/posix/posix.nim(253, 26) Error: undeclared identifier: 'Mqd'
```