### PR TITLE
Document that system:pop() may raise IndexDefect

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -347,7 +347,7 @@ proc missingOrExcl*[A](s: var HashSet[A], key: A): bool =
 proc pop*[A](s: var HashSet[A]): A =
   ## Removes and returns an arbitrary element from the set `s`.
   ##
-  ## Raises KeyError if the set `s` is empty.
+  ## Raises `KeyError` if the set `s` is empty.
   ##
   ## See also:
   ## * `clear proc <#clear,HashSet[A]>`_
@@ -425,7 +425,7 @@ proc intersection*[A](s1, s2: HashSet[A]): HashSet[A] =
     assert c == toHashSet(["b"])
 
   result = initHashSet[A](max(min(s1.data.len, s2.data.len), 2))
-  
+
   # iterate over the elements of the smaller set
   if s1.data.len < s2.data.len:
     for item in s1:
@@ -433,7 +433,7 @@ proc intersection*[A](s1, s2: HashSet[A]): HashSet[A] =
   else:
     for item in s2:
       if item in s1: incl(result, item)
-  
+
 
 proc difference*[A](s1, s2: HashSet[A]): HashSet[A] =
   ## Returns the difference of the sets `s1` and `s2`.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1664,6 +1664,8 @@ proc contains*[T](a: openArray[T], item: T): bool {.inline.}=
 proc pop*[T](s: var seq[T]): T {.inline, noSideEffect.} =
   ## Returns the last item of `s` and decreases `s.len` by one. This treats
   ## `s` as a stack and implements the common *pop* operation.
+  ##
+  ## Raises `IndexDefect` if `s` is empty.
   runnableExamples:
     var a = @[1, 3, 5, 7]
     let b = pop(a)


### PR DESCRIPTION
When using `system:pop()` for the first time, I wondered about the edge case in which the collection is empty.

Given that `pop()` must return an element, I'd say raising is the only logical option, but perhaps it is more obvious for users to be explicit about it.

The patch documents that the error is specifically `IndexDefect`. I don't know if this is intentional or is just a consequence of how the implementation is written today. If it is not intentional and you'd prefer a different wording please just tell me.

Since I was on it, I have also added code markup for `KeyError` in `sets:pop()`.

Some trailing whitespace is cleaned up to.