### PR TITLE
add a testcase for vcc

### DIFF
--- a/tests/misc/tvcc.nim
+++ b/tests/misc/tvcc.nim
@@ -1,0 +1,9 @@
+discard """
+  matrix: "--cc:vcc"
+  disabled: "linux"
+  disabled: "bsd"
+  disabled: "osx"
+  disabled: "unix"
+  disabled: "posix"
+"""
+doAssert true


### PR DESCRIPTION
As expected:

```
2022-11-25T04:24:53.8117234Z ..\..\lib\system\alloc.nim(773, 19) template/generic instantiation of `atomicPrepend` from here
2022-11-25T04:24:53.8252191Z ..\..\lib\system\alloc.nim(764, 18) template/generic instantiation of `storea` from here
2022-11-25T04:24:53.8293285Z ..\..\lib\system\alloc.nim(146, 36) Error: undeclared identifier: 'atomicStoreN'
```
