### PR TITLE
fix #9942 Generic static int parameters with default values cannot be…

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -537,7 +537,7 @@ proc fillTypeS*(dest: PType, kind: TTypeKind, c: PContext) =
 
 proc makeRangeType*(c: PContext; first, last: BiggestInt;
                     info: TLineInfo; intType: PType = nil): PType =
-  let intType = if intType != nil: intType else: getSysType(c.graph, info, tyInt)
+  let intType = if intType != nil: intType.skipTypes({tyStatic}) else: getSysType(c.graph, info, tyInt)
   var n = newNodeI(nkRange, info)
   n.add newIntTypeNode(first, intType)
   n.add newIntTypeNode(last, intType)

--- a/tests/generics/t9942.nim
+++ b/tests/generics/t9942.nim
@@ -8,3 +8,5 @@ type
 
 var f1: Foo[int]
 var f2: Foo[int, 1024]
+doAssert f1.buffer.len == pageSize
+doAssert f2.buffer.len == 1024

--- a/tests/generics/t9942.nim
+++ b/tests/generics/t9942.nim
@@ -1,0 +1,10 @@
+
+const
+  pageSize = 4096
+
+type
+  Foo*[T; size: static[int] = pageSize] = object
+    buffer: array[size, byte] # Error: ordinal type expected
+
+var f1: Foo[int]
+var f2: Foo[int, 1024]


### PR DESCRIPTION
… used as an array size indicator

fix #9942