### PR TITLE
fixes flaky CI with channels and ORC

### DIFF
--- a/tests/threads/ttryrecv.nim
+++ b/tests/threads/ttryrecv.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc"
   outputsub: "channel is empty"
 """
 


### PR DESCRIPTION
channels doesn't seem to work well with arc/orc

```nim
Traceback (most recent call last)
ttryrecv.nim(35)         ttryrecv
channels_builtin.nim(451) close
channels_builtin.nim(176) deinitRawChannel
alloc.nim(1051)          dealloc
alloc.nim(935)           rawDealloc
alloc.nim(550)           listRemove
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```