### PR TITLE
fix #20969 - making vcc work again with cpp backend

### DIFF
--- a/lib/std/sysatomics.nim
+++ b/lib/std/sysatomics.nim
@@ -190,12 +190,12 @@ elif someVcc:
     proc interlockedCompareExchange64(p: pointer; exchange, comparand: int64): int64
       {.importcpp: "_InterlockedCompareExchange64(static_cast<NI64 volatile *>(#), #, #)", header: "<intrin.h>".}
     proc interlockedCompareExchange32(p: pointer; exchange, comparand: int32): int32
-      {.importcpp: "_InterlockedCompareExchange(static_cast<NI volatile *>(#), #, #)", header: "<intrin.h>".}
+      {.importcpp: "_InterlockedCompareExchange(static_cast<long volatile *>(#), #, #)", header: "<intrin.h>".}
     proc interlockedCompareExchange8(p: pointer; exchange, comparand: byte): byte
       {.importcpp: "_InterlockedCompareExchange8(static_cast<char volatile *>(#), #, #)", header: "<intrin.h>".}
     proc interlockedExchange8(location: pointer; desired: int8): int8 {.importcpp: "_InterlockedExchange8(static_cast<NI8 volatile *>(#), #)", header: "<intrin.h>".}
     proc interlockedExchange16(location: pointer; desired: int16): int16 {.importcpp: "_InterlockedExchange16(static_cast<NI16 volatile *>(#), #)", header: "<intrin.h>".}
-    proc interlockedExchange32(location: pointer; desired: int32): int32 {.importcpp: "_InterlockedExchange(static_cast<NI volatile *>(#), #)", header: "<intrin.h>".}
+    proc interlockedExchange32(location: pointer; desired: int32): int32 {.importcpp: "_InterlockedExchange(static_cast<long volatile *>(#), #)", header: "<intrin.h>".}
     proc interlockedExchange64(location: pointer; desired: int64): int64 {.importcpp: "_InterlockedExchange64(static_cast<NI64 volatile *>(#), #)", header: "<intrin.h>".}
   else:
     proc interlockedCompareExchange64(p: pointer; exchange, comparand: int64): int64


### PR DESCRIPTION
fix #20969

Anyway, the use of `NI` is wrong, considering that it varies according to the target architecture. `_InterlockedCompareExchange` and `_InterlockedExchange` are for 32 bits, more precisely, according to [Microsoft documentation](https://learn.microsoft.com/en-us/cpp/intrinsics/interlockedcompareexchange-intrinsic-functions?view=msvc-170), for `long`. 