### PR TITLE
Made generic type classes work with types using static parameters

### DIFF
--- a/tests/metatype/tstatic_generic_typeclass.nim
+++ b/tests/metatype/tstatic_generic_typeclass.nim
@@ -1,0 +1,30 @@
+type MyThing[T: static int] = object
+  when T == 300:
+    a: int
+
+var a = MyThing[300]()
+proc doThing(myThing: MyThing): string = $myThing
+proc doOtherThing[T](myThing: MyThing[T]): string = $myThing
+assert doThing(a) == $a
+assert doThing(MyThing[0]()) == $MyThing[0]()
+assert doOtherThing(a) == "(a: 0)"
+
+type
+  Backend* = enum
+    Cpu,
+    Cuda
+
+  Tensor*[B: static[Backend]; T] = object
+    shape: seq[int]
+    strides: seq[int]
+    offset: int
+    when B == Backend.Cpu:
+      data: seq[T]
+    else:
+      data_ptr: ptr T
+
+template shape*(t: Tensor): seq[int] =
+  t.shape
+
+
+assert Tensor[Cpu, int]().shape == @[]


### PR DESCRIPTION
This checks the conditions of `when` statements inside of generics, ensuring they have resolved generics before attempting to call `semConstExpr.

Perhaps it makes sense to move it inside of `prepareNode`?