### PR TITLE
less verbose type mismatch messages

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -135,6 +135,8 @@
 
 - The experimental strictFuncs feature now disallows a store to the heap via a `ref` or `ptr` indirection.
 
+- - Added the `--legacy:verboseTypeMismatch` switch to get legacy type mismatch error messages.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -231,6 +231,7 @@ type
       ## are not anymore.
     laxEffects
       ## Lax effects system prior to Nim 2.0.
+    verboseTypeMismatch
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf, stressTest

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1654,7 +1654,7 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
     let verbose = actualStr == formalStr or optDeclaredLocs in conf.globalOptions
     var msg = "type mismatch:"
     if verbose: msg.add "\n"
-    if conf.isDefined("nimLegacyTypeMismatch"):
+    if verboseTypeMismatch in conf.legacyFeatures:
       msg.add  " got <$1>" % actualStr
     else:
       msg.add  " got '$1' for '$2'" % [actualStr, n.renderTree]

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1654,7 +1654,7 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
     let verbose = actualStr == formalStr or optDeclaredLocs in conf.globalOptions
     var msg = "type mismatch:"
     if verbose: msg.add "\n"
-    if verboseTypeMismatch in conf.legacyFeatures:
+    if conf.isDefined("nimLegacyTypeMismatch"):
       msg.add  " got <$1>" % actualStr
     else:
       msg.add  " got '$1' for '$2'" % [actualStr, n.renderTree]

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -44,3 +44,4 @@ when defined(windows):
   switch("tlsEmulation", "off")
 
 switch("warningAserror", "UnnamedBreak")
+switch("legacy", "verboseTypeMismatch")

--- a/tests/errmsgs/tconcisetypemismatch.nim
+++ b/tests/errmsgs/tconcisetypemismatch.nim
@@ -1,0 +1,23 @@
+discard """
+  cmd: "nim c --hints:off --skipParentCfg $file"
+  errormsg: "type mismatch"
+  nimout: '''
+tconcisetypemismatch.nim(23, 43) Error: type mismatch
+Expression: inNanoseconds(t2 - t1) / 100.5
+  [1] inNanoseconds(t2 - t1): int64
+  [2] 100.5: float64
+
+Expected one of (first mismatch at position [#]):
+[1] proc `/`(x, y: float): float
+[1] proc `/`(x, y: float32): float32
+[2] proc `/`(x, y: int): float
+'''
+"""
+
+import std/monotimes
+from times import inNanoseconds
+
+let t1 = getMonotime()
+let result = 1 + 2
+let t2 = getMonotime()
+echo "Elapsed: ", (t2 - t1).inNanoseconds / 100.5

--- a/tests/errmsgs/tconcisetypemismatch.nim
+++ b/tests/errmsgs/tconcisetypemismatch.nim
@@ -2,9 +2,9 @@ discard """
   cmd: "nim c --hints:off --skipParentCfg $file"
   errormsg: "type mismatch"
   nimout: '''
-tconcisetypemismatch.nim(23, 43) Error: type mismatch
-Expression: inNanoseconds(t2 - t1) / 100.5
-  [1] inNanoseconds(t2 - t1): int64
+tconcisetypemismatch.nim(23, 49) Error: type mismatch
+Expression: int64(inNanoseconds(t2 - t1)) / 100.5
+  [1] int64(inNanoseconds(t2 - t1)): int64
   [2] 100.5: float64
 
 Expected one of (first mismatch at position [#]):
@@ -20,4 +20,4 @@ from times import inNanoseconds
 let t1 = getMonotime()
 let result = 1 + 2
 let t2 = getMonotime()
-echo "Elapsed: ", (t2 - t1).inNanoseconds / 100.5
+echo "Elapsed: ", (t2 - t1).inNanoseconds.int64 / 100.5

--- a/tests/errmsgs/tconcisetypemismatch.nim
+++ b/tests/errmsgs/tconcisetypemismatch.nim
@@ -2,9 +2,9 @@ discard """
   cmd: "nim c --hints:off --skipParentCfg $file"
   errormsg: "type mismatch"
   nimout: '''
-tconcisetypemismatch.nim(23, 49) Error: type mismatch
-Expression: int64(inNanoseconds(t2 - t1)) / 100.5
-  [1] int64(inNanoseconds(t2 - t1)): int64
+tconcisetypemismatch.nim(23, 47) Error: type mismatch
+Expression: int(inNanoseconds(t2 - t1)) / 100.5
+  [1] int(inNanoseconds(t2 - t1)): int
   [2] 100.5: float64
 
 Expected one of (first mismatch at position [#]):
@@ -20,4 +20,4 @@ from times import inNanoseconds
 let t1 = getMonotime()
 let result = 1 + 2
 let t2 = getMonotime()
-echo "Elapsed: ", (t2 - t1).inNanoseconds.int64 / 100.5
+echo "Elapsed: ", (t2 - t1).inNanoseconds.int / 100.5

--- a/tests/errmsgs/tconcisetypemismatch.nims
+++ b/tests/errmsgs/tconcisetypemismatch.nims
@@ -1,0 +1,21 @@
+switch("path", "$lib/../testament/lib")
+  # so we can `import stdtest/foo` inside tests
+  # Using $lib/../ instead of $nim/ so you can use a different nim to run tests
+  # during local testing, e.g. nim --lib:lib.
+
+## prevent common user config settings to interfere with testament expectations
+## Indifidual tests can override this if needed to test for these options.
+switch("colors", "off")
+
+switch("excessiveStackTrace", "off")
+
+when (NimMajor, NimMinor, NimPatch) >= (1,5,1):
+  # to make it easier to test against older nim versions, (best effort only)
+  switch("filenames", "legacyRelProj")
+  switch("spellSuggest", "0")
+
+# for std/unittest
+switch("define", "nimUnittestOutputLevel:PRINT_FAILURES")
+switch("define", "nimUnittestColor:off")
+
+hint("Processing", off)


### PR DESCRIPTION
Supersedes https://github.com/nim-lang/Nim/pull/20528

fixes https://github.com/nim-lang/RFCs/issues/87
implements https://forum.nim-lang.org/t/9514

screenshot

![image](https://user-images.githubusercontent.com/43030857/195102009-c201bf57-6c92-48ad-8f79-7179e75efebc.png)

**Compared to before, it also omits some useful information like below** Perhaps the error message should expand and collapse according to verbose levels.

![image](https://user-images.githubusercontent.com/43030857/209805759-76c7dcb6-d1c7-401b-aef3-cf7768456856.png)
