### PR TITLE
Support new runtime with nim-gdb

### DIFF
--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -40,7 +40,7 @@ for i, expected in enumerate(outputs):
   gdb.flush()
   currFrame = gdb.selected_frame()
   functionSymbol = currFrame.block().function
-  assert functionSymbol.line == 41, str(functionSymbol.line)
+  assert functionSymbol.line == 24, str(functionSymbol.line)
   raw = ""
   if i == 6:
     # myArray is passed as pointer to int to myDebug. I look up myArray up in the stack

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -1,5 +1,6 @@
 import gdb
 import re
+import sys
 # this test should test the gdb pretty printers of the nim
 # library. But be aware this test is not complete. It only tests the
 # command line version of gdb. It does not test anything for the
@@ -56,7 +57,7 @@ for i, expected in enumerate(outputs):
 
   if output != expected:
     gdb.write(f"\x1b[38;5;196m ({output}) != expected: ({expected})\x1b[0m\n", gdb.STDERR)
-    gdb.execute("quit")
+    gdb.execute("quit 1")
   else:
     gdb.write("\x1b[38;5;34mpassed\x1b[0m\n", gdb.STDLOG)
   gdb.execute("continue")

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -51,7 +51,6 @@ for i, expected in enumerate(outputs):
     rawArg = gdb.execute("info args", to_string = True)
     if match := argRegex.match(rawArg):
       raw = match.group(1)
-
   output = str(raw)
 
   if output != expected:

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -35,7 +35,7 @@ argRegex = re.compile("^.* = (?:No suitable Nim \$ operator found for type: \w+\
 noSuitableRegex = re.compile("(No suitable Nim \$ operator found for type: \w+\s*)")
 
 for i, expected in enumerate(outputs):
-  gdb.write(f"{i+1}) expecting: {expected}: ", gdb.STDLOG)
+  gdb.write(f"\x1b[38;5;105m{i+1}) expecting: {expected}: \x1b[0m", gdb.STDLOG)
   gdb.flush()
   currFrame = gdb.selected_frame()
   functionSymbol = currFrame.block().function
@@ -55,8 +55,8 @@ for i, expected in enumerate(outputs):
   output = str(raw)
 
   if output != expected:
-    gdb.write(f" ({output}) != expected: ({expected})\n", gdb.STDERR)
+    gdb.write(f"\x1b[38;5;196m ({output}) != expected: ({expected})\x1b[0m\n", gdb.STDERR)
     gdb.execute("quit")
   else:
-    gdb.write(f"passed\n", gdb.STDLOG)
+    gdb.write("\x1b[38;5;34mpassed\x1b[0m\n", gdb.STDLOG)
   gdb.execute("continue")

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -1,10 +1,12 @@
 import gdb
+import re
 # this test should test the gdb pretty printers of the nim
 # library. But be aware this test is not complete. It only tests the
 # command line version of gdb. It does not test anything for the
 # machine interface of gdb. This means if if this test passes gdb
 # frontends might still be broken.
 
+gdb.execute("set python print-stack full")
 gdb.execute("source ../../../tools/nim-gdb.py")
 # debug all instances of the generic function `myDebug`, should be 14
 gdb.execute("rbreak myDebug")
@@ -28,13 +30,15 @@ outputs = [
   '{a = 1, b = "some string"}'
 ]
 
+argRegex = re.compile("^.* = (.*)$")
+
 for i, expected in enumerate(outputs):
   gdb.write(f"{i+1}) expecting: {expected}: ", gdb.STDLOG)
   gdb.flush()
-
-  functionSymbol = gdb.selected_frame().block().function
+  currFrame = gdb.selected_frame()
+  functionSymbol = currFrame.block().function
   assert functionSymbol.line == 41, str(functionSymbol.line)
-
+  raw = ""
   if i == 6:
     # myArray is passed as pointer to int to myDebug. I look up myArray up in the stack
     gdb.execute("up")
@@ -44,10 +48,15 @@ for i, expected in enumerate(outputs):
     gdb.execute("up")
     raw = gdb.parse_and_eval("myOtherArray")
   else:
-    raw = gdb.parse_and_eval("arg")
+    rawArg = gdb.execute("info args", to_string = True)
+    if match := argRegex.match(rawArg):
+      raw = match.group(1)
 
   output = str(raw)
 
-  assert output == expected, "{0} : output: ({1}) != expected: ({2})".format(i, output, expected)
-  gdb.write(f"passed\n", gdb.STDLOG)
+  if output != expected:
+    gdb.write(f" ({output}) != expected: ({expected})\n", gdb.STDERR)
+    gdb.execute("quit")
+  else:
+    gdb.write(f"passed\n", gdb.STDLOG)
   gdb.execute("continue")

--- a/tests/untestable/gdb/gdb_pretty_printer_test_output.txt
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_output.txt
@@ -1,3 +1,4 @@
 Loading Nim Runtime support.
 NimEnumPrinter: lookup global symbol 'NTI__z9cu80OJCfNgw9bUdzn5ZEzw_ failed for tyEnum_MyOtherEnum__z9cu80OJCfNgw9bUdzn5ZEzw.
 8
+d

--- a/tests/untestable/gdb/gdb_pretty_printer_test_output.txt
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_output.txt
@@ -1,4 +1,0 @@
-Loading Nim Runtime support.
-NimEnumPrinter: lookup global symbol 'NTI__z9cu80OJCfNgw9bUdzn5ZEzw_ failed for tyEnum_MyOtherEnum__z9cu80OJCfNgw9bUdzn5ZEzw.
-8
-d

--- a/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
@@ -106,7 +106,7 @@ proc testProc(): void =
   # var varObjInt = MyIntVariant(stuff: 5, myKind: 2, mString: "this is my sweet string")
   # myDebug(varObjInt) #17
 
-  echo(counter)
+  assert counter == 15
 
 
 testProc()

--- a/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
@@ -18,23 +18,6 @@ type
   MyObj = object
     a*: int
     b*: string
-  
-  # MyVariant = ref object
-  #   id*: int
-  #   case kind*: MyEnum
-  #   of meOne: mInt*: int
-  #   of meTwo, meThree: discard
-  #   of meFour:
-  #     moInt*: int
-  #     babies*: seq[MyVariant]
-  #   after: float
-
-  # MyIntVariant = ref object
-  #   stuff*: int
-  #   case myKind*: range[0..32766]
-  #   of 0: mFloat*: float
-  #   of 2: mString*: string
-  #   else: mBabies*: seq[MyIntVariant]
 
 var counter = 0
 
@@ -96,15 +79,6 @@ proc testProc(): void =
 
   var obj = MyObj(a: 1, b: "some string")
   myDebug(obj) #15
-
-  # var varObj = MyVariant(id: 13, kind: meFour, moInt: 94,
-  #                        babies: @[MyVariant(id: 18, kind: meOne, mInt: 7, after: 1.0),
-  #                                  MyVariant(id: 21, kind: meThree, after: 2.0)],
-  #                        after: 3.0)
-  # myDebug(varObj) #16
-
-  # var varObjInt = MyIntVariant(stuff: 5, myKind: 2, mString: "this is my sweet string")
-  # myDebug(varObjInt) #17
 
   assert counter == 15
 

--- a/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
@@ -1,19 +1,13 @@
 #!/usr/bin/env bash
-# Exit if anything fails
 set -e
-#!/usr/bin/env bash
 # Compile the test project with fresh debug information.
-nim c --debugger:native --mm:orc --out:gdbNew gdb_pretty_printer_test_program.nim &> /dev/null
+nim c --debugger:native --mm:orc --out:gdbNew gdb_pretty_printer_test_program.nim
 # 2>&1 redirects stderr to stdout (all output in stdout)
 # <(...) is a bash feature that makes the output of a command into a
 # file handle.
-# diff compares the two files, the expected output, and the file
-# handle that is created by the execution of gdb.
-diff ./new_output.txt <(gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbNew 2>&1)
-# The exit code of diff is forwarded as the exit code of this
-# script. So when the comparison fails, the exit code of this script
-# won't be 0. So this script should be embeddable in a test suite.
+gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbNew 2>&1
+
 
 # Do it all again, but with old runtime
 nim c --debugger:native --mm:refc --out:gdbOld gdb_pretty_printer_test_program.nim &> /dev/null
-diff ./old_output.txt <(gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbOld 2>&1)
+gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbOld 2>&1

--- a/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
@@ -3,8 +3,6 @@ set -e
 # Compile the test project with fresh debug information.
 nim c --debugger:native --mm:orc --out:gdbNew gdb_pretty_printer_test_program.nim
 # 2>&1 redirects stderr to stdout (all output in stdout)
-# <(...) is a bash feature that makes the output of a command into a
-# file handle.
 gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbNew 2>&1
 
 

--- a/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
@@ -3,13 +3,17 @@
 set -e
 #!/usr/bin/env bash
 # Compile the test project with fresh debug information.
-nim c --debugger:native gdb_pretty_printer_test_program.nim &> /dev/null
+nim c --debugger:native --mm:orc --out:gdbNew gdb_pretty_printer_test_program.nim &> /dev/null
 # 2>&1 redirects stderr to stdout (all output in stdout)
 # <(...) is a bash feature that makes the output of a command into a
 # file handle.
 # diff compares the two files, the expected output, and the file
 # handle that is created by the execution of gdb.
-diff ./gdb_pretty_printer_test_output.txt <(gdb -x gdb_pretty_printer_test.py --batch-silent --args gdb_pretty_printer_test_program 2>&1)
+diff ./new_output.txt <(gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbNew 2>&1)
 # The exit code of diff is forwarded as the exit code of this
 # script. So when the comparison fails, the exit code of this script
 # won't be 0. So this script should be embeddable in a test suite.
+
+# Do it all again, but with old runtime
+nim c --debugger:native --mm:refc --out:gdbOld gdb_pretty_printer_test_program.nim &> /dev/null
+diff ./old_output.txt <(gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbOld 2>&1)

--- a/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_run.sh
@@ -2,10 +2,12 @@
 set -e
 # Compile the test project with fresh debug information.
 nim c --debugger:native --mm:orc --out:gdbNew gdb_pretty_printer_test_program.nim
+echo "Running new runtime tests..."
 # 2>&1 redirects stderr to stdout (all output in stdout)
 gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbNew 2>&1
 
 
 # Do it all again, but with old runtime
 nim c --debugger:native --mm:refc --out:gdbOld gdb_pretty_printer_test_program.nim &> /dev/null
+echo "Running old runtime tests"
 gdb -x gdb_pretty_printer_test.py --batch-silent --args gdbOld 2>&1

--- a/tools/nim-gdb.py
+++ b/tools/nim-gdb.py
@@ -422,19 +422,16 @@ class NimSetPrinter:
   def to_string(self):
     # Remove the tySet from the type name
     typ = gdb.lookup_type(self.val.type.name[6:])
-    if True:
-      enumStrings = []
-      val = int(self.val)
-      i   = 0
-      while val > 0:
-        if (val & 1) == 1:
-          enumStrings.append(reprEnum(i, typ))
-        val = val >> 1
-        i += 1
+    enumStrings = []
+    val = int(self.val)
+    i   = 0
+    while val > 0:
+      if (val & 1) == 1:
+        enumStrings.append(reprEnum(i, typ))
+      val = val >> 1
+      i += 1
 
-      return '{' + ', '.join(enumStrings) + '}'
-    else:
-      return str(int(self.val))
+    return '{' + ', '.join(enumStrings) + '}'
 
 ################################################################################
 

--- a/tools/nim-gdb.py
+++ b/tools/nim-gdb.py
@@ -308,6 +308,22 @@ class NimBoolPrinter:
 
 ################################################################################
 
+class NimStringV2Printer:
+  pattern = re.compile(r'^NimStringV2$')
+
+  def __init__(self, val):
+    self.val = val
+
+  def display_hint(self):
+    return 'string'
+
+  def to_string(self):
+    if self.val:
+      l = int(self.val["len"])
+      return self.val["p"]["data"].lazy_string(encoding="utf-8", length=l)
+    else:
+      return ""
+
 class NimStringPrinter:
   pattern = re.compile(r'^NimStringDesc \*$')
 


### PR DESCRIPTION
Currently nim-gdb is broken due to the new layout of sequences and strings in the new runtime.

It now relies more on calling Nim procs like `reprEnum` and dollar procs instead of trying to rewrite the logic in python (e.g. This now allows printing of `set[SomeEnum]` properly even when we can't get the string value for the enums)
