### PR TITLE
better procvar ambiguity errors, clean up after #20457

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -70,10 +70,11 @@ type
     efWantStmt, efAllowStmt, efDetermineType, efExplain,
     efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo, efNoSem2Check,
-    efNoUndeclared, efIsDotCall, efCannotBeDotCall
+    efNoUndeclared, efIsDotCall, efCannotBeDotCall,
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
-    efNoDiagnostics, efAllowSymChoice
+    efNoDiagnostics,
+    efTypeAllowed # typeAllowed will be called after
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -73,7 +73,7 @@ type
     efNoUndeclared, efIsDotCall, efCannotBeDotCall
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
-    efNoDiagnostics
+    efNoDiagnostics, efAllowSymChoice
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -91,7 +91,7 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
   elif (result.typ == nil or result.typ.kind == tyNone) and
-    efAllowSymChoice notin flags and isSymChoice(result) and result.len > 0:
+    efAllowSymChoice notin flags and result.kind == nkClosedSymChoice and result.len > 0:
     let first = result[0].sym
     if first.kind == skEnumField:
       # choose the first resolved enum field, i.e. the latest in scope

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -88,8 +88,8 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
   elif (result.typ == nil or result.typ.kind == tyNone) and
-    efTypeAllowed in flags and
-    result.kind == nkClosedSymChoice and result.len > 0:
+      efTypeAllowed in flags and
+      result.kind == nkClosedSymChoice and result.len > 0:
     let first = result[0].sym
     if first.kind == skEnumField:
       # choose the first resolved enum field, i.e. the latest in scope

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -624,7 +624,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
 
     var def: PNode = c.graph.emptyNode
     if a[^1].kind != nkEmpty:
-      def = semExprWithType(c, a[^1], {}, typ)
+      def = semExprWithType(c, a[^1], {efTypeAllowed}, typ)
 
       if def.kind == nkSym and def.sym.kind in {skTemplate, skMacro}:
         typFlags.incl taIsTemplateOrMacro
@@ -776,7 +776,7 @@ proc semConst(c: PContext, n: PNode): PNode =
     var typFlags: TTypeAllowedFlags
 
     # don't evaluate here since the type compatibility check below may add a converter
-    var def = semExprWithType(c, a[^1], {}, typ)
+    var def = semExprWithType(c, a[^1], {efTypeAllowed}, typ)
 
     if def.kind == nkSym and def.sym.kind in {skTemplate, skMacro}:
       typFlags.incl taIsTemplateOrMacro

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1365,6 +1365,23 @@ ambiguous, a static error will be produced.
   p value2
   ```
 
+In some cases, ambiguity of enums is resolved depending on the relation
+between the current scope and the scope the enums were defined in.
+
+  ```nim
+  # a.nim
+  type Foo* = enum abc
+
+  # b.nim
+  import a
+  type Bar = enum abc
+  echo abc is Bar # true
+
+  block:
+    type Baz = enum abc
+    echo abc is Baz # true
+  ```
+
 To implement bit fields with enums see [Bit fields].
 
 

--- a/tests/ambsym/tambprocvar.nim
+++ b/tests/ambsym/tambprocvar.nim
@@ -1,0 +1,19 @@
+discard """
+  action: reject
+  cmd: "nim check $file"
+  nimout: '''
+tambprocvar.nim(15, 11) Error: ambiguous identifier 'foo' -- use one of the following:
+  tambprocvar.foo: proc (x: int){.noSideEffect, gcsafe.}
+  tambprocvar.foo: proc (x: float){.noSideEffect, gcsafe.}
+'''
+"""
+
+block:
+  proc foo(x: int) = discard
+  proc foo(x: float) = discard
+
+  let x = foo
+
+block:
+  let x = `+` #[tt.Error
+          ^ ambiguous identifier '+' -- use one of the following:]#


### PR DESCRIPTION
fixes #6359, fixes #13849, follows up #20457

#18785 is related: The error message is fixed, however there is no way to disambiguate procs in different scopes in the same module.