### PR TITLE
fixes `isLocalVarSym`; an implicit global is a global nonetheless

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -587,8 +587,8 @@ proc semVarMacroPragma(c: PContext, a: PNode, n: PNode): PNode =
 
 template isLocalVarSym(n: PNode): bool =
   n.kind == nkSym and 
-    (n.sym.kind in {skVar, skLet} and not 
-    ({sfGlobal, sfPure} <= n.sym.flags or
+    (n.sym.kind in {skVar, skLet} and not
+    ({sfGlobal, sfPure} * n.sym.flags != {} or
       sfCompileTime in n.sym.flags) or
       n.sym.kind in {skProc, skFunc, skIterator} and 
       sfGlobal notin n.sym.flags


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/20812

The definition of `isLocalVarSym` is not correct. I found it when I was debugging https://github.com/nim-lang/Nim/pull/21024. I tried to reuse this function, but it gave surprising results. 

For a global variable, it doesn't need both `sfGlobal` and `sfPure` flags which indicates it is an explicit global variable because it can be an implicit global variable without a `sfPure` flag. I expect this function identifies all global variables. So I change its definition.

It should still stand correct for tests in https://github.com/nim-lang/Nim/pull/20812 because the previous PR used a guard statement even it was based on a wrong requirement.

```nim
  if {sfGlobal, sfPure} <= v.flags:
    globalVarInitCheck(c, def)
```


