### PR TITLE
Allow `futureLogging` in release builds

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -29,7 +29,7 @@ type
     finished: bool
     error*: ref Exception              ## Stored exception
     errorStackTrace*: string
-    when not defined(release):
+    when not defined(release) or defined(futureLogging):
       stackTrace: seq[StackTraceEntry] ## For debugging purposes only.
       id: int
       fromProc: string

--- a/tests/async/t21447.nim
+++ b/tests/async/t21447.nim
@@ -1,0 +1,8 @@
+discard """
+  action: "compile"
+  cmd: "nim c -d:release -d:futureLogging $file"
+"""
+
+import std/asyncdispatch
+
+

--- a/tests/async/t21447.nim
+++ b/tests/async/t21447.nim
@@ -4,5 +4,3 @@ discard """
 """
 
 import std/asyncdispatch
-
-


### PR DESCRIPTION
Closes #21447 

Keeps extra debug information for `FutureBase` around when compiling with `-d:futureLogging` (Previously only kept it when not building in release)

