### PR TITLE
Use `ErrorColor` when a warning that is turned into an error is raised

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -534,10 +534,11 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
     ignoreMsg = not conf.hasWarn(msg)
     if not ignoreMsg and msg in conf.warningAsErrors:
       title = ErrorTitle
+      color = ErrorColor
     else:
       title = WarningTitle
+      color = WarningColor
     if not ignoreMsg: writeContext(conf, info)
-    color = WarningColor
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint


### PR DESCRIPTION
`nim c --warningAsError[UnreachableCode]:on test.nim`
```nim
proc main() =
  return
  discard 1 + 1
main()
```
**Before PR**
![image](https://user-images.githubusercontent.com/19339842/208325320-c51d1b0a-ce65-44b9-9635-f05d20262340.png)
**After PR**
![image](https://user-images.githubusercontent.com/19339842/208325341-a060cf0c-476d-4a8c-95c8-51c4a497b015.png)
