### PR TITLE
Add mention of breaking change about `[_]` in generics to changelog

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -149,6 +149,13 @@
   proc foo(_, _: int): int = 123
   echo foo(1, 2)
   ```
+- Underscores (`_`) as generic parameters are not supported and cannot be used.
+  Generics that use `_` as parameters will no longer compile requires you to replace `_` with something else:
+  
+  ```nim
+  proc foo[_](t: typedesc[_]): string = "BAR" # Can not compile
+  proc foo[T](t: typedesc[T]): string = "BAR" # Can compile
+  ```
 
 - - Added the `--legacy:verboseTypeMismatch` switch to get legacy type mismatch error messages.
 


### PR DESCRIPTION
As described by #21435 , generic proc declarations making use of `_` as generic parameter are no longer possible. This is a change that was introduced by  #21192 . During the debate over if this should be part of the intended spec in #21435 we concluded that it is and thus should be mentioned as a breaking change in the changelogs.