### PR TITLE
Add addInt

### DIFF
--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -38,8 +38,7 @@ func add(x: var string, tail: string) =
   normalizePathEnd(x, trailingSep=trailingSep)
 
 func add*(x: var Path, y: Path) {.borrow.}
-func addInt*(x: var Path, y: int) {.borrow.}          # Path("/folder").addInt 42
-# func addFloat*(x: var Path, y: SomeFloat) {.borrow.}  # Path("/version").addFloat 2.0
+func addInt*(x: var Path, y: int) {.borrow.}  # Path("/folder").addInt 42
 
 func `/`*(head, tail: Path): Path {.inline.} =
   ## Joins two directory names to one.

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -39,7 +39,7 @@ func add(x: var string, tail: string) =
 
 func add*(x: var Path, y: Path) {.borrow.}
 func addInt*(x: var Path, y: int) {.borrow.}          # Path("/folder").addInt 42
-func addFloat*(x: var Path, y: SomeFloat) {.borrow.}  # Path("/version").addFloat 2.0
+# func addFloat*(x: var Path, y: SomeFloat) {.borrow.}  # Path("/version").addFloat 2.0
 
 func `/`*(head, tail: Path): Path {.inline.} =
   ## Joins two directory names to one.

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -38,6 +38,8 @@ func add(x: var string, tail: string) =
   normalizePathEnd(x, trailingSep=trailingSep)
 
 func add*(x: var Path, y: Path) {.borrow.}
+func addInt*(x: var Path, y: int) {.borrow.}                # Path("/folder").addInt 42
+func addFloat*(x: var Path, y: float | float32) {.borrow.}  # Path("/version").addFloat 2.0
 
 func `/`*(head, tail: Path): Path {.inline.} =
   ## Joins two directory names to one.

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -38,8 +38,8 @@ func add(x: var string, tail: string) =
   normalizePathEnd(x, trailingSep=trailingSep)
 
 func add*(x: var Path, y: Path) {.borrow.}
-func addInt*(x: var Path, y: int) {.borrow.}                # Path("/folder").addInt 42
-func addFloat*(x: var Path, y: float | float32) {.borrow.}  # Path("/version").addFloat 2.0
+func addInt*(x: var Path, y: int) {.borrow.}          # Path("/folder").addInt 42
+func addFloat*(x: var Path, y: SomeFloat) {.borrow.}  # Path("/version").addFloat 2.0
 
 func `/`*(head, tail: Path): Path {.inline.} =
   ## Joins two directory names to one.


### PR DESCRIPTION
- Allow `Path.addInt`. 
- Useful when you have to do `Path"/folder".addInt 42`.
