### PR TITLE
fixes #16656; add nre to lib.md

### DIFF
--- a/doc/lib.md
+++ b/doc/lib.md
@@ -606,6 +606,10 @@ Regular expressions
   This module contains procedures and operators for handling regular
   expressions. The current implementation uses PCRE.
 
+* [nre](nre.html)
+
+  This module contains many help functions for handling regular expressions.
+  The current implementation uses PCRE.
 
 Database support
 ----------------


### PR DESCRIPTION
fixes #16656

since both `re` and `nre` are not getting moved to nimble packages.