### PR TITLE
Move stdlib default path on Linux/posix

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -714,7 +714,7 @@ proc setDefaultLibpath*(conf: ConfigRef) =
     var prefix = getPrefixDir(conf)
     when defined(posix):
       if prefix == AbsoluteDir"/usr":
-        conf.libpath = AbsoluteDir"/usr/lib/nim"
+        conf.libpath = AbsoluteDir"/usr/lib/nim/lib"
       elif prefix == AbsoluteDir"/usr/local":
         conf.libpath = AbsoluteDir"/usr/local/lib/nim"
       else:

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -69,7 +69,7 @@ Hints on the build process:
 
 What to install:
 
-- The expected stdlib location is /usr/lib/nim
+- The expected stdlib location is /usr/lib/nim/lib
 - Global configuration files under /etc/nim
 - Optionally: manpages, documentation, shell completion
 - When installing documentation, .idx files are not required


### PR DESCRIPTION
Most Linux distributions are currently installing the standard library under `/usr/lib/nim/lib`.
This is beneficial to allow installing other files, for example nimdoc.css under `/usr/lib/nim/doc`, without confusion.
(See #14424)
This PR updates the documentation as well.