### PR TITLE
fix #15117 disallow zero size array 

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -335,9 +335,9 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
     if e.typ.kind == tyFromExpr:
       result = makeRangeWithStaticExpr(c, e.typ.n)
     elif e.kind in {nkIntLit..nkUInt64Lit}:
-      if e.intVal < 0:
+      if e.intVal < 1:
         localError(c.config, n.info,
-          "Array length can't be negative, but was " & $e.intVal)
+          "Array length must greater than zero, but was " & $e.intVal)
       result = makeRangeType(c, 0, e.intVal-1, n.info, e.typ)
     elif e.kind == nkSym and e.typ.kind == tyStatic:
       if e.sym.ast != nil:

--- a/tests/misc/t15117.nim
+++ b/tests/misc/t15117.nim
@@ -1,0 +1,7 @@
+discard """
+  action: reject
+"""
+
+const arrLen = 0
+
+let a: array[arrLen, byte] = []


### PR DESCRIPTION
fix #15117
even it compiles with ` cpp(vcc)` , let's disallow it, the only use case is as last field of struct that create a flexible array.

breaks:  

`pkgstemp/stew/tests/test_ctops.nim(50, 25) Error: Array length must greater than zero, but was 0`

`noise-0.1.8-30a83206e751da70c9bf787cad34ac4d3346d0f6/noise/lineImpl.nim(62, 30) Error: Array length must greater than zero, but was 0`

`pkgstemp/nimcrypto/nimcrypto/sha.nim(225, 26) Error: Array length must greater than zero, but was 0`