### PR TITLE
Check file exists in `{.compile.}` pragma

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -505,7 +505,7 @@ proc processCompile(c: PContext, n: PNode) =
                    cname: src, obj: dest, flags: {CfileFlag.External},
                    customArgs: customArgs)
     if not fileExists(src):
-      localError(c.config, n.info, "cannot find " & src.string)
+      localError(c.config, n.info, "cannot find: " & src.string)
     else:
       extccomp.addExternalFileToCompile(c.config, cf)
       recordPragma(c, it, "compile", src.string, dest.string, customArgs)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -504,8 +504,11 @@ proc processCompile(c: PContext, n: PNode) =
     var cf = Cfile(nimname: splitFile(src).name,
                    cname: src, obj: dest, flags: {CfileFlag.External},
                    customArgs: customArgs)
-    extccomp.addExternalFileToCompile(c.config, cf)
-    recordPragma(c, it, "compile", src.string, dest.string, customArgs)
+    if not fileExists(src):
+      localError(c.config, n.info, "cannot find " & src.string)
+    else:
+      extccomp.addExternalFileToCompile(c.config, cf)
+      recordPragma(c, it, "compile", src.string, dest.string, customArgs)
 
   proc getStrLit(c: PContext, n: PNode; i: int): string =
     n[i] = c.semConstExpr(c, n[i])

--- a/tests/pragmas/tcompile_missing_file.nim
+++ b/tests/pragmas/tcompile_missing_file.nim
@@ -1,0 +1,5 @@
+discard """
+  joinable: false
+  errormsg: "cannot find noexist.c"
+"""
+{.compile: "noexist.c".}

--- a/tests/pragmas/tcompile_missing_file.nim
+++ b/tests/pragmas/tcompile_missing_file.nim
@@ -1,5 +1,5 @@
 discard """
   joinable: false
-  errormsg: "cannot find noexist.c"
+  errormsg: "cannot find: noexist.c"
 """
 {.compile: "noexist.c".}


### PR DESCRIPTION
Closes https://github.com/nim-lang/langserver/issues/16

`example.nim`
```nim
{.compile: "noexist.c".}
```

Currently there is no check the file exists which causes an exception when trying to compile which causes `nimsuggest` to crash
```
syncio.nim(766)          open
Error: unhandled exception: cannot open: noexist.c [IOError]
```

This PR checks the file exists and converts it into an actual compile error
```
example.nim(1, 10) Error: cannot find: noexist.c
```