### PR TITLE
Mitigate issues related to compiler options when cross-compiling

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -328,7 +328,9 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
                      platform.OS[conf.target.targetOS].name & '.' &
                      CC[c].name & fullSuffix
     result = getConfigVar(conf, fullCCname)
-    if result.len == 0:
+    if existsConfigVar(conf, fullCCname):
+      result = getConfigVar(conf, fullCCname)
+    else:
       # not overridden for this cross compilation setting?
       result = getConfigVar(conf, CC[c].name & fullSuffix)
   else:

--- a/doc/nimc.md
+++ b/doc/nimc.md
@@ -316,14 +316,16 @@ Another way is to make Nim invoke a cross compiler toolchain:
   nim c --cpu:arm --os:linux myproject.nim
   ```
 
-For cross compilation, the compiler invokes a C compiler named
-like `$cpu.$os.$cc` (for example arm.linux.gcc) and the configuration
-system is used to provide meaningful defaults. For example for `ARM` your
+For cross compilation, the compiler invokes a C compiler named like
+`$cpu.$os.$cc` (for example `arm.linux.gcc`) with options defined in
+`$cpu.$os.$cc.options.always`. The configuration system is used to provide
+meaningful defaults. For example, for Linux on a 32-bit ARM CPU, your
 configuration file should contain something like:
 
     arm.linux.gcc.path = "/usr/bin"
     arm.linux.gcc.exe = "arm-linux-gcc"
     arm.linux.gcc.linkerexe = "arm-linux-gcc"
+    arm.linux.gcc.options.always = "-w -fmax-errors=3"
 
 Cross-compilation for Windows
 =============================


### PR DESCRIPTION
Related to #13259. I don't think this PR should be considered a full resolution of the issue, but rather a mitigation, until a better solution is found.

Two things are changed:

## 1. Document `$cpu.$os.$cc.options.always`

This PR adds a mention of the config `$cpu.$os.$cc.options.always`, which is currently undocumented as far as I can tell, in the Cross-compilation section of the compiler docs. This way someone setting-up cross-compilation for a project will know they should probably set this option, otherwise possibly invalid options will be used.

## 2. Allow an empty string in a full-qualified CC option to override a default option

An example is likely clearer; this PR makes it so:

```ini
# This
arm.any.gcc.options.linker = ""

# Will override the following default when compiling with --os:any --cpu:arm
gcc.options.linker = "-ldl"
```

This is an issue as the current nim.cfg sets `gcc.options.linker = "-ldl"` on unix systems, but this creates a failure to link for the bare-metal ARM toolchain (arm-none-eabi-gcc), and it was *not* overridden by setting `arm.any.gcc.options.linker = ""`. Only a non-empty string would allow the cross-compiler specific option to override the default one.
