### PR TITLE
remove duplicate assignment

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -68,7 +68,6 @@ proc newTransNode(kind: TNodeKind, n: PNode,
                   sons: int): PNode {.inline.} =
   var x = newNodeIT(kind, n.info, n.typ)
   newSeq(x.sons, sons)
-  x.typ = n.typ
 #  x.flags = n.flags
   result = x
 


### PR DESCRIPTION
`newNodeIT` has already assigned `n.typ` to x.