### PR TITLE
Add line directives for C code variables

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -566,6 +566,9 @@ proc localVarDecl(p: BProc; n: PNode): Rope =
     if s.kind == skLet: incl(s.loc.flags, lfNoDeepCopy)
   if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
     result.addf("NIM_ALIGN($1) ", [rope(s.alignment)])
+
+  genCLineDir(result, toFullPath(p.config, n.info), n.info.safeLineNm, p.config)
+
   result.add getTypeDesc(p.module, s.typ, skVar)
   if s.constraint.isNil:
     if sfRegister in s.flags: result.add(" register")

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -273,7 +273,8 @@ proc genCLineDir(r: var Rope, filename: string, line: int; conf: ConfigRef) =
         [rope(makeSingleLineCString(filename)), rope(line)])
 
 proc genCLineDir(r: var Rope, info: TLineInfo; conf: ConfigRef) =
-  genCLineDir(r, toFullPath(conf, info), info.safeLineNm, conf)
+  if optLineDir in conf.options:
+    genCLineDir(r, toFullPath(conf, info), info.safeLineNm, conf)
 
 proc freshLineInfo(p: BProc; info: TLineInfo): bool =
   if p.lastLineInfo.line != info.line or
@@ -287,7 +288,7 @@ proc genLineDir(p: BProc, t: PNode) =
 
   if optEmbedOrigSrc in p.config.globalOptions:
     p.s(cpsStmts).add("//" & sourceLine(p.config, t.info) & "\L")
-  genCLineDir(p.s(cpsStmts), toFullPath(p.config, t.info), line, p.config)
+  genCLineDir(p.s(cpsStmts), t.info, p.config)
   if ({optLineTrace, optStackTrace} * p.options == {optLineTrace, optStackTrace}) and
       (p.prc == nil or sfPure notin p.prc.flags) and t.info.fileIndex != InvalidFileIdx:
     if freshLineInfo(p, t.info):
@@ -567,7 +568,7 @@ proc localVarDecl(p: BProc; n: PNode): Rope =
   if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
     result.addf("NIM_ALIGN($1) ", [rope(s.alignment)])
 
-  genCLineDir(result, toFullPath(p.config, n.info), n.info.safeLineNm, p.config)
+  genCLineDir(result, n.info, p.config)
 
   result.add getTypeDesc(p.module, s.typ, skVar)
   if s.constraint.isNil:


### PR DESCRIPTION
Not sure if this is where to put it, or maybe there is a better way. I would like some feedback.

I encountered an issue when I was trying to write the LLDB python debugger extension. When trying to get the line declaration of a variable, it was reporting incorrectly.

The reason this is required is because since Nim declares all local C variables at the top of the procedure, the debugger thinks the variables are in-scope and initialized. So the Python debugging extension then thinks that it's okay to access the memory of the local variable, even though it has not been initialized yet. Which causes memory access violations.

So my solution is to compare the line number and file of the currently executing debugger line to the declaration line number and file of the variable.