### PR TITLE
Made generic type classes work with types using static parameters

### DIFF
--- a/tests/generics/tgeneric_static_typeclass.nim
+++ b/tests/generics/tgeneric_static_typeclass.nim
@@ -1,0 +1,22 @@
+type MyThing[T: static int] = object
+  when T == 300:
+    a: int
+
+var a = MyThing[300]()
+proc doThing(myThing: MyThing): string = $myThing
+assert doThing(a) == $a
+assert doThing(MyThing[0]()) == $MyThing[0]()
+
+
+type
+  Backend* = enum
+    Cpu
+
+  Tensor*[B: static[Backend]; T] = object
+    shape: seq[int]
+    strides: seq[int]
+    offset: int
+    data: seq[T]
+
+template shape*(t: Tensor): seq[int] =
+  t.shape


### PR DESCRIPTION
Simply only replaces the generic parameters if there are no `tfInferrableStatic` remaining.

Closes #6331