### PR TITLE
fix #16003 js: ref object assignment silently gives wrong results

### DIFF
--- a/tests/js/t16003.nim
+++ b/tests/js/t16003.nim
@@ -1,0 +1,10 @@
+
+type
+  Node = ref object
+    val: int
+proc bar(c: Node): var int =
+  var n = c
+  n.val
+var a = Node(val: 3)
+a.bar() = 5
+doAssert a.val == 5 # fails, got 3


### PR DESCRIPTION
fix #16003