### PR TITLE
add deprecated warnings for `{.deadcodeelim: on.}`

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -929,7 +929,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wThreadVar:
         noVal(c, it)
         incl(sym.flags, {sfThread, sfGlobal})
-      of wDeadCodeElimUnused: discard  # deprecated, dead code elim always on
+      of wDeadCodeElimUnused:
+        warningDeprecated(c.config, n.info, "'{.deadcodeelim: on.}' is deprecated, now a noop")  # deprecated, dead code elim always on
       of wNoForward: pragmaNoForward(c, it)
       of wReorder: pragmaNoForward(c, it, flag = sfReorder)
       of wMagic: processMagic(c, it, sym)


### PR DESCRIPTION
Lots of C wrappers generated by old version `c2nim` use `{.deadcodeelim: on.}`. It would be better to warn its deprecation in case of confusion.