### PR TITLE
fixes #13583; enforce void for `nkWhileStmt`

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -38,6 +38,8 @@ const
   errPragmaOnlyInHeaderOfProcX = "pragmas are only allowed in the header of a proc; redefinition of $1"
   errCannotAssignToGlobal = "cannot assign local to global variable"
 
+proc implicitlyDiscardable(n: PNode): bool
+
 proc semDiscard(c: PContext, n: PNode): PNode =
   result = n
   checkSonsLen(n, 1, c.config)
@@ -101,6 +103,9 @@ proc semWhile(c: PContext, n: PNode; flags: TExprFlags): PNode =
     result.typ = c.enforceVoidContext
   elif efInTypeof in flags:
     result.typ = n[1].typ
+  elif implicitlyDiscardable(n[1]):
+    result[1].typ = c.enforceVoidContext
+    result.typ = c.enforceVoidContext
 
 proc semProc(c: PContext, n: PNode): PNode
 

--- a/tests/discard/tdiscardable.nim
+++ b/tests/discard/tdiscardable.nim
@@ -81,6 +81,18 @@ block: # bug #13583
 
     iterator test(): int {.closure.} =
       while true:
+        block:
+          yield 12
+          hello()
+
+    let t = test
+    doAssert t() == 12
+
+  block:
+    proc hello(): int {.discardable.} = 12
+
+    iterator test(): int {.closure.} =
+      while true:
         yield 12
         hello()
 

--- a/tests/discard/tdiscardable.nim
+++ b/tests/discard/tdiscardable.nim
@@ -65,3 +65,25 @@ proc main2() =
 
 main1()
 main2()
+
+block: # bug #13583
+  block:
+    proc hello(): int {.discardable.} = 12
+
+    iterator test(): int {.closure.} =
+      while true:
+        hello()
+
+    let t = test
+
+  block:
+    proc hello(): int {.discardable.} = 12
+
+    iterator test(): int {.closure.} =
+      while true:
+        yield 12
+        hello()
+
+    let t = test
+    doAssert t() == 12
+


### PR DESCRIPTION
Fixes #13583

A node of a `nkWhileStmt` kind cannot have a type in normal cases. If its last node has a type, it means the final last node contains a node calling a `discardable` function. We know that it cannot be interpreted as an expression in while statement. We should enforce void type for it. Arguably, we can rewrite it as a `discard` statement.