### PR TITLE
Fix long link commands on macOS (v2)

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -834,6 +834,15 @@ proc linkViaResponseFile(conf: ConfigRef; cmd: string) =
   finally:
     removeFile(linkerArgs)
 
+proc linkViaShellScript(conf: ConfigRef; cmd: string) =
+  let linkerScript = conf.projectName & "_" & "linkerScript.sh"
+  writeFile(linkerScript, cmd)
+  let shell = getEnv("SHELL")
+  try:
+    execLinkCmd(conf, shell & " " & linkerScript)
+  finally:
+    removeFile(linkerScript)
+
 proc getObjFilePath(conf: ConfigRef, f: Cfile): string =
   if noAbsolutePaths(conf): f.obj.extractFilename
   else: f.obj.string
@@ -856,9 +865,12 @@ proc preventLinkCmdMaxCmdLen(conf: ConfigRef, linkCmd: string) =
   # Windows's command line limit is about 8K (8191 characters) so C compilers on
   # Windows support a feature where the command line can be passed via ``@linkcmd``
   # to them.
-  const MaxCmdLen = when defined(windows): 8_000 else: 32_000
+  const MaxCmdLen = when defined(windows): 8_000 elif defined(macosx): 260_000 else: 32_000
   if linkCmd.len > MaxCmdLen:
-    linkViaResponseFile(conf, linkCmd)
+    when defined(macosx):
+      linkViaShellScript(conf, linkCmd)
+    else:
+      linkViaResponseFile(conf, linkCmd)
   else:
     execLinkCmd(conf, linkCmd)
 


### PR DESCRIPTION
This is the v2 patch that does the same thing as https://github.com/nim-lang/Nim/pull/21381 for v1.6

This PR addresses two issues with long link command-line arguments:

1. macOS command line length limit it typically 262144 (as returned by `getconf ARG_MAX`), not 8000 or 32000. This PR bumps up the length limit for macOS.
2. macOS's version of `ar` does not work with response files (i.e. `ar rcs @somefile`) so very long link commands would simply fail. This change puts long link commands in a shell script and executes the script.