### PR TITLE
update azure ubuntu 18 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       Linux_i386:
         # on 'ubuntu-16.04' (not supported anymore anyways) it errored with:
         # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-        vmImage: 'ubuntu-18.04'
+        vmImage: 'ubuntu-22.04'
         CPU: i386
       OSX_amd64:
         vmImage: 'macOS-11'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       Linux_i386:
         # on 'ubuntu-16.04' (not supported anymore anyways) it errored with:
         # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-20.04'
         CPU: i386
       OSX_amd64:
         vmImage: 'macOS-11'


### PR DESCRIPTION
Azure gives: [error]This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023.