### PR TITLE
test #21023

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -540,6 +540,9 @@ proc useSeqOrStrOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     # XXX: replace these with assertions.
     if t.assignment == nil:
       return # protect from recursion
+    let call = genBuiltin(c, mDefault, "default", x)
+    call.typ = x.typ
+    body.add newAsgnStmt(x, call)
     body.add newHookCall(c, t.assignment, x, y)
   of attachedSink:
     # we always inline the move for better performance:

--- a/tests/arc/tcaseobj.nim
+++ b/tests/arc/tcaseobj.nim
@@ -269,3 +269,45 @@ proc bug20305 =
   echo x.pChildren
 
 bug20305()
+
+
+
+import std/[asyncdispatch]
+
+type
+  Result2*[T, E] = object
+    case o: bool
+      of false:
+        e: E
+      of true:
+        v: T
+
+  UnpackDefect* = object of Defect
+template ok*[T, E](R: type Result2[T, E], x: untyped): R =
+  R(o: true, v: x)
+
+
+
+type
+  MGErrorKind* = enum
+    mgeUnexpected, mgeNotFound
+  
+type Foo = object
+  case kind* : MGErrorKind
+   of mgeUnexpected:
+    ex : Exception
+   else: discard 
+
+type Boo = object
+  a* : seq[int]
+
+
+   
+proc startSession*() : Future[Result2[Boo, Foo]] {.async.} =
+  let fut = newFuture[string]("")
+  fut.complete("")
+  discard await fut
+
+  return Result2[Boo, Foo].ok(Boo(a: @[2, 5]))
+
+discard waitFor startSession()

--- a/tests/arc/tcaseobj.nim
+++ b/tests/arc/tcaseobj.nim
@@ -302,7 +302,6 @@ type Boo = object
   a* : seq[int]
 
 
-   
 proc startSession*() : Future[Result2[Boo, Foo]] {.async.} =
   let fut = newFuture[string]("")
   fut.complete("")
@@ -310,4 +309,4 @@ proc startSession*() : Future[Result2[Boo, Foo]] {.async.} =
 
   return Result2[Boo, Foo].ok(Boo(a: @[2, 5]))
 
-discard waitFor startSession()
+doAssert $(waitFor startSession()) == "(o: true, v: (a: @[2, 5]))"


### PR DESCRIPTION
Not a fix, just in order to learn more about the problem. For an object with case statements, the copy hook cannot work properly for object initialization, because the field doesn't have a valid default value. 