### PR TITLE
Add `cursor` annotations to lists iterator variables

### DIFF
--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -188,13 +188,13 @@ func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (
     result.add(elem)
 
 template itemsListImpl() {.dirty.} =
-  var it = L.head
+  var it {.cursor.} = L.head
   while it != nil:
     yield it.value
     it = it.next
 
 template itemsRingImpl() {.dirty.} =
-  var it = L.head
+  var it {.cursor.} = L.head
   if it != nil:
     while true:
       yield it.value


### PR DESCRIPTION
See https://nim-lang.github.io/Nim/destructors.html#the-cursor-pragma

> Automatic reference counting also has the disadvantage that it introduces overhead when iterating over linked structures. The cursor pragma can also be used to avoid this overhead:
> 
> ```nim
> var it {.cursor.} = listRoot
> while it != nil:
>   use(it)
>   it = it.next
> ```

Note: I don't know how to benchmark this, I get null results with benchy.