### PR TITLE
adds compiler support for object construction shorthand (full fields initializer)

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3072,7 +3072,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
           result = semConv(c, n, expectedType)
         elif ambig and n.len == 1:
           errorUseQualifier(c, n.info, s)
-        elif n.len == 1:
+        elif n.len == 1 or (n.kind == nkCall and useObjConstr(c, n, flags, expectedType)):
           result = semObjConstr(c, n, flags, expectedType)
         elif s.magic == mNone: result = semDirectOp(c, n, flags, expectedType)
         else: result = semMagic(c, n, s, flags, expectedType)

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -506,12 +506,12 @@ proc semGenericStmt(c: PContext, n: PNode,
       result[i] = semGenericStmt(c, n[i], flags, ctx)
     if result[0].kind == nkSym:
       let fmoduleId = getModule(result[0].sym).id
-      var isVisable = false
+      var isVisible = false
       for module in c.friendModules:
         if module.id == fmoduleId:
-          isVisable = true
+          isVisible = true
           break
-      if isVisable:
+      if isVisible:
         for i in 1..<result.len:
           if result[i].kind == nkExprColonExpr:
             result[i][1].flags.incl nfSkipFieldChecking

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -428,9 +428,8 @@ proc replaceObjConstr(c: PContext; field: PNode, result: PNode, iterField: var i
     let oldIterField = iterField
     replaceObjConstr(c, field[0], result, iterField, flags)
     if iterField > oldIterField:
-      doAssert discriminatorVal != nil and discriminatorVal.kind == nkIntLit # todo error messages
       if discriminatorVal == nil or discriminatorVal.kind != nkIntLit:
-        localError(c.config, result.info, "Using unnamed fields, the discriminator can only be initialized with values known at the compile time")
+        localError(c.config, result.info, "The discriminator can only be initialized with unnamed fields known at the compile time")
       else:
         let matchedBranch = field.pickCaseBranch discriminatorVal
         if matchedBranch != nil:

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -433,10 +433,12 @@ proc replaceObjConstr(c: PContext; field: PNode, result: PNode, iterField: var i
       if matchedBranch != nil:
         replaceObjConstr(c, matchedBranch.lastSon, result, iterField, flags)
   of nkSym:
-    if result[iterField].kind != nkExprColonExpr:
-      result[iterField] = newTree(nkExprColonExpr, field, result[iterField])
+    if result[iterField].kind == nkExprColonExpr and field.sym.name.id == considerQuotedIdent(c, result[iterField][0]).id:
       inc iterField
-    elif field.sym.name.id == considerQuotedIdent(c, result[iterField][0]).id:
+    elif not fieldVisible(c, field.sym):
+      discard
+    elif result[iterField].kind != nkExprColonExpr:
+      result[iterField] = newTree(nkExprColonExpr, field, result[iterField])
       inc iterField
     else:
       localError(c.config, result.info, "When mixing named fields and unnamed fields, every field needs to be initialized in order")
@@ -488,9 +490,11 @@ proc filterObjConstr(c: PContext; field: PNode, n: PNode, iterField: var int, fl
       result = false
 
   of nkSym:
-    if n[iterField].kind != nkExprColonExpr:
+    if n[iterField].kind == nkExprColonExpr and field.sym.name.id == considerQuotedIdent(c, n[iterField][0]).id:
       inc iterField
-    elif field.sym.name.id == considerQuotedIdent(c, n[iterField][0]).id:
+    elif not fieldVisible(c, field.sym):
+      discard
+    elif n[iterField].kind != nkExprColonExpr:
       inc iterField
     else:
       result = false

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -429,9 +429,12 @@ proc replaceObjConstr(c: PContext; field: PNode, result: PNode, iterField: var i
     replaceObjConstr(c, field[0], result, iterField, flags)
     if iterField > oldIterField:
       doAssert discriminatorVal != nil and discriminatorVal.kind == nkIntLit # todo error messages
-      let matchedBranch = field.pickCaseBranch discriminatorVal
-      if matchedBranch != nil:
-        replaceObjConstr(c, matchedBranch.lastSon, result, iterField, flags)
+      if discriminatorVal == nil or discriminatorVal.kind != nkIntLit:
+        localError(c.config, result.info, "Using unnamed fields, the discriminator can only be initialized with values known at the compile time")
+      else:
+        let matchedBranch = field.pickCaseBranch discriminatorVal
+        if matchedBranch != nil:
+          replaceObjConstr(c, matchedBranch.lastSon, result, iterField, flags)
   of nkSym:
     if result[iterField].kind == nkExprColonExpr and field.sym.name.id == considerQuotedIdent(c, result[iterField][0]).id:
       inc iterField

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1828,6 +1828,23 @@ an `object` type or a `ref object` type:
 Note that, unlike tuples, objects require the field names along with their values.
 For a `ref object` type `system.new` is invoked implicitly.
 
+The field names can be omitted if all the values are given in order. It can be mixed with field names along with values.
+
+  ```nim
+  var a1 = Student("Anton", 5)
+  var a2 = PStudent("Anton", age: 5)
+  ```
+
+Note that, objects with only one field must use field names along with values. Otherwise, they will be recognized as type conversions.
+
+  ```nim
+  type
+    Teacher = object
+      name: string
+  # var t = Teacher("lisa") # Error: type mismatch: got 'string' for '"lisa"'
+                          # but expected 'Teacher = object'
+  var t = Teacher(name: "lisa")
+  ```
 
 Object variants
 ---------------

--- a/tests/constructors/t5965_1.nim
+++ b/tests/constructors/t5965_1.nim
@@ -1,3 +1,9 @@
+discard """
+  errormsg: "When mixing named fields and unnamed fields, every field needs to be initialized in order"
+  file: "t5965_1.nim"
+  line: 10
+"""
+
 type Foo = object
   a, b, c: int
 

--- a/tests/constructors/t5965_1.nim
+++ b/tests/constructors/t5965_1.nim
@@ -1,9 +1,3 @@
-discard """
-  errormsg: "incorrect object construction syntax"
-  file: "t5965_1.nim"
-  line: 10
-"""
-
 type Foo = object
   a, b, c: int
 

--- a/tests/constructors/t5965_2.nim
+++ b/tests/constructors/t5965_2.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "incorrect object construction syntax"
+  errormsg: "The object construction is given more fields than required"
   file: "t5965_2.nim"
   line: 10
 """

--- a/tests/generics/m3770.nim
+++ b/tests/generics/m3770.nim
@@ -1,6 +1,25 @@
 type
   Noice* = object
     hidden: int
-  
-template jjj*: Noice =
+
+  Ciao* = object
+    hidden1: int
+    hidden2: int
+
+  Gull* = ref object
+    hidden1: int
+    field*: int
+    hidden2: int
+    field2*: int
+
+
+template jjj*(): Noice =
+  var x = 7
   Noice(hidden: 15)
+
+template said*(): Ciao =
+  var x = 7
+  Ciao(hidden1: 15 + x, 1)
+
+proc foo*: Gull =
+  result = Gull(1, 2, 3, 4)

--- a/tests/generics/t3770.nim
+++ b/tests/generics/t3770.nim
@@ -3,7 +3,19 @@ import m3770
 
 doAssert $jjj() == "(hidden: 15)"  # works
 
+doAssert $said() == "(hidden1: 22, hidden2: 1)"
+
 proc someGeneric(_: type) =
   doAssert $jjj() == "(hidden: 15)" # fails: "Error: the field 'hidden' is not accessible."
+  when false: # todo somehow make it work?
+    doAssert $said() == "(hidden1: 22, hidden2: 1)"
 
 someGeneric(int)
+
+doAssert $(foo()[]) == "(hidden1: 1, field: 2, hidden2: 3, field2: 4)"
+
+proc bar() =
+  var s = Gull(13, 14)
+  doAssert $(s[]) == "(hidden1: 0, field: 13, hidden2: 0, field2: 14)"
+
+bar()

--- a/tests/objects/t17437.nim
+++ b/tests/objects/t17437.nim
@@ -1,15 +1,3 @@
-discard """
-  cmd: "nim check $file"
-  errormsg: ""
-  nimout: '''
-t17437.nim(20, 16) Error: undeclared identifier: 'x'
-t17437.nim(20, 16) Error: expression 'x' has no type (or is ambiguous)
-t17437.nim(20, 19) Error: incorrect object construction syntax
-t17437.nim(20, 19) Error: incorrect object construction syntax
-t17437.nim(20, 12) Error: expression '' has no type (or is ambiguous)
-'''
-"""
-
 # bug #17437 invalid object construction should result in error
 
 type
@@ -17,6 +5,8 @@ type
     x, y: int
 
 proc m =
+  var x = 12
+  var y = 1
   var v = V(x: x, y)
 
 m()

--- a/tests/spec/mobjectconstr_unnamed.nim
+++ b/tests/spec/mobjectconstr_unnamed.nim
@@ -1,0 +1,39 @@
+type
+  Standard* = object
+    name: string
+    id*: int
+    owner*: string
+
+  Color1* = enum
+    Red, Blue, Green
+
+  Case1* = object
+    name*: string
+    id*: int
+    color*: Color1
+    owner: string
+
+
+## inplace object construction works
+doAssert Standard("Tree", 1, "sky") == Standard(name: "Tree", id: 1, owner: "sky")
+
+proc initStandard*(name: string, id: int, owner: string): Standard =
+  Standard(name, id, owner)
+
+## It works in the procs
+doAssert initStandard("Tree", 1, "sky") == Standard(name: "Tree", id: 1, owner: "sky")
+static: doAssert initStandard("Tree", 1, "sky") == Standard(name: "Tree", id: 1, owner: "sky")
+
+template toStandard*(name: string, id: int, owner: string): Standard =
+  Standard(name, id, owner)
+
+## It works in the procs
+doAssert toStandard("Tree", 1, "sky") == Standard(name: "Tree", id: 1, owner: "sky")
+static: doAssert toStandard("Tree", 1, "sky") == Standard(name: "Tree", id: 1, owner: "sky")
+
+proc initColorRed*(name: string = "red", id: int = 1314, owner: string): Case1 =
+  result = Case1(name, id, Red, owner)
+
+doAssert Case1("red", 1314, color: Red, owner: "unknown") == Case1("red", 1314, color: Red, "unknown")
+doAssert Case1("red", 1314, Red, owner: "unknown") == Case1("red", 1314, Red, "unknown")
+doAssert initColorRed(owner = "unknown") == Case1("red", id: 1314, Red, "unknown")

--- a/tests/spec/tobjectconstr_unamed.nim
+++ b/tests/spec/tobjectconstr_unamed.nim
@@ -67,7 +67,7 @@ block:
 
   block:
     var x = Ciao(12, false, false, "123")
-    doAssert x.num == false
+    doAssert x.done == false
 
   block:
     var x = Ciao(12, flag: true, 1, "123")

--- a/tests/spec/tobjectconstr_unamed.nim
+++ b/tests/spec/tobjectconstr_unamed.nim
@@ -1,0 +1,78 @@
+type
+  Vector = object
+    a: int = 999
+    b, c: int
+
+block: # positional construction
+  ## It specifies all the unnamed parameters
+  var x = Vector(1, 2, 3)
+  doAssert x.b == 2
+
+block:
+  ## unnamed parameters can be mixed with named parameters
+  block:
+    var x = Vector(a: 1, 2, 3)
+    doAssert x.c == 3
+
+  block:
+    var x = Vector(1, b: 2, 3)
+    doAssert x.c == 3
+
+  block:
+    var x = Vector(1, 2, c: 3)
+    doAssert x.c == 3
+
+  block:
+    ## Parameters can be omitted before a named parameter
+    var x = Vector(b: 2, 3)
+    doAssert x.c == 3
+
+
+block:
+  ## Object variants support unnamed parameters for tags, which should be known at the compile time.
+  type
+    Color = enum
+      Red, Blue, Yellow
+    Factor = object
+      id: int
+      case flag: Color
+      of Red:
+        num: int
+      of Blue, Yellow:
+        done: bool
+      name: string
+
+  block:
+    var x = Factor(1, Red, 2, "1314")
+    doAssert x.num == 2
+
+  block:
+    var x = Factor(1, Blue, true, "1314")
+    doAssert x.done == true
+
+  block:
+    var x = Factor(1, Yellow, false, "1314")
+    doAssert x.done == false
+
+
+  type
+    Ciao = object
+      id: int
+      case flag: bool = false
+      of true:
+        num: int
+      of false:
+        done: bool
+      name: string
+
+  block:
+    var x = Ciao(12, false, false, "123")
+    doAssert x.num == false
+
+  block:
+    var x = Ciao(12, flag: true, 1, "123")
+    doAssert x.num == 1
+
+  block:
+    var x = Ciao(flag: true, 1, "123")
+    doAssert x.num == 1

--- a/tests/spec/tobjectconstr_unnamed.nim
+++ b/tests/spec/tobjectconstr_unnamed.nim
@@ -1,3 +1,5 @@
+import mobjectconstr_unnamed
+
 type
   Vector = object
     a: int = 999
@@ -66,3 +68,23 @@ block:
   block:
     var x = Ciao(12, flag: true, 1, "123")
     doAssert x.num == 1
+
+## It works in the third module
+block:
+  doAssert initStandard("", 1, "sky") == Standard(id: 1, owner: "sky")
+  doAssert initStandard("", 1, "sky") == Standard(1, "sky")
+  doAssert toStandard("", 1, "sky") == Standard(1, "sky")
+
+  proc foo() =
+    doAssert initStandard("", 1, "sky") == Standard(id: 1, owner: "sky")
+    doAssert initStandard("", 1, "sky") == Standard(1, "sky")
+    doAssert toStandard("", 1, "sky") == Standard(1, "sky")
+
+  foo()
+
+  template bar() = 
+    doAssert initStandard("", 1, "sky") == Standard(id: 1, owner: "sky")
+    doAssert initStandard("", 1, "sky") == Standard(1, "sky")
+    doAssert toStandard("", 1, "sky") == Standard(1, "sky")
+
+  bar()

--- a/tests/spec/tobjectconstr_unnamed.nim
+++ b/tests/spec/tobjectconstr_unnamed.nim
@@ -4,12 +4,12 @@ type
     b, c: int
 
 block: # positional construction
-  ## It specifies all the unnamed parameters
+  ## It specifies all the unnamed fields
   var x = Vector(1, 2, 3)
   doAssert x.b == 2
 
 block:
-  ## unnamed parameters can be mixed with named parameters
+  ## unnamed fields can be mixed with named fields
   block:
     var x = Vector(a: 1, 2, 3)
     doAssert x.c == 3
@@ -22,14 +22,8 @@ block:
     var x = Vector(1, 2, c: 3)
     doAssert x.c == 3
 
-  block:
-    ## Parameters can be omitted before a named parameter
-    var x = Vector(b: 2, 3)
-    doAssert x.c == 3
-
-
 block:
-  ## Object variants support unnamed parameters for tags, which should be known at the compile time.
+  ## Object variants support unnamed fields for tags, which should be known at the compile time.
   type
     Color = enum
       Red, Blue, Yellow
@@ -71,8 +65,4 @@ block:
 
   block:
     var x = Ciao(12, flag: true, 1, "123")
-    doAssert x.num == 1
-
-  block:
-    var x = Ciao(flag: true, 1, "123")
     doAssert x.num == 1


### PR DESCRIPTION
closes https://github.com/nim-lang/RFCs/issues/418
closes https://github.com/nim-lang/RFCs/issues/517

- [x] testing with defaults
- [x] object variants
- [x] private fields visible issues (still doesn't work with the last issue: private fields with generics)
- [x] mixing up with named fields
- [x] proper error messages
- [x] documentation
- [x] refactor `replaceObjConstr` and `filterObjConstr` into one proc returns enums
- [x] retry after failing the construction

```nim
type
  Vector = object
    a: int = 999
    b, c: int

block: # positional construction
  var x = Vector(1, 2, 3)
  echo x

block: # mixed with named parameters
  block:
    var x = Vector(a: 1, 2, 3)
    echo x

  block:
    var x = Vector(1, b: 2, 3)
    echo x

  block:
    var x = Vector(1, 2, c: 3)
    echo x

when false: # not allowed
  block:
     var x = Vector(b: 2, 3)
     echo x

type
  Color = enum
    Red, Blue, Yellow
  Factor = object
    id: int
    case flag: Color
    of Red:
      num: int
    of Blue, Yellow:
      done: bool
    name: string

block:
  var x = Factor(1, Red, 2, "1314")
  echo x

block:
  var x = Factor(1, Blue, true, "1314")
  echo x

block:
  var x = Factor(1, Yellow, false, "1314")
  echo x


type
  Ciao = object
    id: int
    case flag: bool = false
    of true:
      num: int
    of false:
      done: bool
    name: string

block:
  var x = Ciao(12, false, false, "123")
  echo x

block:
  var x = Ciao(12, flag: true, 1, "123")
  echo x

when false:  ## not allowed
  block:
    var x = Ciao(flag: true, 1, "123")
    echo x
```

## Warning

Object constructions with a single unamed field will be interpreted as type conversions, which means

```nim
type
  Vector = object
    a: int

var x = Vector(1)
```

will get a type mismatch error.