### PR TITLE
Fix the nimble build on Windows

### DIFF
--- a/nim.nimble
+++ b/nim.nimble
@@ -9,6 +9,6 @@ skipDirs = @["build" , "changelogs" , "ci" , "csources_v2" , "drnim" , "nimdoc",
 
 before install:
   when defined(windows):
-    exec "./build_all.bat"
+    exec "build_all.bat"
   else:
     exec "./build_all.sh"


### PR DESCRIPTION
- `nimble install` fails on Windows, the `./` is not needed.