### PR TITLE
This adds `parseutils.parseSize`, an inverse to `strutils.formatSize`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 
 
 [//]: # "Additions:"
-
+- Added `parseutils.parseSize` - inverse to `strutils.formatSize` - to parse human readable sizes.
 
 [//]: # "Deprecations:"
 

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1647,6 +1647,7 @@ proc genArrToSeq(p: BProc, n: PNode, d: var TLoc) =
     return
   if d.k == locNone:
     getTemp(p, n.typ, d)
+  initLocExpr(p, n[1], a)
   # generate call to newSeq before adding the elements per hand:
   let L = toInt(lengthOrd(p.config, n[1].typ))
   if optSeqDestructors in p.config.globalOptions:
@@ -1658,7 +1659,6 @@ proc genArrToSeq(p: BProc, n: PNode, d: var TLoc) =
     var lit = newRopeAppender()
     intLiteral(L, lit)
     genNewSeqAux(p, d, lit, L == 0)
-  initLocExpr(p, n[1], a)
   # bug #5007; do not produce excessive C source code:
   if L < 10:
     for i in 0..<L:

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -25,7 +25,7 @@ proc undefSymbol*(symbols: StringTableRef; symbol: string) =
 #  result = if isDefined(symbol): gSymbols[symbol] else: nil
 
 iterator definedSymbolNames*(symbols: StringTableRef): string =
-  for key, val in pairs(symbols):
+  for key in keys(symbols):
     yield key
 
 proc countDefinedSymbols*(symbols: StringTableRef): int =

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -685,7 +685,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
       n[0] = a
   of nkBracket, nkCurly:
     result = copyNode(n)
-    for i, son in n.pairs:
+    for son in n.items:
       var a = getConstExpr(m, son, idgen, g)
       if a == nil: return nil
       result.add a
@@ -709,7 +709,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
     # tuple constructor
     result = copyNode(n)
     if (n.len > 0) and (n[0].kind == nkExprColonExpr):
-      for i, expr in n.pairs:
+      for expr in n.items:
         let exprNew = copyNode(expr) # nkExprColonExpr
         exprNew.add expr[0]
         let a = getConstExpr(m, expr[1], idgen, g)
@@ -717,7 +717,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         exprNew.add a
         result.add exprNew
     else:
-      for i, expr in n.pairs:
+      for expr in n.items:
         let a = getConstExpr(m, expr, idgen, g)
         if a == nil: return nil
         result.add a

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -40,7 +40,7 @@ const
 
 iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym =
   internalAssert c.config, n.kind == nkGenericParams
-  for i, a in n.pairs:
+  for a in n.items:
     internalAssert c.config, a.kind == nkSym
     var q = a.sym
     if q.typ.kind in {tyTypeDesc, tyGenericParam, tyStatic, tyConcept}+tyTypeClasses:

--- a/doc/nimgrep.md
+++ b/doc/nimgrep.md
@@ -77,7 +77,7 @@ That means you can always use only 1 such an option with logical OR, e.g.
 .. Note::
    If you want logical AND on patterns you should compose 1 appropriate pattern,
    possibly combined with multi-line mode `(?s)`:literal:.
-   E.g. to require that multi-line context of matches has occurences of
+   E.g. to require that multi-line context of matches has occurrences of
    **both** PAT1 and PAT2 use positive lookaheads (`(?=PAT)`:literal:):
      ```cmd
      nimgrep --inContext:'(?s)(?=.*PAT1)(?=.*PAT2)'

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -158,7 +158,7 @@ proc parseProtocol(protocol: string): tuple[orig: string, major, minor: int] =
 proc sendStatus(client: AsyncSocket, status: string): Future[void] =
   client.send("HTTP/1.1 " & status & "\c\L\c\L")
 
-func hasChunkedEncoding(request: Request): bool = 
+func hasChunkedEncoding(request: Request): bool =
   ## Searches for a chunked transfer encoding
   const transferEncoding = "Transfer-Encoding"
 
@@ -300,7 +300,7 @@ proc processRequest(
     while true:
       lineFut.mget.setLen(0)
       lineFut.clean()
-      
+
       # The encoding format alternates between specifying a number of bytes to read
       # and the data to be read, of the previously specified size
       if sizeOrData mod 2 == 0:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2393,7 +2393,7 @@ proc contains*[A](t: CountTable[A], key: A): bool =
   return hasKey[A](t, key)
 
 proc getOrDefault*[A](t: CountTable[A], key: A; default: int = 0): int =
-  ## Retrieves the value at `t[key]` if`key` is in `t`. Otherwise, the
+  ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## integer value of `default` is returned.
   ##
   ## See also:
@@ -2713,7 +2713,7 @@ proc contains*[A](t: CountTableRef[A], key: A): bool =
   return hasKey[A](t, key)
 
 proc getOrDefault*[A](t: CountTableRef[A], key: A, default: int): int =
-  ## Retrieves the value at `t[key]` if`key` is in `t`. Otherwise, the
+  ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## integer value of `default` is returned.
   ##
   ## See also:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -621,7 +621,7 @@ when defineSsl:
 
   proc newContext*(protVersion = protSSLv23, verifyMode = CVerifyPeer,
                    certFile = "", keyFile = "", cipherList = CiphersIntermediate,
-                   caDir = "", caFile = ""): SslContext =
+                   caDir = "", caFile = "", ciphersuites = CiphersModern): SslContext =
     ## Creates an SSL context.
     ##
     ## Protocol version is currently ignored by default and TLS is used.
@@ -675,10 +675,10 @@ when defineSsl:
       raiseSSLError()
     when not defined(openssl10) and not defined(libressl):
       let sslVersion = getOpenSSLVersion()
-      if sslVersion >= 0x010101000 and not sslVersion == 0x020000000:
+      if sslVersion >= 0x010101000 and sslVersion != 0x020000000:
         # In OpenSSL >= 1.1.1, TLSv1.3 cipher suites can only be configured via
         # this API.
-        if newCTX.SSL_CTX_set_ciphersuites(cipherList) != 1:
+        if newCTX.SSL_CTX_set_ciphersuites(ciphersuites) != 1:
           raiseSSLError()
     # Automatically the best ECDH curve for client exchange. Without this, ECDH
     # ciphers will be ignored by the server.

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -643,7 +643,7 @@ func parseSize*(s: openArray[char], size: var int, alwaysBin=false): int =
       result = start                    #..is no unit to the end of `s`.
     var sizeF = number * scale + 0.5
     if sizeF > int.high.float:
-      sizeF = int.high.float            #NOTE: int.high.float.int = -2^63 bug :(
+      sizeF = int.high.float
     size = sizeF.int
 
 type

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -592,6 +592,57 @@ proc parseFloat*(s: openArray[char], number: var float): int {.
   if result != 0:
     number = bf
 
+func parseSize*(s: openArray[char], size: var int, alwaysBin=false): int =
+  ## Parse a size qualified by binary or metric units into `size`.  This format
+  ## is often called "human readable".  Result is the number of processed chars
+  ## or 0 on parse errors and size is rounded to the nearest integer.  Trailing
+  ## garbage like "/s" in "1k/s" is allowed and detected by `result < s.len`.
+  ##
+  ## To simplify use, following non-rare wild conventions, and since fractional
+  ## information is so rare, unit  matching is case-insensitive but for the 'i'
+  ## distinguishing binary-metric from metric which cannot be 'I'.
+  ##
+  ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still
+  ## know if units are bytes | bits or infer this fact via the case of s[^1] (if
+  ## users can even be relied upon to use 'B' for byte and 'b' for bit or have
+  ## that be s[^1]).
+  ##
+  ## If `alwaysBin==true` then scales are always binary-metric, but e.g. "KiB"
+  ## is still accepted for clarity.
+  ##
+  ## **See also:**
+  ## * https://en.wikipedia.org/wiki/Binary_prefix
+  ## * `formatSize module<strutils.html>`_ for formatting
+  const prefix = "b" & "kmgtpezy"       # byte|bit & lowCase metric-ish prefixes
+  const scaleM = [1.0, 1e3, 1e6, 1e9, 1e12, 1e15, 1e18, 1e21, 1e24] # 10^(3*idx)
+  const scaleB = [1.0, 1024, 1048576, 1073741824, 1099511627776.0,  # 2^(10*idx)
+                  1125899906842624.0, 1152921504606846976.0,        # ldexp?
+                  1.180591620717411303424e21, 1.208925819614629174706176e24]
+  var number: float
+  var scale = 1.0
+  result = parseFloat(s, number)
+  if number < 0:                        # While parseFloat accepts negatives ..
+    result = 0                          #.. we do not since sizes cannot be < 0
+  if result > 0:
+    let start = result                  # Save spot to maybe unwind white to EOS
+    while result < s.len and s[result] in Whitespace:
+      inc result
+    if result < s.len:                  # Illegal starting char => unity
+      if (let si = prefix.find(s[result].toLowerASCII); si >= 0):
+        inc result                      # Now parse the scale
+        scale = if alwaysBin: scaleB[si] else: scaleM[si]
+        if result < s.len and s[result] == 'i':
+          scale = scaleB[si]            # Switch from default to binary-metric
+          inc result
+        if result < s.len and s[result].toLowerASCII == 'b':
+          inc result                    # Skip optional '[bB]'
+    else:                               # Unwind result advancement when there..
+      result = start                    #..is no unit to the end of `s`.
+    var sizeF = number * scale + 0.5
+    if sizeF > int.high.float:
+      sizeF = int.high.float            #NOTE: int.high.float.int = -2^63 bug :(
+    size = sizeF.int
+
 type
   InterpolatedKind* = enum ## Describes for `interpolatedFragments`
                            ## which part of the interpolated string is

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -641,10 +641,10 @@ func parseSize*(s: openArray[char], size: var int, alwaysBin=false): int =
           inc result                    # Skip optional '[bB]'
     else:                               # Unwind result advancement when there..
       result = start                    #..is no unit to the end of `s`.
-    var sizeF = number * scale + 0.5
-    if sizeF > int.high.float:
-      sizeF = int.high.float
-    size = sizeF.int
+    var sizeF = number * scale + 0.5    # Saturate to int.high when appropriate
+    size = if sizeF > 9223372036854774784.0: int.high else: sizeF.int
+# Above constant=2^63-1024 avoids C UB; github.com/nim-lang/Nim/issues/20102 or
+# stackoverflow.com/questions/20923556/math-pow2-63-1-math-pow2-63-512-is-true
 
 type
   InterpolatedKind* = enum ## Describes for `interpolatedFragments`

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -592,6 +592,9 @@ proc parseFloat*(s: openArray[char], number: var float): int {.
   if result != 0:
     number = bf
 
+func toLowerAscii(c: char): char =
+  if c in {'A'..'Z'}: char(uint8(c) xor 0b0010_0000'u8) else: c
+
 func parseSize*(s: openArray[char], size: var int, alwaysBin=false): int =
   ## Parse a size qualified by binary or metric units into `size`.  This format
   ## is often called "human readable".  Result is the number of processed chars
@@ -628,13 +631,13 @@ func parseSize*(s: openArray[char], size: var int, alwaysBin=false): int =
     while result < s.len and s[result] in Whitespace:
       inc result
     if result < s.len:                  # Illegal starting char => unity
-      if (let si = prefix.find(s[result].toLowerASCII); si >= 0):
+      if (let si = prefix.find(s[result].toLowerAscii); si >= 0):
         inc result                      # Now parse the scale
         scale = if alwaysBin: scaleB[si] else: scaleM[si]
         if result < s.len and s[result] == 'i':
           scale = scaleB[si]            # Switch from default to binary-metric
           inc result
-        if result < s.len and s[result].toLowerASCII == 'b':
+        if result < s.len and s[result].toLowerAscii == 'b':
           inc result                    # Skip optional '[bB]'
     else:                               # Unwind result advancement when there..
       result = start                    #..is no unit to the end of `s`.

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -887,7 +887,7 @@ proc reversed*(s: openArray[char]): string =
 
 proc graphemeLen*(s: openArray[char]; i: Natural): Natural =
   ## The number of bytes belonging to byte index ``s[i]``,
-  ## including following combining code unit.
+  ## including following combining code units.
   runnableExamples:
     let a = "añyóng"
     doAssert a.graphemeLen(1) == 2 ## ñ

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -467,10 +467,10 @@ else:
       raiseInvalidLibrary MainProc
 
   proc SSL_CTX_set_ciphersuites*(ctx: SslCtx, str: cstring): cint =
-    var theProc {.global.}: proc(ctx: SslCtx, str: cstring) {.cdecl, gcsafe.}
+    var theProc {.global.}: proc(ctx: SslCtx, str: cstring): cint {.cdecl, gcsafe.}
     if theProc.isNil:
       theProc = cast[typeof(theProc)](sslSymThrows("SSL_CTX_set_ciphersuites"))
-    theProc(ctx, str)
+    result = theProc(ctx, str)
 
 proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -105,6 +105,7 @@ pkg "nimfp", "nim c -o:nfp -r src/fp.nim"
 pkg "nimgame2", "nim c --mm:refc nimgame2/nimgame.nim"
   # XXX Doesn't work with deprecated 'randomize', will create a PR.
 pkg "nimgen", "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
+pkg "nimib"
 pkg "nimlsp"
 pkg "nimly", "nim c -r tests/test_readme_example.nim"
 pkg "nimongo", "nimble test_ci", allowFailure = true

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -88,8 +88,7 @@ proc test() =
     ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
     ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
     # Value Edge cases
-    ass parseSize("9223372036854775807", sz) == 19
-    ass sz == int.high.float.int     # This is presently -2^63 :(
+    ass parseSize("9223372036854775807", sz) == 19; ass sz == int.high.float.int
 
 test()
 static: test()

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -55,5 +55,41 @@ proc test() =
     doAssert res == @[(17, "9.123456789012344"), (18, "11.123456789012344"),
                       (17, "9.123456789012344"), (17, "8.123456789012344"),
                       (16, "9.12345678901234"), (17, "9.123456789012344")]
+
+  block:
+    template ass(x) = doAssert(x) # Avoid hint[LineTooLong]
+    var sz: int
+    # Good, complete parses
+    ass parseSize("1  b", sz)    == 4; ass sz == 1
+    ass parseSize("1  B", sz)    == 4; ass sz == 1
+    ass parseSize("1k", sz)      == 2; ass sz == 1000
+    ass parseSize("1 kib", sz)   == 5; ass sz == 1024
+    ass parseSize("1 ki", sz)    == 4; ass sz == 1024
+    ass parseSize("1mi", sz)     == 3; ass sz == 1048576
+    ass parseSize("1 mi", sz)    == 4; ass sz == 1048576
+    ass parseSize("1 mib", sz)   == 5; ass sz == 1048576
+    ass parseSize("1 Mib", sz)   == 5; ass sz == 1048576
+    ass parseSize("1 MiB", sz)   == 5; ass sz == 1048576
+    ass parseSize("1.23GiB", sz) == 7; ass sz == 1320702444 # 1320702443.52
+    ass parseSize("0.001k", sz)  == 6; ass sz == 1
+    ass parseSize("0.0004k", sz) == 7; ass sz == 0
+    ass parseSize("0.0006k", sz) == 7; ass sz == 1
+    # Incomplete parses
+    ass parseSize("1  ", sz)     == 1; ass sz == 1  # Trailing white IGNORED
+    ass parseSize("1  B ", sz)   == 4; ass sz == 1  # Trailing white IGNORED
+    ass parseSize("1  B/s", sz)  == 4; ass sz == 1  # Trailing junk IGNORED
+    ass parseSize("1 kX", sz)    == 3; ass sz == 1000
+    ass parseSize("1 kiX", sz)   == 4; ass sz == 1024
+    ass parseSize("1j", sz)      == 1; ass sz == 1  # Unknown prefix
+    ass parseSize("1 jib", sz)   == 2; ass sz == 1  # ..also IGNORED
+    ass parseSize("1  ji", sz)   == 3; ass sz == 1
+    # Bad parses; `sz` should stay last good|incomplete val
+    ass parseSize("-1b", sz)     == 0; ass sz == 1  # Negative numbers
+    ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
+    ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
+    # Value Edge cases
+    ass parseSize("9223372036854775807", sz) == 19
+    ass sz == int.high.float.int     # This is presently -2^63 :(
+
 test()
 static: test()

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -88,7 +88,7 @@ proc test() =
     ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
     ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
     # Value Edge cases
-    ass parseSize("9223372036854775807", sz) == 19; ass sz == int.high.float.int
+    ass parseSize("9223372036854775807", sz) == 19; ass sz == int.high
 
 test()
 static: test()

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -56,39 +56,39 @@ proc test() =
                       (17, "9.123456789012344"), (17, "8.123456789012344"),
                       (16, "9.12345678901234"), (17, "9.123456789012344")]
 
-  block:
-    template ass(x) = doAssert(x) # Avoid hint[LineTooLong]
-    var sz: int
-    # Good, complete parses
-    ass parseSize("1  b", sz)    == 4; ass sz == 1
-    ass parseSize("1  B", sz)    == 4; ass sz == 1
-    ass parseSize("1k", sz)      == 2; ass sz == 1000
-    ass parseSize("1 kib", sz)   == 5; ass sz == 1024
-    ass parseSize("1 ki", sz)    == 4; ass sz == 1024
-    ass parseSize("1mi", sz)     == 3; ass sz == 1048576
-    ass parseSize("1 mi", sz)    == 4; ass sz == 1048576
-    ass parseSize("1 mib", sz)   == 5; ass sz == 1048576
-    ass parseSize("1 Mib", sz)   == 5; ass sz == 1048576
-    ass parseSize("1 MiB", sz)   == 5; ass sz == 1048576
-    ass parseSize("1.23GiB", sz) == 7; ass sz == 1320702444 # 1320702443.52
-    ass parseSize("0.001k", sz)  == 6; ass sz == 1
-    ass parseSize("0.0004k", sz) == 7; ass sz == 0
-    ass parseSize("0.0006k", sz) == 7; ass sz == 1
-    # Incomplete parses
-    ass parseSize("1  ", sz)     == 1; ass sz == 1  # Trailing white IGNORED
-    ass parseSize("1  B ", sz)   == 4; ass sz == 1  # Trailing white IGNORED
-    ass parseSize("1  B/s", sz)  == 4; ass sz == 1  # Trailing junk IGNORED
-    ass parseSize("1 kX", sz)    == 3; ass sz == 1000
-    ass parseSize("1 kiX", sz)   == 4; ass sz == 1024
-    ass parseSize("1j", sz)      == 1; ass sz == 1  # Unknown prefix
-    ass parseSize("1 jib", sz)   == 2; ass sz == 1  # ..also IGNORED
-    ass parseSize("1  ji", sz)   == 3; ass sz == 1
-    # Bad parses; `sz` should stay last good|incomplete val
-    ass parseSize("-1b", sz)     == 0; ass sz == 1  # Negative numbers
-    ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
-    ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
-    # Value Edge cases
-    ass parseSize("9223372036854775807", sz) == 19; ass sz == int.high
-
 test()
 static: test()
+
+block:
+  template ass(x) = doAssert(x) # Avoid hint[LineTooLong]
+  var sz: int
+  # Good, complete parses
+  ass parseSize("1  b", sz)    == 4; ass sz == 1
+  ass parseSize("1  B", sz)    == 4; ass sz == 1
+  ass parseSize("1k", sz)      == 2; ass sz == 1000
+  ass parseSize("1 kib", sz)   == 5; ass sz == 1024
+  ass parseSize("1 ki", sz)    == 4; ass sz == 1024
+  ass parseSize("1mi", sz)     == 3; ass sz == 1048576
+  ass parseSize("1 mi", sz)    == 4; ass sz == 1048576
+  ass parseSize("1 mib", sz)   == 5; ass sz == 1048576
+  ass parseSize("1 Mib", sz)   == 5; ass sz == 1048576
+  ass parseSize("1 MiB", sz)   == 5; ass sz == 1048576
+  ass parseSize("1.23GiB", sz) == 7; ass sz == 1320702444 # 1320702443.52
+  ass parseSize("0.001k", sz)  == 6; ass sz == 1
+  ass parseSize("0.0004k", sz) == 7; ass sz == 0
+  ass parseSize("0.0006k", sz) == 7; ass sz == 1
+  # Incomplete parses
+  ass parseSize("1  ", sz)     == 1; ass sz == 1  # Trailing white IGNORED
+  ass parseSize("1  B ", sz)   == 4; ass sz == 1  # Trailing white IGNORED
+  ass parseSize("1  B/s", sz)  == 4; ass sz == 1  # Trailing junk IGNORED
+  ass parseSize("1 kX", sz)    == 3; ass sz == 1000
+  ass parseSize("1 kiX", sz)   == 4; ass sz == 1024
+  ass parseSize("1j", sz)      == 1; ass sz == 1  # Unknown prefix
+  ass parseSize("1 jib", sz)   == 2; ass sz == 1  # ..also IGNORED
+  ass parseSize("1  ji", sz)   == 3; ass sz == 1
+  # Bad parses; `sz` should stay last good|incomplete val
+  ass parseSize("-1b", sz)     == 0; ass sz == 1  # Negative numbers
+  ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
+  ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
+  # Value Edge cases
+  ass parseSize("9223372036854775807", sz) == 19; ass sz == int.high


### PR DESCRIPTION
`parseSize` has a fairly flexible interface, allowing the caller to pin to binary-metric instead of switching off between metric `10^(3*bank)` and binary-metric `2^(10*bank)` based on "KB" vs "KiB" (for example).

It is useful for parsing the compiler's own output logs or for many other situations.  The doc comment and tests explain behavior in more detail.