### PR TITLE
fix in msg `doAssert()` to update grammar.txt

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -42,7 +42,7 @@ when isMainModule or defined(nimTestGrammar):
 
     proc checkSameGrammar*() =
       doAssert sameFileContent(newGrammarText, "doc/grammar.txt"),
-              "execute 'nim r compiler.nim' to keep grammar.txt up-to-date"
+              "execute 'nim r compiler/parser.nim' to keep grammar.txt up-to-date"
   else:
     writeGrammarFile("doc/grammar.txt")
     import ".." / tools / grammar_nanny


### PR DESCRIPTION
The `doAssert()` msg points to a non-existent file to update grammar.txt