### PR TITLE
Update nim.cfg

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -181,10 +181,9 @@ nimblepath="$home/.nimble/pkgs/"
 
 gcc.maxerrorsimpl = "-fmax-errors=3"
 
-@if freebsd:
+@if freebsd or netbsd:
   tlsEmulation:off
 @elif bsd:
-  # at least NetBSD has problems with thread local storage:
   tlsEmulation:on
 @end
 


### PR DESCRIPTION
tlsEmulation:on under NetBSD-10Beta and NetBSD-current produces an executable which crashes immediately as follows:

Core was generated by `koch'.
Program terminated with signal SIGSEGV, Segmentation fault. #0  0x000000000047b4c2 in nimZeroMem ()
(gdb) bt
#0  0x000000000047b4c2 in nimZeroMem ()
#1  0x00000000004897b2 in threadVarAlloc__system_2162 () #2  0x000000000048980e in initThreadVarsEmulation () #3  0x0000000000489848 in PreMain ()
#4  0x000000000048986a in NimMain ()
#5  0x00000000004898a9 in main ()

I can't speak about the other BSDs.