### PR TITLE
Do not use system.NimVersion for nim.nimble

### DIFF
--- a/nim.nimble
+++ b/nim.nimble
@@ -1,4 +1,4 @@
-version = system.NimVersion
+version = "1.9.1"
 author = "Andreas Rumpf"
 description = "Compiler package providing the compiler sources as a library."
 license = "MIT"


### PR DESCRIPTION
- That version is evaluaed in the context of `nim` version used by `nimble`