### PR TITLE
Bare excepts are deprecated, fix a warning in unittest

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -550,7 +550,7 @@ template test*(name, body) {.dirty.} =
         defer: testTeardownIMPL()
       body
 
-    except:
+    except CatchableError:
       let e = getCurrentException()
       let eTypeDesc = "[" & exceptionTypeName(e) & "]"
       checkpoint("Unhandled exception: " & getCurrentExceptionMsg() & " " & eTypeDesc)

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -550,7 +550,7 @@ template test*(name, body) {.dirty.} =
         defer: testTeardownIMPL()
       body
 
-    except CatchableError:
+    except Exception:
       let e = getCurrentException()
       let eTypeDesc = "[" & exceptionTypeName(e) & "]"
       checkpoint("Unhandled exception: " & getCurrentExceptionMsg() & " " & eTypeDesc)


### PR DESCRIPTION
I've been getting this recently:

```
/home/kraptor/.choosenim/toolchains/nim-#devel/lib/pure/unittest.nim(553, 5) Warning: The bare except clause is deprecated; use `except CatchableError:` instead [BareExcept]
```