### PR TITLE
unpublic `arrayWith` and rename it to `nimArrayWith`

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -642,10 +642,10 @@ proc defaultNodeField(c: PContext, a: PNode, aTyp: PType, id: var IntSet): PNode
     if child != nil:
       let node = newNode(nkIntLit)
       node.intVal = toInt64(lengthOrd(c.graph.config, aTypSkip))
-            result = semExpr(c, newTree(nkCall, newSymNode(getCompilerProc(c.graph, "nimArrayWith"), a.info),
-              semExprWithType(c, child),
-              node
-                ))
+      result = semExpr(c, newTree(nkCall, newSymNode(getCompilerProc(c.graph, "nimArrayWith"), a.info),
+        semExprWithType(c, child),
+        node
+          ))
       result.typ = aTyp
   elif aTypSkip.kind == tyTuple:
     var hasDefault = false

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -642,7 +642,7 @@ proc defaultNodeField(c: PContext, a: PNode, aTyp: PType, id: var IntSet): PNode
     if child != nil:
       let node = newNode(nkIntLit)
       node.intVal = toInt64(lengthOrd(c.graph.config, aTypSkip))
-      result = semExpr(c, newTree(nkCall, newSymNode(getSysSym(c.graph, a.info, "arrayWith"), a.info),
+            result = semExpr(c, newTree(nkCall, newSymNode(getCompilerProc(c.graph, "nimArrayWith"), a.info),
               semExprWithType(c, child),
               node
                 ))

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2796,7 +2796,7 @@ when notJSnotNims and not defined(nimSeqsV2):
       assert y == "abcgh"
     discard
 
-proc arrayWith*[T](y: T, size: static int): array[size, T] {.noinit.} = # ? exempt from default value for result
+proc nimArrayWith[T](y: T, size: static int): array[size, T] {.compilerRtl, raises: [].} =
   ## Creates a new array filled with `y`.
   for i in 0..size-1:
     result[i] = y

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -267,7 +267,7 @@ template main {.dirty.} =
         doAssert $(@my) == """@['\x00', '\x00', '\x00', '\x00', '\x00']"""
 
   block: # array
-    var x: array[10, Object] = arrayWith(default(Object), 10)
+    var x: array[10, Object] = default(array[10, Object])
     let y = x[0]
     doAssert y.value == 12
     doAssert y.time == 1.2


### PR DESCRIPTION
There is no need to add `arrayWith` for defaults. Sticking to `default(array[...])` is a good option.