### PR TITLE
alternative to #20864; fixes #20026; cancel optimizations for public procs in the system

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -14,7 +14,8 @@ proc canRaiseDisp(p: BProc; n: PNode): bool =
   if n.kind == nkSym and {sfNeverRaises, sfImportc, sfCompilerProc} * n.sym.flags != {}:
     result = false
   elif optPanics in p.config.globalOptions or
-      (n.kind == nkSym and sfSystemModule in getModule(n.sym).flags):
+      (n.kind == nkSym and sfSystemModule in getModule(n.sym).flags and
+       (sfExported notin n.sym.flags or n.sym.magic != mNone)):
     # we know we can be strict:
     result = canRaise(n)
   else:

--- a/tests/stdlib/tstring.nim
+++ b/tests/stdlib/tstring.nim
@@ -1,5 +1,4 @@
 discard """
-  matrix: "--mm:refc"
   targets: "c cpp js"
 """
 
@@ -69,7 +68,7 @@ proc main() =
       discard
     else:
       # bug #6223
-      doAssertRaises(IndexDefect):
+      doAssertRaises(IndexDefect): # bug #20026
         discard s[0..999]
 
   block: # ==, cmp


### PR DESCRIPTION
fixes #20026

alternative to #20864

better safe than sorry.