### PR TITLE
fixes #21496; Ambiguous calls compiles when module name are equal

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -343,7 +343,8 @@ proc addDeclAt*(c: PContext; scope: PScope, sym: PSym, info: TLineInfo) =
   if sym.name.s == "_": return
   let conflict = scope.addUniqueSym(sym)
   if conflict != nil:
-    if sym.kind == skModule and conflict.kind == skModule and sym.owner == conflict.owner:
+    if sym.kind == skModule and conflict.kind == skModule and
+                        sym.position == conflict.position:
       # e.g.: import foo; import foo
       # xxx we could refine this by issuing a different hint for the case
       # where a duplicate import happens inside an include.

--- a/tests/import/buzz/m21496.nim
+++ b/tests/import/buzz/m21496.nim
@@ -1,0 +1,1 @@
+proc fb* = echo "buzz!"

--- a/tests/import/fizz/m21496.nim
+++ b/tests/import/fizz/m21496.nim
@@ -1,0 +1,1 @@
+proc fb* = echo "fizz!"

--- a/tests/import/t21496.nim
+++ b/tests/import/t21496.nim
@@ -1,0 +1,9 @@
+discard """
+  errormsg: "redefinition of 'm21496'; previous declaration here: t21496.nim(5, 12)"
+"""
+
+import fizz/m21496, buzz/m21496
+
+# bug #21496
+
+m21496.fb()


### PR DESCRIPTION
fixes #21496