### PR TITLE
fixes #10938; fixes #13312; fixes #13918; fixes #20985; always initializes global variables with null values in VM

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1909,8 +1909,12 @@ proc genVarSection(c: PCtx; n: PNode) =
           c.genAdditionalCopy(a[2], opcWrDeref, tmp, 0, val)
           c.freeTemp(val)
           c.freeTemp(tmp)
-        elif not importcCondVar(s): # fixes #10938
-          # todo I made it correct first, it's your turn to make it faster
+        elif not importcCondVar(s) and not (s.typ.kind == tyProc and s.typ.callConv == ccClosure): # fixes #10938
+          # there is a pre-existing issue with closure types in VM
+          # if `(var s: proc () = default(proc ()); doAssert s == nil)` works for you;
+          # you might remove the second condition.
+          # the problem is that closure types are tuples in VM, but the types of its children
+          # shouldn't have the same type as closure types.
           let tmp = c.genx(a[0], {gfNodeAddr})
           let sa = getNullValue(s.typ, a.info, c.config)
           let val = c.genx(sa)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1909,6 +1909,14 @@ proc genVarSection(c: PCtx; n: PNode) =
           c.genAdditionalCopy(a[2], opcWrDeref, tmp, 0, val)
           c.freeTemp(val)
           c.freeTemp(tmp)
+        else: # fixes #10938
+          # todo I made it correct first, it's your turn to make it faster
+          let tmp = c.genx(a[0], {gfNodeAddr})
+          let sa = getNullValue(s.typ, a.info, c.config)
+          let val = c.genx(sa)
+          c.genAdditionalCopy(sa, opcWrDeref, tmp, 0, val)
+          c.freeTemp(val)
+          c.freeTemp(tmp)
       else:
         setSlot(c, s)
         if a[2].kind == nkEmpty:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1909,7 +1909,7 @@ proc genVarSection(c: PCtx; n: PNode) =
           c.genAdditionalCopy(a[2], opcWrDeref, tmp, 0, val)
           c.freeTemp(val)
           c.freeTemp(tmp)
-        else: # fixes #10938
+        elif not importcCondVar(s): # fixes #10938
           # todo I made it correct first, it's your turn to make it faster
           let tmp = c.genx(a[0], {gfNodeAddr})
           let sa = getNullValue(s.typ, a.info, c.config)

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -564,14 +564,14 @@ block:
 block:
   static:
     let x = int 1
-    echo x.type   # Foo
+    doAssert $(x.type) == "Foo"  # Foo
 
 block:
   static:
     let x = int 1
     let y = x + 1
     # Error: unhandled exception: value out of range: -8 notin 0 .. 65535 [RangeDefect]
-    echo y
+    doAssert y == 2
 
 
 type Atom* = object
@@ -601,3 +601,45 @@ proc foo(s: sink string) = doAssert s.len == 3
 
 static:
   foo("abc")
+
+
+static:
+  for i in '1' .. '2': # bug #10938
+    var s: set[char]
+    doAssert s == {}
+    incl(s, i)
+
+  for _ in 0 ..< 3: # bug #13312
+    var s: string
+    s.add("foo")
+    doAssert s == "foo"
+
+  for i in 1 .. 5: # bug #13918
+    var arr: array[3, int]
+    var val: int
+    doAssert arr == [0, 0, 0] and val == 0
+    for j in 0 ..< len(arr):
+      arr[j] = i
+      val = i
+
+# bug #20985
+let a = block:
+  var groups: seq[seq[int]]
+  for i in 0 ..< 3:
+    var group: seq[int]
+    for j in 0 ..< 3:
+      group.add j
+    groups.add group
+  groups
+
+const b = block:
+  var groups: seq[seq[int]]
+  for i in 0 ..< 3:
+    var group: seq[int]
+    for j in 0 ..< 3:
+      group.add j
+    groups.add group
+  groups
+
+doAssert a == @[@[0, 1, 2], @[0, 1, 2], @[0, 1, 2]]
+doAssert b == @[@[0, 1, 2], @[0, 1, 2], @[0, 1, 2]]


### PR DESCRIPTION
fixes #10938
fixes #13312
fixes #13918
fixes #20985
closes https://github.com/nim-lang/RFCs/issues/276


There is a pre-existing issue, I don't feel like solving it in this PR

![image](https://user-images.githubusercontent.com/43030857/218266099-6d5cb095-bf7f-440c-bb9e-1c7d5fea4d3c.png)


```nim
(var s: proc () = default(proc ()); doAssert s == nil)
```