### PR TITLE
fixes #21317; 1.6.4 regression; etyBaseIndex should return fat pointers [backport 1.6]

### DIFF
--- a/tests/system/trefs.nim
+++ b/tests/system/trefs.nim
@@ -1,0 +1,15 @@
+discard """
+  targets: "c js"
+"""
+
+# bug #21317
+proc parseHook*(v: var ref int) =
+  var a: ref int
+  new(a)
+  a[] = 123
+  v = a
+
+proc fromJson2*(): ref int =
+  parseHook(result)
+
+doAssert fromJson2()[] == 123


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/19393
fixes #21317