### PR TITLE
allow string literal for path `/` join

### DIFF
--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -50,6 +50,13 @@ func `/`*(head: Path, tail: Path | static[string]): Path {.inline.} =
   ## * `splitPath proc`_
   ## * `uri.combine proc <uri.html#combine,Uri,Uri>`_
   ## * `uri./ proc <uri.html#/,Uri,string>`_
+  runnableExamples:
+    assert Path"/foo" / Path"bar" == Path"/foo/bar"
+    assert Path"/foo" / "bar" == Path"/foo/bar"
+    assert Path"foo" / "bar" == Path"foo/bar"
+    assert Path"foo" / "bar/" == Path"foo/bar/"
+    assert Path"foo/" / "bar/" == Path"foo/bar/"
+
   Path(joinPath(head.string, tail.string))
 
 func splitPath*(path: Path): tuple[head, tail: Path] {.inline.} =

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -39,7 +39,7 @@ func add(x: var string, tail: string) =
 
 func add*(x: var Path, y: Path) {.borrow.}
 
-func `/`*(head, tail: Path): Path {.inline.} =
+func `/`*(head: Path, tail: Path | static[string]): Path {.inline.} =
   ## Joins two directory names to one.
   ##
   ## returns normalized path concatenation of `head` and `tail`, preserving

--- a/tests/stdlib/tpaths.nim
+++ b/tests/stdlib/tpaths.nim
@@ -24,6 +24,15 @@ func joinPath*(parts: varargs[Path]): Path =
 func joinPath(head, tail: Path): Path {.inline.} =
   head / tail
 
+block literalJoinPath:
+  doAssert Path"foo" / "bar" / "baz" == Path"foo/bar/baz"
+  doAssert Path"/foo" / "bar" / "baz" == Path"/foo/bar/baz"
+  doAssert Path"foo" / "bar/" == Path"foo/bar/"
+  doAssert Path"/foo" / "//" == Path"/foo/"
+
+  const bar = "bar"
+  doAssert Path"/foo" / bar == Path"/foo/bar"
+
 block absolutePath:
   doAssertRaises(ValueError): discard absolutePath(Path"a", Path"b")
   doAssert absolutePath(Path"a") == getCurrentDir() / Path"a"


### PR DESCRIPTION
- resolves nim-lang/RFCs#490

additionally allow constant time evaluating string for path joining