### PR TITLE
fix #21018 Nimpretty breaks with multi-line lambda procedures

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -449,7 +449,7 @@ proc emitTok*(em: var Emitter; L: Lexer; tok: Token) =
       em.indentLevel = tok.indent
     elif (em.lastTok in (splitters + oprSet) and
         tok.tokType notin (closedPars - {tkBracketDotRi})):
-      if tok.tokType in openPars and tok.indent > em.indentStack[^1]:
+      if (em.lastTok in openPars or tok.tokType in openPars) and tok.indent >= em.indentStack[^1]:
         while em.indentStack[^1] < tok.indent:
           em.indentStack.add(em.indentStack[^1] + em.indWidth)
       while em.indentStack[^1] > tok.indent:

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -1405,9 +1405,8 @@ proc getIndentWidth*(fileIdx: FileIndex, inputstream: PLLStream;
   while tok.tokType != tkEof:
     rawGetTok(lex, tok)
     if tok.indent > 0 and prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing}:
-      if result == 0:
-        result = tok.indent
-      result = min(tok.indent, result)
+      result = tok.indent
+      if result > 0: break
     prevToken = tok.tokType
   closeLexer(lex)
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -1405,8 +1405,9 @@ proc getIndentWidth*(fileIdx: FileIndex, inputstream: PLLStream;
   while tok.tokType != tkEof:
     rawGetTok(lex, tok)
     if tok.indent > 0 and prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing}:
-      result = tok.indent
-      if result > 0: break
+      if result == 0:
+        result = tok.indent
+      result = min(tok.indent, result)
     prevToken = tok.tokType
   closeLexer(lex)
 

--- a/nimpretty/tests/expected/multilines_proc_expr.nim
+++ b/nimpretty/tests/expected/multilines_proc_expr.nim
@@ -1,0 +1,17 @@
+import std/sequtils
+
+block:
+  block:
+    var _ = 0
+    proc f (): int {.used.} =
+      return 0
+
+let _ = "foo,bar,baz"
+  .map(proc (c: char): char = c)
+  .map(
+    proc (c: char): char =
+      return c
+  )
+
+proc f: bool {.used.} =
+  return true

--- a/nimpretty/tests/multilines_proc_expr.nim
+++ b/nimpretty/tests/multilines_proc_expr.nim
@@ -1,0 +1,17 @@
+import std/sequtils
+
+block:
+  block:
+    var _ = 0
+    proc f (): int {.used.} =
+                    return 0
+
+let _ = "foo,bar,baz"
+  .map(proc (c: char): char = c)
+  .map(
+    proc (c: char): char =
+          return c
+  )
+
+proc f: bool {.used.} =
+  return true


### PR DESCRIPTION
- fixed a problem in which indenting a program containing proc expressions would cause it to collapse
  - I think the reason is that the indentation is not stacked in the Emitter's `indentStack` at the start of a parenthesis that spans multiple lines.
  - Also, the standard indentation is calculated based on the number of spaces for the first indentation that appears in the file, but we changed it to the minimum number of spaces.
  - If the first number of indentations to appear was, say, 200, it was obviously wrong to align on that basis.

- This is my first time committing to nim so please let me know if I'm wrong.