### PR TITLE
issue a warning for ptr to cstring conversion[backport]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -96,6 +96,10 @@
 - The `gorge`/`staticExec` calls will now return a descriptive message in the output
   if the execution fails for whatever reason. To get back legacy behaviour use `-d:nimLegacyGorgeErrors`.
 
+- Pointer to `cstring` conversion now triggers a `[PtrToCstringConv]` warning.
+  This warning will become an error in future versions! Use a `cast` operation
+  like `cast[cstring](x)` instead.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -80,6 +80,7 @@ type
     warnAnyEnumConv = "AnyEnumConv",
     warnHoleEnumConv = "HoleEnumConv",
     warnCstringConv = "CStringConv",
+    warnPtrToCstringConv = "PtrToCstringConv",
     warnEffect = "Effect",
     warnCastSizes = "CastSizes"
     warnTemplateRedefinition = "TemplateRedefinition",
@@ -176,6 +177,7 @@ const
     warnAnyEnumConv: "$1",
     warnHoleEnumConv: "$1",
     warnCstringConv: "$1",
+    warnPtrToCstringConv: "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
     warnEffect: "$1",
     warnCastSizes: "$1",
     warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding an explicit .redefine pragma",

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1238,6 +1238,11 @@ proc track(tracked: PEffects, n: PNode) =
       message(tracked.config, n.info, warnCstringConv,
         "implicit conversion to 'cstring' from a non-const location: $1; this will become a compile time error in the future" %
           $n[1])
+    if n.typ.skipTypes(abstractInst).kind == tyCstring and
+        isCharArrayPtr(n[1].typ, true):
+      message(tracked.config, n.info, warnPtrToCstringConv,
+          $n[1].typ)
+
 
     let t = n.typ.skipTypes(abstractInst)
     if t.kind == tyEnum:


### PR DESCRIPTION
Both implicit and explicit (?) conversion will be warned since it is an unsafe conversion. Unsafe features should probably be restricted to `cast` family.

ref https://github.com/nim-lang/Nim/pull/20761


here is the warning

```
Warning: unsafe conversion to 'cstring' from 'ptr char'; this will become a compile time error in the future [PtrToCstringConv]
```