### PR TITLE
asyncdispatch: for NuttX, add destructor to clear global dispatcher.

### DIFF
--- a/lib/std/exitprocs.nim
+++ b/lib/std/exitprocs.nim
@@ -41,14 +41,11 @@ else:
 proc callClosures() {.noconv.} =
   withLock gFunsLock:
     for i in countdown(gFuns.len-1, 0):
-      let fun =
-        when defined(nuttx):
-          gFuns.pop()
-        else:
-          gFuns[i]
+      let fun = gFuns[i]
       case fun.kind
       of kClosure: fun.fun1()
       of kNoconv: fun.fun2()
+    gFuns.setLen(0)
 
 template fun() =
   if gFuns.len == 0:

--- a/lib/std/exitprocs.nim
+++ b/lib/std/exitprocs.nim
@@ -41,7 +41,11 @@ else:
 proc callClosures() {.noconv.} =
   withLock gFunsLock:
     for i in countdown(gFuns.len-1, 0):
-      let fun = gFuns[i]
+      let fun =
+        when defined(nuttx):
+          gFuns.pop()
+        else:
+          gFuns[i]
       case fun.kind
       of kClosure: fun.fun1()
       of kNoconv: fun.fun2()


### PR DESCRIPTION
When the task ends, all opened file descriptors are closed by OS, but the memory is left as it is, so the gDisp(global dispatcher) is not released and the "value" of the epoll fd inside gDisp is left as it is.

Therefore, when the task was started a second time, it judged that epoll_create1() had already been executed, resulting in an error.

For NuttX only, I was able to deal with this by explicitly registering the process of clearing gDisp with atexit() before using the asyncdispatch function.