### PR TITLE
fixes #16790; fixes #19075; put big arrays on the constant seqs; don't inline them in the VM; big performance boost

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -32,7 +32,7 @@ when defined(nimPreviewSlimSystem):
   import std/assertions
 
 import
-  strutils, ast, types, msgs, renderer, vmdef,
+  strutils, ast, types, msgs, renderer, vmdef, trees,
   intsets, magicsys, options, lowerings, lineinfos, transf, astmsgs
 
 from modulegraphs import getBody
@@ -2053,7 +2053,10 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       genLit(c, n, dest)
     of skConst:
       let constVal = if s.astdef != nil: s.astdef else: s.typ.n
-      gen(c, constVal, dest)
+      if dontInlineConstant(n, constVal):
+        genLit(c, constVal, dest)
+      else:
+        gen(c, constVal, dest)
     of skEnumField:
       # we never reach this case - as of the time of this comment,
       # skEnumField is folded to an int in semfold.nim, but this code

--- a/tests/vm/t19075.nim
+++ b/tests/vm/t19075.nim
@@ -1,0 +1,19 @@
+discard """
+  timeout: 10
+  joinable: false
+"""
+
+# bug #19075
+const size = 50_000
+
+const stuff = block:
+    var a: array[size, int]
+    a
+
+const zeugs = block:
+    var zeugs: array[size, int]
+    for i in 0..<size:
+        zeugs[i] = stuff[i]
+    zeugs
+
+doAssert zeugs[0] == 0


### PR DESCRIPTION
fixes #16790
fixes #19075

I hope it won't put too much stress on the constants sequence, which looks up an element by linear search. Though, we might relieve the burden of it [using BiTable to store integer, float, and string literals](https://github.com/nim-lang/Nim/pull/21316).
