### PR TITLE
fixes a long-standing ARC bug

### DIFF
--- a/compiler/aliasanalysis.nim
+++ b/compiler/aliasanalysis.nim
@@ -63,6 +63,8 @@ proc aliases*(obj, field: PNode): AliasKind =
   # x.f -> x: false
   # x.f -> x.f: true
   # x.f -> x.v: false
+  # x -> x[]: true
+  # x[] -> x: false
   # x -> x[0]: true
   # x[0] -> x: false
   # x[0] -> x[0]: true
@@ -76,11 +78,11 @@ proc aliases*(obj, field: PNode): AliasKind =
     var n = n
     while true:
       case n.kind
-      of PathKinds0 - {nkDotExpr, nkBracketExpr}:
+      of PathKinds0 - {nkDotExpr, nkBracketExpr, nkDerefExpr, nkHiddenDeref}:
         n = n[0]
       of PathKinds1:
         n = n[1]
-      of nkDotExpr, nkBracketExpr:
+      of nkDotExpr, nkBracketExpr, nkDerefExpr, nkHiddenDeref:
         result.add n
         n = n[0]
       of nkSym:
@@ -114,6 +116,8 @@ proc aliases*(obj, field: PNode): AliasKind =
       if currFieldPath.sym != currObjPath.sym: return no
     of nkDotExpr:
       if currFieldPath[1].sym != currObjPath[1].sym: return no
+    of nkDerefExpr, nkHiddenDeref:
+      discard
     of nkBracketExpr:
       if currFieldPath[1].kind in nkLiterals and currObjPath[1].kind in nkLiterals:
         if currFieldPath[1].intVal != currObjPath[1].intVal:

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -546,3 +546,15 @@ proc fooz(sec: var InputSectionBase) =
 var sec = create(InputSection)
 sec[] = InputSection(relocations: newSeq[int]())
 fooz sec[]
+
+block:
+  type
+    Data = ref object
+      id: int
+  proc main =
+    var x = Data(id: 99)
+    var y = x
+    x[] = Data(id: 778)[]
+    doAssert y.id == 778
+    doAssert x[].id == 778
+  main()


### PR DESCRIPTION
```nim
type
  Data = ref object
    id: int
proc main =
  var x = Data(id: 99)
  var y = x
  x[] = Data()[]
  echo y[]
  echo x[]
main()
```
gives `SIGSEGV: Illegal storage access. (Attempt to read from nil?)`

Imo, `x[]` should be thought of as a partial write so we cannot sink x.