### PR TITLE
echo: only lock when threading is enabled

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2716,7 +2716,8 @@ when notJSnotNims:
     initSysLock echoLock
     addSysExitProc(proc() {.noconv.} = deinitSys(echoLock))
 
-  const stdOutLock = not defined(windows) and
+  const stdOutLock = compileOption("threads") and
+                    not defined(windows) and
                     not defined(android) and
                     not defined(nintendoswitch) and
                     not defined(freertos) and


### PR DESCRIPTION
I think that's correct, and beside being a bit cheaper, it also enables handle weird targets where `flockfile` is not available (for instance wasi)