### PR TITLE
alternative fixes for #21393

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -165,6 +165,7 @@ type
     importModuleMap*: Table[int, int] # (module.id, module.id)
     lastTLineInfo*: TLineInfo
     sideEffects*: Table[int, seq[(TLineInfo, PSym)]] # symbol.id index
+    dangerousAssign*: Table[int, (TLineInfo, PSym)]
     inUncheckedAssignSection*: int
 
 template config*(c: PContext): ConfigRef = c.graph.config

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1101,9 +1101,8 @@ proc track(tracked: PEffects, n: PNode) =
           tracked.hasSideEffect = true
           localError(tracked.config, n[0].info,
               "cannot mutate location $1 within a strict func" % renderTree(n[0]))
-        else:
-          if tracked.owner.kind == skProc:
-            markDangerousAssign(tracked, tracked.owner, n[0].info)
+        elif (not tracked.inEnforcedNoSideEffects) and tracked.owner.kind == skProc:
+          markDangerousAssign(tracked, tracked.owner, n[0].info)
 
   of nkVarSection, nkLetSection:
     for child in n:


### PR DESCRIPTION
It propagates `hasDangerousAssign` to its owner, like what has been done for sideeffects.