### PR TITLE
Make float match better than float32 for integer literals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -103,7 +103,7 @@
 - `logging` will default to flushing all log level messages. To get the legacy behaviour of only flushing Error and Fatal messages, use `-d:nimV1LogFlushBehavior`.
 
 - Object fields now support default values, see https://nim-lang.github.io/Nim/manual.html#types-default-values-for-object-fields for details.
-- 
+- Integer literals now match `float` better than `float32`.
 
 ## Standard library additions and changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -103,6 +103,7 @@
 - `logging` will default to flushing all log level messages. To get the legacy behaviour of only flushing Error and Fatal messages, use `-d:nimV1LogFlushBehavior`.
 
 - Object fields now support default values, see https://nim-lang.github.io/Nim/manual.html#types-default-values-for-object-fields for details.
+- 
 
 ## Standard library additions and changes
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -31,6 +31,7 @@ type
 
   TTypeRelation* = enum      # order is important!
     isNone, isConvertible,
+    isCrossLitConv,
     isIntConv,
     isSubtype,
     isSubrange,              # subrange of the wanted type; no type conversion

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2621,8 +2621,10 @@ of the argument.
 4. Subrange or subtype match: `a` is a `range[T]` and `T`
    matches `f` exactly. Or: `a` is a subtype of `f`.
 5. Integral conversion match: `a` is convertible to `f` and `f` and `a`
-   is some integer or floating-point type.
-6. Conversion match: `a` is convertible to `f`, possibly via a user
+   are both integer types or both floating-point types, excluding `float32`.
+6. Literal conversion match: `a` is an integer literal and `f` is
+   a floating-point type, excluding `float32`.
+7. Conversion match: `a` is convertible to `f`, possibly via a user
    defined `converter`.
 
 These matching categories have a priority: An exact match is better than a
@@ -2636,7 +2638,8 @@ algorithm returns true:
   ```nim
   for each matching category m in ["exact match", "literal match",
                                   "generic match", "subtype match",
-                                  "integral match", "conversion match"]:
+                                  "integral match", "literal conversion match",
+                                  "conversion match"]:
     if count(p, m) > count(q, m): return true
     elif count(p, m) == count(q, m):
       discard "continue with next category m"

--- a/tests/typerel/tfloat32lit.nim
+++ b/tests/typerel/tfloat32lit.nim
@@ -1,0 +1,8 @@
+block:
+  proc foo(x: float): string = "float"
+  proc foo(x: float32): string = "float32"
+
+  doAssert foo(1.0) == "float"
+  doAssert foo(1.0'f32) == "float32"
+  # issue #17201
+  doAssert foo(1) == "float"


### PR DESCRIPTION
This is suggested in #17201:

> The literal-to-typed conversion should be able to figure out if 2 should be float64 or float32 when being passed.

This PR is to show how this could be implemented, but I'm not sure if it's worth it. If not this can be closed as wontfix, otherwise can unmark as draft.