### PR TITLE
fix typeRel of typeDesc

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1840,7 +1840,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       elif f.base.kind == tyNone:
         result = isGeneric
       else:
-        result = typeRel(c, f.base, a.base, flags)
+        let r = typeRel(c, f.base, a.base, flags)
+        if r >= isIntConv:
+          result = r
 
       if result != isNone:
         put(c, f, a)
@@ -1848,7 +1850,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       if tfUnresolved in f.flags:
         result = typeRel(c, prev.base, a, flags)
       elif a.kind == tyTypeDesc:
-        result = typeRel(c, prev.base, a.base, flags)
+        let r = typeRel(c, prev.base, a.base, flags)
+        if r >= isIntConv:
+          result = r
       else:
         result = isNone
 

--- a/tests/typerel/tint.nim
+++ b/tests/typerel/tint.nim
@@ -1,0 +1,4 @@
+
+template a(T: type int32) = discard
+template a(T: type int64) = discard
+a(int)


### PR DESCRIPTION
can't relys on `isConvertible` here,  should atleast `isIntConv` or higher.