### PR TITLE
render post expr blocks better

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1008,7 +1008,7 @@ const postExprBlocks = {nkStmtList, nkStmtListExpr,
 
 proc postStatements(g: var TSrcGen, n: PNode, i: int, fromStmtList: bool) =
   var i = i
-  if n[i].kind == nkStmtList:
+  if n[i].kind in {nkStmtList, nkStmtListExpr}:
     if fromStmtList:
       put(g, tkColon, ":")
     else:
@@ -1020,7 +1020,7 @@ proc postStatements(g: var TSrcGen, n: PNode, i: int, fromStmtList: bool) =
   for j in i ..< n.len:
     if n[j].kind == nkDo:
       optNL(g)
-    elif n[j].kind == nkStmtList:
+    elif n[j].kind in {nkStmtList, nkStmtListExpr}:
       optNL(g)
       put(g, tkDo, "do")
       put(g, tkColon, ":")

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -5,7 +5,7 @@ discard """
 
 # if excessive, could remove 'cpp' from targets
 
-from strutils import startsWith, endsWith, contains, strip
+from strutils import endsWith, contains, strip
 from std/macros import newLit
 import std/assertions
 

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -5,7 +5,7 @@ discard """
 
 # if excessive, could remove 'cpp' from targets
 
-from strutils import endsWith, contains, strip
+from strutils import startsWith, endsWith, contains, strip
 from std/macros import newLit
 import std/assertions
 
@@ -270,6 +270,57 @@ func fn1(): int =
 func fn2(): int =
   ## comment
   result = 1"""
+
+  block: # block calls
+    let a = deb:
+      foo(a, b, (c, d)):
+        e
+        f
+      do: g
+      of h: i
+      elif j: k
+      except m: n
+      do () -> u: v
+      finally: o
+
+      a + b:
+        c
+        d
+      do:
+        e
+        f
+      else: g
+
+      *a: b
+      do: c
+    
+    doAssert a == """foo(a, b, (c, d)):
+  e
+  f
+do:
+  g
+of h:
+  i
+elif j:
+  k
+except m:
+  n
+do -> u:
+  v
+finally:
+  o
+a + b:
+  c
+  d
+do:
+  e
+  f
+else:
+  g
+*a:
+  b
+do:
+  c"""
 
 static: main()
 main()


### PR DESCRIPTION
refs #17292 "bug 5"

Original issue mentions `*a: b` but there is a common use of this syntax in the form of `--define:abc`. With this patch this is correctly rendered. Also multiple post expr blocks of different kinds are supported.

Originally part of #20071, StmtListExpr with semicolons in that PR is not included.