### PR TITLE
Update tssl.nim

### DIFF
--- a/tests/stdlib/tssl.nim
+++ b/tests/stdlib/tssl.nim
@@ -2,6 +2,7 @@ discard """
   joinable: false
   disabled: "freebsd"
   disabled: "openbsd"
+  disabled: "netbsd"
 """
 # disabled: pending bug #15713
 import std/[net, nativesockets, assertions, typedthreads]


### PR DESCRIPTION
This test hangs also under NetBSD and prevents the rest of the tests to carry over to the end.