### PR TITLE
Add `--genCDeps` for better integration with CMake

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -326,6 +326,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "run", "r": result = contains(conf.globalOptions, optRun)
   of "symbolfiles": result = conf.symbolFiles != disabledSf
   of "genscript": result = contains(conf.globalOptions, optGenScript)
+  of "gencdeps": result = contains(conf.globalOptions, optGenCDeps)
   of "threads": result = contains(conf.globalOptions, optThreads)
   of "tlsemulation": result = contains(conf.globalOptions, optTlsEmulation)
   of "implicitstatic": result = contains(conf.options, optImplicitStatic)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -915,6 +915,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if switch.normalize == "gendeps": deprecatedAlias(switch, "genscript")
     processOnOffSwitchG(conf, {optGenScript}, arg, pass, info)
     processOnOffSwitchG(conf, {optCompileOnly}, arg, pass, info)
+  of "gencdeps":
+    processOnOffSwitchG(conf, {optGenCDeps}, arg, pass, info)
   of "colors": processOnOffSwitchG(conf, {optUseColors}, arg, pass, info)
   of "lib":
     expectArg(conf, switch, arg, pass, info)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -60,7 +60,7 @@ proc writeCMakeDepsFile(conf: ConfigRef) =
   var prevset = initCountTable[string]()
   if open(fl, fname.string, fmRead):
     for line in fl.lines: prevset.inc(line)
-  fl.close()
+    fl.close()
   # write cfiles out
   if fileset != prevset:
     fl = open(fname.string, fmWrite)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -57,7 +57,7 @@ proc writeCMakeDepsFile(conf: ConfigRef) =
   let fileset = cfiles.toCountTable()
   # read old cfiles list
   var fl: File
-  var prevset: CountTable[string]
+  var prevset = initCountTable[string]()
   if open(fl, fname.string, fmRead):
     for line in fl.lines: prevset.inc(line)
   fl.close()

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -52,7 +52,7 @@ proc writeCMakeDepsFile(conf: ConfigRef) =
   ## only updated when the C file list changes.
   let fname = getNimcacheDir(conf) / conf.outFile.changeFileExt("cdeps")
   # generate output files list
-  var cfiles: seq[string]
+  var cfiles: seq[string] = @[]
   for it in conf.toCompile: cfiles.add(it.cname.string)
   let fileset = cfiles.toCountTable()
   # read old cfiles list

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -60,6 +60,7 @@ type                          # please make sure we have under 32 options
     optGenStaticLib,          # generate a static library
     optGenGuiApp,             # generate a GUI application
     optGenScript,             # generate a script file to compile the *.c files
+    optGenCDeps,              # generate a list of *.c files to be read by CMake
     optGenMapping,            # generate a mapping file
     optRun,                   # run the compiled project
     optUseNimcache,           # save artifacts (including binary) in $nimcache


### PR DESCRIPTION
This PR adds an option to generate a `.cdeps` file which contains a newline separate list of the generated source files. The file is only written if the list changes thereby keeping the timestamp stable and useful as an input to CMake or other build systems. 

Based on https://forum.nim-lang.org/t/9656 and working with CMake systems for embedded systems.

The `.cdeps` file can be used like: 

```cmake
set(CDEPS "${CMAKE_CURRENT_LIST_DIR}/.nimcache/main.cdeps")
set(NIMBASE "${CMAKE_CURRENT_LIST_DIR}/.nimcache/nimbase.h")

set_directory_properties(PROPERTIES CMAKE_CONFIGURE_DEPENDS ${CDEPS})
file(STRINGS ${CDEPS} CFILES ENCODING UTF-8)

message(WARN " CFILES: ${CFILES}") # contains all cfiles that need to be compiled
```
