### PR TITLE
Fix infinite recursion introduced in 7031ea6 [backport 1.6]

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -234,7 +234,7 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int, 
       localError(conf, conf.m.trackPos, "found no symbol at this position " & (conf $ conf.m.trackPos))
 
 proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int, graph: ModuleGraph) =
-  executeNoHooks(cmd, file, dirtyfile, line, col, graph)
+  executeNoHooks(cmd, file, dirtyfile, line, col, "", graph)
 
 proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int; tag: string,
              graph: ModuleGraph) =


### PR DESCRIPTION
This fixes a bug introduced by @yyoncho in [7031ea6](https://github.com/nim-lang/Nim/commit/7031ea65cd220360b8e9f566fd28f01bc0bf53c4). Essentially some rewriting gone awry, this makes all nimsuggest pre-v3 crash after an infinite recursion. Discovered since it broke NimLSP.

On a related note it would be great if we had better tests for Nimsuggest and using Nimsuggest as a library. These recent changes for langserver have had some adverse effects on the library support.