### PR TITLE
Support IBM Z architecture

### DIFF
--- a/lib/system/platforms.nim
+++ b/lib/system/platforms.nim
@@ -37,7 +37,8 @@ type
     riscv64,                   ## RISC-V 64-bit processor
     wasm32,                    ## WASM, 32-bit
     e2k,                       ## MCST Elbrus 2000
-    loongarch64                ## LoongArch 64-bit processor
+    loongarch64,               ## LoongArch 64-bit processor
+    s390x                      ## IBM Z
 
   OsPlatform* {.pure.} = enum ## the OS this program will run on.
     none, dos, windows, os2, linux, morphos, skyos, solaris,
@@ -97,5 +98,6 @@ const
                elif defined(wasm32): CpuPlatform.wasm32
                elif defined(e2k): CpuPlatform.e2k
                elif defined(loongarch64): CpuPlatform.loongarch64
+               elif defined(s390x): CpuPlatform.s390x
                else: CpuPlatform.none
     ## the CPU this program will run on.

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -103,6 +103,9 @@ endif
 ifeq ($(ucpu),x86_64)
   mycpu = amd64
 endif
+ifeq ($(ucpu),s390x)
+  mycpu = s390x
+endif
 ifeq ($(ucpu),sparc)
   mycpu = sparc
 endif


### PR DESCRIPTION
(Formerly IBM zSystems)
Tested on release 1.6.10 on an IBM/S390 by tweaking the makefile
Related to https://github.com/nim-lang/Nim/issues/15253