### PR TITLE
Change the default stdlib location for Linux packaging

### DIFF
--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -69,8 +69,11 @@ Hints on the build process:
 
 What to install:
 
-- The expected stdlib location is /usr/lib/nim
-- Global configuration files under /etc/nim
+- The expected stdlib location is `/usr/lib/nim/lib`, previously it was just `/usr/lib/nim`
+- `nimdoc.css` and `nimdoc.cls` from the `doc` folder should go into `/usr/lib/nim/doc/`
+- `tools/nim-gdb.py` should go into `/usr/lib/nim/tools/`
+- `tools/dochack/dochack.js` should be installed to `/usr/lib/nim/tools/dochack/`
+- Global configuration files under `/etc/nim`
 - Optionally: manpages, documentation, shell completion
 - When installing documentation, .idx files are not required
 - The "compiler" directory contains compiler sources and should not be part of the compiler binary package


### PR DESCRIPTION
While trying to repair documentation generation with package installed Nim versions I came across a much deeper issue with how Nim currently handles system wide installations. I propose both a documentation and a logic change to improve how installation paths are resolved.

## Change the default stdlib location for Linux packaging

The currently documented location of the standard library for Linux packaging is `/usr/lib/nim`. This default unfortunately no longer works with `nim doc` because it needs files not contained in the standard library. These are `doc/nimdoc.css` and `tools/dochack/dochack.js` and with Nim 2 also `doc/nimdoc.cls`. I propose to change the recommended stdlib location to the subfolder `/usr/lib/nim/lib` to be able to include these files in a way that is compatible with the official binary downloads. The new layout should be:

* `/usr/lib/nim/lib` for the standard library
* `/usr/lib/nim/doc` for the nimdoc files
* `/usr/lib/nim/tools` for dochack and nim-gdb.py

This matches the concept from the official distribution of having a single prefix directory in which all Nim related files are placed.

## Change how installation paths are resolved

The compiler currently includes special workarounds for package installations to determine the correct standard library path even when binaries are placed outside the prefix directory. They are implemented in `options.nim` and specifically target `/usr/bin` and `/usr/local/bin`. This PR moves that logic from `setDefaultLibpath` up to `getPrefixDir` to fix path resolution not just for the library path, but for all paths relative to the prefix directory. At the same time this breaks resolving the old hardcoded stdlib paths `/usr/lib/nim` and `/usr/local/lib/nim`. I believe this to be a worthwhile tradeoff because the new behavior aligns with what is documented in the docstring for `getPrefixDir` and how it behaves for manual installs and it makes packaging the necessary documentation assets possible without having to place them in nonsensical paths (`/usr/doc` and `/usr/tools`).