### PR TITLE
Add: missing nintendo-switch define

### DIFF
--- a/doc/nimc.md
+++ b/doc/nimc.md
@@ -440,6 +440,7 @@ or setup a ``nim.cfg`` file like so:
     #nim.cfg
     --mm:orc
     --d:nimAllocPagesViaMalloc
+    --define:nimInheritHandles
     --passC="-I$DEVKITPRO/libnx/include"
     --passL="-specs=$DEVKITPRO/libnx/switch.specs -L$DEVKITPRO/libnx/lib -lnx"
 


### PR DESCRIPTION
Hey, I've opened an issue recently: https://github.com/nim-lang/Nim/issues/21008

Here's a PR to the docs section. You cannot open a file without it :)