### PR TITLE
Docs expand `using` parameters 

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -962,7 +962,7 @@ proc toLangSymbol(k: TSymKind, n: PNode, baseName: string): LangSymbol =
       var literal = ""
       var r: TSrcGen
       initTokRender(r, genNode, {renderNoBody, renderNoComments,
-        renderNoPragmas, renderNoProcDefs})
+        renderNoPragmas, renderNoProcDefs, renderExpandUsing})
       var kind = tkEof
       while true:
         getNextTok(r, kind, literal)
@@ -995,7 +995,7 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   var r: TSrcGen
   # Obtain the plain rendered string for hyperlink titles.
   initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments,
-    renderNoPragmas, renderNoProcDefs})
+    renderNoPragmas, renderNoProcDefs, renderExpandUsing})
   while true:
     getNextTok(r, kind, literal)
     if kind == tkEof:
@@ -1028,7 +1028,7 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
                rstLangSymbol, priority = symbolPriority(k), info = lineinfo)
 
   nodeToHighlightedHtml(d, n, result, {renderNoBody, renderNoComments,
-    renderDocComments, renderSyms}, symbolOrIdEnc)
+    renderDocComments, renderSyms, renderExpandUsing}, symbolOrIdEnc)
 
   let seeSrc = genSeeSrc(d, toFullPath(d.conf, n.info), n.info.line.int)
 
@@ -1094,7 +1094,7 @@ proc genJsonItem(d: PDoc, n, nameNode: PNode, k: TSymKind): JsonItem =
     name = getName(d, nameNode)
     comm = genRecComment(d, n)
     r: TSrcGen
-  initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments})
+  initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments, renderExpandUsing})
   result.json = %{ "name": %name, "type": %($k), "line": %n.info.line.int,
                    "col": %n.info.col}
   if comm != nil:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -434,10 +434,13 @@ proc lsons(g: TSrcGen; n: PNode, start: int = 0, theEnd: int = - 1): int =
   result = 0
   for i in start..n.len + theEnd: inc(result, lsub(g, n[i]))
 
-template origUsingType(n: PNode): PSym =
+proc origUsingType(n: PNode): PSym {.inline.} =
   ## Returns the type that a parameter references. Check with referencesUsing first
   ## to check `n` is actually referencing a using node
-  n[0].sym.typ.sym
+  # If the node is untyped the typ field will be nil
+  if n[0].sym.typ != nil:
+    n[0].sym.typ.sym
+  else: nil
 
 proc referencesUsing(n: PNode): bool =
   ## Returns true if n references a using statement.

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -438,7 +438,8 @@ proc referencesUsing(n: PNode): bool =
   ## Returns true if n references a using statement.
   ## e.g. proc foo(x) # x doesn't have type or def value so it references a using
   result = n.kind == nkIdentDefs and
-           n[0].kind == nkSym and # If using doc0 (without sempass) then we can't find what its referencing
+           # Sometimes the node might not have been semmed (e.g. doc0) and will be nkIdent instead
+           n[0].kind == nkSym and
            n[1].kind == nkEmpty and n[2].kind == nkEmpty
 
 proc lsub(g: TSrcGen; n: PNode): int =

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -437,7 +437,9 @@ proc lsons(g: TSrcGen; n: PNode, start: int = 0, theEnd: int = - 1): int =
 proc referencesUsing(n: PNode): bool =
   ## Returns true if n references a using statement.
   ## e.g. proc foo(x) # x doesn't have type or def value so it references a using
-  result = n.kind == nkIdentDefs and n[1].kind == nkEmpty and n[2].kind == nkEmpty
+  result = n.kind == nkIdentDefs and
+           n[0].kind == nkSym and # If using doc0 (without sempass) then we can't find what its referencing
+           n[1].kind == nkEmpty and n[2].kind == nkEmpty
 
 proc lsub(g: TSrcGen; n: PNode): int =
   # computes the length of a tree

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -116,7 +116,8 @@
 
 </ul>
 <ul class="simple nested-toc-section">bar
-  <li><a class="reference" href="#bar%2CT%2CT" title="bar[T](a, b: T): T">bar[T](a, b: T): T</a></li>
+  <li><a class="reference" href="#bar" title="bar(f: FooBuzz)">bar(f: FooBuzz)</a></li>
+<li><a class="reference" href="#bar%2CT%2CT" title="bar[T](a, b: T): T">bar[T](a, b: T): T</a></li>
 
 </ul>
 <ul class="simple nested-toc-section">baz
@@ -539,7 +540,15 @@
 
 </div>
 <div id="bar-procs-all">
-  <div id="bar,T,T">
+  <div id="bar">
+  <dt><pre><span class="Keyword">proc</span> <a href="#bar"><span class="Identifier">bar</span></a><span class="Other">(</span><span class="Identifier">f</span><span class="Other">:</span> <a href="testproject.html#FooBuzz"><span class="Identifier">FooBuzz</span></a><span class="Other">)</span> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">forbids</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span>.}</pre></dt>
+  <dd>
+    
+    
+    
+  </dd>
+</div>
+<div id="bar,T,T">
   <dt><pre><span class="Keyword">proc</span> <a href="#bar%2CT%2CT"><span class="Identifier">bar</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span></pre></dt>
   <dd>
     

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -7,6 +7,7 @@ bar	testproject.html#bar,T,T	testproject: bar[T](a, b: T): T
 baz	testproject.html#baz,T,T	testproject: baz[T](a, b: T): T	
 buzz	testproject.html#buzz,T,T	testproject: buzz[T](a, b: T): T	
 FooBuzz	testproject.html#FooBuzz	testproject: FooBuzz	
+bar	testproject.html#bar	testproject: bar(f: FooBuzz)	
 aVariable	testproject.html#aVariable	testproject: aVariable	
 A	testproject.html#A	testproject: A	
 B	testproject.html#B	testproject: B	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -78,6 +78,8 @@
           </ul></dd>
 <dt><a name="bar" href="#bar"><span>bar:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
+          data-doc-search-tag="testproject: bar(f: FooBuzz)" href="testproject.html#bar">testproject: bar(f: FooBuzz)</a></li>
+          <li><a class="reference external"
           data-doc-search-tag="testproject: bar[T](a, b: T): T" href="testproject.html#bar%2CT%2CT">testproject: bar[T](a, b: T): T</a></li>
           <li><a class="reference external"
           data-doc-search-tag="testproject: bar(): untyped" href="testproject.html#bar.m">testproject: bar(): untyped</a></li>

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -42,6 +42,11 @@ proc buzz*[T](a, b: T): T {.deprecated: "since v0.20".} =
 type
   FooBuzz* {.deprecated: "FooBuzz msg".} = int
 
+using f: FooBuzz
+
+proc bar*(f) = # `f` should be expanded to `f: FooBuzz`
+  discard
+
 import std/macros
 
 var aVariable*: array[1, int]


### PR DESCRIPTION
Closes #13534

Renderer can now be passed `renderExpandUsing` flag which expands parameters that reference `using` statements to have their full type. This was added to the renderer so that the AST isn't affected by doc generation and also allows other code using the renderer to do same expansion to make types clearer (e.g. type mismatch error message)

```nim
type Test* = object

using x: Test

proc hello*(x; l: int) = discard
```
![image](https://user-images.githubusercontent.com/19339842/206946916-cefc683e-bbbe-4e88-93e2-ad66718081d8.png)
