### PR TITLE
add a prepass for codeReordering

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -270,7 +270,7 @@ proc onOff(c: PContext, n: PNode, op: TOptions, resOptions: var TOptions) =
   if isTurnedOn(c, n): resOptions.incl op
   else: resOptions.excl op
 
-proc pragmaNoForward(c: PContext, n: PNode; flag=sfNoForward) =
+proc pragmaNoForward*(c: PContext, n: PNode; flag=sfNoForward) =
   if isTurnedOn(c, n):
     incl(c.module.flags, flag)
     c.features.incl codeReordering
@@ -392,7 +392,7 @@ proc pragmaToOptions*(w: TSpecialWord): TOptions {.inline.} =
   of wSinkInference: {optSinkInference}
   else: {}
 
-proc processExperimental(c: PContext; n: PNode) =
+proc processExperimental*(c: PContext; n: PNode) =
   if n.kind notin nkPragmaCallKinds or n.len != 2:
     c.features.incl oldExperimentalFeatures
   else:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -392,7 +392,7 @@ proc pragmaToOptions*(w: TSpecialWord): TOptions {.inline.} =
   of wSinkInference: {optSinkInference}
   else: {}
 
-proc processExperimental*(c: PContext; n: PNode) =
+proc processExperimental(c: PContext; n: PNode) =
   if n.kind notin nkPragmaCallKinds or n.len != 2:
     c.features.incl oldExperimentalFeatures
   else:

--- a/tests/misc/tnoforward.nim
+++ b/tests/misc/tnoforward.nim
@@ -1,5 +1,4 @@
 discard """
-  matrix: "--experimental:codeReordering"
   output: "10"
 """
 

--- a/tests/modules/t8665.nim
+++ b/tests/modules/t8665.nim
@@ -1,5 +1,4 @@
 discard """
-  matrix: "--experimental:codeReordering"
   action: compile
 """
 

--- a/tests/modules/treorder.nim
+++ b/tests/modules/treorder.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--experimental:codeReordering -d:testdef"
+  matrix: "-d:testdef"
   output: '''works 34
 34
 defined

--- a/tests/pragmas/treorder.nim
+++ b/tests/pragmas/treorder.nim
@@ -1,5 +1,4 @@
 discard """
-matrix: "--experimental:codeReordering"
 output:'''0
 1
 2


### PR DESCRIPTION
I can add a early return when it finds a codeReordering feature. Though It won't help the common cases.