### PR TITLE
fixes #21144; try expression will not match the less indentation except

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1770,11 +1770,13 @@ proc parseTry(p: var Parser; isExpr: bool): PNode =
   #|            (optInd 'except' optionalExprList colcom stmt)*
   #|            (optInd 'finally' colcom stmt)?
   result = newNodeP(nkTryStmt, p)
+  let parentIndent = p.currInd # isExpr
   getTok(p)
   colcom(p, result)
   result.add(parseStmt(p))
   var b: PNode = nil
-  while sameOrNoInd(p) or isExpr:
+
+  while sameOrNoInd(p) or (isExpr and parentIndent <= p.tok.indent):
     case p.tok.tokType
     of tkExcept:
       b = newNodeP(nkExceptBranch, p)

--- a/tests/parser/ttry.nim
+++ b/tests/parser/ttry.nim
@@ -1,0 +1,27 @@
+# bug #21144
+block:
+  try:
+    let c = try:
+        10
+      except ValueError as exc:
+        10
+  except ValueError as exc:
+    discard
+
+if true:
+  block:
+    let c = try:
+          10
+        except ValueError as exc:
+          10
+    except OSError:
+      99
+
+
+try:
+  let c = try:
+    10
+  except ValueError as exc:
+    10
+except ValueError as exc:
+  discard


### PR DESCRIPTION
fixes #21144

try expression will not match the less indent except than the whole statement.

side-effects: if the parent level doesn't support except expressions, it won't report indentation errors anymore. Probably, we should match the less indentation except, if the parent level statements don't support except branches. 

```nim
if true:
  block:
    let c = try:
          10
        except ValueError as exc:
          10
  except OSError:
      99
```

