### PR TITLE
fixes #21261; always checking `nimTestErrorFlag` in the main module

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1801,6 +1801,9 @@ proc genInitCode(m: BModule) =
 
     if optStackTrace in m.initProc.options and preventStackTrace notin m.flags:
       prc.add(deinitFrame(m.initProc))
+  elif sfMainModule in m.module.flags and m.config.exc == excGoto:
+    if getCompilerProc(m.g.graph, "nimTestErrorFlag") != nil:
+      m.appcg(prc, "\t#nimTestErrorFlag();$n", [])
 
   prc.addf("}$N", [])
 

--- a/tests/exception/m21261.nim
+++ b/tests/exception/m21261.nim
@@ -1,0 +1,1 @@
+raise (ref Exception)(msg: "something")

--- a/tests/exception/t21261.nim
+++ b/tests/exception/t21261.nim
@@ -1,0 +1,9 @@
+discard """
+  exitcode: 1
+  outputsub: '''
+m21261.nim(1)            m21261
+Error: unhandled exception: something [Exception]
+'''
+"""
+
+import m21261


### PR DESCRIPTION
fixes #21261

Or check it only when there are imports from other modules. Though I don't know whether it makes much difference, since the main module is supposed to achieve something in most cases.