### PR TITLE
Specify that address is taken when converter takes a var parameter

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1980,6 +1980,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
         param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
       elif src.kind in {tyVar}:
         # Analyse the converter return type
+        arg.sym.flags.incl sfAddrTaken
         param = newNodeIT(nkHiddenAddr, arg.info, s.typ[1])
         param.add copyTree(arg)
       else:

--- a/tests/js/t21247.nim
+++ b/tests/js/t21247.nim
@@ -1,0 +1,18 @@
+discard """
+  targets: js
+"""
+import std/typetraits
+
+type
+  QueryParams* = distinct seq[(string, string)]
+
+converter toBase*(params: var QueryParams): var seq[(string, string)] =
+  params.distinctBase
+
+proc foo(): QueryParams =
+  # Issue was that the implicit converter call didn't say that it took the
+  # address of the parameter it was converting. This led to the parameter not being
+  # passed as a fat pointer which toBase expected
+  result.add(("hello", "world"))
+
+assert foo().distinctBase() == @[("hello", "world")]

--- a/tests/js/t21247.nim
+++ b/tests/js/t21247.nim
@@ -1,6 +1,3 @@
-discard """
-  targets: js
-"""
 import std/typetraits
 
 type


### PR DESCRIPTION
Closes #21247 

Converters didn't properly specify that they take the address of var parameters which meant JS backend didn't convert the parameter into a fat pointer which the converter expected