### PR TITLE
Make `Time` work with `std/strformat`

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2109,7 +2109,7 @@ proc format*(dt: DateTime, f: static[string]): string {.raises: [].} =
   const f2 = initTimeFormat(f)
   result = dt.format(f2)
 
-proc formatValue*(result: var string; value: DateTime, specifier: string) =
+proc formatValue*(result: var string; value: DateTime | Time, specifier: string) =
   ## adapter for strformat. Not intended to be called directly.
   result.add format(value,
     if specifier.len == 0: "yyyy-MM-dd'T'HH:mm:sszzz" else: specifier)
@@ -2132,10 +2132,6 @@ proc format*(time: Time, f: static[string], zone: Timezone = local()): string
   ## Overload that validates `f` at compile time.
   const f2 = initTimeFormat(f)
   result = time.inZone(zone).format(f2)
-
-template formatValue*(result: var string; value: Time, specifier: string) =
-  ## adapter for `strformat`. Not intended to be called directly.
-  result.add format(value, specifier)
 
 proc parse*(input: string, f: TimeFormat, zone: Timezone = local(),
     loc: DateTimeLocale = DefaultLocale): DateTime

--- a/tests/stdlib/t21406.nim
+++ b/tests/stdlib/t21406.nim
@@ -1,0 +1,5 @@
+import std/[times, strformat]
+import std/assertions
+
+doAssert fmt"{getTime()}" == $getTime()
+doAssert fmt"{now()}" == $now()


### PR DESCRIPTION
Closes #21406 

Before it used a template which didn't correctly handle an empty specifier (which is the default with strformat). Now it uses the same `formatValue` as `DateTime`