### PR TITLE
fixes #21116; always mangles the param

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -48,11 +48,9 @@ proc fillBackendName(m: BModule; s: PSym) =
     writeMangledName(m.ndi, s, m.config)
 
 proc fillParamName(m: BModule; s: PSym) =
-  ## we cannot use 'sigConflicts' here since we have a BModule, not a BProc.
-  ## Fortunately C's scoping rules are sane enough so that that doesn't
-  ## cause any trouble.
   if s.loc.r == "":
     var res = s.name.s.mangle
+    res.add idOrSig(s, res, m.sigConflicts)
     # Take into account if HCR is on because of the following scenario:
     #   if a module gets imported and it has some more importc symbols in it,
     # some param names might receive the "_0" suffix to distinguish from what
@@ -69,8 +67,6 @@ proc fillParamName(m: BModule; s: PSym) =
     # and a function called in main or proxy uses `socket` as a parameter name.
     # That would lead to either needing to reload `proxy` or to overwrite the
     # executable file for the main module, which is running (or both!) -> error.
-    # always mangles the param; bug #21116
-    res.add "_0"
     s.loc.r = res.rope
     writeMangledName(m.ndi, s, m.config)
 

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -69,8 +69,8 @@ proc fillParamName(m: BModule; s: PSym) =
     # and a function called in main or proxy uses `socket` as a parameter name.
     # That would lead to either needing to reload `proxy` or to overwrite the
     # executable file for the main module, which is running (or both!) -> error.
-    if m.hcrOn or isKeyword(s.name) or m.g.config.cppDefines.contains(res):
-      res.add "_0"
+    # always mangles the param; bug #21116
+    res.add "_0"
     s.loc.r = res.rope
     writeMangledName(m.ndi, s, m.config)
 

--- a/tests/ccgbugs/t21116.nim
+++ b/tests/ccgbugs/t21116.nim
@@ -1,0 +1,11 @@
+discard """
+  target: "c cpp"
+  disabled: windows
+"""
+# bug #21116
+import posix
+
+proc p(glob: string) =
+  discard posix.glob(glob, 0, nil, nil)
+
+p "*"

--- a/tests/ccgbugs/t21116.nim
+++ b/tests/ccgbugs/t21116.nim
@@ -3,9 +3,8 @@ discard """
   disabled: windows
 """
 # bug #21116
-import posix
+import std/os
 
 proc p(glob: string) =
-  discard posix.glob(glob, 0, nil, nil)
-
-p "*"
+  for _ in walkFiles(glob): discard
+p("dir/*")

--- a/tests/ccgbugs/tnoalias.nim
+++ b/tests/ccgbugs/tnoalias.nim
@@ -1,5 +1,5 @@
 discard """
-  ccodecheck: "\\i@'NI* NIM_NOALIAS field;' @'NIM_CHAR* NIM_NOALIAS x,' @'void* NIM_NOALIAS q'"
+  ccodecheck: "\\i@'NI* NIM_NOALIAS field;' @'NIM_CHAR* NIM_NOALIAS x__0qEngDE9aYoYsF8tWnyPacw,' @'void* NIM_NOALIAS q'"
 """
 
 type


### PR DESCRIPTION
fixes #21116

```c
N_LIB_PRIVATE N_NIMCALL(void, p__test55_2)(NimStringV2 glob__icdZQ89bZ6Q81ZmV9cDcnAEQ);
```
Or something simpler? 