### PR TITLE
fixes #21377; fixes `@[]` and `{}` type inference as returns in generics

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -998,13 +998,11 @@ proc afterCallActions(c: PContext; n, orig: PNode, flags: TExprFlags; expectedTy
     fixAbstractType(c, result)
     analyseIfAddressTakenInCall(c, result)
     if callee.magic != mNone:
-      result = magicsAfterOverloadResolution(c, result, flags)
+      result = magicsAfterOverloadResolution(c, result, flags, expectedType)
     when false:
       if result.typ != nil and
           not (result.typ.kind == tySequence and result.typ[0].kind == tyEmpty):
         liftTypeBoundOps(c, result.typ, n.info)
-    if result.typ != nil and expectedType != nil and result.typ.kind == tySequence and expectedType.kind == tySequence and result.typ[0].kind == tyEmpty:
-      result.typ = expectedType # type inference for empty sequence returns for generic procs # bug #21377
     #result = patchResolvedTypeBoundOp(c, result)
   if c.matchedConcept == nil:
     result = evalAtCompileTime(c, result)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1004,7 +1004,7 @@ proc afterCallActions(c: PContext; n, orig: PNode, flags: TExprFlags; expectedTy
           not (result.typ.kind == tySequence and result.typ[0].kind == tyEmpty):
         liftTypeBoundOps(c, result.typ, n.info)
     if result.typ != nil and expectedType != nil and result.typ.kind == tySequence and expectedType.kind == tySequence and result.typ[0].kind == tyEmpty:
-      result.typ = expectedType # type inference for empty sequence returns for generic procs
+      result.typ = expectedType # type inference for empty sequence returns for generic procs # bug #21377
     #result = patchResolvedTypeBoundOp(c, result)
   if c.matchedConcept == nil:
     result = evalAtCompileTime(c, result)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1003,6 +1003,8 @@ proc afterCallActions(c: PContext; n, orig: PNode, flags: TExprFlags; expectedTy
       if result.typ != nil and
           not (result.typ.kind == tySequence and result.typ[0].kind == tyEmpty):
         liftTypeBoundOps(c, result.typ, n.info)
+    if result.typ != nil and expectedType != nil and result.typ.kind == tySequence and expectedType.kind == tySequence and result.typ[0].kind == tyEmpty:
+      result.typ = expectedType # type inference for empty sequence returns for generic procs
     #result = patchResolvedTypeBoundOp(c, result)
   if c.matchedConcept == nil:
     result = evalAtCompileTime(c, result)

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -131,7 +131,7 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
     if sfBorrow notin orig.flags: 
       # We do not want to generate a body for generic borrowed procs.
       # As body is a sym to the borrowed proc.
-      b = semProcBody(c, b)
+      b = semProcBody(c, b, result.typ[0])
     result.ast[bodyPos] = hloBody(c, b)
     excl(result.flags, sfForward)
     trackProc(c, result, result.ast[bodyPos])

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -526,7 +526,7 @@ proc checkDefault(c: PContext, n: PNode): PNode =
     message(c.config, n.info, warnUnsafeDefault, typeToString(constructed))
 
 proc magicsAfterOverloadResolution(c: PContext, n: PNode,
-                                   flags: TExprFlags): PNode =
+                                   flags: TExprFlags; expectedType: PType = nil): PNode =
   ## This is the preferred code point to implement magics.
   ## ``c`` the current module, a symbol table to a very good approximation
   ## ``n`` the ast like it would be passed to a real macro
@@ -635,5 +635,9 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
     result = n
   of mPrivateAccess:
     result = semPrivateAccess(c, n)
+  of mArrToSeq:
+    result = n
+    if result.typ != nil and expectedType != nil and result.typ.kind == tySequence and expectedType.kind == tySequence and result.typ[0].kind == tyEmpty:
+      result.typ = expectedType # type inference for empty sequence # bug #21377
   else:
     result = n

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -255,3 +255,10 @@ block: # regression #20807
   test: fail()
   doAssert not (compiles do:
     let x: seq[int] = `@`[string]([]))
+
+block: # bug #21377
+  proc b[T](v: T): seq[int] =
+    let x = 0
+    @[]
+
+  doAssert b(0) == @[]

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -264,6 +264,13 @@ block: # bug #21377
   doAssert b(0) == @[]
 
 block: # bug #21377
+  proc b[T](v: T): seq[T] =
+    let x = 0
+    @[]
+
+  doAssert b(0) == @[]
+
+block: # bug #21377
   proc b[T](v: T): set[bool] =
     let x = 0
     {}

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -245,7 +245,7 @@ block: # bug #11777
   var s: S = {1, 2}
   doAssert 1 in s
 
-block: # regression #20807
+block: # bug #20807
   var s: seq[string]
   template fail =
     s = @[]
@@ -262,3 +262,24 @@ block: # bug #21377
     @[]
 
   doAssert b(0) == @[]
+
+block: # bug #21377
+  proc b[T](v: T): set[bool] =
+    let x = 0
+    {}
+
+  doAssert b(0) == {}
+
+block: # bug #21377
+  proc b[T](v: T): array[0, int] =
+    let x = 0
+    []
+
+  doAssert b(0) == []
+
+block: # bug #21377
+  proc b[T](v: T): array[0, (string, string)] =
+    let x = 0
+    {:}
+
+  doAssert b(0) == {:}


### PR DESCRIPTION
fixes #21377

The first cause is that `semProcBody` in instantiateBody didn't pass `expectedType` so it didn't work for empty sets. The second cause is that generic procs create `nkStmtListExpr`s for values assigned to results. The type inference for assign is not enough. It can infer the type of the whole `nkStmtListExpr`, not the type of its lastSon. Finally I choose to infer the type directly for the `mArrToSeq` magic.