### PR TITLE
osappdirs: added `getStateDir` and `getRuntimeDir`, small fix to `getDataDir`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 
 [//]: # "Additions:"
 - Added `parseutils.parseSize` - inverse to `strutils.formatSize` - to parse human readable sizes.
+- Added `getStateDir` alongside the procs for the other XDG user directories.
 
 [//]: # "Deprecations:"
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 [//]: # "Additions:"
 - Added `parseutils.parseSize` - inverse to `strutils.formatSize` - to parse human readable sizes.
-- Added `getStateDir` alongside the procs for the other XDG user directories.
+- Added `getStateDir` and `getRuntimeDir` alongside the procs for the other XDG user directories.
 
 [//]: # "Deprecations:"
 

--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -13,6 +13,7 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
   ##
   ## See also:
   ## * `getDataDir proc`_
+  ## * `getStateDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -36,6 +37,7 @@ proc getDataDir*(): string {.rtl, extern: "nos$1"
   ## 
   ## See also:
   ## * `getHomeDir proc`_
+  ## * `getStateDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -47,6 +49,31 @@ proc getDataDir*(): string {.rtl, extern: "nos$1"
     result = getEnv("XDG_DATA_HOME", getEnv("HOME") / "Library" / "Application Support")
   else:
     result = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local" / "share")
+  result.normalizePathEnd(trailingSep = true)
+
+proc getStateDir*(): string {.rtl, extern: "nos$1"
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the state directory of the current user for applications.
+  ##
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_STATE_HOME` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("~/.local/state" or "~/Library/Application Support" on macOS).
+  ##
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getDataDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
+  when defined(windows):
+    result = getEnv("LOCALAPPDATA")
+  elif defined(macosx):
+    result = getEnv("XDG_STATE_HOME", getEnv("HOME") / "Library" / "Application Support")
+  else:
+    result = getEnv("XDG_STATE_HOME", getEnv("HOME") / ".local" / "state")
   result.normalizePathEnd(trailingSep = true)
 
 proc getConfigDir*(): string {.rtl, extern: "nos$1",
@@ -64,6 +91,7 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getDataDir proc`_
+  ## * `getStateDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_
@@ -87,6 +115,7 @@ proc getCacheDir*(): string =
   ##
   ## **See also:**
   ## * `getHomeDir proc`_
+  ## * `getStateDir proc`_
   ## * `getTempDir proc`_
   ## * `getConfigDir proc`_
   ## * `getDataDir proc`_
@@ -149,6 +178,7 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
   ##
   ## See also:
   ## * `getHomeDir proc`_
+  ## * `getStateDir proc`_
   ## * `getConfigDir proc`_
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_

--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -30,12 +30,12 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
 proc getDataDir*(): string {.rtl, extern: "nos$1"
   tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the data directory of the current user for applications.
-  ## 
+  ##
   ## On non-Windows OSs, this proc conforms to the XDG Base Directory
   ## spec. Thus, this proc returns the value of the `XDG_DATA_HOME` environment
   ## variable if it is set, otherwise it returns the default configuration
   ## directory ("~/.local/share" or "~/Library/Application Support" on macOS).
-  ## 
+  ##
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getStateDir proc`_

--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -14,6 +14,7 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
   ## See also:
   ## * `getDataDir proc`_
   ## * `getStateDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -38,6 +39,7 @@ proc getDataDir*(): string {.rtl, extern: "nos$1"
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getStateDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -63,6 +65,7 @@ proc getStateDir*(): string {.rtl, extern: "nos$1"
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getDataDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
@@ -74,6 +77,31 @@ proc getStateDir*(): string {.rtl, extern: "nos$1"
     result = getEnv("XDG_STATE_HOME", getEnv("HOME") / "Library" / "Application Support")
   else:
     result = getEnv("XDG_STATE_HOME", getEnv("HOME") / ".local" / "state")
+  result.normalizePathEnd(trailingSep = true)
+
+proc getRuntimeDir*(): string {.rtl, extern: "nos$1"
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the state directory of the current user for applications.
+  ##
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_RUNTIME_DIR` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("/run/user/$UID" or "~/Library/Caches/TemporaryItems" on macOS).
+  ##
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getDataDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
+  when defined(windows):
+    result = getEnv("LOCALAPPDATA") / "Temp"
+  elif defined(macosx):
+    result = getEnv("XDG_RUNTIME_DIR", getEnv("HOME") / "Library" / "Caches" / "TemporaryItems")
+  else:
+    result = getEnv("XDG_RUNTIME_DIR", "/run" / "user" / getEnv("UID"))
   result.normalizePathEnd(trailingSep = true)
 
 proc getConfigDir*(): string {.rtl, extern: "nos$1",
@@ -92,6 +120,7 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   ## * `getHomeDir proc`_
   ## * `getDataDir proc`_
   ## * `getStateDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getTempDir proc`_
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_
@@ -116,6 +145,7 @@ proc getCacheDir*(): string =
   ## **See also:**
   ## * `getHomeDir proc`_
   ## * `getStateDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getTempDir proc`_
   ## * `getConfigDir proc`_
   ## * `getDataDir proc`_
@@ -179,6 +209,7 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getStateDir proc`_
+  ## * `getRuntimeDir proc`_
   ## * `getConfigDir proc`_
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_


### PR DESCRIPTION
Following up on #20558, I added the procs `getStateDir` and `getRuntimeDir` after the XDG Base Directory specification and found appropriate macOS and Windows directories at <https://github.com/platformdirs/platformdirs/tree/main/src/platformdirs>.

I noticed that some of the osappdir procs use the `LOCALAPPDATA` (per user) variable while others use `APPDATA` (global). I suppose we could add bunch more procs to make a per user or global equivalent of the current proc. Maybe this would make it even more feasible to use variables for some of the macOS paths because a lot of them are just the same.