### PR TITLE
Add `getDataDir` proc

### DIFF
--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -43,7 +43,7 @@ proc getDataDir*(): string {.rtl, extern: "nos$1"
   ## * `setCurrentDir proc`_
   when defined(windows):
     result = getEnv("APPDATA")
-  elif defined(macos):
+  elif defined(macosx):
     result = getEnv("XDG_DATA_HOME", getEnv("HOME") / "Library" / "Application Support")
   else:
     result = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local" / "share")

--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -12,6 +12,7 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
   ## for the convenience of processing paths coming from user configuration files.
   ##
   ## See also:
+  ## * `getDataDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -23,6 +24,30 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
 
   when defined(windows): return getEnv("USERPROFILE") & "\\"
   else: return getEnv("HOME") & "/"
+
+proc getDataDir*(): string {.rtl, extern: "nos$1"
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the data directory of the current user for applications.
+  ## 
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_DATA_HOME` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("~/.local/share" or "~/Library/Application Support" on macOS).
+  ## 
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
+  when defined(windows):
+    result = getEnv("APPDATA")
+  elif defined(macos):
+    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / "Library" / "Application Support")
+  else:
+    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local" / "share")
+  result.normalizePathEnd(trailingSep = true)
 
 proc getConfigDir*(): string {.rtl, extern: "nos$1",
   tags: [ReadEnvEffect, ReadIOEffect].} =
@@ -38,6 +63,7 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   ##
   ## See also:
   ## * `getHomeDir proc`_
+  ## * `getDataDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_
@@ -63,6 +89,7 @@ proc getCacheDir*(): string =
   ## * `getHomeDir proc`_
   ## * `getTempDir proc`_
   ## * `getConfigDir proc`_
+  ## * `getDataDir proc`_
   # follows https://crates.io/crates/platform-dirs
   when defined(windows):
     result = getEnv("LOCALAPPDATA")


### PR DESCRIPTION
This adds `getDataDir` to fit in with the line of `getConfigDir` and `getCacheDir`. They respectively use the `XDG_DATA_HOME`, `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` environment variables.

Please let me know if there are any issues with this PR, as this is my first time contributing to Nim.