### PR TITLE
avoiding unnecessary allocation for dollar IpAddress

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1930,7 +1930,7 @@ proc `$`*(address: IpAddress): string =
     result.add '.'
     result.addInt address.address_v4[3]
   of IpAddressFamily.IPv6:
-    result = newStringOfCap(48)
+    result = newStringOfCap(39)
     var
       currentZeroStart = -1
       currentZeroCount = 0

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1921,7 +1921,7 @@ proc `$`*(address: IpAddress): string =
   ## Converts an IpAddress into the textual representation
   case address.family
   of IpAddressFamily.IPv4:
-    result = newStringOfCap(16)
+    result = newStringOfCap(15)
     result.addInt address.address_v4[0]
     result.add '.'
     result.addInt address.address_v4[1]


### PR DESCRIPTION
**Explanation for IPv4**:
The [inet.h](https://github.com/torvalds/linux/blob/1b929c02afd37871d5afb9d498426f83432e71c2/include/linux/inet.h#L49) file uses 16 as the string in C needs the last null byte

However, strings in Nim do not need this. So one byte is being allocated unnecessary and will never be used. Longest string for ipv4 is 255.255.255.255 or something like that.

**Explanation for IPv6**:
It is currently allocating 48 bytes. However, the Nim implementation for IPv6 will print a maximum of 39 characters (ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff or any other IPv6 without leading zeros). Nim does not implement IPv6 "0000:0000:0000:0000:0000:ffff:255.255.255.255" (45 characters) nor "0000:0000:0000:0000:0000:ffff:255.255.255.255%3" (47 characters).

The indication in [inet.h](https://github.com/torvalds/linux/blob/1b929c02afd37871d5afb9d498426f83432e71c2/include/linux/inet.h#L50) for 48 is due to the maximum use of 47 characters of a C string that needs a null byte at the end. So 48.