### PR TITLE
fix bugs with dot & call operators [backport]

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -340,7 +340,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s
-  if {nfDotField, nfDotSetter, nfExplicitCall} * n.flags <= {nfDotField, nfDotSetter}:
+  if nfExplicitCall notin n.flags and {nfDotField, nfDotSetter} * n.flags != {}:
     let sym = n[1].typ.typSym
     var typeHint = ""
     if sym == nil:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -287,7 +287,7 @@ proc notFoundError*(c: PContext, n: PNode, errors: CandidateErrors) =
     # fail fast:
     globalError(c.config, n.info, "type mismatch")
     return
-  if {nfDotField, nfDotSetter} * n.flags != {}:
+  if nfExplicitCall notin n.flags and {nfDotField, nfDotSetter} * n.flags != {}:
     let ident = considerQuotedIdent(c, n[0], n).s
     let sym = n[1].typ.typSym
     var typeHint = ""

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -622,7 +622,7 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
 proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
   assert n.kind == nkBracketExpr
   for i in 1..<n.len:
-    let e = semExpr(c, n[i])
+    let e = semExprWithType(c, n[i])
     if e.typ == nil:
       n[i].typ = errorType(c)
     else:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -377,9 +377,10 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
                     filter, result, alt, errors, efExplain in flags,
                     errorsEnabled, flags)
 
+  var dummyErrors: CandidateErrors
   template pickBestSpecialOp(headSymbol) =
     pickBestCandidate(c, headSymbol, n, orig, initialBinding,
-                      filter, result, alt, (var dummyErrors: CandidateErrors; dummyErrors), efExplain in flags,
+                      filter, result, alt, dummyErrors, efExplain in flags,
                       false, flags)
 
   let overloadsState = result.state

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -988,13 +988,13 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
     let t = n[0].typ
     if t != nil and t.kind in {tyVar, tyLent}:
       n[0] = newDeref(n[0])
-    elif isSymChoice(n[0]):
-      return semDirectOp(c, n, flags, expectedType)
     elif n[0].kind == nkBracketExpr:
       let s = bracketedMacro(n[0])
       if s != nil:
         setGenericParams(c, n[0])
         return semDirectOp(c, n, flags, expectedType)
+    elif isSymChoice(n[0]):
+      return semDirectOp(c, n, flags, expectedType)
 
   var t: PType = nil
   if n[0].typ != nil:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -994,6 +994,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
         setGenericParams(c, n[0])
         return semDirectOp(c, n, flags, expectedType)
     elif isSymChoice(n[0]):
+      # overloaded generic procs e.g. newSeq[int] can end up here
       return semDirectOp(c, n, flags, expectedType)
 
   var t: PType = nil

--- a/nimsuggest/tests/tgeneric_highlight.nim
+++ b/nimsuggest/tests/tgeneric_highlight.nim
@@ -8,12 +8,10 @@ $nimsuggest --tester $file
 highlight;;skType;;1;;7;;3
 highlight;;skProc;;1;;0;;6
 highlight;;skProc;;1;;0;;6
-highlight;;skType;;1;;7;;3
 highlight;;skProc;;1;;0;;6
 highlight;;skType;;2;;14;;3
 highlight;;skProc;;2;;7;;6
 highlight;;skProc;;2;;7;;6
-highlight;;skType;;2;;14;;3
 highlight;;skProc;;2;;7;;6
 highlight;;skTemplate;;3;;0;;8
 highlight;;skType;;3;;9;;3

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -13,14 +13,8 @@ proc e(o: ExplainedConcept): int
   required type for o: ExplainedConcept
   but expression '10' is of type: int literal(10)
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
-texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
-texplain.nim(128, 6) ExplainedConcept: expression '.' cannot be called
-texplain.nim(128, 6) ExplainedConcept: expression '' has no type (or is ambiguous)
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 texplain.nim(129, 6) ExplainedConcept: undeclared field: 'bar'
-texplain.nim(129, 6) ExplainedConcept: undeclared field: '.'
-texplain.nim(129, 6) ExplainedConcept: expression '.' cannot be called
-texplain.nim(129, 6) ExplainedConcept: expression '' has no type (or is ambiguous)
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 
 texplain.nim(168, 10) Hint: Non-matching candidates for e(10)
@@ -29,14 +23,8 @@ proc e(o: ExplainedConcept): int
   required type for o: ExplainedConcept
   but expression '10' is of type: int literal(10)
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
-texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
-texplain.nim(128, 6) ExplainedConcept: expression '.' cannot be called
-texplain.nim(128, 6) ExplainedConcept: expression '' has no type (or is ambiguous)
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 texplain.nim(129, 6) ExplainedConcept: undeclared field: 'bar'
-texplain.nim(129, 6) ExplainedConcept: undeclared field: '.'
-texplain.nim(129, 6) ExplainedConcept: expression '.' cannot be called
-texplain.nim(129, 6) ExplainedConcept: expression '' has no type (or is ambiguous)
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 
 texplain.nim(172, 20) Error: type mismatch: got <NonMatchingType>
@@ -88,14 +76,8 @@ proc f(o: NestedConcept)
   required type for o: NestedConcept
   but expression 'y' is of type: MatchingType
 texplain.nim(132, 6) RegularConcept: undeclared field: 'foo'
-texplain.nim(132, 6) RegularConcept: undeclared field: '.'
-texplain.nim(132, 6) RegularConcept: expression '.' cannot be called
-texplain.nim(132, 6) RegularConcept: expression '' has no type (or is ambiguous)
 texplain.nim(132, 5) RegularConcept: concept predicate failed
 texplain.nim(133, 6) RegularConcept: undeclared field: 'bar'
-texplain.nim(133, 6) RegularConcept: undeclared field: '.'
-texplain.nim(133, 6) RegularConcept: expression '.' cannot be called
-texplain.nim(133, 6) RegularConcept: expression '' has no type (or is ambiguous)
 texplain.nim(132, 5) RegularConcept: concept predicate failed
 texplain.nim(136, 5) NestedConcept: concept predicate failed
 
@@ -121,7 +103,25 @@ expression: f(y)'''
 
 
 
-# line 120 HERE
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# line 124 HERE
 
 type
   ExplainedConcept {.explain.} = concept o

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -53,7 +53,7 @@ block:
 
     # non-routine type shows `()` overloads:
     b(123) #[tt.Error
-     ^ type mismatch: got <Bar, int literal(123)>]#
+     ^ attempting to call routine: 'b']#
 
 # issue #7777
 
@@ -74,3 +74,10 @@ block:
 
   var tt: TestType
   discard tt.field
+
+block: # related to issue #6981
+  proc `()`(a:string, b:string):string = a & b
+  proc mewSeq[T](a,b:int)=discard
+  proc mewSeq[T](c:int)= discard
+  mewSeq[int]() #[tt.Error
+             ^ type mismatch: got <>]#

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -9,20 +9,6 @@ cmd: '''nim check --hints:off $file'''
 # issue #13063
 
 block:
-  template `.`(a: int, b: untyped): untyped = 123
-  var b: float
-  echo b.x #[tt.Error
-        ^ undeclared field: 'x' for type system.float [type declared in ..\..\lib\system\basic_types.nim(15, 3)]]#
-
-block:
-  template `()`(a: int, b: untyped): untyped = 123
-  var b: float
-  echo b.x #[tt.Error
-        ^ undeclared field: 'x' for type system.float [type declared in ..\..\lib\system\basic_types.nim(15, 3)]]#
-  echo b.x() #[tt.Error
-        ^ attempting to call undeclared routine: 'x']#
-
-block:
   type Foo = object
   type Bar = object
     x1: int
@@ -30,7 +16,7 @@ block:
   block:
     template `.`(a: Foo, b: untyped): untyped = 123
     echo b.x #[tt.Error
-          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
   block:
     template `.()`(a: Foo, b: untyped): untyped = 123
     echo b.x() #[tt.Error
@@ -38,7 +24,7 @@ block:
   block:
     template `.=`(a: Foo, b: untyped, c: untyped) = b = c
     b.x = 123 #[tt.Error
-        ^ undeclared field: 'x=' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+        ^ undeclared field: 'x=' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
     # yeah it says x= but does it matter in practice
   block:
     template `()`(a: Foo, b: untyped, c: untyped) = echo "something"
@@ -54,6 +40,11 @@ block:
     # non-routine type shows `()` overloads:
     b(123) #[tt.Error
      ^ attempting to call routine: 'b']#
+
+    echo b.x #[tt.Error
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
+    echo b.x() #[tt.Error
+          ^ attempting to call undeclared routine: 'x']#
 
 # issue #7777
 

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -34,7 +34,7 @@ block:
   block:
     template `.()`(a: Foo, b: untyped): untyped = 123
     echo b.x() #[tt.Error
-          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+          ^ expression 'x' cannot be called]#
   block:
     template `.=`(a: Foo, b: untyped, c: untyped) = b = c
     b.x = 123 #[tt.Error
@@ -70,7 +70,7 @@ block:
     let private = newIdentNode("private_" & $field)
     result = quote do:
       `obj`.getField(`private`) #[tt.Error
-           ^ undeclared field: 'getField' for type terrmsgs.TestType [type declared in terrmsgs.nim(63, 8)]#
+           ^ expression 'getField' cannot be called]#
 
   var tt: TestType
   discard tt.field

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -1,0 +1,56 @@
+discard """
+action: reject
+cmd: '''nim check --hints:off $file'''
+"""
+
+{.experimental: "dotOperators".}
+{.experimental: "callOperator".}
+
+# issue #13063
+
+block:
+  template `.`(a: int, b: untyped): untyped = 123
+  var b: float
+  echo b.x #[tt.Error
+        ^ undeclared field: 'x' for type system.float [type declared in ..\..\lib\system\basic_types.nim(15, 3)]]#
+
+block:
+  template `()`(a: int, b: untyped): untyped = 123
+  var b: float
+  echo b.x #[tt.Error
+        ^ undeclared field: 'x' for type system.float [type declared in ..\..\lib\system\basic_types.nim(15, 3)]]#
+  echo b.x() #[tt.Error
+        ^ attempting to call undeclared routine: 'x']#
+
+block:
+  type Foo = object
+  type Bar = object
+    x1: int
+  var b: Bar
+  block:
+    template `.`(a: Foo, b: untyped): untyped = 123
+    echo b.x #[tt.Error
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+  block:
+    template `.()`(a: Foo, b: untyped): untyped = 123
+    echo b.x() #[tt.Error
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+  block:
+    template `.=`(a: Foo, b: untyped, c: untyped) = b = c
+    b.x = 123 #[tt.Error
+        ^ undeclared field: 'x=' for type terrmsgs.Bar [type declared in terrmsgs.nim(27, 8)]]#
+    # yeah it says x= but does it matter in practice
+  block:
+    template `()`(a: Foo, b: untyped, c: untyped) = echo "something"
+
+    # completely undeclared::
+    xyz(123) #[tt.Error
+    ^ undeclared identifier: 'xyz']#
+
+    # already declared routine:
+    min(123) #[tt.Error
+       ^ type mismatch: got <int literal(123)>]#
+
+    # non-routine type shows `()` overloads:
+    b(123) #[tt.Error
+     ^ type mismatch: got <Bar, int literal(123)>]#

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -54,3 +54,23 @@ block:
     # non-routine type shows `()` overloads:
     b(123) #[tt.Error
      ^ type mismatch: got <Bar, int literal(123)>]#
+
+# issue #7777
+
+import macros
+
+block:
+  type TestType = object
+    private_field: string
+
+  when false:
+    template getField(obj, field: untyped): untyped = obj.field
+
+  macro `.`(obj: TestType, field: untyped): untyped =
+    let private = newIdentNode("private_" & $field)
+    result = quote do:
+      `obj`.getField(`private`) #[tt.Error
+           ^ undeclared field: 'getField' for type terrmsgs.TestType [type declared in terrmsgs.nim(63, 8)]#
+
+  var tt: TestType
+  discard tt.field

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -1,10 +1,12 @@
 discard """
 action: reject
-cmd: '''nim check --hints:off $file'''
+cmd: '''nim check $options $file'''
+matrix: "; -d:testWithout"
 """
 
-{.experimental: "dotOperators".}
-{.experimental: "callOperator".}
+when not defined(testWithout): # test for same errors before and after
+  {.experimental: "dotOperators".}
+  {.experimental: "callOperator".}
 
 # issue #13063
 
@@ -16,15 +18,15 @@ block:
   block:
     template `.`(a: Foo, b: untyped): untyped = 123
     echo b.x #[tt.Error
-          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(15, 8)]]#
   block:
     template `.()`(a: Foo, b: untyped): untyped = 123
     echo b.x() #[tt.Error
-          ^ expression 'x' cannot be called]#
+          ^ attempting to call undeclared routine: 'x']#
   block:
     template `.=`(a: Foo, b: untyped, c: untyped) = b = c
     b.x = 123 #[tt.Error
-        ^ undeclared field: 'x=' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
+        ^ undeclared field: 'x=' for type terrmsgs.Bar [type declared in terrmsgs.nim(15, 8)]]#
     # yeah it says x= but does it matter in practice
   block:
     template `()`(a: Foo, b: untyped, c: untyped) = echo "something"
@@ -42,7 +44,7 @@ block:
      ^ attempting to call routine: 'b']#
 
     echo b.x #[tt.Error
-          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(13, 8)]]#
+          ^ undeclared field: 'x' for type terrmsgs.Bar [type declared in terrmsgs.nim(15, 8)]]#
     echo b.x() #[tt.Error
           ^ attempting to call undeclared routine: 'x']#
 
@@ -61,7 +63,7 @@ block:
     let private = newIdentNode("private_" & $field)
     result = quote do:
       `obj`.getField(`private`) #[tt.Error
-           ^ expression 'getField' cannot be called]#
+           ^ attempting to call undeclared routine: 'getField']#
 
   var tt: TestType
   discard tt.field

--- a/tests/specialops/tnewseq.nim
+++ b/tests/specialops/tnewseq.nim
@@ -1,0 +1,22 @@
+# issue #6981
+
+import std/assertions
+
+{.experimental: "callOperator".}
+
+block: # issue #6981
+  proc `()`(a:string, b:string):string = a & b
+
+  var s = newSeq[int](3)
+
+  doAssert s == @[0, 0, 0]
+
+block: # generalized example from #6981
+  proc mewSeq[T](a: int)=discard
+  proc mewSeq[T]()= discard
+  mewSeq[int]()
+
+block: # issue #9831
+  type Foo = object
+  proc `()`(foo: Foo) = discard
+  let x = newSeq[int]()


### PR DESCRIPTION
fixes #13063, fixes #7777, fixes #6981, fixes #9831

"Wrong" behavior of `newSeq[int]`-type calls fixed as well, discovered because of these issues, they should not go through `nfExprCall`