### PR TITLE
reimplement methods with vtables for ARC/ORC; alternative to #21342; uses a global array of function pointers

### DIFF
--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -13,8 +13,10 @@ import
   intsets, options, ast, msgs, idents, renderer, types, magicsys,
   sempass2, modulegraphs, lineinfos
 
+import std/[tables]
+
 when defined(nimPreviewSlimSystem):
-  import std/assertions
+  import std/[assertions]
 
 
 proc genConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
@@ -168,15 +170,20 @@ proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
     of Invalid:
       if witness.isNil: witness = g.methods[i].methods[0]
   # create a new dispatcher:
+  # stores the id and the position
+  if s.typ[1].skipTypes(skipPtrs).itemId notin g.bucketTable:
+    g.bucketTable[s.typ[1].skipTypes(skipPtrs).itemId] = 1
+  else:
+    g.bucketTable.inc(s.typ[1].skipTypes(skipPtrs).itemId)
   g.methods.add((methods: @[s], dispatcher: createDispatcher(s, g, idgen)))
-  #echo "adding ", s.info
+
   if witness != nil:
     localError(g.config, s.info, "invalid declaration order; cannot attach '" & s.name.s &
                        "' to method defined here: " & g.config$witness.info)
   elif sfBase notin s.flags:
     message(g.config, s.info, warnUseBase)
 
-proc relevantCol(methods: seq[PSym], col: int): bool =
+proc relevantCol*(methods: seq[PSym], col: int): bool =
   # returns true iff the position is relevant
   var t = methods[0].typ[col].skipTypes(skipPtrs)
   if t.kind == tyObject:
@@ -185,7 +192,7 @@ proc relevantCol(methods: seq[PSym], col: int): bool =
       if not sameType(t2, t):
         return true
 
-proc cmpSignatures(a, b: PSym, relevantCols: IntSet): int =
+proc cmpSignatures*(a, b: PSym, relevantCols: IntSet): int =
   for col in 1..<a.typ.len:
     if contains(relevantCols, col):
       var aa = skipTypes(a.typ[col], skipPtrs)
@@ -194,7 +201,7 @@ proc cmpSignatures(a, b: PSym, relevantCols: IntSet): int =
       if (d != high(int)) and d != 0:
         return d
 
-proc sortBucket(a: var seq[PSym], relevantCols: IntSet) =
+proc sortBucket*(a: var seq[PSym], relevantCols: IntSet) =
   # we use shellsort here; fast and simple
   var n = a.len
   var h = 1
@@ -213,7 +220,7 @@ proc sortBucket(a: var seq[PSym], relevantCols: IntSet) =
       a[j] = v
     if h == 1: break
 
-proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PSym =
+proc genIfDispatcher*(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PSym =
   var base = methods[0].ast[dispatcherPos].sym
   result = base
   var paramLen = base.typ.len
@@ -272,7 +279,7 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PS
   nilchecks.flags.incl nfTransf # should not be further transformed
   result.ast[bodyPos] = nilchecks
 
-proc generateMethodDispatchers*(g: ModuleGraph): PNode =
+proc generateMethodIfDispatchers*(g: ModuleGraph): PNode =
   result = newNode(nkStmtList)
   for bucket in 0..<g.methods.len:
     var relevantCols = initIntSet()
@@ -282,4 +289,4 @@ proc generateMethodDispatchers*(g: ModuleGraph): PNode =
         # if multi-methods are not enabled, we are interested only in the first field
         break
     sortBucket(g.methods[bucket].methods, relevantCols)
-    result.add newSymNode(genDispatcher(g, g.methods[bucket].methods, relevantCols))
+    result.add newSymNode(genIfDispatcher(g, g.methods[bucket].methods, relevantCols))

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2845,7 +2845,7 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
       var p = newInitProc(globals, m)
       attachProc(p, prc)
 
-  var disp = generateMethodDispatchers(graph)
+  var disp = generateMethodIfDispatchers(graph)
   for i in 0..<disp.len:
     let prc = disp[i].sym
     if not globals.generatedSyms.containsOrIncl(prc.id):

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -18,6 +18,7 @@ import ic / [packed_ast, ic]
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
+
 type
   SigHash* = distinct MD5Digest
 
@@ -89,7 +90,11 @@ type
     owners*: seq[PSym]
     suggestSymbols*: Table[FileIndex, seq[SymInfoPair]]
     suggestErrors*: Table[FileIndex, seq[Suggest]]
+
     methods*: seq[tuple[methods: seq[PSym], dispatcher: PSym]] # needs serialization!
+    bucketTable*: CountTable[ItemId]
+    objectTree*: Table[ItemId, seq[tuple[depth: int, value: PType]]]
+
     systemModule*: PSym
     sysTypes*: array[TTypeKind, PType]
     compilerprocs*: TStrTable

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -13,6 +13,8 @@ import
   modulegraphs, varpartitions, typeallowed, nilcheck, errorhandling, tables,
   semstrictfuncs
 
+import std/options as opt
+
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
@@ -88,6 +90,38 @@ type
 const
   errXCannotBeAssignedTo = "'$1' cannot be assigned to"
   errLetNeedsInit = "'let' symbol requires an initialization"
+
+
+proc getObjDepth(t: PType): Option[tuple[depth: int, root: ItemId]] =
+  var x = t
+  var res: tuple[depth: int, root: ItemId]
+  res.depth = -1
+  var stack = newSeq[ItemId]()
+  while x != nil:
+    x = skipTypes(x, skipPtrs)
+    if x.kind != tyObject:
+      return none(tuple[depth: int, root: ItemId])
+    stack.add x.itemId
+    x = x[0]
+    inc(res.depth)
+  res.root = stack[^2]
+  result = some(res)
+
+proc collectObjectTree(graph: ModuleGraph, n: PNode) =
+  for section in n:
+    if section.kind == nkTypeDef and section[^1].kind in {nkObjectTy, nkRefTy, nkPtrTy}:
+      let typ = section[^1].typ.skipTypes(skipPtrs)
+      if typ.len > 0 and typ[0] != nil:
+        let depthItem = getObjDepth(typ)
+        if isSome(depthItem):
+          let (depthLevel, root) = depthItem.unsafeGet
+          if depthLevel == 1:
+            graph.objectTree[root] = @[]
+          else:
+            if root notin graph.objectTree:
+              graph.objectTree[root] = @[(depthLevel, typ)]
+            else:
+              graph.objectTree[root].add (depthLevel, typ)
 
 proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
   if typ == nil: return
@@ -1249,8 +1283,11 @@ proc track(tracked: PEffects, n: PNode) =
   of nkProcDef, nkConverterDef, nkMethodDef, nkIteratorDef, nkLambda, nkFuncDef, nkDo:
     if n[0].kind == nkSym and n[0].sym.ast != nil:
       trackInnerProc(tracked, getBody(tracked.graph, n[0].sym))
-  of nkTypeSection, nkMacroDef, nkTemplateDef:
+  of nkMacroDef, nkTemplateDef:
     discard
+  of nkTypeSection:
+    if tracked.isTopLevel:
+      collectObjectTree(tracked.graph, n)
   of nkCast:
     if n.len == 2:
       track(tracked, n[1])
@@ -1568,14 +1605,19 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     checkNil(s, body, g.config, c.idgen)
 
 proc trackStmt*(c: PContext; module: PSym; n: PNode, isTopLevel: bool) =
-  if n.kind in {nkPragma, nkMacroDef, nkTemplateDef, nkProcDef, nkFuncDef,
-                nkTypeSection, nkConverterDef, nkMethodDef, nkIteratorDef}:
-    return
-  let g = c.graph
-  var effects = newNodeI(nkEffectList, n.info)
-  var t: TEffects
-  initEffects(g, effects, module, t, c)
-  t.isTopLevel = isTopLevel
-  track(t, n)
-  when defined(drnim):
-    if c.graph.strongSemCheck != nil: c.graph.strongSemCheck(c.graph, module, n)
+  case n.kind
+  of {nkPragma, nkMacroDef, nkTemplateDef, nkProcDef, nkFuncDef,
+                nkConverterDef, nkMethodDef, nkIteratorDef}:
+    discard
+  of nkTypeSection:
+    if isTopLevel:
+      collectObjectTree(c.graph, n)
+  else:
+    let g = c.graph
+    var effects = newNodeI(nkEffectList, n.info)
+    var t: TEffects
+    initEffects(g, effects, module, t, c)
+    t.isTopLevel = isTopLevel
+    track(t, n)
+    when defined(drnim):
+      if c.graph.strongSemCheck != nil: c.graph.strongSemCheck(c.graph, module, n)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1568,6 +1568,7 @@ when not defined(js) and defined(nimV2):
       align: int16
       depth: int16
       display: ptr UncheckedArray[uint32] # classToken
+      vTable: ptr UncheckedArray[pointer]
       when defined(nimTypeNames):
         name: cstring
       traceImpl: pointer

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -209,3 +209,7 @@ template tearDownForeignThreadGc* =
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inline.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token
+
+proc nimGetVTable(p: pointer, index: int): pointer
+       {.compilerRtl, inline, raises: [].} =
+  result = cast[ptr PNimTypeV2](p).vTable[index]

--- a/tests/method/nim.cfg
+++ b/tests/method/nim.cfg
@@ -1,1 +1,0 @@
-multimethods:on

--- a/tests/method/tgeneric_methods.nim
+++ b/tests/method/tgeneric_methods.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:arc; --mm:refc"
+  matrix: "--mm:arc --multimethods:on; --mm:refc --multimethods:on"
   output: '''wow2
 X 1
 X 3'''

--- a/tests/method/tmultim.nim
+++ b/tests/method/tmultim.nim
@@ -9,6 +9,7 @@ collide: unit, thing |
 collide: thing, unit |
 do nothing
 '''
+  matrix: "--multimethods:on"
   joinable: false
   disabled: true
 """

--- a/tests/method/tmultimjs.nim
+++ b/tests/method/tmultimjs.nim
@@ -4,7 +4,6 @@ discard """
 Hi derived!
 hello
 '''
-  disabled: true
 """
 
 

--- a/tests/method/tvtable.nim
+++ b/tests/method/tvtable.nim
@@ -1,0 +1,19 @@
+type FooBase = ref object of RootObj
+  dummy: int
+type Foo = ref object of FooBase
+  value : float32
+type Foo2 = ref object of Foo
+  change : float32
+method bar(x: FooBase, a: float32) {.base.} =
+  discard
+method bar(x: Foo, a: float32)  =
+  x.value += a
+method bar(x: Foo2, a: float32)  =
+  x.value += a
+
+
+proc test() =
+  var x = new Foo2
+  x.bar(2.3)
+
+test()


### PR DESCRIPTION
alternative to #21342

It intends to put `vtables` in a global static array instead of fields of objects. The object only store indexes.


## Benefits

- potential performance improvement