### PR TITLE
bump csource_v2 to include fix for linking parameter maximum length

### DIFF
--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -2,4 +2,4 @@ nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v2
 nim_csourcesUrl=https://github.com/nim-lang/csources_v2.git
 nim_csourcesBranch=master
-nim_csourcesHash=b66c420697c574be18a20dd4720248a715b4287e
+nim_csourcesHash=86742fb02c6606ab01a532a0085784effb2e753e


### PR DESCRIPTION
> If accepted, I believe it should be used in csources_v2 and also backport 2.0

ref https://github.com/nim-lang/Nim/pull/21186