### PR TITLE
tests/errmsgs/tcall_with_default_arg.nim: sync

### DIFF
--- a/tests/errmsgs/tcall_with_default_arg.nim
+++ b/tests/errmsgs/tcall_with_default_arg.nim
@@ -1,5 +1,5 @@
 discard """
-outputsub: '''tcall_with_default_arg.nim(16) anotherFoo'''
+outputsub: '''tcall_with_default_arg.nim(8) fail'''
 exitcode: 1
 """
 # issue: #5604


### PR DESCRIPTION
Sorting out a test failure. Behavior seems to have changed somewhere back then...