### PR TITLE
Remove deprecated posix.CLONE_STOPPED

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -182,6 +182,9 @@
 - Removed deprecated `std/posix.CMSG_SPACE` and `std/posix.CMSG_LEN` that takes wrong argument types.
 - Removed deprecated `osproc.poDemon`, symbol with typo.
 
+- Removed deprecated `posix.CLONE_STOPPED`.
+
+
 ## Language changes
 
 - [Tag tracking](https://nim-lang.github.io/Nim/manual.html#effect-system-tag-tracking) supports the definition of forbidden tags by the `.forbids` pragma

--- a/lib/posix/linux.nim
+++ b/lib/posix/linux.nim
@@ -29,7 +29,7 @@ const
   CLONE_NEWPID* = 0x20000000'i32
   CLONE_NEWNET* = 0x40000000'i32
   CLONE_IO* = 0x80000000'i32
-  CLONE_STOPPED* {.deprecated.} = 0x02000000'i32
+
 
 # fn should be of type proc (a2: pointer) {.cdecl.}
 proc clone*(fn: pointer; child_stack: pointer; flags: cint;


### PR DESCRIPTION
- Remove deprecated `std/posix.CLONE_STOPPED` const.
