### PR TITLE
A Nim equivalent of javascript's setTimeout and setInterval

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -307,62 +307,6 @@ proc adjustTimeout(
 
 proc runOnce(timeout: int): bool {.gcsafe.}
 
-proc doAfter*(ms: int or float, todo: proc ()): PendingOps =
-  ## Executes actions passed as `todo` after `ms` milliseconds
-  ## Without blocking the main execution flow while waiting
-  ## An equivalent of javascript's setTimeout
-
-  runnableExamples:
-    discard doAfter(2_500) do():
-      echo "2.5 seconds passed !"
-
-    var pend = doAfter(3_000) do():
-      echo "This line will never be executed !"
-
-    # Let's cancel the second pennding process
-    # 1.5 seconds before its execution :
-    discard doAfter(1_500) do(): cancel pend
-
-  var pend = PendingOps()
-
-  let  p = proc () {.async.} =
-    var pend = pend
-    await sleepAsync(ms)
-    if pend.status == PENDING:
-      pend.status = RUNNING
-      todo()
-      pend.status = FINISHED
-
-  discard p()
-
-  pend
-
-proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
-  ## Executes actions passed as `todo` every `ms` milliseconds
-  ## Without blocking the main execution flow while waiting
-  ## An equivalent of javascript's setInterval
-
-  runnableExamples:
-    var cycle = doEvery(2_000) do():
-      echo "This line will be executed three times !"
-
-    # To stop the background process after 6.5 seconds:
-    discard doAfter(6_500) do(): stop cycle
-
-  var cycle = CyclicOps()
-  cycle.status = RUNNING
-
-  let  p = proc () {.async.} =
-    var cycle = cycle
-    while true:
-      await sleepAsync(ms)
-      if cycle.status == STOPPED: break
-      todo()
-
-  discard p()
-
-  cycle
-
 proc callSoon*(cbproc: proc () {.gcsafe.}) {.gcsafe.}
   ## Schedule `cbproc` to be called as soon as possible.
   ## The callback is called when control returns to the event loop.
@@ -2065,6 +2009,62 @@ proc send*(socket: AsyncFD, data: string,
 # -- Await Macro
 import asyncmacro
 export asyncmacro
+
+proc doAfter*(ms: int or float, todo: proc ()): PendingOps =
+  ## Executes actions passed as `todo` after `ms` milliseconds
+  ## Without blocking the main execution flow while waiting
+  ## An equivalent of javascript's setTimeout
+
+  runnableExamples:
+    discard doAfter(2_500) do():
+      echo "2.5 seconds passed !"
+
+    var pend = doAfter(3_000) do():
+      echo "This line will never be executed !"
+
+    # Let's cancel the second pennding process
+    # 1.5 seconds before its execution :
+    discard doAfter(1_500) do(): cancel pend
+
+  var pend = PendingOps()
+
+  let  p = proc () {.async.} =
+    var pend = pend
+    await sleepAsync(ms)
+    if pend.status == PENDING:
+      pend.status = RUNNING
+      todo()
+      pend.status = FINISHED
+
+  discard p()
+
+  pend
+
+proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
+  ## Executes actions passed as `todo` every `ms` milliseconds
+  ## Without blocking the main execution flow while waiting
+  ## An equivalent of javascript's setInterval
+
+  runnableExamples:
+    var cycle = doEvery(2_000) do():
+      echo "This line will be executed three times !"
+
+    # To stop the background process after 6.5 seconds:
+    discard doAfter(6_500) do(): stop cycle
+
+  var cycle = CyclicOps()
+  cycle.status = RUNNING
+
+  proc p() {.async.} =
+    var cycle = cycle
+    while true:
+      await sleepAsync(ms)
+      if cycle.status == STOPPED: break
+      todo()
+
+  discard p()
+
+  cycle
 
 proc readAll*(future: FutureStream[string]): owned(Future[string]) {.async.} =
   ## Returns a future that will complete when all the string data from the

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -247,28 +247,28 @@ type
     callbacks*: Deque[proc () {.gcsafe.}]
 
   PStatus = enum
-    PENDING, CANCELED, RUNNING, FINISHED
+    pending, canceled, running, finished
   PendingOps* = ref object
-    status: PStatus = PENDING
+    status: PStatus = pending
 
   CStatus = enum
-    RUNNING, STOPPED
+    running, stopped
   CyclicOps* = ref object
-    status: CStatus = RUNNING
+    status: CStatus = running
 
 proc `$`*(pend: PendingOps): string =
   "[ Pending Ops Handle: " & $pend.status & " ]"
 
 proc cancel*(pend: PendingOps) =
-  if pend.status == PENDING:
-    pend.status = CANCELED
+  if pend.status == pending:
+    pend.status = canceled
 
 proc `$`*(cycle: CyclicOps): string =
   "[ Cyclic Ops Handle: " & $cycle.status & " ]"
 
 proc stop*(cycle: CyclicOps) =
-  if cycle.status == RUNNING:
-    cycle.status = STOPPED
+  if cycle.status == running:
+    cycle.status = stopped
 
 proc processTimers(
   p: PDispatcherBase, didSomeWork: var bool
@@ -2031,10 +2031,10 @@ proc doAfter*(ms: int or float, todo: proc ()): PendingOps =
   let  p = proc () {.async.} =
     var pend = pend
     await sleepAsync(ms)
-    if pend.status == PENDING:
-      pend.status = RUNNING
+    if pend.status == pending:
+      pend.status = running
       todo()
-      pend.status = FINISHED
+      pend.status = finished
 
   discard p()
 
@@ -2053,13 +2053,13 @@ proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
     discard doAfter(6_500) do(): stop cycle
 
   var cycle = CyclicOps()
-  cycle.status = RUNNING
+  cycle.status = running
 
   proc p() {.async.} =
     var cycle = cycle
     while true:
       await sleepAsync(ms)
-      if cycle.status == STOPPED: break
+      if cycle.status == stopped: break
       todo()
 
   discard p()

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -2121,6 +2121,56 @@ proc doEvery*(todo: proc (), ms: int or float): CyclicOps =
 
   return cycle
 
+template once*(cond: bool, todo: proc ()) =
+  ## Checks `cond` in background every 5 milliseconds
+  ## And executes actions passed as `todo` once it's true
+
+  runnableExamples:
+    import threadpool, os
+  
+    var hasFinished = false
+
+    proc longOps() =
+      # let's fake long operations with sleep
+      sleep 5_000
+      hasFinished = true
+
+    spawn longOps()
+    once(hasFinished) do(): echo "Finished !"
+
+  let p = proc () {.async.} =
+    while not cond:
+      await sleepAsync(5)
+    todo()
+
+  discard p()
+
+template doOnce*(todo: proc (), cond: bool) =
+  ## Checks `cond` in background every 5 milliseconds
+  ## And executes actions passed as `todo` once it's true
+
+  runnableExamples:
+    import threadpool, os
+  
+    var hasFinished = false
+
+    proc longOps() =
+      # let's fake long operations with sleep
+      sleep 5_000
+      hasFinished = true
+    
+    proc notify() = echo "Finished !"
+
+    spawn longOps()
+    notify.doOnce(hasFinished)
+
+  let p = proc () {.async.} =
+    while not cond:
+      await sleepAsync(5)
+    todo()
+
+  discard p()
+
 proc readAll*(future: FutureStream[string]): owned(Future[string]) {.async.} =
   ## Returns a future that will complete when all the string data from the
   ## specified future stream is retrieved.

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -2028,7 +2028,7 @@ proc doAfter*(ms: int or float, todo: proc ()): PendingOps =
 
   var pend = PendingOps()
 
-  let  p = proc () {.async.} =
+  proc p() {.async.} =
     var pend = pend
     await sleepAsync(ms)
     if pend.status == pending:
@@ -2038,7 +2038,7 @@ proc doAfter*(ms: int or float, todo: proc ()): PendingOps =
 
   discard p()
 
-  pend
+  return pend
 
 proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
   ## Executes actions passed as `todo` every `ms` milliseconds
@@ -2053,7 +2053,6 @@ proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
     discard doAfter(6_500) do(): stop cycle
 
   var cycle = CyclicOps()
-  cycle.status = running
 
   proc p() {.async.} =
     var cycle = cycle
@@ -2064,7 +2063,7 @@ proc doEvery*(ms: int or float, todo: proc ()): CyclicOps =
 
   discard p()
 
-  cycle
+  return cycle
 
 proc readAll*(future: FutureStream[string]): owned(Future[string]) {.async.} =
   ## Returns a future that will complete when all the string data from the


### PR DESCRIPTION
# doAfter
Executes actions passed as `todo` after `ms` milliseconds

Without blocking the main execution flow while waiting

An equivalent of javascript's setTimeout

```nim
  runnableExamples:
    discard doAfter 2_500:
      echo "2.5 seconds passed !"

    var pend = doAfter 3_000:
      echo "This line will never be executed !"

    # Let's cancel the second pennding process
    # 1.5 seconds before its execution :
    discard doAfter 1_500: cancel pend
```

# doEvery
Executes actions passed as `todo` every `ms` milliseconds
Without blocking the main execution flow while waiting
An equivalent of javascript's setInterval

```nim
  runnableExamples:
    var cycle = doEvery 2_000:
      echo "This line will be executed three times !"

    # To stop the background process after 6.5 seconds:
    discard doAfter 6_500: stop cycle
```