### PR TITLE
fix #20997

### DIFF
--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -10,7 +10,10 @@
 # set handling
 
 type
-  NimSet = array[0..8192-1, uint8]
+  NimSet = distinct openArray[uint8]
+
+proc toOpenArray(x: NimSet; first, last: int): openArray[uint8] {.
+  magic: "Slice".}
 
 proc cardSetImpl(s: openArray[uint8], len: int): int {.inline.} =
   var i = 0
@@ -25,4 +28,4 @@ proc cardSetImpl(s: openArray[uint8], len: int): int {.inline.} =
     inc(i, 1)
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
-  result = cardSetImpl(s, len)
+  result = cardSetImpl(s.toOpenArray(0, len), len)

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -9,13 +9,8 @@
 
 # set handling
 
-type
-  NimSet = distinct openArray[uint8]
 
-proc toOpenArray(x: NimSet; first, last: int): openArray[uint8] {.
-  magic: "Slice".}
-
-proc cardSetImpl(s: openArray[uint8], len: int): int {.inline.} =
+proc cardSetImpl(s: ptr UncheckedArray[uint8], len: int): int {.inline.} =
   var i = 0
   result = 0
   when defined(x86) or defined(amd64):
@@ -27,5 +22,5 @@ proc cardSetImpl(s: openArray[uint8], len: int): int {.inline.} =
     inc(result, countBits32(uint32(s[i])))
     inc(i, 1)
 
-proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
-  result = cardSetImpl(s.toOpenArray(0, len), len)
+proc cardSet(s: ptr UncheckedArray[uint8], len: int): int {.compilerproc, inline.} =
+  result = cardSetImpl(s, len)


### PR DESCRIPTION
fix #20997, this is subsequent PR of https://github.com/nim-lang/Nim/pull/21010

<s>it's bit tricky here, have to use `NimSet = distinct openArray[uint8]`, otherwise `cardSet` compiler proc will match directly call to system.card , in my case `lib\pure\parseopt.nim` `card(p.shortNoVal)` , which will cause `error: too few arguments to function ‘cardSet’`

then I have to use `toOpenArray`, so I copy paste the magic proc there, can't casting to `openArray[uint8]` for now.</s>