### PR TITLE
Disable threads for os:any

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -100,6 +100,11 @@ nimblepath="$home/.nimble/pkgs/"
   gcc.options.always %= "${gcc.options.always} -fsanitize=null -fsanitize-undefined-trap-on-error"
 @end
 
+# Turn off threads support when compiling for bare-metal targets (--os:any)
+@if any:
+  threads:off
+@end
+
 @if unix and mingw:
   # Cross compile for Windows from Linux/OSX using MinGW
   i386.windows.gcc.exe = "i686-w64-mingw32-gcc"

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -45,6 +45,8 @@ when defined(nimPreviewSlimSystem):
 when defined(genode):
   import genode/env
 
+when hostOS == "any":
+  {.error: "Threads not implemented for os:any. Please compile with --threads:off.".}
 
 when hasAllocStack or defined(zephyr) or defined(freertos) or defined(nuttx) or
     defined(cpu16) or defined(cpu8):


### PR DESCRIPTION
`threads:on` is now default for the upcoming release of Nim 2.0.

However, from my understanding at least, threads are fundamentally an OS-specific construct and don't really make sense in a bare-metal context (eg. OS kernel development or embedded). Moreover, the Nim compiler User Guide has this to say about `os:any`:

> The --os:any target makes sure Nim does not depend on any specific operating system primitives. Your platform should support only some basic ANSI C library stdlib and stdio functions which should be available on almost any platform.

I for one encountered some rather confusing errors when I tried compiling a MCU project with nim-devel for the first time (`arm-none-eabi-gcc` has no idea what `-pthread` is).

I'd therefore like to propose the following changes in order to make `threads:off` a sane default when compiling with `os:any`:

1. Set `threads:off` in the system-level nim.cfg file when `any` is defined`

2. Add a useful compile-time error to the typedthreads.nim module in order to nudge the user towards a clear solution.

Threads should still be supported for embedded targets when using one of the nim-supported RTOS `os` options: FreeRTOS (which includes ESP-IDF / nesper), Zephyr and the newly supported NuttX.
