### PR TITLE
fixes #20914; fixes the alignment of big sets

### DIFF
--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -319,10 +319,10 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
         typ.align = int16(conf.floatInt64Align)
       elif align(length, 8) mod 8 == 0:
         typ.size = align(length, 8) div 8
-        typ.align = int16(conf.floatInt64Align)
+        typ.align = 1
       else:
         typ.size = align(length, 8) div 8 + 1
-        typ.align = int16(conf.floatInt64Align)
+        typ.align = 1
   of tyRange:
     computeSizeAlign(conf, typ[0])
     typ.size = typ[0].size

--- a/tests/misc/tsizeof3.nim
+++ b/tests/misc/tsizeof3.nim
@@ -49,3 +49,10 @@ block: # bug #20914
     var s: GoodboySave
     doAssert sizeof(s) == 108
     doAssert csizeof(s) == static(sizeof(s))
+
+  block:
+    proc calignof[T](a: T): int {.importc:"alignof", header: "<stdalign.h>".}
+
+    var s: set[0..256]
+    doAssert alignof(s) == 1
+    doAssert calignof(s) == static(alignof(s))

--- a/tests/misc/tsizeof3.nim
+++ b/tests/misc/tsizeof3.nim
@@ -27,3 +27,25 @@ type
 
 static:
   doAssert(compiles(offsetOf(Payload, vals)))
+
+
+type
+  GoodboySave* {.bycopy.} = object
+    saveCount: uint8
+    savePoint: uint16
+    shards: uint32
+    friendCount: uint8
+    friendCards: set[0..255]
+    locationsKnown: set[0..127]
+    locationsUnlocked: set[0..127]
+    pickupsObtained: set[0..127]
+    pickupsUsed: set[0..127]
+    pickupCount: uint8
+
+block: # bug #20914
+  block:
+    proc csizeof[T](a: T): int {.importc:"sizeof", nodecl.}
+
+    var s: GoodboySave
+    doAssert sizeof(s) == 108
+    doAssert csizeof(s) == static(sizeof(s))


### PR DESCRIPTION
fixes #20914

The set of which the length exceeds 64 stores elements in a char array which should use align of 1.