### PR TITLE
Allow users to set log flushing rules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -100,6 +100,8 @@
   This warning will become an error in future versions! Use a `cast` operation
   like `cast[cstring](x)` instead.
 
+- `logging` will default to flushing all log level messages. To get the legacy behaviour of only flushing Error and Fatal messages, use `-d:nimV1LogFlushBehavior`.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"
@@ -119,7 +121,7 @@
 - `std/oids` now uses `int64` to store time internally (before it was int32).
 - `std/uri.Uri` dollar `$` improved, precalculates the `string` result length from the `Uri`.
 - `std/uri.Uri.isIpv6` is now exported.
-- `std/logging.ConsoleLogger` and `FileLogger` now have a `flushThreshold` attribute to set what log message levels are automatically flushed. Use `-d:nimFlushAllLogs` to automatically flush all message levels.
+- `std/logging.ConsoleLogger` and `FileLogger` now have a `flushThreshold` attribute to set what log message levels are automatically flushed. For Nim v1 use `-d:nimFlushAllLogs` to automatically flush all message levels. Flushing all logs is the default behavior for Nim v2.
 
 
 - `std/net.IpAddress` dollar `$` improved, uses a fixed capacity for the `string` result based from the `IpAddressFamily`.

--- a/changelog.md
+++ b/changelog.md
@@ -119,6 +119,7 @@
 - `std/oids` now uses `int64` to store time internally (before it was int32).
 - `std/uri.Uri` dollar `$` improved, precalculates the `string` result length from the `Uri`.
 - `std/uri.Uri.isIpv6` is now exported.
+- `std/logging.ConsoleLogger` and `FileLogger` now have a `flushThreshold` attribute to set what log message levels are automatically flushed. Use `-d:nimFlushAllLogs` to automatically flush all message levels.
 
 
 - `std/net.IpAddress` dollar `$` improved, uses a fixed capacity for the `string` result based from the `IpAddressFamily`.

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -199,6 +199,12 @@ const
   ## If a different format string is preferred, refer to the
   ## `documentation about format strings<#basic-usage-format-strings>`_
   ## for more information, including a list of available variables.
+  defaultFlushThreshold = when defined(nimFlushAllLogs): lvlAll else: lvlError
+  ## The threshold above which log messages to file-like loggers
+  ## are automatically flushed.
+  ## 
+  ## By default, only error and fatal messages are logged,
+  ## but defining ``-d:nimFlushAllLogs`` will make all levels be flushed
 
 type
   Logger* = ref object of RootObj
@@ -388,7 +394,7 @@ method log*(logger: ConsoleLogger, level: Level, args: varargs[string, `$`]) =
         discard
 
 proc newConsoleLogger*(levelThreshold = lvlAll, fmtStr = defaultFmtStr,
-    useStderr = false, flushThreshold = lvlError): ConsoleLogger =
+    useStderr = false, flushThreshold = defaultFlushThreshold): ConsoleLogger =
   ## Creates a new `ConsoleLogger<#ConsoleLogger>`_.
   ##
   ## By default, log messages are written to ``stdout``. If ``useStderr`` is
@@ -459,7 +465,7 @@ when not defined(js):
   proc newFileLogger*(file: File,
                       levelThreshold = lvlAll,
                       fmtStr = defaultFmtStr,
-                      flushThreshold = lvlError): FileLogger =
+                      flushThreshold = defaultFlushThreshold): FileLogger =
     ## Creates a new `FileLogger<#FileLogger>`_ that uses the given file handle.
     ##
     ## **Note:** This proc is not available for the JavaScript backend.
@@ -491,7 +497,7 @@ when not defined(js):
                       levelThreshold = lvlAll,
                       fmtStr = defaultFmtStr,
                       bufSize: int = -1,
-                      flushThreshold = lvlError): FileLogger =
+                      flushThreshold = defaultFlushThreshold): FileLogger =
     ## Creates a new `FileLogger<#FileLogger>`_ that logs to a file with the
     ## given filename.
     ##
@@ -548,7 +554,7 @@ when not defined(js):
                             fmtStr = defaultFmtStr,
                             maxLines: Positive = 1000,
                             bufSize: int = -1,
-                            flushThreshold = lvlError): RollingFileLogger =
+                            flushThreshold = defaultFlushThreshold): RollingFileLogger =
     ## Creates a new `RollingFileLogger<#RollingFileLogger>`_.
     ##
     ## Once the current log file being written to contains ``maxLines`` lines,

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -199,7 +199,10 @@ const
   ## If a different format string is preferred, refer to the
   ## `documentation about format strings<#basic-usage-format-strings>`_
   ## for more information, including a list of available variables.
-  defaultFlushThreshold = when defined(nimFlushAllLogs): lvlAll else: lvlError
+  defaultFlushThreshold = when NimMajor >= 2:
+      when defined(nimV1LogFlushBehavior): lvlError else: lvlAll
+    else:
+      when defined(nimFlushAllLogs): lvlAll else: lvlError
   ## The threshold above which log messages to file-like loggers
   ## are automatically flushed.
   ## 

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -265,8 +265,6 @@ when not defined(js):
       baseMode: FileMode # initial file mode
       logFiles: int # how many log files already created, e.g. basename.1, basename.2...
       bufSize: int # size of output buffer (-1: use system defaults, 0: unbuffered, >0: fixed buffer size)
-      flushThreshold*: Level ## Only messages that are at or above this
-                           ## threshold will be flushed immediately
 
 var
   level {.threadvar.}: Level          ## global log filter


### PR DESCRIPTION
Currently, only `lvlError` and `lvlFatal` log messages are flushed to console and file loggers. I keep forgetting this is the case and spend too much time trying to figure out why my logging isn't working. I'd like the default behavior to eventually be "log all levels."

But to maintain backward compatibility, I propose this PR, which still only flushes Error and Fatal (well, and `lvlNone` -- and I don't know the ramifications of that), but also lets us change the behavior either globally by compiling with:

```
-d:nimFlushAllLogs
```

Or when creating loggers like this:

```nim
newConsoleLogger(flushThreshold=lvlAll)
newFileLogger("somefile.log", flushThreshold=lvlAll)
```

Maybe in Nim v2 `-d:nimFlushAllLogs` could be the default and we could add `-d:nimV1FlushLogLevel`?  If this is agreeable, I'll change this PR to include:

```nim
defaultFlushThreshold = when NimMajor >= 2:
      when defined(nimV1FlushLogLevel): lvlError else: lvlAll
    else:
      when defined(nimFlushAllLogs): lvlAll else: lvlError
```