### PR TITLE
Overrides `=copy` for `PackedSets`

### DIFF
--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -12,11 +12,6 @@
 ##
 ## Supports any Ordinal type.
 ##
-## .. note:: Currently the assignment operator `=` for `PackedSet[A]`
-##   performs some rather meaningless shallow copy. Since Nim currently does
-##   not allow the assignment operator to be overloaded, use the `assign proc
-##   <#assign,PackedSet[A],PackedSet[A]>`_ to get a deep copy.
-##
 ## See also
 ## ========
 ## * `sets module <sets.html>`_ for more general hash sets
@@ -412,18 +407,9 @@ proc isNil*[A](x: PackedSet[A]): bool {.inline.} =
 
   x.head.isNil and x.elems == 0
 
-proc assign*[A](dest: var PackedSet[A], src: PackedSet[A]) =
+proc `=copy`*[A](dest: var PackedSet[A], src: PackedSet[A]) =
   ## Copies `src` to `dest`.
   ## `dest` does not need to be initialized by the `initPackedSet proc <#initPackedSet>`_.
-  runnableExamples:
-    var
-      a = initPackedSet[int]()
-      b = initPackedSet[int]()
-    b.incl(5)
-    b.incl(7)
-    a.assign(b)
-    assert len(a) == 2
-
   if src.elems <= src.a.len:
     dest.data = @[]
     dest.max = 0
@@ -451,6 +437,19 @@ proc assign*[A](dest: var PackedSet[A], src: PackedSet[A]) =
       dest.head = n
       dest.data[h] = n
       it = it.next
+
+proc assign*[A](dest: var PackedSet[A], src: PackedSet[A]) {.inline, deprecated.} =
+  ## Copies `src` to `dest`.
+  ## `dest` does not need to be initialized by the `initPackedSet proc <#initPackedSet>`_.
+  runnableExamples:
+    var
+      a = initPackedSet[int]()
+      b = initPackedSet[int]()
+    b.incl(5)
+    b.incl(7)
+    a.assign(b)
+    assert len(a) == 2
+  `=copy`(dest, src)
 
 proc union*[A](s1, s2: PackedSet[A]): PackedSet[A] =
   ## Returns the union of the sets `s1` and `s2`.


### PR DESCRIPTION
ref #21393

fixes the problem, I'm going to look into the root cause later. 

It is a breaking change:

> Currently the assignment operator `=` for `PackedSet[A]`
  performs some rather meaningless shallow copy. Since Nim currently does
  not allow the assignment operator to be overloaded, use the `assign proc
  <#assign,PackedSet[A],PackedSet[A]>`_ to get a deep copy.

The PR intends to fix the shallow issue. It overrides the `=copy` type binding operation and does a deep copy. The root cause might be that the `strictfuncs` cannot identify the 
mutation of underlying refs.