### PR TITLE
Revert "fixes #20883; Unspecified generic on default value segfaults the compiler"

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -81,7 +81,6 @@ type
     info*: TLineInfo
     allowMetaTypes*: bool     # allow types such as seq[Number]
                               # i.e. the result contains unresolved generics
-    fromStaticExpr*: bool
     skipTypedesc*: bool       # whether we should skip typeDescs
     isReturnType*: bool
     owner*: PSym              # where this instantiation comes from
@@ -239,8 +238,6 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
       assert result.kind notin nkCallKinds
   else:
     if n.len > 0:
-      if n.kind in nkCallKinds and n[0].kind == nkIdent and cl.fromStaticExpr:
-        localError(cl.c.config, n.info, "An unresolved call in staticExpr: '" & renderTree(n) & "'")
       newSons(result, n.len)
       if start > 0:
         result[0] = n[0]
@@ -663,11 +660,10 @@ proc initTypeVars*(p: PContext, typeMap: LayeredIdTable, info: TLineInfo;
   result.owner = owner
 
 proc replaceTypesInBody*(p: PContext, pt: TIdTable, n: PNode;
-                         owner: PSym, allowMetaTypes = false, fromStaticExpr = false): PNode =
+                         owner: PSym, allowMetaTypes = false): PNode =
   var typeMap = initLayeredTypeMap(pt)
   var cl = initTypeVars(p, typeMap, n.info, owner)
   cl.allowMetaTypes = allowMetaTypes
-  cl.fromStaticExpr = fromStaticExpr
   pushInfoContext(p.config, n.info)
   result = replaceTypeVarsN(cl, n)
   popInfoContext(p.config)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -807,8 +807,7 @@ proc tryResolvingStaticExpr(c: var TCandidate, n: PNode,
   # N is bound to a concrete value during the matching of the first param.
   # This proc is used to evaluate such static expressions.
   let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil,
-                                        allowMetaTypes = allowUnresolved,
-                                        fromStaticExpr = true)
+                                        allowMetaTypes = allowUnresolved)
   result = c.c.semExpr(c.c, instantiated)
 
 proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =


### PR DESCRIPTION
Reverts nim-lang/Nim#20917

```nim
type F = float32
proc doIt[F](x: F; y=F(0)) = discard
doIt 0.0f32, 0.0
```

```nim
template tmpl(F: type, term: untyped, term0=term(0)) = discard

func f(x: float): float =
  template term(n): untyped = float(n)
  tmpl float, term, term0=0.0
```
Two other cases need to be considered. I will look into later. Revert it so that it won't cause problems for v2.