### PR TITLE
fixes #14255; Crash in compiler when using `system.any` by accident.

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -302,7 +302,7 @@ proc semConv(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   result = newNodeI(nkConv, n.info)
 
   var targetType = semTypeNode(c, n[0], nil)
-  case targetType.kind
+  case targetType.skipTypes({tyDistinct}).kind
   of tyTypeDesc:
     internalAssert c.config, targetType.len > 0
     if targetType.base.kind == tyNone:

--- a/tests/arc/t20588.nim
+++ b/tests/arc/t20588.nim
@@ -5,9 +5,9 @@ discard """
 t20588.nim(20, 12) Error: illegal type conversion to 'auto'
 t20588.nim(21, 14) Error: illegal type conversion to 'typed'
 t20588.nim(22, 16) Error: illegal type conversion to 'untyped'
+t20588.nim(24, 7) Error: illegal type conversion to 'any'
 '''
 """
-
 
 
 
@@ -20,3 +20,6 @@ t20588.nim(22, 16) Error: illegal type conversion to 'untyped'
 discard 0.0.auto
 discard typed("abc")
 discard untyped(4)
+var a = newSeq[bool](1000)
+if any(a):
+  echo "ok?"


### PR DESCRIPTION
fixes #14255