### PR TITLE
Nimsuggest now defines the backends symbol

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -27,7 +27,6 @@ import compiler / [options, commands, modules, sem,
   passes, passaux, msgs,
   sigmatch, ast,
   idents, modulegraphs, prefixmatches, lineinfos, cmdlinehelper,
-  pathutils]
   pathutils, condsyms]
 
 when defined(nimPreviewSlimSystem):
@@ -554,9 +553,7 @@ proc mainCommand(graph: ModuleGraph) =
   registerPass graph, verbosePass
   registerPass graph, semPass
   conf.setCmd cmdIdeTools
-
   defineSymbol(conf.symbols, $conf.backend)
-
   wantMainModule(conf)
 
   if not fileExists(conf.projectFull):
@@ -956,11 +953,12 @@ else:
     proc mockCommand(graph: ModuleGraph) =
       retval = graph
       let conf = graph.config
+      conf.setCmd cmdIdeTools
       defineSymbol(conf.symbols, $conf.backend)
       clearPasses(graph)
       registerPass graph, verbosePass
       registerPass graph, semPass
-      conf.setCmd cmdIdeTools
+
       wantMainModule(conf)
 
       if not fileExists(conf.projectFull):

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -28,6 +28,7 @@ import compiler / [options, commands, modules, sem,
   sigmatch, ast,
   idents, modulegraphs, prefixmatches, lineinfos, cmdlinehelper,
   pathutils]
+  pathutils, condsyms]
 
 when defined(nimPreviewSlimSystem):
   import std/typedthreads
@@ -553,6 +554,9 @@ proc mainCommand(graph: ModuleGraph) =
   registerPass graph, verbosePass
   registerPass graph, semPass
   conf.setCmd cmdIdeTools
+
+  defineSymbol(conf.symbols, $conf.backend)
+
   wantMainModule(conf)
 
   if not fileExists(conf.projectFull):
@@ -952,6 +956,7 @@ else:
     proc mockCommand(graph: ModuleGraph) =
       retval = graph
       let conf = graph.config
+      defineSymbol(conf.symbols, $conf.backend)
       clearPasses(graph)
       registerPass graph, verbosePass
       registerPass graph, semPass

--- a/nimsuggest/tests/t20440.nim
+++ b/nimsuggest/tests/t20440.nim
@@ -1,0 +1,7 @@
+when not defined(js):
+  {.fatal: "Crash".}
+echo 4
+
+discard """
+$nimsuggest --v3 --tester $file
+"""

--- a/nimsuggest/tests/t20440.nims
+++ b/nimsuggest/tests/t20440.nims
@@ -1,0 +1,1 @@
+switch("backend", "js")


### PR DESCRIPTION
Nimsuggest now adds define for the backend being run (e.g. `defined(js)` now returns true when running suggest with js backend)

Closes #20440