### PR TITLE
Add docs informing about gotcha of clients

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -47,7 +47,7 @@
 ## otherwise you will get an `Undeclared identifier: 'await'` error.
 ##
 ## **Note:** An asynchronous client instance can only deal with one
-## request at a time. To send multiple requests in paralle, use
+## request at a time. To send multiple requests in parallel, use
 ## multiple client instances.
 ##
 ## Using HTTP POST

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -46,6 +46,10 @@
 ## **Note:** You need to run asynchronous examples in an async proc
 ## otherwise you will get an `Undeclared identifier: 'await'` error.
 ##
+## **Note:** An asynchronous client instance can only deal with one
+## request at a time. To send multiple requests in paralle, use
+## multiple client instances.
+##
 ## Using HTTP POST
 ## ===============
 ##


### PR DESCRIPTION
It is a hidden problem that AsyncHttpClient-instances *can not* deal with multiple requests at once. Similar to normal HttpClients they can only deal with sending one request at a time. This is not told anywhere in the documentation, but critical information that should be available to the user.