### PR TITLE
`std/asyncjs` allow transforming proc types

### DIFF
--- a/tests/js/tasyncjs.nim
+++ b/tests/js/tasyncjs.nim
@@ -94,4 +94,9 @@ proc main() {.async.} =
     doAssert "foobar: 7" in $reason.message
   echo "done" # justified here to make sure we're running this, since it's inside `async`
 
+block asyncPragmaInType:
+  type Handler = proc () {.async.}
+  proc foo() {.async.} = discard
+  var x: Handler = foo
+
 discard main()


### PR DESCRIPTION
Allows defining async proc types when using `std/asyncjs`
```nim
# Works with asyncdispatch, but doesn't currently work with asyncjs
type Handler = proc () {.async.}
```
Copies the implementation from [asyncmacro](https://github.com/nim-lang/Nim/blob/devel/lib/pure/asyncmacro.nim#L147-L151) 