### PR TITLE
 fixes #14444; add `genLineDir` before assignment

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1114,7 +1114,6 @@ proc genSeqElem(p: BProc, n, x, y: PNode, d: var TLoc) =
   if ty.kind in {tyRef, tyPtr}:
     ty = skipTypes(ty.lastSon, abstractVarRange) # emit range check:
   if optBoundsCheck in p.options:
-    genLineDir(p, n)
     linefmt(p, cpsStmts,
             "if ($1 < 0 || $1 >= $2){ #raiseIndexError2($1,$2-1); ",
             [rdCharLoc(b), lenExpr(p, a)])

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1114,6 +1114,7 @@ proc genSeqElem(p: BProc, n, x, y: PNode, d: var TLoc) =
   if ty.kind in {tyRef, tyPtr}:
     ty = skipTypes(ty.lastSon, abstractVarRange) # emit range check:
   if optBoundsCheck in p.options:
+    genLineDir(p, n)
     linefmt(p, cpsStmts,
             "if ($1 < 0 || $1 >= $2){ #raiseIndexError2($1,$2-1); ",
             [rdCharLoc(b), lenExpr(p, a)])

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1620,6 +1620,7 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
     initLoc(a, locNone, le, OnUnknown)
     a.flags.incl(lfEnforceDeref)
     a.flags.incl(lfPrepareForMutation)
+    genLineDir(p, le) # it can be a nkBracketExpr, which may raise
     expr(p, le, a)
     a.flags.excl(lfPrepareForMutation)
     if fastAsgn: incl(a.flags, lfNoDeepCopy)

--- a/tests/errmsgs/t14444.nim
+++ b/tests/errmsgs/t14444.nim
@@ -1,0 +1,14 @@
+discard """
+  matrix: "--hints:off"
+  exitcode: "1"
+  output: '''
+t14444.nim(13)           t14444
+fatal.nim(51)            sysFatal
+Error: unhandled exception: index out of bounds, the container is empty [IndexDefect]
+'''
+"""
+
+when true: # bug #14444
+  var i: string
+  i[10] = 'j'
+  echo i


### PR DESCRIPTION
 fixes #14444

BTW, when I debugged the compilers, sometimes I felt that the stacktrace of the compiler is a bit warped. It seemed that something useful was missing.

I suppose it shall better to fix `proc genSeqElem` directly. 