### PR TITLE
Add back error message to tprevent_forloopvar_mutations

### DIFF
--- a/tests/varres/tprevent_forloopvar_mutations.nim
+++ b/tests/varres/tprevent_forloopvar_mutations.nim
@@ -1,5 +1,14 @@
 discard """
   errormsg: "type mismatch: got <int>"
+  nimout: '''tprevent_forloopvar_mutations.nim(16, 7) Error: type mismatch: got <int>
+but expected one of:
+proc inc[T, V: Ordinal](x: var T; y: V = 1)
+  first type mismatch at position: 1
+  required type for x: var T: Ordinal
+  but expression 'i' is immutable, not 'var'
+
+expression: inc i
+'''
 """
 
 for i in 0..10:


### PR DESCRIPTION
This error message was removed in #20829 for some reason despite being the point of the test.