### PR TITLE
allow omitting stmts using `finally` as post expr blocks; make it consistent with `else`, `except` etc.

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1496,7 +1496,7 @@ proc postExprBlocks(p: var Parser, x: PNode): PNode =
     result = makeCall(result)
     getTok(p)
     skipComment(p, result)
-    if p.tok.tokType notin {tkOf, tkElif, tkElse, tkExcept}:
+    if p.tok.tokType notin {tkOf, tkElif, tkElse, tkExcept, tkFinally}:
       var stmtList = newNodeP(nkStmtList, p)
       stmtList.add parseStmt(p)
       # to keep backwards compatibility (see tests/vm/tstringnil)

--- a/tests/parser/tpostexprblocks.nim
+++ b/tests/parser/tpostexprblocks.nim
@@ -498,6 +498,13 @@ StmtList
         StmtList
           DiscardStmt
             Empty
+
+  Call
+    Ident "foo"
+    Finally
+      StmtList
+        DiscardStmt
+          Empty
 '''
 """
 
@@ -653,5 +660,9 @@ dumpTree:
     discard
   except (a, b):
     discard
+  finally:
+    discard
+
+  foo:
   finally:
     discard


### PR DESCRIPTION
ref https://github.com/nim-works/nimskull/pull/533#discussion_r1103879899
follow up https://github.com/nim-lang/Nim/pull/16896 