### PR TITLE
add link to setutils in system module docs

### DIFF
--- a/lib/system_overview.rst
+++ b/lib/system_overview.rst
@@ -99,6 +99,7 @@ Proc                                Usage
 ===============================     ======================================
 
 **See also:**
+* `setutils module <setutils.html>`_ for bit set convenience functions
 * `sets module <sets.html>`_ for hash sets
 * `intsets module <intsets.html>`_ for efficient int sets
 


### PR DESCRIPTION
With this change, the `system` docs now link to `setutils` in the "See also" subsection in the "Sets" section. 