### PR TITLE
fixes #14409; fixes #10674 VM callbacks switch to table-index seqs

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1351,7 +1351,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let prc = if not isClosure: bb.sym else: bb[0].sym
       if prc.offset < -1:
         # it's a callback:
-        c.callbacks[-prc.offset-2].value(
+        c.callbacks[-prc.offset-2](
           VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc])
@@ -1674,7 +1674,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         rb = instr.regB
         rc = instr.regC
         idx = int(regs[rb+rc-1].intVal)
-        callback = c.callbacks[idx].value
+        callback = c.callbacks[idx]
         args = VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                 currentException: c.currentExceptionA,
                 currentLineInfo: c.debug[pc])

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -10,7 +10,7 @@
 ## This module contains the type definitions for the new evaluation engine.
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
-import tables
+import std/[tables, strutils]
 
 import ast, idents, options, modulegraphs, lineinfos
 
@@ -302,10 +302,18 @@ proc refresh*(c: PCtx, module: PSym; idgen: IdGenerator) =
   c.loopIterations = c.config.maxLoopIterationsVM
   c.idgen = idgen
 
+proc reverseName(s: string): string =
+  result = newStringOfCap(s.len)
+  let y = s.split('.')
+  for i in 1..y.len:
+    result.add y[^i]
+    if i != y.len:
+      result.add '.'
+
 proc registerCallback*(c: PCtx; name: string; callback: VmCallback): int {.discardable.} =
   result = c.callbacks.len
   c.callbacks.add(callback)
-  c.callbackIndex[name] = result
+  c.callbackIndex[reverseName(name)] = result
 
 const
   firstABxInstr* = opcTJmp

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -259,7 +259,8 @@ type
     traceActive*: bool
     loopIterations*: int
     comesFromHeuristic*: TLineInfo # Heuristic for better macro stack traces
-    callbacks*: seq[tuple[key: string, value: VmCallback]]
+    callbacks*: seq[VmCallback]
+    callbackIndex*: Table[string, int]
     errorFlag*: string
     cache*: IdentCache
     config*: ConfigRef
@@ -292,7 +293,7 @@ proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph; idgen: IdGenerator
   PCtx(code: @[], debug: @[],
     globals: newNode(nkStmtListExpr), constants: newNode(nkStmtList), types: @[],
     prc: PProc(blocks: @[]), module: module, loopIterations: g.config.maxLoopIterationsVM,
-    comesFromHeuristic: unknownLineInfo, callbacks: @[], errorFlag: "",
+    comesFromHeuristic: unknownLineInfo, callbacks: @[], callbackIndex: initTable[string, int](), errorFlag: "",
     cache: cache, config: g.config, graph: g, idgen: idgen)
 
 proc refresh*(c: PCtx, module: PSym; idgen: IdGenerator) =
@@ -303,7 +304,8 @@ proc refresh*(c: PCtx, module: PSym; idgen: IdGenerator) =
 
 proc registerCallback*(c: PCtx; name: string; callback: VmCallback): int {.discardable.} =
   result = c.callbacks.len
-  c.callbacks.add((name, callback))
+  c.callbacks.add(callback)
+  c.callbackIndex[name] = result
 
 const
   firstABxInstr* = opcTJmp

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2016,24 +2016,16 @@ proc genProc*(c: PCtx; s: PSym): int
 
 proc toKey(s: PSym): string =
   var s = s
-  var res = newSeq[string]()
-  var size = 0
   while s != nil:
-    res.add s.name.s
-    inc(size, s.name.s.len)
+    result.add s.name.s
     if s.owner != nil:
       if sfFromGeneric in s.flags:
         s = s.owner.owner
       else:
         s = s.owner
+      result.add "."
     else:
       break
-
-  result = newStringOfCap(size + res.len - 1)
-  for i in 1..res.len:
-    result.add res[^i]
-    if i != res.len:
-      result.add "."
 
 proc procIsCallback(c: PCtx; s: PSym): bool =
   if s.offset < -1: return true

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -254,7 +254,7 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap2si(readLines, ioop)
     systemop getCurrentExceptionMsg
     systemop getCurrentException
-    registerCallback c, "stdlib.*.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
+    registerCallback c, "stdlib.osdirs.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
     registerCallback c, "stdlib.compilesettings.querySetting", proc (a: VmArgs) =
       setResult(a, querySettingImpl(c.config, getInt(a, 0)))

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -23,7 +23,7 @@ proc initInterpreter(script: string): Interpreter =
 
 proc main() =
   let i = initInterpreter("myscript.nim")
-  i.implementRoutine("*", "exposed", "addFloats", proc (a: VmArgs) =
+  i.implementRoutine("nim", "exposed", "addFloats", proc (a: VmArgs) =
     setResult(a, getFloat(a, 0) + getFloat(a, 1) + getFloat(a, 2))
   )
   i.evalScript()


### PR DESCRIPTION
fixes #14409
fixes #10674

- VM callbacks switch to table-index seqs
- drops support for wildcard 

todo

- [ ] allow different styles of identifiers?
- [ ] if we calculates the hash of the list of string directly, it saves allocations for strings.