### PR TITLE
fix #20972 Invalid and UB codegen for old-style case object transitions in refc

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -310,6 +310,7 @@ type
                       #
                       # This is disallowed but can cause the typechecking to go into
                       # an infinite loop, this flag is used as a sentinel to stop it.
+    sfDiscriminantAllInOne
 
   TSymFlags* = set[TSymFlag]
 

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1599,7 +1599,8 @@ proc asgnFieldDiscriminant(p: BProc, e: PNode) =
   initLocExpr(p, e[0], a)
   getTemp(p, a.t, tmp)
   expr(p, e[1], tmp)
-  if optTinyRtti notin p.config.globalOptions and p.inUncheckedAssignSection == 0:
+  if optTinyRtti notin p.config.globalOptions and p.inUncheckedAssignSection == 0 and
+    sfDiscriminantAllInOne notin dotExpr[1].sym.flags:
     let field = dotExpr[1].sym
     genDiscriminantCheck(p, a, tmp, dotExpr[0].typ, field)
     message(p.config, e.info, warnCaseTransition)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -772,6 +772,8 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
                  formatMissingEnums(c, a))
     else:
       localError(c.config, a.info, "not all cases are covered")
+  if n.len == 2 and chckCovered:
+    incl(a[0].sym.flags, sfDiscriminantAllInOne)
   father.add a
 
 proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,

--- a/tests/misc/t20972.nim
+++ b/tests/misc/t20972.nim
@@ -1,9 +1,10 @@
 
 discard """
-  matrix: "--gc:refc; --gc:arc"
+  cmd: "nim $target -d:release $options $file"
+  matrix: "--mm:refc; --mm:arc;"
 """
-{.passC: "-fsanitize=undefined -Wall -Wextra -pedantic -flto".}
-{.passL: "-fsanitize=undefined -flto".}
+{.passC: "-fsanitize=undefined -fsanitize-undefined-trap-on-error -Wall -Wextra -pedantic -flto".}
+{.passL: "-fsanitize=undefined -fsanitize-undefined-trap-on-error -flto".}
 
 type ForkedEpochInfo = object
   case kind: bool

--- a/tests/misc/t20972.nim
+++ b/tests/misc/t20972.nim
@@ -1,0 +1,14 @@
+
+discard """
+  matrix: "--gc:refc; --gc:arc"
+"""
+{.passC: "-fsanitize=undefined -Wall -Wextra -pedantic -flto".}
+{.passL: "-fsanitize=undefined -flto".}
+
+type ForkedEpochInfo = object
+  case kind: bool
+  of true, false: discard
+var info = ForkedEpochInfo(kind: true)
+doAssert info.kind
+info.kind = false
+doAssert not info.kind

--- a/tests/misc/t20972.nim
+++ b/tests/misc/t20972.nim
@@ -1,6 +1,6 @@
 
 discard """
-  cmd: "nim $target -d:release $options $file"
+  cmd: "nim $target -d:release $options -r $file"
   matrix: "--mm:refc; --mm:arc;"
 """
 {.passC: "-fsanitize=undefined -fsanitize-undefined-trap-on-error -Wall -Wextra -pedantic -flto".}


### PR DESCRIPTION
fix #20972

I was trying to figure out how to fix `FieldDiscriminantCheck`, in the end it's obvious no need to check as all case in one branch.