### PR TITLE
Don't repeat suggestions for same symbol

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -289,7 +289,7 @@ proc suggestField(c: PContext, s: PSym; f: PNode; info: TLineInfo; outputs: var 
                               s.getQuality, pm, c.inTypeContext > 0, 0))
 
 template wholeSymTab(cond, section: untyped) {.dirty.} =
-  for (item, scopeN, isLocal) in allSyms(c):
+  for (item, scopeN, isLocal) in uniqueSyms(c):
     let it = item
     var pm: PrefixMatch
     if cond:
@@ -362,7 +362,7 @@ proc suggestOperations(c: PContext, n, f: PNode, typ: PType, outputs: var Sugges
 
 proc suggestEverything(c: PContext, n, f: PNode, outputs: var Suggestions) =
   # do not produce too many symbols:
-  for (it, scopeN, isLocal) in allSyms(c):
+  for (it, scopeN, isLocal) in uniqueSyms(c):
     var pm: PrefixMatch
     if filterSym(it, f, pm):
       outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, ideSug, n.info,
@@ -680,7 +680,7 @@ proc suggestSentinel*(c: PContext) =
   inc(c.compilesContextId)
   var outputs: Suggestions = @[]
   # suggest everything:
-  for (it, scopeN, isLocal) in allSyms(c):
+  for (it, scopeN, isLocal) in uniqueSyms(c):
     var pm: PrefixMatch
     if filterSymNoOpr(it, nil, pm):
       outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, ideSug,

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -5,21 +5,21 @@ discard """
   nimout: '''
 tspellsuggest.nim(45, 13) Error: undeclared identifier: 'fooBar'
 candidates (edit distance, scope distance); see '--spellSuggest':
- (1, 0): 'fooBar8' [var declared in tspellsuggest.nim(43, 9)]
- (1, 1): 'fooBar7' [var declared in tspellsuggest.nim(41, 7)]
- (1, 3): 'fooBar1' [var declared in tspellsuggest.nim(33, 5)]
- (1, 3): 'fooBar2' [let declared in tspellsuggest.nim(34, 5)]
- (1, 3): 'fooBar3' [const declared in tspellsuggest.nim(35, 7)]
- (1, 3): 'fooBar4' [proc declared in tspellsuggest.nim(36, 6)]
- (1, 3): 'fooBar5' [template declared in tspellsuggest.nim(37, 10)]
- (1, 3): 'fooBar6' [macro declared in tspellsuggest.nim(38, 7)]
- (1, 5): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
- (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
- (1, 5): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
- (1, 5): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
- (2, 5): 'FooCar' [type declared in mspellsuggest.nim(6, 6)]
- (2, 5): 'GooBa' [type declared in mspellsuggest.nim(7, 6)]
- (3, 0): 'fooBarBaz' [const declared in tspellsuggest.nim(44, 11)]
+ (1, 0): 'fooBar8'
+ (1, 1): 'fooBar7'
+ (1, 3): 'fooBar1'
+ (1, 3): 'fooBar2'
+ (1, 3): 'fooBar3'
+ (1, 3): 'fooBar4'
+ (1, 3): 'fooBar5'
+ (1, 3): 'fooBar6'
+ (1, 5): 'FooBar'
+ (1, 5): 'fooBar4'
+ (1, 5): 'fooBar9'
+ (1, 5): 'fooCar'
+ (2, 5): 'FooCar'
+ (2, 5): 'GooBa'
+ (3, 0): 'fooBarBaz'
 '''
 """
 

--- a/tests/misc/tspellsuggest2.nim
+++ b/tests/misc/tspellsuggest2.nim
@@ -5,18 +5,18 @@ discard """
   nimout: '''
 tspellsuggest2.nim(45, 13) Error: undeclared identifier: 'fooBar'
 candidates (edit distance, scope distance); see '--spellSuggest':
- (1, 0): 'fooBar8' [var declared in tspellsuggest2.nim(43, 9)]
- (1, 1): 'fooBar7' [var declared in tspellsuggest2.nim(41, 7)]
- (1, 3): 'fooBar1' [var declared in tspellsuggest2.nim(33, 5)]
- (1, 3): 'fooBar2' [let declared in tspellsuggest2.nim(34, 5)]
- (1, 3): 'fooBar3' [const declared in tspellsuggest2.nim(35, 7)]
- (1, 3): 'fooBar4' [proc declared in tspellsuggest2.nim(36, 6)]
- (1, 3): 'fooBar5' [template declared in tspellsuggest2.nim(37, 10)]
- (1, 3): 'fooBar6' [macro declared in tspellsuggest2.nim(38, 7)]
- (1, 5): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
- (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
- (1, 5): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
- (1, 5): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
+ (1, 0): 'fooBar8'
+ (1, 1): 'fooBar7'
+ (1, 3): 'fooBar1'
+ (1, 3): 'fooBar2'
+ (1, 3): 'fooBar3'
+ (1, 3): 'fooBar4'
+ (1, 3): 'fooBar5'
+ (1, 3): 'fooBar6'
+ (1, 5): 'FooBar'
+ (1, 5): 'fooBar4'
+ (1, 5): 'fooBar9'
+ (1, 5): 'fooCar'
 '''
 """
 

--- a/tests/misc/tspellsuggest3.nim
+++ b/tests/misc/tspellsuggest3.nim
@@ -1,0 +1,21 @@
+discard """
+  # pending bug #16521 (bug 12) use `matrix`
+  cmd: "nim c --spellsuggest:4 --hints:off $file"
+  action: "reject"
+  nimout: '''
+tspellsuggest3.nim(21, 1) Error: undeclared identifier: 'fooBar'
+candidates (edit distance, scope distance); see '--spellSuggest':
+ (1, 2): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
+ (1, 2): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
+ (1, 2): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
+ (1, 2): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
+'''
+"""
+
+import ./mspellsuggest
+import ./mspellsuggest
+import ./mspellsuggest
+import ./mspellsuggest
+
+
+fooBar

--- a/tests/misc/tspellsuggest3.nim
+++ b/tests/misc/tspellsuggest3.nim
@@ -5,10 +5,10 @@ discard """
   nimout: '''
 tspellsuggest3.nim(21, 1) Error: undeclared identifier: 'fooBar'
 candidates (edit distance, scope distance); see '--spellSuggest':
- (1, 2): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
- (1, 2): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
- (1, 2): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
- (1, 2): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
+ (1, 2): 'FooBar'
+ (1, 2): 'fooBar4'
+ (1, 2): 'fooBar9'
+ (1, 2): 'fooCar'
 '''
 """
 


### PR DESCRIPTION
Tracks seen symbols while iterating through all symbols to find similar spellings/suggestions. This is done to stop repeated suggestions for the same symbol occuring.

Bare bones example
```nim
echo l
```
`nim check --spellSuggest:4 test.nim`
```
test.nim(1, 6) Error: undeclared identifier: 'l'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (1, 3): '$' [func declared in /home/jake/.choosenim/toolchains/nim-#devel/lib/system/dollars.nim(12, 8)]
 (1, 3): '$' [func declared in /home/jake/.choosenim/toolchains/nim-#devel/lib/system/dollars.nim(31, 8)]
 (1, 3): '$' [func declared in /home/jake/.choosenim/toolchains/nim-#devel/lib/system/dollars.nim(31, 8)]
 (1, 3): '$' [func declared in /home/jake/.choosenim/toolchains/nim-#devel/lib/system/dollars.nim(31, 8)]
```
The bottom `$` is repeated three times