### PR TITLE
std/encodings: Fix open() documentation in regard to exception raised

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -339,7 +339,7 @@ proc getCurrentEncoding*(uiApp = false): string =
 
 proc open*(destEncoding = "UTF-8", srcEncoding = "CP1252"): EncodingConverter =
   ## Opens a converter that can convert from `srcEncoding` to `destEncoding`.
-  ## Raises `IOError` if it cannot fulfill the request.
+  ## Raises `EncodingError` if it cannot fulfill the request.
   when not defined(windows):
     result = iconvOpen(destEncoding, srcEncoding)
     if result == nil:


### PR DESCRIPTION
The doc for `open()` erroneously states that it may raise `IOError`, while the actual exception raised is `EncodingError`.