### PR TITLE
fix issue #20922 by handling missing expr in `exprList` for `tkOf`

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -435,9 +435,12 @@ proc exprList(p: var Parser, endTok: TokType, result: PNode) =
   #| exprList = expr ^+ comma
   when defined(nimpretty):
     inc p.em.doIndentMore
+  let startTok = p.tok.tokType
   getTok(p)
   optInd(p, result)
   # progress guaranteed
+  if startTok == tkOf and p.tok.tokType == endTok:
+    parMessage(p, "an 'of' branch must be succeeded by an expression, but got '$1'", p.tok)
   while (p.tok.tokType != endTok) and (p.tok.tokType != tkEof):
     var a = parseExpr(p)
     result.add(a)

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -29,6 +29,7 @@ symbol = '`' (KEYW|IDENT|literal|(operator|'('|')'|'['|']'|'{'|'}'|'=')+)+ '`'
        | IDENT | KEYW
 exprColonEqExpr = expr (':'|'=' expr)?
 exprList = expr ^+ comma
+optionalExprList = expr ^* comma
 exprColonEqExprList = exprColonEqExpr (comma exprColonEqExpr)* (comma)?
 qualifiedIdent = symbol ('.' optInd symbol)?
 setOrTableConstr = '{' ((exprColonEqExpr comma)* | ':' ) '}'
@@ -98,7 +99,7 @@ typeDefAux = simpleExpr ('not' expr
 postExprBlocks = ':' stmt? ( IND{=} doBlock
                            | IND{=} 'of' exprList ':' stmt
                            | IND{=} 'elif' expr ':' stmt
-                           | IND{=} 'except' exprList ':' stmt
+                           | IND{=} 'except' optionalExprList ':' stmt
                            | IND{=} 'finally' ':' stmt
                            | IND{=} 'else' ':' stmt )*
 exprStmt = simpleExpr
@@ -139,10 +140,10 @@ caseStmt = 'case' expr ':'? COMMENT?
             (IND{>} ofBranches DED
             | IND{=} ofBranches)
 tryStmt = 'try' colcom stmt &(IND{=}? 'except'|'finally')
-           (IND{=}? 'except' exprList colcom stmt)*
+           (IND{=}? 'except' optionalExprList colcom stmt)*
            (IND{=}? 'finally' colcom stmt)?
 tryExpr = 'try' colcom stmt &(optInd 'except'|'finally')
-           (optInd 'except' exprList colcom stmt)*
+           (optInd 'except' optionalExprList colcom stmt)*
            (optInd 'finally' colcom stmt)?
 blockStmt = 'block' symbol? colcom stmt
 blockExpr = 'block' symbol? colcom stmt

--- a/tests/parser/t20922.nim
+++ b/tests/parser/t20922.nim
@@ -1,0 +1,36 @@
+discard """
+  cmd: "nim check $options $file"
+  action: "reject"
+  nimout: '''
+t20922.nim(18, 5) Error: an 'of' branch must be succeeded by an expression, but got ':'
+t20922.nim(18, 3) Error: illformed AST:
+of :
+  '+':
+    incDataPtrByte
+t20922.nim(26, 7) Error: an 'of' branch must be succeeded by an expression, but got ':'
+t20922.nim(26, 5) Error: illformed AST:
+of :
+  x: int
+t20922.nim(14, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(24, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
+'''
+"""
+# original test case issue #t20922
+type Token = enum
+  incDataPtr,
+  incDataPtrByte
+
+proc mapInstrToToken(instr: char): Token =
+  case instr:
+  of '>':
+    incDataPtr
+  of: '+':
+    incDataPtrByte
+
+# same issue with `of` in object branches (different parser procs calling `exprList`)
+type
+  Bar = enum A, B
+  Foo = object
+    case kind: Bar
+    of: x: int
+    of B: y: float

--- a/tests/parser/t20922.nim
+++ b/tests/parser/t20922.nim
@@ -1,28 +1,28 @@
 discard """
-  cmd: "nim check $options $file"
+  cmd: "nim check $options --verbosity:0 $file"
   action: "reject"
   nimout: '''
-t20922.nim(18, 5) Error: expression expected, but found ':'
+t20922.nim(37, 5) Error: expression expected, but found ':'
 Error: in expression ' '+'': identifier expected, but found ''
-t20922.nim(18, 7) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(37, 7) Error: attempting to call undeclared routine: '<Error>'
 Error: in expression ' '+'': identifier expected, but found ''
-t20922.nim(18, 7) Error: attempting to call undeclared routine: '<Error>'
-t20922.nim(18, 7) Error: expression '' cannot be called
-t20922.nim(18, 7) Error: expression '' has no type (or is ambiguous)
-t20922.nim(18, 7) Error: VM problem: dest register is not set
-t20922.nim(26, 7) Error: expression expected, but found ':'
-t20922.nim(27, 5) Error: ':' or '=' expected, but got 'keyword of'
-t20922.nim(26, 9) Error: undeclared identifier: 'x'
-t20922.nim(26, 9) Error: expression 'x' has no type (or is ambiguous)
+t20922.nim(37, 7) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(37, 7) Error: expression '' cannot be called
+t20922.nim(37, 7) Error: expression '' has no type (or is ambiguous)
+t20922.nim(37, 7) Error: VM problem: dest register is not set
+t20922.nim(45, 7) Error: expression expected, but found ':'
+t20922.nim(46, 5) Error: ':' or '=' expected, but got 'keyword of'
+t20922.nim(45, 9) Error: undeclared identifier: 'x'
+t20922.nim(45, 9) Error: expression 'x' has no type (or is ambiguous)
 Error: in expression ' x': identifier expected, but found ''
-t20922.nim(26, 9) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(45, 9) Error: attempting to call undeclared routine: '<Error>'
 Error: in expression ' x': identifier expected, but found ''
-t20922.nim(26, 9) Error: attempting to call undeclared routine: '<Error>'
-t20922.nim(26, 9) Error: expression '' cannot be called
-t20922.nim(26, 9) Error: expression '' has no type (or is ambiguous)
-t20922.nim(26, 9) Error: VM problem: dest register is not set
-t20922.nim(14, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
-t20922.nim(24, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(45, 9) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(45, 9) Error: expression '' cannot be called
+t20922.nim(45, 9) Error: expression '' has no type (or is ambiguous)
+t20922.nim(45, 9) Error: VM problem: dest register is not set
+t20922.nim(33, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(43, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
 '''
 """
 # original test case issue #20922

--- a/tests/parser/t20922.nim
+++ b/tests/parser/t20922.nim
@@ -2,17 +2,17 @@ discard """
   cmd: "nim check $options $file"
   action: "reject"
   nimout: '''
-t20922.nim(18, 5) Error: an 'of' branch must be succeeded by an expression, but got ':'
-t20922.nim(18, 3) Error: illformed AST:
+t20922.nim(27, 5) Error: an 'of' branch must be succeeded by an expression, but got ':'
+t20922.nim(27, 3) Error: illformed AST:
 of :
   '+':
     incDataPtrByte
-t20922.nim(26, 7) Error: an 'of' branch must be succeeded by an expression, but got ':'
-t20922.nim(26, 5) Error: illformed AST:
+t20922.nim(35, 7) Error: an 'of' branch must be succeeded by an expression, but got ':'
+t20922.nim(35, 5) Error: illformed AST:
 of :
   x: int
-t20922.nim(14, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
-t20922.nim(24, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(23, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(33, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
 '''
 """
 # original test case issue #t20922

--- a/tests/parser/t20922.nim
+++ b/tests/parser/t20922.nim
@@ -2,20 +2,30 @@ discard """
   cmd: "nim check $options $file"
   action: "reject"
   nimout: '''
-t20922.nim(27, 5) Error: an 'of' branch must be succeeded by an expression, but got ':'
-t20922.nim(27, 3) Error: illformed AST:
-of :
-  '+':
-    incDataPtrByte
-t20922.nim(35, 7) Error: an 'of' branch must be succeeded by an expression, but got ':'
-t20922.nim(35, 5) Error: illformed AST:
-of :
-  x: int
-t20922.nim(23, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
-t20922.nim(33, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(18, 5) Error: expression expected, but found ':'
+Error: in expression ' '+'': identifier expected, but found ''
+t20922.nim(18, 7) Error: attempting to call undeclared routine: '<Error>'
+Error: in expression ' '+'': identifier expected, but found ''
+t20922.nim(18, 7) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(18, 7) Error: expression '' cannot be called
+t20922.nim(18, 7) Error: expression '' has no type (or is ambiguous)
+t20922.nim(18, 7) Error: VM problem: dest register is not set
+t20922.nim(26, 7) Error: expression expected, but found ':'
+t20922.nim(27, 5) Error: ':' or '=' expected, but got 'keyword of'
+t20922.nim(26, 9) Error: undeclared identifier: 'x'
+t20922.nim(26, 9) Error: expression 'x' has no type (or is ambiguous)
+Error: in expression ' x': identifier expected, but found ''
+t20922.nim(26, 9) Error: attempting to call undeclared routine: '<Error>'
+Error: in expression ' x': identifier expected, but found ''
+t20922.nim(26, 9) Error: attempting to call undeclared routine: '<Error>'
+t20922.nim(26, 9) Error: expression '' cannot be called
+t20922.nim(26, 9) Error: expression '' has no type (or is ambiguous)
+t20922.nim(26, 9) Error: VM problem: dest register is not set
+t20922.nim(14, 6) Hint: 'mapInstrToToken' is declared but not used [XDeclaredButNotUsed]
+t20922.nim(24, 3) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
 '''
 """
-# original test case issue #t20922
+# original test case issue #20922
 type Token = enum
   incDataPtr,
   incDataPtrByte


### PR DESCRIPTION
Not quite sure if this is the right way to fix #20922 especially because `nim check` still happily prints the illformed AST message in addition (but that may well be expected behavior?). Anyhow, as this was simple enough to do, I'll let you decide. :)