### PR TITLE
fixes bareExcept warnings; catch specific exceptions

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -381,7 +381,7 @@ const
 proc listen*(server: AsyncHttpServer; port: Port; address = ""; domain = AF_INET) =
   ## Listen to the given port and address.
   when declared(maxDescriptors):
-    server.maxFDs = try: maxDescriptors() except: nimMaxDescriptorsFallback
+    server.maxFDs = try: maxDescriptors() except OSError: nimMaxDescriptorsFallback
   else:
     server.maxFDs = nimMaxDescriptorsFallback
   server.socket = newAsyncSocket(domain)

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -260,7 +260,7 @@ proc runCurrentTask() =
     current.state = CORO_EXECUTING
     try:
       current.fn() # Start coroutine execution
-    except:
+    except CatchableError:
       echo "Unhandled exception in coroutine."
       writeStackTrace()
     current.state = CORO_FINISHED

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -260,7 +260,7 @@ proc runCurrentTask() =
     current.state = CORO_EXECUTING
     try:
       current.fn() # Start coroutine execution
-    except CatchableError:
+    except:
       echo "Unhandled exception in coroutine."
       writeStackTrace()
     current.state = CORO_FINISHED

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -519,7 +519,7 @@ proc copyDirWithPermissions*(source, dest: string,
     try:
       setFilePermissions(dest, getFilePermissions(source), followSymlinks =
                          false)
-    except:
+    except OSError:
       if not ignorePermissionErrors:
         raise
   for kind, path in walkDir(source):

--- a/lib/std/private/osfiles.nim
+++ b/lib/std/private/osfiles.nim
@@ -319,7 +319,7 @@ proc copyFileWithPermissions*(source, dest: string,
     try:
       setFilePermissions(dest, getFilePermissions(source), followSymlinks =
                          (cfSymlinkFollow in options))
-    except:
+    except OSError:
       if not ignorePermissionErrors:
         raise
 
@@ -418,6 +418,6 @@ proc moveFile*(source, dest: string) {.rtl, extern: "nos$1",
       copyFile(source, dest, {cfSymlinkAsIs})
       try:
         removeFile(source)
-      except:
+      except OSError:
         discard tryRemoveFile(dest)
         raise


### PR DESCRIPTION
fixes some simple cases because they only raise `OSError`. Other often used modules need to catch Defect, otherwise they cause breaking changes.