### PR TITLE
chore: wider nim cache name detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@
 !*.*
 
 # Cache
-nimcache/
-rnimcache/
-dnimcache/
+nimcache*/
+rnimcache*/
+dnimcache*/
 
 *.o
 !/icons/*.o


### PR DESCRIPTION
## Summary
ignores directories such as nimcache19445
![image](https://user-images.githubusercontent.com/54838975/201475379-596bd0c7-9e8e-41e5-8928-1c77c8efa210.png)
