### PR TITLE
fixes a truncated issue related to `setInheritable`

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -423,7 +423,7 @@ proc readLine*(f: File, line: var string): bool {.tags: [ReadIOEffect],
       const numberOfCharsToRead = 2048
       var numberOfCharsRead = 0'i32
       var buffer = newWideCString("", numberOfCharsToRead)
-      if readConsole(cast[IoHandle](getOsfhandle(cint getFileHandle(f))), addr(buffer[0]),
+      if readConsole(cast[IoHandle](getOsfhandle(getFileHandle(f))), addr(buffer[0]),
         numberOfCharsToRead, addr(numberOfCharsRead), nil) == 0:
         var error = getLastError()
         var errorMsg: string


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/21102

It is an implicate breaking change, perhaps we need to add a new proc for `setInheritable`.


```nim
proc getOsFileHandle*(f: File): FileHandle =
  ## Returns the OS file handle of the file `f`. This is only useful for
  ## platform specific programming.
  when defined(windows):
    result = FileHandle getOsfhandle(cint getFileHandle(f))
  else:
    result = c_fileno(f)
```
`getOsFileHandle` is dangerous because it truncates the Handle, we probably should deprecate it.