### PR TITLE
fixes #21278; `deques.shrink` off by one bug

### DIFF
--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -440,7 +440,7 @@ proc shrink*[T](deq: var Deque[T], fromFirst = 0, fromLast = 0) =
     deq.head = (deq.head + 1) and deq.mask
 
   for i in 0 ..< fromLast:
-    destroy(deq.data[deq.tail])
+    destroy(deq.data[(deq.tail - 1) and deq.mask])
     deq.tail = (deq.tail - 1) and deq.mask
 
   dec deq.count, fromFirst + fromLast

--- a/tests/stdlib/tdeques.nim
+++ b/tests/stdlib/tdeques.nim
@@ -183,6 +183,12 @@ proc main() =
     clear(a)
     doAssert len(a) == 0
 
+  block: # bug #21278
+    var a = [10, 20, 30, 40].toDeque
+
+    a.shrink(fromFirst = 0, fromLast = 1)
+    doAssert $a == "[10, 20, 30]"
+
 
 static: main()
 main()


### PR DESCRIPTION
fixes #21278