### PR TITLE
Mention toSet in the docs of the set type

### DIFF
--- a/doc/sets_fragment.txt
+++ b/doc/sets_fragment.txt
@@ -38,6 +38,14 @@ can also be used to include elements (and ranges of elements):
                            # from '0' to '9'
   ```
 
+The module [`std/setutils`](https://nim-lang.org/docs/setutils.html) provides a way to initialize a set from an iterable:
+
+```nim
+import std/setutils
+
+let uniqueChars = myString.toSet
+```
+
 These operations are supported by sets:
 
 ==================    ========================================================


### PR DESCRIPTION
When looking at the docs of the `set` type I was looking for an idiom like `toHashSet` or `toIntSet`, more concise than writing a loop.

Once the `std/setutils` module has been mentioned, there's no need to say more, I believe, users can go and see what else does it provide.

The word "set" is typed in regular font, following the existing conventions.