### PR TITLE
fixes #21243; ships `build_all.sh` on Unix [backport]

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -121,6 +121,7 @@ Files: "bin/nim"
 InstallScript: "yes"
 UninstallScript: "yes"
 Files: "bin/nim-gdb"
+Files: "build_all.sh"
 
 
 [InnoSetup]


### PR DESCRIPTION
fixes #21243