### PR TITLE
Support tuples in nim-gdb

### DIFF
--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -28,7 +28,8 @@ outputs = [
   'seq(3, 3) = {"one", "two", "three"}',
   'Table(3, 64) = {[4] = "four", [5] = "five", [6] = "six"}',
   'Table(3, 8) = {["two"] = 2, ["three"] = 3, ["one"] = 1}',
-  '{a = 1, b = "some string"}'
+  '{a = 1, b = "some string"}',
+  '("hello", 42)'
 ]
 
 argRegex = re.compile("^.* = (?:No suitable Nim \$ operator found for type: \w+\s*)*(.*)$")

--- a/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
+++ b/tests/untestable/gdb/gdb_pretty_printer_test_program.nim
@@ -80,7 +80,10 @@ proc testProc(): void =
   var obj = MyObj(a: 1, b: "some string")
   myDebug(obj) #15
 
-  assert counter == 15
+  var tup = ("hello", 42)
+  myDebug(tup) # 16
+
+  assert counter == 16
 
 
 testProc()

--- a/tools/nim-gdb.py
+++ b/tools/nim-gdb.py
@@ -160,7 +160,7 @@ class DollarPrintFunction (gdb.Function):
 
 
   @staticmethod
-  def invoke_static(arg):
+  def invoke_static(arg, ignore_errors = False):
     if arg.type.code == gdb.TYPE_CODE_PTR and arg.type.target().name in NIM_STRING_TYPES:
       return arg
     argTypeName = str(arg.type)
@@ -175,8 +175,8 @@ class DollarPrintFunction (gdb.Function):
         func_value = gdb.lookup_global_symbol(func, gdb.SYMBOL_FUNCTIONS_DOMAIN).value()
         return func_value(arg.address)
 
-
-    debugPrint(f"No suitable Nim $ operator found for type: {getNimName(argTypeName)}\n")
+    if not ignore_errors:
+      debugPrint(f"No suitable Nim $ operator found for type: {getNimName(argTypeName)}\n")
     return None
 
   def invoke(self, arg):
@@ -643,7 +643,9 @@ class NimTuplePrinter:
     self.val = val
 
   def to_string(self):
-    return ""
+    # We don't have field names so just print out the tuple as if it was anonymous
+    tupleValues = [str(self.val[field.name]) for field in self.val.type.fields()]
+    return f"({', '.join(tupleValues)})"
 
 ################################################################################
 

--- a/tools/nim-gdb.py
+++ b/tools/nim-gdb.py
@@ -112,6 +112,12 @@ class NimTypeRecognizer:
       result = self.type_map_static.get(tname, None)
       if result:
         return result
+      elif tname.startswith("tyEnum_"):
+        return getNimName(tname)
+      elif tname.startswith("tyTuple__"):
+        # We make the name be the field types (Just like in Nim)
+        fields = ", ".join([self.recognize(field.type) for field in type_obj.fields()])
+        return f"({fields})"
 
       rti = getNimRti(tname)
       if rti:
@@ -627,6 +633,17 @@ class NimTablePrinter:
         if int(entry['Field0']) != 0:
           yield (idxStr + '.Field1', entry['Field1'])
           yield (idxStr + '.Field2', entry['Field2'])
+
+################################################################################
+
+class NimTuplePrinter:
+  pattern = re.compile(r"^tyTuple__([A-Za-z0-9]*)")
+
+  def __init__(self, val):
+    self.val = val
+
+  def to_string(self):
+    return ""
 
 ################################################################################
 


### PR DESCRIPTION
With example program
```nim
type
  Colour = enum
    Red
    Green
    Blue
proc main() =
  var x = ("Hello World", Red)
  echo x
    
main()
```

GDB now renders `x` like a tuple e.g. (`$1 =` is printing the value, `type =` is calling ptype)

![image](https://user-images.githubusercontent.com/19339842/220214132-acb95ee8-ce10-4954-84e2-614fe4fc1396.png)

It works for named tuples also, but prints them the same way since there is no way to tell them apart
e.g. `(x: string, y: int)` and `(string, int)` are the same struct in the C code