### PR TITLE
don't access void* out of alignment in refc GC to avoid UB

### DIFF
--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -391,7 +391,6 @@ else:
             let regEnd = sp +% sizeof(registers)
             while sp <% regEnd:
               gcMark(gch, cast[PPointer](sp)[])
-              gcMark(gch, cast[PPointer](sp +% sizeof(pointer) div 2)[])
               sp = sp +% sizeof(pointer)
         # Make sure sp is word-aligned
         sp = sp and not (sizeof(pointer) - 1)


### PR DESCRIPTION
Not entirely sure why this is there. Maybe there's a good reason. This PR exists either to remove this, and remove the UB:
```
Nim/lib/system/gc_common.nim:394:7: runtime error: load of misaligned address 0x7ffc22446544 for type 'void *', which requires 8 byte alignment
0x7ffc22446544: note: pointer points here
  e0 50 dd 2f e8 7f 00 00  95 17 fb c4 e5 fb 58 db  50 e0 d5 2f e8 7f 00 00  00 00 00 00 00 00 00 00
```
or trigger some documentation of why it's crucial that it's there (and only for `amd64`? Not other 64-bit platforms? Seems dubious. See above regarding removal and/or documentation.)