### PR TITLE
fixes #22163; use `{.push warning[BareExcept]:off.}` to override settings temporarily

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -761,8 +761,11 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
       defectiveRobot()
 
   template expectBody(errorTypes, lineInfoLit, body): NimNode {.dirty.} =
+    {.push warning[BareExcept]:off.}
     try:
+      {.push warning[BareExcept]:on.}
       body
+      {.pop.}
       checkpoint(lineInfoLit & ": Expect Failed, no exception was thrown.")
       fail()
     except errorTypes:
@@ -770,6 +773,7 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
     except:
       checkpoint(lineInfoLit & ": Expect Failed, unexpected exception was thrown.")
       fail()
+    {.pop.}
 
   var errorTypes = newNimNode(nnkBracket)
   for exp in exceptions:

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -544,14 +544,14 @@ template test*(name, body) {.dirty.} =
     for formatter in formatters:
       formatter.testStarted(name)
 
-    {.warning[BareExcept]:off.}
+    {.push warning[BareExcept]:off.}
     try:
       when declared(testSetupIMPLFlag): testSetupIMPL()
       when declared(testTeardownIMPLFlag):
         defer: testTeardownIMPL()
-      {.warning[BareExcept]:on.}
+      {.push warning[BareExcept]:on.}
       body
-      {.warning[BareExcept]:off.}
+      {.pop.}
 
     except:
       let e = getCurrentException()
@@ -573,7 +573,7 @@ template test*(name, body) {.dirty.} =
       )
       testEnded(testResult)
       checkpoints = @[]
-    {.warning[BareExcept]:on.}
+    {.pop.}
 
 proc checkpoint*(msg: string) =
   ## Set a checkpoint identified by `msg`. Upon test failure all

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -103,7 +103,7 @@ template doAssertRaises*(exception: typedesc, code: untyped) =
   const begin = "expected raising '" & astToStr(exception) & "', instead"
   const msgEnd = " by: " & astToStr(code)
   template raisedForeign {.gensym.} = raiseAssert(begin & " raised foreign exception" & msgEnd)
-  {.warning[BareExcept]:off.}
+  {.push warning[BareExcept]:off.}
   when Exception is exception:
     try:
       if true:
@@ -122,6 +122,6 @@ template doAssertRaises*(exception: typedesc, code: untyped) =
       mixin `$` # alternatively, we could define $cstring in this module
       raiseAssert(begin & " raised '" & $e.name & "'" & msgEnd)
     except: raisedForeign()
-  {.warning[BareExcept]:on.}
+  {.pop.}
   if wrong:
     raiseAssert(begin & " nothing was raised" & msgEnd)


### PR DESCRIPTION
> The `push/pop` pragmas are very similar to the option directive,
    but are used to override the settings temporarily.

`{.warning[BareExcept]:off.}` works accidentally and might not continue to work in the future.

ref https://github.com/nim-lang/Nim/pull/21390 (in fact, #21390 doesn't affect semantic options like `{.warning[BareExcept]:off.}`, but it is misused here). In the future `push pragmas` will continue to work reliably => https://github.com/nim-lang/Nim/pull/21388

fixes #22163