### PR TITLE
Enumerate module symbols; fix nim-lang/RFCs#18

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -231,6 +231,7 @@
 - Added `openArray[char]` overloads for `std/parseutils` allowing more code reuse.
 - Added `openArray[char]` overloads for `std/unicode` allowing more code reuse.
 - Added `safe` parameter to `base64.encodeMime`.
+- Added `macros.moduleSymbols` for enumerating a module's symbols.
 
 [//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -714,7 +714,7 @@ type
     mInstantiationInfo, mGetTypeInfo, mGetTypeInfoV2,
     mNimvm, mIntDefine, mStrDefine, mBoolDefine, mGenericDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
-    mSymIsInstantiationOf, mNodeId, mPrivateAccess, mZeroDefault
+    mSymIsInstantiationOf, mNodeId, mPrivateAccess, mZeroDefault, mModuleSymbols
 
 
 const

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -154,3 +154,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasGenericDefine")
   defineSymbol("nimHasDefineAliases")
   defineSymbol("nimHasWarnBareExcept")
+  defineSymbol("nimHasModuleSymbols")

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -243,8 +243,7 @@ proc nextModuleIter*(mi: var ModuleIter; g: ModuleGraph): PSym =
   else:
     result = nextIdentIter(mi.ti, g.ifaces[mi.modIndex].interfSelect(mi.importHidden))
 
-iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
-  let importHidden = optImportHidden in m.options
+iterator allSyms*(g: ModuleGraph; m: PSym, importHidden: bool): PSym =
   if isCachedModule(g, m):
     var rodIt: RodIter
     var r = initRodIterAllSyms(rodIt, g.config, g.cache, g.packed, FileIndex m.position, importHidden)
@@ -255,6 +254,10 @@ iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
     for s in g.ifaces[m.position].interfSelect(importHidden).data:
       if s != nil:
         yield s
+
+iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
+  let importHidden = optImportHidden in m.options
+  for ai in allSyms(g, m, importHidden): yield ai
 
 proc someSym*(g: ModuleGraph; m: PSym; name: PIdent): PSym =
   let importHidden = optImportHidden in m.options

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1305,12 +1305,11 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         else:
           let enablePrivate = regs[rc].intVal.bool
           let node = newNode(nkBracket)
-          const nodeFlags = {nfIsRef, nfNoRewrite}
           for ai in allSyms(c.graph, sym, importHidden = enablePrivate):
             let ni = newSymNode(ai)
-            ni.flags.incl nodeFlags
+            ni.flags.incl nfIsRef
             node.sons.add ni
-          node.flags.incl nodeFlags
+          node.flags.incl nfIsRef
           regs[ra].node = node
     of opcEcho:
       let rb = instr.regB

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -183,7 +183,8 @@ type
     opcSetType,   # dest.typ = types[Bx]
     opcTypeTrait,
     opcSymOwner,
-    opcSymIsInstantiationOf
+    opcSymIsInstantiationOf,
+    opcModuleSymbols
 
   TBlock* = object
     label*: PSym

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1258,6 +1258,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mGetImplTransf: genUnaryABC(c, n, dest, opcGetImplTransf)
   of mSymOwner: genUnaryABC(c, n, dest, opcSymOwner)
   of mSymIsInstantiationOf: genBinaryABC(c, n, dest, opcSymIsInstantiationOf)
+  of mModuleSymbols: genBinaryABC(c, n, dest, opcModuleSymbols)
   of mNChild: genBinaryABC(c, n, dest, opcNChild)
   of mNSetChild: genVoidABC(c, n, dest, opcNSetChild)
   of mNDel: genVoidABC(c, n, dest, opcNDel)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1801,3 +1801,37 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
         result.add ni
       else: break
     else: break
+
+func moduleSymbols*(module: NimNode, enablePrivate = false): NimNode {.magic: "ModuleSymbols".} =
+  ## Returns a sequence of `module`'s symbols. When `enablePrivate == true`,
+  ## private symbols are also returned.
+  runnableExamples("-d:foobar"):
+    import std/macros
+    macro callByName(module: typed, name: static string, args: varargs[untyped]): untyped =
+      # finds the 1st symbol with name `name` from `module` and calls it with `args`.
+      result = newStmtList()
+      for si in moduleSymbols(module):
+        if si.strVal == name:
+          result.add quote do: `si`(`args`)
+    doAssert callByName(system, "defined", foobar)
+
+  runnableExamples:
+    import std/[macros, sugar, strutils]
+    macro findSymbolNames(module: typed, kinds: static set[NimSymKind]): seq[string] =
+      # Returns all the symbol names from `module` of kind in `kinds`.
+      result = newLit: collect:
+        for si in moduleSymbols(module):
+          if si.symKind in kinds: si.strVal
+    doAssert "NimMinor" in findSymbolNames(system, {nskConst})
+
+    macro findProcs(module: typed, returnTypeKinds: static set[NimTypeKind]): untyped =
+      # returns a listing of `procName: lineInfo` for procs with a given return type kind
+      var ret = ""
+      for si in moduleSymbols(module):
+        if si.symKind in {nskProc}:
+          let t = si.getType
+          if t[1].typeKind in returnTypeKinds:
+            ret.add si.strVal & ": " & si.getImpl.lineInfo & "\n"
+      result = newLit ret
+    const listing = findProcs(system, {ntyVoid})
+    doAssert "addQuoted" in listing

--- a/tests/macros/modulesymbols/tmodulesymbols.nim
+++ b/tests/macros/modulesymbols/tmodulesymbols.nim
@@ -1,0 +1,32 @@
+import std/macros
+from std/algorithm import sorted
+
+proc fn1*() = discard
+proc fn2*() = discard
+const s3* = 1
+var s4* = 1
+
+# private symbols won't be listed in moduleSymbols by default
+var s5 = 1
+proc fn6() = discard
+
+template main =
+  proc moduleSymbolsTestImpl(mymod: NimNode, enablePrivate: bool): auto =
+    let children = mymod.moduleSymbols(enablePrivate)
+    result = newTree(nnkBracket)
+    for ai in children:
+      result.add newLit $ai
+
+  macro moduleSymbolsTest(mymod: typed, enablePrivate: static bool = false): untyped =
+    result = moduleSymbolsTestImpl(mymod, enablePrivate)
+
+  const symbols = moduleSymbolsTest(tmodulesymbols)
+  let public = @["fn1", "fn2", "s3", "s4"]
+  doAssert symbols.sorted == public
+
+  const symbols2 = moduleSymbolsTest(tmodulesymbols, enablePrivate = true)
+  for ai in public & @["fn6", "s5"]:
+    doAssert ai in symbols2
+
+static: main()
+main()

--- a/tests/macros/modulesymbols/tmodulesymbols_error_not_module.nim
+++ b/tests/macros/modulesymbols/tmodulesymbols_error_not_module.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "node is not a module symbol"
+"""
+import std/macros
+macro syms(x: typed) = moduleSymbols(x)
+syms(syms)

--- a/tests/macros/modulesymbols/tmodulesymbols_error_not_symbol.nim
+++ b/tests/macros/modulesymbols/tmodulesymbols_error_not_symbol.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "node is not a symbol"
+"""
+import std/macros
+macro syms(x: typed) = moduleSymbols(x)
+syms(nil)


### PR DESCRIPTION
Adds `macros.moduleSymbols` which returns a module's symbols.

This PR is just a slight modification of @timotheecour's work in #9560. That PR was closed as stale. However, #9560 was accepted, contingent on some changes:

> In order to proceed
> 
> 1. rename it to something else, `reflection` typically is used for runtime reflection.
> 2. Make it clear and ideally enforce it that the resulting sequence of NimNodes cannot be mutated. Or that mutations do not affect the compilation pipeline.
> 
> _Originally posted by @Araq in https://github.com/nim-lang/Nim/issues/9560#issuecomment-950588587_

1. I ditched creating another module and just added it to `macros`.
2. I could use some help with ensuring immutability.
    1. How can symbol nodes be mutated? Everything I've tried doesn't work.
    1. I naively included `nfNoRewrite` on the symbol copies, but I think that may be wrong.

I'm opening this draft to get some feedback before continuing. I'm going to have very limited time to respond, or make any changes for the next month, so please be patient with me.