### PR TITLE
alternative to #21046; a workaround using var instead of let

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -241,7 +241,7 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil)
       if a.len == 2 and a[0].isInfixAs():
         # support ``except Exception as ex: body``
         let isImported = semExceptBranchType(a[0][1])
-        let symbol = newSymG(skLet, a[0][2], c)
+        let symbol = newSymG(skVar, a[0][2], c)
         symbol.typ = if isImported: a[0][1].typ
                      else: a[0][1].typ.toRef(c.idgen)
         addDecl(c, symbol)

--- a/tests/init/tlet.nim
+++ b/tests/init/tlet.nim
@@ -3,6 +3,18 @@
 proc bar(x: out string) =
   x = "abc"
 
+template moe = # bug #21043
+  try:
+    discard
+  except ValueError as e:
+    echo(e.msg)
+
+template moe0 {.dirty.} = # bug #21043
+  try:
+    discard
+  except ValueError as e:
+    echo(e.msg)
+
 proc foo() =
   block:
     let x: string
@@ -25,10 +37,13 @@ proc foo() =
       discard "def"
     doAssert x == "abc"
   block: #
-    let x: int
+    let x {.used.} : int
   block: #
     let x: float
     x = 1.234
     doAssert x == 1.234
+
+  moe()
+  moe0()
 static: foo()
 foo()

--- a/tests/iter/tyieldintry.nim
+++ b/tests/iter/tyieldintry.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "; --experimental:strictDefs"
   targets: "c cpp"
 """
 


### PR DESCRIPTION
A workaround ref https://github.com/nim-lang/Nim/commit/22e762bddc13f8eef0294474ed0afcce2832ccb0#r92386520, which still gives essentially the same warning/error

```
tlet.nim(10, 10) Warning: use explicit initialization of 'e`gensym8' for clarity [Uninit]
tlet.nim(16, 10) Warning: use explicit initialization of 'e' for clarity [Uninit]
```

alternative to https://github.com/nim-lang/Nim/pull/21046