### PR TITLE
NuttX added supports getrlimit(RLIMIT_NOFILE), so remove NuttX specific codes.

### DIFF
--- a/lib/posix/posix_other_consts.nim
+++ b/lib/posix/posix_other_consts.nim
@@ -473,9 +473,6 @@ var FD_SETSIZE* {.importc: "FD_SETSIZE", header: "<sys/select.h>".}: cint
 when defined(zephyr):
   # Zephyr specific hardcoded value
   var FD_MAX* {.importc: "CONFIG_POSIX_MAX_FDS ", header: "<sys/select.h>".}: cint
-elif defined(nuttx):
-  # NuttX specific user configuration value
-  var NACTIVESOCKETS* {.importc: "CONFIG_NET_NACTIVESOCKETS", header: "<nuttx/config.h>".}: cint
 
 # <sys/socket.h>
 var MSG_CTRUNC* {.importc: "MSG_CTRUNC", header: "<sys/socket.h>".}: cint

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -2033,9 +2033,6 @@ when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
       result = 16_700_000
     elif defined(zephyr) or defined(freertos):
       result = FD_MAX
-    elif defined(nuttx):
-      # The maximum number of concurrently active UDP and TCP ports.
-      result = NACTIVESOCKETS
     else:
       var fdLim: RLimit
       if getrlimit(RLIMIT_NOFILE, fdLim) < 0:

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -337,9 +337,6 @@ else:
         16_700_000
       elif defined(zephyr) or defined(freertos):
         FD_MAX
-      elif defined(nuttx):
-        # The maximum number of concurrently active UDP and TCP ports.
-        NACTIVESOCKETS
       else:
         var fdLim: RLimit
         var res = int(getrlimit(RLIMIT_NOFILE, fdLim))


### PR DESCRIPTION
NuttX now supports POSIX-compliant get_rlimit(RLIMIT_NOFILE) to get max file descriptor value.
So, I removed "when defined(nuttx):" blocks.
