### PR TITLE
fixes #21195; `std/assertions` continue to use `sysFatal` when `nimPreviewSlimSystem` is not defined

### DIFF
--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -8,6 +8,7 @@
 #
 
 when not defined(nimPreviewSlimSystem) and not declared(sysFatal):
+  include "system/rawquits"
   include "system/fatal"
 
 ## This module implements assertion handling.

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -7,6 +7,9 @@
 #    distribution, for details about the copyright.
 #
 
+when not defined(nimPreviewSlimSystem) and not declared(sysFatal):
+  include "system/fatal"
+
 ## This module implements assertion handling.
 
 import std/private/miscdollars
@@ -28,7 +31,10 @@ when not defined(nimHasSinkInference):
 
 proc raiseAssert*(msg: string) {.noinline, noreturn, nosinks.} =
   ## Raises an `AssertionDefect` with `msg`.
-  raise newException(AssertionDefect, msg)
+  when defined(nimPreviewSlimSystem):
+    raise newException(AssertionDefect, msg)
+  else:
+    sysFatal(AssertionDefect, msg)
 
 proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
   ## Raises an `AssertionDefect` with `msg`, but this is hidden

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1630,8 +1630,7 @@ template newException*(exceptn: typedesc, message: string;
   (ref exceptn)(msg: message, parent: parentException)
 
 when not defined(nimPreviewSlimSystem):
-  import std/assertions
-  export assertions
+  include std/assertions
 
 import system/iterators
 export iterators

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1088,31 +1088,9 @@ proc align(address, alignment: int): int =
   else:
     result = (address + (alignment - 1)) and not (alignment - 1)
 
-when defined(nimNoQuit):
-  proc rawQuit(errorcode: int = QuitSuccess) = discard "ignoring quit"
-
-elif defined(genode):
-  import genode/env
-
-  var systemEnv {.exportc: runtimeEnvSym.}: GenodeEnvPtr
-
-  type GenodeEnv* = GenodeEnvPtr
-    ## Opaque type representing Genode environment.
-
-  proc rawQuit(env: GenodeEnv; errorcode: int) {.magic: "Exit", noreturn,
-    importcpp: "#->parent().exit(@); Genode::sleep_forever()", header: "<base/sleep.h>".}
-
-  proc rawQuit(errorcode: int = QuitSuccess) {.inline, noreturn.} =
-    systemEnv.rawQuit(errorcode)
-
-
-elif defined(js) and defined(nodejs) and not defined(nimscript):
-  proc rawQuit(errorcode: int = QuitSuccess) {.magic: "Exit",
-    importc: "process.exit", noreturn.}
-
-else:
-  proc rawQuit(errorcode: cint) {.
-    magic: "Exit", importc: "exit", header: "<stdlib.h>", noreturn.}
+include system/rawquits
+when defined(genode):
+  export GenodeEnv
 
 template sysAssert(cond: bool, msg: string) =
   when defined(useSysAssert):
@@ -1630,7 +1608,8 @@ template newException*(exceptn: typedesc, message: string;
   (ref exceptn)(msg: message, parent: parentException)
 
 when not defined(nimPreviewSlimSystem):
-  include std/assertions
+  import std/assertions
+  export assertions
 
 import system/iterators
 export iterators

--- a/lib/system/rawquits.nim
+++ b/lib/system/rawquits.nim
@@ -1,0 +1,27 @@
+import system/ctypes
+
+when defined(nimNoQuit):
+  proc rawQuit(errorcode: int = QuitSuccess) = discard "ignoring quit"
+
+elif defined(genode):
+  import genode/env
+
+  var systemEnv {.exportc: runtimeEnvSym.}: GenodeEnvPtr
+
+  type GenodeEnv = GenodeEnvPtr
+    ## Opaque type representing Genode environment.
+
+  proc rawQuit(env: GenodeEnv; errorcode: int) {.magic: "Exit", noreturn,
+    importcpp: "#->parent().exit(@); Genode::sleep_forever()", header: "<base/sleep.h>".}
+
+  proc rawQuit(errorcode: int = QuitSuccess) {.inline, noreturn.} =
+    systemEnv.rawQuit(errorcode)
+
+
+elif defined(js) and defined(nodejs) and not defined(nimscript):
+  proc rawQuit(errorcode: int = QuitSuccess) {.magic: "Exit",
+    importc: "process.exit", noreturn.}
+
+else:
+  proc rawQuit(errorcode: cint) {.
+    magic: "Exit", importc: "exit", header: "<stdlib.h>", noreturn.}

--- a/tests/assert/panicoverride.nim
+++ b/tests/assert/panicoverride.nim
@@ -1,0 +1,15 @@
+# panicoverride.nim
+
+proc printf(fmt: cstring) {.varargs, importc, header:"stdio.h".}
+proc exit(code: cint) {.importc, header:"stdlib.h".}
+
+{.push stack_trace: off, profiler:off.}
+
+proc rawoutput(s: cstring) =
+  printf("RAW: %s\n", s)
+  
+proc panic(s: cstring) {.noreturn.} =
+  printf("PANIC: %s\n", s)
+  exit(0)
+
+{.pop.}

--- a/tests/assert/t21195.nim
+++ b/tests/assert/t21195.nim
@@ -1,0 +1,6 @@
+discard """
+  matrix: "--verbosity:0 --os:standalone --mm:none"
+"""
+# bug #21195
+var n = 11
+assert(n == 12)

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim $target $options -d:nimPreviewSlimSystem --excessiveStackTrace:off $file"
   output: '''true'''
 """
-
+import std/assertions
 const expected = """
 tassert_c.nim(35)        tassert_c
 tassert_c.nim(34)        foo

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: "nim $target $options --excessiveStackTrace:off $file"
+  cmd: "nim $target $options -d:nimPreviewSlimSystem --excessiveStackTrace:off $file"
   output: '''true'''
 """
 

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -8,7 +8,7 @@ t9768.nim(29, 33)        main
 t9768.nim(24, 11)        foo1
 '''
 """
-
+import std/assertions
 
 
 

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -1,13 +1,13 @@
 discard """
   errormsg: "unhandled exception: t9768.nim(24, 3) `a < 4`  [AssertionDefect]"
   file: "std/assertions.nim"
+  matrix: "-d:nimPreviewSlimSystem"
   nimout: '''
 stack trace: (most recent call last)
 t9768.nim(29, 33)        main
 t9768.nim(24, 11)        foo1
 '''
 """
-
 
 
 


### PR DESCRIPTION
fixes #21195