### PR TITLE
This adds `parseutils.parseSize`, an inverse to `strutils.formatSize`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 
 
 [//]: # "Additions:"
-
+- Added `parseutils.parseSize` - inverse to `strutils.formatSize` - to parse human readable sizes.
 
 [//]: # "Deprecations:"
 

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -602,8 +602,8 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
   ## garbage like "/s" in "1k/s" is allowed and detected by `result < s.len`.
   ##
   ## To simplify use, following non-rare wild conventions, and since fractional
-  ## information is so rare, unit matching is case-insensitive but for the 'i'
-  ## distinguishing binary-metric from metric which cannot be 'I'.
+  ## data like milli-bytes is so rare, unit matching is case-insensitive but for
+  ## the 'i' distinguishing binary-metric from metric which cannot be 'I'.
   ##
   ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still
   ## know if units are bytes | bits or infer this fact via the case of s[^1] (if

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -641,8 +641,8 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
           inc result                    # Skip optional '[bB]'
     else:                               # Unwind result advancement when there..
       result = start                    #..is no unit to the end of `s`.
-    var sizeF = number * scale + 0.5    # Saturate to int.high when appropriate
-    size = if sizeF > 9223372036854774784.0: int.high else: sizeF.int
+    var sizeF = number * scale + 0.5    # Saturate to int64.high when too big
+    size = if sizeF > 9223372036854774784.0: int64.high else: sizeF.int64
 # Above constant=2^63-1024 avoids C UB; github.com/nim-lang/Nim/issues/20102 or
 # stackoverflow.com/questions/20923556/math-pow2-63-1-math-pow2-63-512-is-true
 

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -603,7 +603,7 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
   ##
   ## To simplify use, following non-rare wild conventions, and since fractional
   ## data like milli-bytes is so rare, unit matching is case-insensitive but for
-  ## the 'i' distinguishing binary-metric from metric which cannot be 'I'.
+  ## the 'i' distinguishing binary-metric from metric (which cannot be 'I').
   ##
   ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still
   ## know if units are bytes | bits or infer this fact via the case of s[^1] (if

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -608,13 +608,13 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
   ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still
   ## know if units are bytes | bits or infer this fact via the case of s[^1] (if
   ## users can even be relied upon to use 'B' for byte and 'b' for bit or have
-  ## that be s[^1]).  Trailing text stops the parse, as usual.
+  ## that be s[^1]).
   ##
   ## If `alwaysBin==true` then scales are always binary-metric, but e.g. "KiB"
   ## is still accepted for clarity.  If the value would exceed the range of
-  ## `int64`, `size` is set to `int64.high`.  Supported metric prefix chars
-  ## include k, m, g, t, p, e, z, y (but z & y saturate to int64.high unless
-  ## number is a small fraction).  It is unlikely you will need beyond 'peta'.
+  ## `int64`, `size` saturates to `int64.high`.  Supported metric prefix chars
+  ## include k, m, g, t, p, e, z, y (but z & y saturate unless the number is a
+  ## small fraction).
   ##
   ## **See also:**
   ## * https://en.wikipedia.org/wiki/Binary_prefix

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -592,6 +592,60 @@ proc parseFloat*(s: openArray[char], number: var float): int {.
   if result != 0:
     number = bf
 
+func toLowerAscii(c: char): char =
+  if c in {'A'..'Z'}: char(uint8(c) xor 0b0010_0000'u8) else: c
+
+func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
+  ## Parse a size qualified by binary or metric units into `size`.  This format
+  ## is often called "human readable".  Result is the number of processed chars
+  ## or 0 on parse errors and size is rounded to the nearest integer.  Trailing
+  ## garbage like "/s" in "1k/s" is allowed and detected by `result < s.len`.
+  ##
+  ## To simplify use, following non-rare wild conventions, and since fractional
+  ## information is so rare, unit  matching is case-insensitive but for the 'i'
+  ## distinguishing binary-metric from metric which cannot be 'I'.
+  ##
+  ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still
+  ## know if units are bytes | bits or infer this fact via the case of s[^1] (if
+  ## users can even be relied upon to use 'B' for byte and 'b' for bit or have
+  ## that be s[^1]).
+  ##
+  ## If `alwaysBin==true` then scales are always binary-metric, but e.g. "KiB"
+  ## is still accepted for clarity.
+  ##
+  ## **See also:**
+  ## * https://en.wikipedia.org/wiki/Binary_prefix
+  ## * `formatSize module<strutils.html>`_ for formatting
+  const prefix = "b" & "kmgtpezy"       # byte|bit & lowCase metric-ish prefixes
+  const scaleM = [1.0, 1e3, 1e6, 1e9, 1e12, 1e15, 1e18, 1e21, 1e24] # 10^(3*idx)
+  const scaleB = [1.0, 1024, 1048576, 1073741824, 1099511627776.0,  # 2^(10*idx)
+                  1125899906842624.0, 1152921504606846976.0,        # ldexp?
+                  1.180591620717411303424e21, 1.208925819614629174706176e24]
+  var number: float
+  var scale = 1.0
+  result = parseFloat(s, number)
+  if number < 0:                        # While parseFloat accepts negatives ..
+    result = 0                          #.. we do not since sizes cannot be < 0
+  if result > 0:
+    let start = result                  # Save spot to maybe unwind white to EOS
+    while result < s.len and s[result] in Whitespace:
+      inc result
+    if result < s.len:                  # Illegal starting char => unity
+      if (let si = prefix.find(s[result].toLowerAscii); si >= 0):
+        inc result                      # Now parse the scale
+        scale = if alwaysBin: scaleB[si] else: scaleM[si]
+        if result < s.len and s[result] == 'i':
+          scale = scaleB[si]            # Switch from default to binary-metric
+          inc result
+        if result < s.len and s[result].toLowerAscii == 'b':
+          inc result                    # Skip optional '[bB]'
+    else:                               # Unwind result advancement when there..
+      result = start                    #..is no unit to the end of `s`.
+    var sizeF = number * scale + 0.5    # Saturate to int.high when appropriate
+    size = if sizeF > 9223372036854774784.0: int.high else: sizeF.int
+# Above constant=2^63-1024 avoids C UB; github.com/nim-lang/Nim/issues/20102 or
+# stackoverflow.com/questions/20923556/math-pow2-63-1-math-pow2-63-512-is-true
+
 type
   InterpolatedKind* = enum ## Describes for `interpolatedFragments`
                            ## which part of the interpolated string is

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -611,7 +611,8 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
   ## that be s[^1]).
   ##
   ## If `alwaysBin==true` then scales are always binary-metric, but e.g. "KiB"
-  ## is still accepted for clarity.
+  ## is still accepted for clarity.  If the value would exceed the range of
+  ## `int64`, `size` is set to `int64.high`.
   ##
   ## **See also:**
   ## * https://en.wikipedia.org/wiki/Binary_prefix

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -602,7 +602,7 @@ func parseSize*(s: openArray[char], size: var int64, alwaysBin=false): int =
   ## garbage like "/s" in "1k/s" is allowed and detected by `result < s.len`.
   ##
   ## To simplify use, following non-rare wild conventions, and since fractional
-  ## information is so rare, unit  matching is case-insensitive but for the 'i'
+  ## information is so rare, unit matching is case-insensitive but for the 'i'
   ## distinguishing binary-metric from metric which cannot be 'I'.
   ##
   ## An optional trailing 'B|b' is ignored but processed.  I.e., you must still

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -92,4 +92,5 @@ block:  # With this included, static: test() crashes the compiler (from a
   ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
   ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
   # Value Edge cases
-  ass parseSize("9223372036854775807", sz) == 19; ass sz == int64.high
+  when not defined(i386): # Transition/rounding value may need adjustment
+    ass parseSize("9223372036854775807", sz) == 19; ass sz == int64.high

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -61,36 +61,41 @@ static: test()
 
 block:  # With this included, static: test() crashes the compiler (from a
         # VM problem with parseSize calling parseFloat).
-  template ass(x) = doAssert(x) # Avoid hint[LineTooLong]
   var sz: int64
+  template checkParseSize(s, expectLen, expectVal) =
+    if (let got = parseSize(s, sz); got != expectLen):
+      raise newException(IOError, "got len " & $got & " != " & $expectLen)
+    if sz != expectVal:
+      raise newException(IOError, "got sz " & $sz & " != " & $expectVal)
+  #              STRING    LEN SZ
   # Good, complete parses
-  ass parseSize("1  b", sz)    == 4; ass sz == 1
-  ass parseSize("1  B", sz)    == 4; ass sz == 1
-  ass parseSize("1k", sz)      == 2; ass sz == 1000
-  ass parseSize("1 kib", sz)   == 5; ass sz == 1024
-  ass parseSize("1 ki", sz)    == 4; ass sz == 1024
-  ass parseSize("1mi", sz)     == 3; ass sz == 1048576
-  ass parseSize("1 mi", sz)    == 4; ass sz == 1048576
-  ass parseSize("1 mib", sz)   == 5; ass sz == 1048576
-  ass parseSize("1 Mib", sz)   == 5; ass sz == 1048576
-  ass parseSize("1 MiB", sz)   == 5; ass sz == 1048576
-  ass parseSize("1.23GiB", sz) == 7; ass sz == 1320702444 # 1320702443.52
-  ass parseSize("0.001k", sz)  == 6; ass sz == 1
-  ass parseSize("0.0004k", sz) == 7; ass sz == 0
-  ass parseSize("0.0006k", sz) == 7; ass sz == 1
+  checkParseSize "1  b"   , 4, 1
+  checkParseSize "1  B"   , 4, 1
+  checkParseSize "1k"     , 2, 1000
+  checkParseSize "1 kib"  , 5, 1024
+  checkParseSize "1 ki"   , 4, 1024
+  checkParseSize "1mi"    , 3, 1048576
+  checkParseSize "1 mi"   , 4, 1048576
+  checkParseSize "1 mib"  , 5, 1048576
+  checkParseSize "1 Mib"  , 5, 1048576
+  checkParseSize "1 MiB"  , 5, 1048576
+  checkParseSize "1.23GiB", 7, 1320702444 # 1320702443.52 rounded
+  checkParseSize "0.001k" , 6, 1
+  checkParseSize "0.0004k", 7, 0
+  checkParseSize "0.0006k", 7, 1
   # Incomplete parses
-  ass parseSize("1  ", sz)     == 1; ass sz == 1  # Trailing white IGNORED
-  ass parseSize("1  B ", sz)   == 4; ass sz == 1  # Trailing white IGNORED
-  ass parseSize("1  B/s", sz)  == 4; ass sz == 1  # Trailing junk IGNORED
-  ass parseSize("1 kX", sz)    == 3; ass sz == 1000
-  ass parseSize("1 kiX", sz)   == 4; ass sz == 1024
-  ass parseSize("1j", sz)      == 1; ass sz == 1  # Unknown prefix
-  ass parseSize("1 jib", sz)   == 2; ass sz == 1  # ..also IGNORED
-  ass parseSize("1  ji", sz)   == 3; ass sz == 1
-  # Bad parses; `sz` should stay last good|incomplete val
-  ass parseSize("-1b", sz)     == 0; ass sz == 1  # Negative numbers
-  ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
-  ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
+  checkParseSize "1  "    , 1, 1          # Trailing white IGNORED
+  checkParseSize "1  B "  , 4, 1          # Trailing white IGNORED
+  checkParseSize "1  B/s" , 4, 1          # Trailing junk IGNORED
+  checkParseSize "1 kX"   , 3, 1000
+  checkParseSize "1 kiX"  , 4, 1024
+  checkParseSize "1j"     , 1, 1          # Unknown prefix IGNORED
+  checkParseSize "1 jib"  , 2, 1          # Unknown prefix post space
+  checkParseSize "1  ji"  , 3, 1
+  # Bad parses; `sz` should stay last good|incomplete value
+  checkParseSize "-1b"    , 0, 1          # Negative numbers
+  checkParseSize "abc"    , 0, 1          # Non-numeric
+  checkParseSize " 12"    , 0, 1          # Leading white
   # Value Edge cases
   when not defined(i386): # Transition/rounding value may need adjustment
-    ass parseSize("9223372036854775807", sz) == 19; ass sz == int64.high
+    checkParseSize "9223372036854775807", 19, int64.high

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -55,5 +55,41 @@ proc test() =
     doAssert res == @[(17, "9.123456789012344"), (18, "11.123456789012344"),
                       (17, "9.123456789012344"), (17, "8.123456789012344"),
                       (16, "9.12345678901234"), (17, "9.123456789012344")]
+
 test()
 static: test()
+
+block:  # With this included, static: test() crashes the compiler (from a
+        # VM problem with parseSize calling parseFloat).
+  template ass(x) = doAssert(x) # Avoid hint[LineTooLong]
+  var sz: int64
+  # Good, complete parses
+  ass parseSize("1  b", sz)    == 4; ass sz == 1
+  ass parseSize("1  B", sz)    == 4; ass sz == 1
+  ass parseSize("1k", sz)      == 2; ass sz == 1000
+  ass parseSize("1 kib", sz)   == 5; ass sz == 1024
+  ass parseSize("1 ki", sz)    == 4; ass sz == 1024
+  ass parseSize("1mi", sz)     == 3; ass sz == 1048576
+  ass parseSize("1 mi", sz)    == 4; ass sz == 1048576
+  ass parseSize("1 mib", sz)   == 5; ass sz == 1048576
+  ass parseSize("1 Mib", sz)   == 5; ass sz == 1048576
+  ass parseSize("1 MiB", sz)   == 5; ass sz == 1048576
+  ass parseSize("1.23GiB", sz) == 7; ass sz == 1320702444 # 1320702443.52
+  ass parseSize("0.001k", sz)  == 6; ass sz == 1
+  ass parseSize("0.0004k", sz) == 7; ass sz == 0
+  ass parseSize("0.0006k", sz) == 7; ass sz == 1
+  # Incomplete parses
+  ass parseSize("1  ", sz)     == 1; ass sz == 1  # Trailing white IGNORED
+  ass parseSize("1  B ", sz)   == 4; ass sz == 1  # Trailing white IGNORED
+  ass parseSize("1  B/s", sz)  == 4; ass sz == 1  # Trailing junk IGNORED
+  ass parseSize("1 kX", sz)    == 3; ass sz == 1000
+  ass parseSize("1 kiX", sz)   == 4; ass sz == 1024
+  ass parseSize("1j", sz)      == 1; ass sz == 1  # Unknown prefix
+  ass parseSize("1 jib", sz)   == 2; ass sz == 1  # ..also IGNORED
+  ass parseSize("1  ji", sz)   == 3; ass sz == 1
+  # Bad parses; `sz` should stay last good|incomplete val
+  ass parseSize("-1b", sz)     == 0; ass sz == 1  # Negative numbers
+  ass parseSize("abc", sz)     == 0; ass sz == 1  # Non-numeric
+  ass parseSize(" 12", sz)     == 0; ass sz == 1  # Leading white
+  # Value Edge cases
+  ass parseSize("9223372036854775807", sz) == 19; ass sz == int64.high

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -97,5 +97,4 @@ block:  # With this included, static: test() crashes the compiler (from a
   checkParseSize "abc"    , 0, 1          # Non-numeric
   checkParseSize " 12"    , 0, 1          # Leading white
   # Value Edge cases
-  when not defined(i386): # Transition/rounding value may need adjustment
-    checkParseSize "9223372036854775807", 19, int64.high
+  checkParseSize "9223372036854775807", 19, int64.high


### PR DESCRIPTION
which has existed since 2017.

It is useful for parsing the compiler's own output logs (like SuccessX) or many other scenarios where "human readable" units have been chosen. The doc comment and tests explain accepted syntax in detail.

Big units lead to small numbers, often with a fractional part, but we parse into an `int64` since that is what `formatSize` stringifies and this is an inverse over partial function slots.  Although metric prefixes z & y for zettabyte & yottabyte are accepted, these will saturate the result at `int64.high` unless the qualified number is a small fraction.  This should not be much of a problem until such sizes are common (at which point another overload with the parse result either `float64` or `int128` could be added).

Tests avoids `test()` because of a weakly related static: test() failure as mentioned in https://github.com/nim-lang/Nim/pull/21325. This is a more elemental VM failure.  As such, it needs its own failure exhibition issue that is a smaller test case.  (I am working on that, but unless there is a burning need to `parseSize` at compile-time before run-time it need not hold up this PR.)

This PR replaces https://github.com/nim-lang/Nim/pull/21325 which got a little git-mangled.