### PR TITLE
Improve jsheaders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -134,6 +134,9 @@
 - `std/net.IpAddress` dollar `$` improved, uses a fixed capacity for the `string` result based from the `IpAddressFamily`.
 - `std/jsfetch.newFetchOptions` now has default values for all parameters
 
+- `std/jsheaders` now accepts `SomeNumber | bool | cstring` data types.
+
+
 [//]: # "Additions:"
 - Added ISO 8601 week date utilities in `times`:
   - Added `IsoWeekRange`, a range type for weeks in a week-based year.

--- a/lib/std/jsheaders.nim
+++ b/lib/std/jsheaders.nim
@@ -25,7 +25,7 @@ func keys*(self: Headers): seq[cstring] {.importjs: "Array.from(#.$1())".}
 func values*(self: Headers): seq[cstring] {.importjs: "Array.from(#.$1())".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/values
 
-func entries*(self: Headers): seq[tuple[key: cstring, value: SomeNumber | bool | cstring]] {.importjs: "Array.from(#.$1())".}
+func entries*(self: Headers): seq[tuple[key, value: cstring]] {.importjs: "Array.from(#.$1())".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries
 
 func `[]`*(self: Headers; key: cstring): cstring {.importjs: "#.get(#)".}
@@ -52,7 +52,7 @@ runnableExamples("-r:off"):
 
   block:
     let header: Headers = newHeaders()
-    header.add("key", "value")
+    header.add("key".cstring, "value".cstring)
     assert header.hasKey("key")
     assert header.keys() == @["key".cstring]
     assert header.values() == @["value".cstring]
@@ -69,15 +69,15 @@ runnableExamples("-r:off"):
 
   block:
     let header: Headers = newHeaders()
-    header.add("key", "a")
-    header.add("key", "b")  ## Duplicated.
-    header.add("key", "c")  ## Duplicated.
+    header.add("key", "a".cstring)
+    header.add("key", "b".cstring)  ## Duplicated.
+    header.add("key", "c".cstring)  ## Duplicated.
     assert header["key"] == "a, b, c".cstring
     header["key"] = "value".cstring
     assert header["key"] == "value".cstring
 
   block:
     let header: Headers = newHeaders()
-    header["key"] = "a"
-    header["key"] = "b"  ## Overwrites.
+    header["key"] = "a".cstring
+    header["key"] = "b".cstring  ## Overwrites.
     assert header["key"] == "b".cstring

--- a/lib/std/jsheaders.nim
+++ b/lib/std/jsheaders.nim
@@ -7,7 +7,7 @@ type Headers* = ref object of JsRoot ## HTTP Headers API.
 func newHeaders*(): Headers {.importjs: "new Headers()".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers
 
-func add*(self: Headers; key: cstring; value: cstring) {.importjs: "#.append(#, #)".}
+func add*(self: Headers; key: cstring; value: SomeNumber | bool | cstring) {.importjs: "#.append(#, #)".}
   ## Allows duplicated keys.
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/append
 
@@ -25,14 +25,14 @@ func keys*(self: Headers): seq[cstring] {.importjs: "Array.from(#.$1())".}
 func values*(self: Headers): seq[cstring] {.importjs: "Array.from(#.$1())".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/values
 
-func entries*(self: Headers): seq[tuple[key, value: cstring]] {.importjs: "Array.from(#.$1())".}
+func entries*(self: Headers): seq[tuple[key: cstring, value: SomeNumber | bool | cstring]] {.importjs: "Array.from(#.$1())".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries
 
 func `[]`*(self: Headers; key: cstring): cstring {.importjs: "#.get(#)".}
   ## Get *all* items with `key` from the headers, including duplicated values.
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/get
 
-func `[]=`*(self: Headers; key: cstring; value: cstring) {.importjs: "#.set(#, #)".}
+func `[]=`*(self: Headers; key: cstring; value: SomeNumber | bool | cstring) {.importjs: "#.set(#, #)".}
   ## Do *not* allow duplicated keys, overwrites duplicated keys.
   ## https://developer.mozilla.org/en-US/docs/Web/API/Headers/set
 


### PR DESCRIPTION
- `std/jsheaders` now accepts `SomeNumber | bool | cstring` data types, similar to Javascript. Changelog updated.

![jsheaders](https://user-images.githubusercontent.com/1189414/204114374-f0509220-47f2-4721-9c50-cf4cb98c65dd.png)
