### PR TITLE
a better message if graphviz's dot/nodejs is not found in PATH

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -75,8 +75,8 @@ proc commandGenDepend(graph: ModuleGraph) =
   # dot in graphivz tool kit is required
   let graphvizDotPath = findExe("dot")
   if graphvizDotPath.len == 0:
-    echo "Please install Graphviz first, see https://graphviz.org/download"
-    raise newException(IOError, "Graphviz's dot not found in PATH")
+    quit("gendepend: Graphviz's tool dot is required," &
+    "see https://graphviz.org/download for downloading")
 
   execExternalProgram(graph.config, "dot -Tpng -o" &
       changeFileExt(project, "png").string &

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -73,10 +73,10 @@ proc commandGenDepend(graph: ModuleGraph) =
   generateDot(graph, project)
 
   # dot in graphivz tool kit is required
-  let graphivzDotPath = findExe("dot")
-  if graphivzDotPath.len == 0:
+  let graphvizDotPath = findExe("dot")
+  if graphvizDotPath.len == 0:
     echo "Please install Graphviz first, see https://graphviz.org/download"
-    raise newException(IOError, "Graphivz's dot not found in PATH: " & graphivzDotPath)
+    raise newException(IOError, "Graphviz's dot not found in PATH")
 
   execExternalProgram(graph.config, "dot -Tpng -o" &
       changeFileExt(project, "png").string &

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -71,6 +71,13 @@ proc commandGenDepend(graph: ModuleGraph) =
   let project = graph.config.projectFull
   writeDepsFile(graph)
   generateDot(graph, project)
+
+  # dot in graphivz tool kit is required
+  let graphivzDotPath = findExe("dot")
+  if graphivzDotPath.len == 0:
+    echo "Please install Graphviz first, see https://graphviz.org/download"
+    raise newException(IOError, "Graphivz's dot not found in PATH: " & graphivzDotPath)
+
   execExternalProgram(graph.config, "dot -Tpng -o" &
       changeFileExt(project, "png").string &
       ' ' & changeFileExt(project, "dot").string)

--- a/compiler/nodejs.nim
+++ b/compiler/nodejs.nim
@@ -7,4 +7,4 @@ proc findNodeJs*(): string {.inline.} =
     result = findExe("node")
   if result.len == 0:
     echo "Please install NodeJS first, see https://nodejs.org/en/download"
-    raise newException(IOError, "NodeJS not found in PATH: " & result)
+    raise newException(IOError, "NodeJS not found in PATH")


### PR DESCRIPTION
Originally it looks like blow when using command `gendepend` but `dot` is not found locally:

```shell
nim gendepend compiler/nim.nim
```

```shell
oserrors.nim(92)         raiseOSError
Error: unhandled exception: The system cannot find the file specified.
 [OSError]
```

Currently it looks like:

![img](https://user-images.githubusercontent.com/97684920/223745218-ccda25aa-4935-4875-93ab-5f36d30a5b6c.png)

Targeting issue: #21474 

And when NodeJs is not found in PATH, the report message will not contains an empty path of non-existent NodeJs(which means a empty string follows the `:`), like below:

```shell
Error: unhandled exception: NodeJS not found in PATH: [IOError]
```
Now it looks like:

```shell
Error: unhandled exception: NodeJS not found in PATH [IOError] # no extra `:` with an empty string.
```

