### PR TITLE
fixes a CI error

### DIFF
--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -64,7 +64,7 @@ when defined(nimTrunnerFfi):
 hello world stderr
 hi stderr
 """
-    let output = runNimCmdChk("vm/mevalffi.nim", fmt"{opt} --experimental:compiletimeFFI")
+    let output = runNimCmdChk("vm/mevalffi.nim", fmt"{opt} --warnings:off --experimental:compiletimeFFI")
     doAssert output == fmt"""
 {prefix}foo
 foo:100


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/20832

Another issue is caused by vm which doesn't support cast `ptr char` to `cstring`. It can be achieved in the following PRs.