### PR TITLE
fixes pragmas reorder

### DIFF
--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -106,6 +106,7 @@ proc computeDeps(cache: IdentCache; n: PNode, declares, uses: var IntSet; topLev
     if a.kind == nkExprColonExpr and a[0].kind == nkIdent and a[0].ident.s == "pragma":
       # user defined pragma
       decl(a[1])
+      for i in 1..<n.safeLen: deps(n[i])
     else:
       for i in 0..<n.safeLen: deps(n[i])
   of nkMixinStmt, nkBindStmt: discard

--- a/tests/pragmas/tpragmas_reorder.nim
+++ b/tests/pragmas/tpragmas_reorder.nim
@@ -1,0 +1,19 @@
+discard """
+  matrix: "--experimental:codeReordering"
+"""
+
+runnableExamples:
+  import strtabs
+  var t = newStringTable()
+  t["name"] = "John"
+  t["city"] = "Monaco"
+  doAssert t.len == 2
+  doAssert t.hasKey "name"
+  doAssert "name" in t
+
+include "system/inclrtl"
+
+{.pragma: rtlFunc, rtl.}
+
+proc hasKey*(): bool {.rtlFunc.} =
+  discard


### PR DESCRIPTION
otherwise, gives `tpragmas_reorder.nim(16, 20) Error: invalid pragma: rtl` errors


ref https://github.com/nim-lang/Nim/pull/21202