### PR TITLE
fixes #12381; Close socket handle if not able to connect

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -2031,6 +2031,7 @@ proc dial*(address: string, port: Port,
     if connect(lastFd, it.ai_addr, it.ai_addrlen.SockLen) == 0'i32:
       success = true
       break
+    lastFd.close()
     lastError = osLastError()
     it = it.ai_next
   freeAddrInfo(aiList)


### PR DESCRIPTION
This PR fixes #12381 by closing lastFd when the connection fails.  