### PR TITLE
Introducing the pattern "then-catch-finally" in Nim

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1987,36 +1987,46 @@ import asyncmacro
 export asyncmacro
 
 proc then*[T](fut: Future[T], todo: proc(value: T)) =
-  try:
-    todo(await fut)
-  except:
-    discard
+  proc p() {.async.} =
+    try:
+      todo(await fut)
+    except CatchableError:
+      discard
+  discard p()
 
 proc then*[T](fut: Future[T], todo: proc()) =
-  try:
-    discard await fut
-    todo()
-  except:
-    discard
+  proc p() {.async.} =
+    try:
+      discard await fut
+      todo()
+    except CatchableError:
+      discard
+  discard p()
 
 proc catch*[T](fut: Future[T], todo: proc(error: ref Exception)) =
-  try:
-    discard await fut
-  except Exception as error:
-    todo(error)
+  proc p() {.async.} =
+    try:
+      discard await fut
+    except Exception as error:
+      todo(error)
+  discard p()
 
 proc catch*[T](fut: Future[T], todo: proc()) =
-  try:
-    discard await fut
-  except Exception as error:
-    todo()
+  proc p() {.async.} =
+    try:
+      discard await fut
+    except Exception as error:
+      todo()
+  discard p()
 
 proc `finally`*[T](fut: Future[T], todo: proc()) =
-  try:
-    discard await fut
-  except:
-    discard
-  todo()
+  proc p() {.async.} =
+    try:
+      discard await fut
+    except:
+      discard
+    todo()
+  discard p()
 
 proc readAll*(future: FutureStream[string]): owned(Future[string]) {.async.} =
   ## Returns a future that will complete when all the string data from the

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1990,7 +1990,7 @@ proc then*[T](fut: Future[T], todo: proc(value: T)) =
   proc p() {.async.} =
     try:
       todo(await fut)
-    except CatchableError:
+    except:
       discard
   discard p()
 
@@ -1999,7 +1999,7 @@ proc then*[T](fut: Future[T], todo: proc()) =
     try:
       discard await fut
       todo()
-    except CatchableError:
+    except:
       discard
   discard p()
 

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1986,6 +1986,38 @@ proc send*(socket: AsyncFD, data: string,
 import asyncmacro
 export asyncmacro
 
+proc then*[T](fut: Future[T], todo: proc(value: T)) =
+  try:
+    todo(await fut)
+  except:
+    discard
+
+proc then*[T](fut: Future[T], todo: proc()) =
+  try:
+    discard await fut
+    todo()
+  except:
+    discard
+
+proc catch*[T](fut: Future[T], todo: proc(error: ref Exception)) =
+  try:
+    discard await fut
+  except Exception as error:
+    todo(error)
+
+proc catch*[T](fut: Future[T], todo: proc()) =
+  try:
+    discard await fut
+  except Exception as error:
+    todo()
+
+proc `finally`*[T](fut: Future[T], todo: proc()) =
+  try:
+    discard await fut
+  except:
+    discard
+  todo()
+
 proc readAll*(future: FutureStream[string]): owned(Future[string]) {.async.} =
   ## Returns a future that will complete when all the string data from the
   ## specified future stream is retrieved.


### PR DESCRIPTION
This PR is my second attempt to implement then-catch in Nim, the first is here: [https://github.com/nim-lang/Nim/pull/21002](https://github.com/nim-lang/Nim/pull/21002).

The great downside of the "then-catch" pattern is that it introduces new conditions to check for each Future, which is an overhead that is useless for all those who don't need `then` or `catch`.

So in this new implementation, the pattern is active only if you compile with the flag: `-d:futsugar` or the pragma: `{.define: futsugar.}`. So anybody can choose whether or not he wants to use it.

Instead of:
```nim
proc cb(fut: Future[T]) =
  if fut.failed:
    myErrLogger fut.error 
  else:
    echo fut.value + 1

  echo "Goodbye !"

myFuture.callback = cb
```
We can now write:
```nim
myFuture.then do(val: int):
  echo val + 1
myFuture.catch do(err: ref Exception):
  myErrLogger err
myFuture.finally do():
  echo "Goodbye !"
```

Based on ideas discussed in RFC: [nim-lang/RFCs#458](https://github.com/nim-lang/RFCs/issues/458)