### PR TITLE
nimdoc: stick search result inside browser viewport

### DIFF
--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -769,7 +769,13 @@ div.search_results {
   background-color: var(--third-background);
   margin: 3em;
   padding: 1em;
-  border: 1px solid #4d4d4d; }
+  border: 1px solid #4d4d4d;
+  position: sticky;
+  top: 0;
+  isolation: isolate;
+  z-index: 1;
+  max-height: 100vh;
+  overflow-y: scroll; }
 
 div#global-links ul {
   margin-left: 0;


### PR DESCRIPTION
Previously the search result stays at the page top. If you search something while scrolled down, you can't see the search results.

https://user-images.githubusercontent.com/74560659/225076935-dfc27869-fce2-4036-9940-4e1dc2e81d37.mp4

