### PR TITLE
fix 'a means' to 'a mean' in tut1.md

### DIFF
--- a/doc/tut1.md
+++ b/doc/tut1.md
@@ -1446,7 +1446,7 @@ Varargs
 -------
 
 A `varargs` parameter is like an openarray parameter. However, it is
-also a means to implement passing a variable number of
+also a mean to implement passing a variable number of
 arguments to a procedure. The compiler converts the list of arguments
 to an array automatically:
 


### PR DESCRIPTION
Here might be wrong:

> A `varargs` parameter is like an openarray parameter. However, it is also a means to implement passing a variable number of arguments to a procedure.

I've just changed it to 'a mean' :)