### PR TITLE
add the cpp target

### DIFF
--- a/tests/cpp/t12946.nim
+++ b/tests/cpp/t12946.nim
@@ -1,3 +1,7 @@
+discard """
+  targets: "c cpp"
+"""
+
 import std/atomics
 type Futex = distinct Atomic[int32]
 


### PR DESCRIPTION
The issue is related to cpp codegen, the previous test doesn't test cpp backend, which will join into the megatest.

> 2022-12-22T16:27:09.0854669Z [2m[33mJOINED: [1m[36mtests/cpp/t12946.nim c[0m