### PR TITLE
work around chronos

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -52,7 +52,7 @@ pkg "cascade"
 pkg "cello", url = "https://github.com/nim-lang/cello", useHead = true
 pkg "chroma"
 pkg "chronicles", "nimble install -y stew@#head; nim c -o:chr -r chronicles.nim"
-pkg "chronos", "nimble install -y bearssl@#head stew@#head httputils@#head; nim c -r -d:release tests/testall"
+pkg "chronos", "nimble install -y bearssl@#head stew@#head httputils@#head; nim c -r -d:release --mm:refc tests/testall"
 pkg "cligen", "nim c --path:. -r cligen.nim"
 pkg "combparser", "nimble test --gc:orc"
 pkg "compactdict"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -52,7 +52,7 @@ pkg "cascade"
 pkg "cello", url = "https://github.com/nim-lang/cello", useHead = true
 pkg "chroma"
 pkg "chronicles", "nimble install -y stew@#head; nim c -o:chr -r chronicles.nim"
-pkg "chronos", "nimble install -y bearssl@#head stew@#head; nimble install httputils@#head; nim c -r -d:release tests/testall"
+pkg "chronos", "nim c -r -d:release tests/testall", url = "https://github.com/nim-lang/nim-chronos"
 pkg "cligen", "nim c --path:. -r cligen.nim"
 pkg "combparser", "nimble test --gc:orc"
 pkg "compactdict"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -52,7 +52,7 @@ pkg "cascade"
 pkg "cello", url = "https://github.com/nim-lang/cello", useHead = true
 pkg "chroma"
 pkg "chronicles", "nimble install -y stew@#head; nim c -o:chr -r chronicles.nim"
-pkg "chronos", "nimble install -y bearssl@#head stew@#head httputils@#head; nim c -r -d:release --mm:refc tests/testall"
+pkg "chronos", "nimble install -y bearssl@#head stew@#head; nimble install httputils@#head; nim c -r -d:release tests/testall"
 pkg "cligen", "nim c --path:. -r cligen.nim"
 pkg "combparser", "nimble test --gc:orc"
 pkg "compactdict"


### PR DESCRIPTION
I don't know why the CI failed on Macos not on Linux. 

chronos has [CI](https://github.com/status-im/nim-chronos/blob/75d030ff71264513fb9701c75a326cd36fcb4692/.github/workflows/ci.yml#L29) against the devel branch, it will be eventually fine.

The root cause is that chronos has an outdated lock file. Either remove or update it will fix the problem. So it is not a big deal.