### PR TITLE
remove useless defines

### DIFF
--- a/lib/wrappers/postgres.nim
+++ b/lib/wrappers/postgres.nim
@@ -216,10 +216,6 @@ proc pqclientEncoding*(conn: PPGconn): int32{.cdecl, dynlib: dllName,
     importc: "PQclientEncoding".}
 proc pqsetClientEncoding*(conn: PPGconn, encoding: cstring): int32{.cdecl,
     dynlib: dllName, importc: "PQsetClientEncoding".}
-when defined(USE_SSL):
-  # Get the SSL structure associated with a connection
-  proc pqgetssl*(conn: PPGconn): PSSL{.cdecl, dynlib: dllName,
-                                       importc: "PQgetssl".}
 proc pqsetErrorVerbosity*(conn: PPGconn, verbosity: PGVerbosity): PGVerbosity{.
     cdecl, dynlib: dllName, importc: "PQsetErrorVerbosity".}
 proc pqtrace*(conn: PPGconn, debug_port: File){.cdecl, dynlib: dllName,


### PR DESCRIPTION
`PSSL` is not actually defined, if users happen to compile its program with `-d:USE_SSL`, it will break the program.

`nim c -d:USE_SSL`

```
lib\wrappers\postgres.nim(221, 34) Error: undeclared identifier: 'PSSL'
```

I would like to document every define in a single place using runnableExamples.
