### PR TITLE
tuple unpacking for vars as just sugar, allowing nesting

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -343,6 +343,26 @@
 
 - `=wasMoved` can be overridden by users.
 
+- Tuple unpacking for variables is now treated as syntax sugar that directly
+  expands into multiple assignments. Along with this, tuple unpacking for
+  variables can now be nested.
+
+  ```nim
+  proc returnsNestedTuple(): (int, (int, int), int, int) = (4, (5, 7), 2, 3)
+
+  let (x, (_, y), _, z) = returnsNestedTuple()
+  # roughly becomes
+  let
+    tmpTup1 = returnsNestedTuple()
+    x = tmpTup1[0]
+    tmpTup2 = tmpTup1[1]
+    y = tmpTup2[1]
+    z = tmpTup1[3]
+  ```
+
+  As a result `nnkVarTuple` nodes in variable sections will no longer be
+  reflected in `typed` AST.
+
 ## Compiler changes
 
 - The `gc` switch has been renamed to `mm` ("memory management") in order to reflect the

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -1,6 +1,6 @@
 import sem, cgen, modulegraphs, ast, llstream, parser, msgs,
        lineinfos, reorder, options, semdata, cgendata, modules, pathutils,
-       packages, syntaxes, depends, vm, pragmas, idents, lookups
+       packages, syntaxes, depends, vm, pragmas, idents, lookups, wordrecg
 
 import pipelineutils
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1824,7 +1824,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     result.add(n[1])
     return semExprNoType(c, result)
   of nkPar, nkTupleConstr:
-    if a.len >= 2:
+    if a.len >= 2 or a.kind == nkTupleConstr:
       # unfortunately we need to rewrite ``(x, y) = foo()`` already here so
       # that overloading of the assignment operator still works. Usually we
       # prefer to do these rewritings in transf.nim:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -653,39 +653,74 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         localError(c.config, a.info, errXExpected, "tuple")
       elif a.len-2 != tup.len:
         localError(c.config, a.info, errWrongNumberOfVariables)
-      b = newNodeI(nkVarTuple, a.info)
-      newSons(b, a.len)
-      # keep type desc for doc generator
-      # NOTE: at the moment this is always ast.emptyNode, see parser.nim
-      b[^2] = a[^2]
-      b[^1] = def
-      addToVarSection(c, result, n, b)
-    elif tup.kind == tyTuple and def.kind in {nkPar, nkTupleConstr} and
-        a.kind == nkIdentDefs and a.len > 3:
-      message(c.config, a.info, warnEachIdentIsTuple)
-
-    for j in 0..<a.len-2:
-      if a[j].kind == nkDotExpr:
-        fillPartialObject(c, a[j],
-          if a.kind != nkVarTuple: typ else: tup[j])
-        addToVarSection(c, result, n, a)
-        continue
-      var v = semIdentDef(c, a[j], symkind, false)
-      styleCheckDef(c, v)
-      onDef(a[j].info, v)
-      if sfGenSym notin v.flags:
-        if not isDiscardUnderscore(v): addInterfaceDecl(c, v)
-      else:
-        if v.owner == nil: v.owner = c.p.owner
-      when oKeepVariableNames:
-        if c.inUnrolledContext > 0: v.flags.incl(sfShadowed)
+      var tmpTuple: PSym
+      # if the RHS is a tuple literal, we can directly assign the variables to
+      # the field expressions, otherwise we have to use a temp
+      let useTemp = def.kind notin {nkPar, nkTupleConstr}
+      if useTemp:
+        tmpTuple = newSym(skLet, getIdent(c.cache, "tmpTuple"), nextSymId c.idgen, getCurrOwner(c), n.info)
+        tmpTuple.typ = typ
+        tmpTuple.flags.incl(sfGenSym)
+        b = newNodeI(nkIdentDefs, a.info)
+        newSons(b, 3)
+        b[0] = newSymNode(tmpTuple)
+        # NOTE: at the moment this is always ast.emptyNode, see parser.nim
+        b[1] = a[^2]
+        b[2] = def
+        addToVarSection(c, result, n, b)
+      var fieldAssignments = newNodeI(n.kind, a.info)
+      for j in 0..<a.len-2:
+        let name = a[j]
+        if name.kind == nkIdent and name.ident.s == "_":
+          continue
+        var tupleField: PNode
+        if name.kind == nkVarTuple:
+          # nested tuple
+          tupleField = newNodeI(nkVarTuple, name.info)
+          newSons(tupleField, name.len)
+          for k in 0..<name.len-2:
+            tupleField[k] = name[k]
         else:
-          let shadowed = findShadowedVar(c, v)
-          if shadowed != nil:
-            shadowed.flags.incl(sfShadowed)
-            if shadowed.kind == skResult and sfGenSym notin v.flags:
-              message(c.config, a.info, warnResultShadowed)
-      if a.kind != nkVarTuple:
+          tupleField = newNodeI(nkIdentDefs, name.info)
+          newSons(tupleField, 3)
+          tupleField[0] = name
+        tupleField[^2] = c.graph.emptyNode
+        if useTemp:
+          tupleField[^1] = newTreeI(nkBracketExpr, name.info, newSymNode(tmpTuple), newIntNode(nkIntLit, j))
+        else:
+          var val = def[j]
+          if val.kind == nkExprColonExpr: val = val[1]
+          tupleField[^1] = val
+        fieldAssignments.add(tupleField)
+      let resSection = semVarOrLet(c, fieldAssignments, symkind)
+      for resDef in resSection:
+        addToVarSection(c, result, n, resDef)
+    else:
+      if tup.kind == tyTuple and def.kind in {nkPar, nkTupleConstr} and
+          a.kind == nkIdentDefs and a.len > 3:
+        # var a, b = (1, 2)
+        message(c.config, a.info, warnEachIdentIsTuple)
+
+      for j in 0..<a.len-2:
+        if a[j].kind == nkDotExpr:
+          fillPartialObject(c, a[j], typ)
+          addToVarSection(c, result, n, a)
+          continue
+        var v = semIdentDef(c, a[j], symkind, false)
+        styleCheckDef(c, v)
+        onDef(a[j].info, v)
+        if sfGenSym notin v.flags:
+          if not isDiscardUnderscore(v): addInterfaceDecl(c, v)
+        else:
+          if v.owner == nil: v.owner = c.p.owner
+        when oKeepVariableNames:
+          if c.inUnrolledContext > 0: v.flags.incl(sfShadowed)
+          else:
+            let shadowed = findShadowedVar(c, v)
+            if shadowed != nil:
+              shadowed.flags.incl(sfShadowed)
+              if shadowed.kind == skResult and sfGenSym notin v.flags:
+                message(c.config, a.info, warnResultShadowed)
         if def.kind != nkEmpty:
           if sfThread in v.flags: localError(c.config, def.info, errThreadvarCannotInit)
         setVarType(c, v, typ)
@@ -708,35 +743,26 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         b.add copyTree(def)
         addToVarSection(c, result, n, b)
         v.ast = b
-      else:
-        if def.kind in {nkPar, nkTupleConstr}: v.ast = def[j]
-        # bug #7663, for 'nim check' this can be a non-tuple:
-        if tup.kind == tyTuple: setVarType(c, v, tup[j])
-        else: v.typ = tup
-        b[j] = newSymNode(v)
-      if def.kind == nkEmpty:
-        let actualType = v.typ.skipTypes({tyGenericInst, tyAlias,
-                                          tyUserTypeClassInst})
-        if actualType.kind in {tyObject, tyDistinct} and
-           actualType.requiresInit:
-          defaultConstructionError(c, v.typ, v.info)
-        else:
-          checkNilable(c, v)
-        # allow let to not be initialised if imported from C:
-        if v.kind == skLet and sfImportc notin v.flags and (strictDefs notin c.features or not isLocalSym(v)):
-          localError(c.config, a.info, errLetNeedsInit)
-      if sfCompileTime in v.flags:
-        if a.kind != nkVarTuple:
+        if def.kind == nkEmpty:
+          let actualType = v.typ.skipTypes({tyGenericInst, tyAlias,
+                                            tyUserTypeClassInst})
+          if actualType.kind in {tyObject, tyDistinct} and
+            actualType.requiresInit:
+            defaultConstructionError(c, v.typ, v.info)
+          else:
+            checkNilable(c, v)
+          # allow let to not be initialised if imported from C:
+          if v.kind == skLet and sfImportc notin v.flags and (strictDefs notin c.features or not isLocalSym(v)):
+            localError(c.config, a.info, errLetNeedsInit)
+        if sfCompileTime in v.flags:
           var x = newNodeI(result.kind, v.info)
           x.add result[i]
           vm.setupCompileTimeVar(c.module, c.idgen, c.graph, x)
-        else:
-          localError(c.config, a.info, "cannot destructure to compile time variable")
-      if v.flags * {sfGlobal, sfThread} == {sfGlobal}:
-        message(c.config, v.info, hintGlobalVar)
-      if {sfGlobal, sfPure} <= v.flags:
-        globalVarInitCheck(c, def)
-      suggestSym(c.graph, v.info, v, c.graph.usageSym)
+        if v.flags * {sfGlobal, sfThread} == {sfGlobal}:
+          message(c.config, v.info, hintGlobalVar)
+        if {sfGlobal, sfPure} <= v.flags:
+          globalVarInitCheck(c, def)
+        suggestSym(c.graph, v.info, v, c.graph.usageSym)
 
 proc semConst(c: PContext, n: PNode): PNode =
   result = copyNode(n)
@@ -793,19 +819,56 @@ proc semConst(c: PContext, n: PNode): PNode =
         localError(c.config, a.info, errXExpected, "tuple")
       elif a.len-2 != typ.len:
         localError(c.config, a.info, errWrongNumberOfVariables)
-      b = newNodeI(nkVarTuple, a.info)
-      newSons(b, a.len)
-      b[^2] = a[^2]
-      b[^1] = def
+      var tmpTuple: PSym
+      # if the RHS is a tuple literal, we can directly assign the variables to
+      # the field expressions, otherwise we have to use a temp
+      let useTemp = def.kind notin {nkPar, nkTupleConstr}
+      if useTemp:
+        tmpTuple = newSym(skConst, getIdent(c.cache, "tmpTuple"), nextSymId c.idgen, getCurrOwner(c), n.info)
+        tmpTuple.typ = typ
+        tmpTuple.flags.incl(sfGenSym)
+        b = newNodeI(nkConstDef, a.info)
+        newSons(b, 3)
+        b[0] = newSymNode(tmpTuple)
+        # NOTE: at the moment this is always ast.emptyNode, see parser.nim
+        b[1] = a[^2]
+        b[2] = def
+        addToVarSection(c, result, n, b)
+      var fieldAssignments = newNodeI(n.kind, a.info)
+      for j in 0..<a.len-2:
+        let name = a[j]
+        if name.kind == nkIdent and name.ident.s == "_":
+          continue
+        var tupleField: PNode
+        if name.kind == nkVarTuple:
+          # nested tuple
+          tupleField = newNodeI(nkVarTuple, name.info)
+          newSons(tupleField, name.len)
+          for k in 0..<name.len-2:
+            tupleField[k] = name[k]
+        else:
+          tupleField = newNodeI(nkConstDef, name.info)
+          newSons(tupleField, 3)
+          tupleField[0] = name
+        tupleField[^2] = c.graph.emptyNode
+        if useTemp:
+          tupleField[^1] = newTreeI(nkBracketExpr, name.info, newSymNode(tmpTuple), newIntNode(nkIntLit, j))
+        else:
+          var val = def[j]
+          if val.kind == nkExprColonExpr: val = val[1]
+          tupleField[^1] = val
+        fieldAssignments.add(tupleField)
+      let resSection = semConst(c, fieldAssignments)
+      for resDef in resSection:
+        addToVarSection(c, result, n, resDef)
+    else:
+      for j in 0..<a.len-2:
+        var v = semIdentDef(c, a[j], skConst)
+        if sfGenSym notin v.flags: addInterfaceDecl(c, v)
+        elif v.owner == nil: v.owner = getCurrOwner(c)
+        styleCheckDef(c, v)
+        onDef(a[j].info, v)
 
-    for j in 0..<a.len-2:
-      var v = semIdentDef(c, a[j], skConst)
-      if sfGenSym notin v.flags: addInterfaceDecl(c, v)
-      elif v.owner == nil: v.owner = getCurrOwner(c)
-      styleCheckDef(c, v)
-      onDef(a[j].info, v)
-
-      if a.kind != nkVarTuple:
         setVarType(c, v, typ)
         when false:
           v.ast = def               # no need to copy
@@ -822,12 +885,7 @@ proc semConst(c: PContext, n: PNode): PNode =
         b.add a[1]
         b.add copyTree(def)
         v.ast = b
-      else:
-        setVarType(c, v, typ[j])
-        v.ast = if def[j].kind != nkExprColonExpr: def[j]
-                else: def[j][1]
-        b[j] = newSymNode(v)
-    addToVarSection(c, result, n, b)
+      addToVarSection(c, result, n, b)
   dec c.inStaticContext
 
 include semfields

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -673,7 +673,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
       var fieldAssignments = newNodeI(n.kind, a.info)
       for j in 0..<a.len-2:
         let name = a[j]
-        if name.kind == nkIdent and name.ident.s == "_":
+        if useTemp and name.kind == nkIdent and name.ident.s == "_":
           continue
         var tupleField: PNode
         if name.kind == nkVarTuple:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -667,6 +667,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         # NOTE: at the moment this is always ast.emptyNode, see parser.nim
         b[1] = a[^2]
         b[2] = def
+        tmpTuple.ast = b
         addToVarSection(c, result, n, b)
       var fieldAssignments = newNodeI(n.kind, a.info)
       for j in 0..<a.len-2:
@@ -833,6 +834,7 @@ proc semConst(c: PContext, n: PNode): PNode =
         # NOTE: at the moment this is always ast.emptyNode, see parser.nim
         b[1] = a[^2]
         b[2] = def
+        tmpTuple.ast = b
         addToVarSection(c, result, n, b)
       var fieldAssignments = newNodeI(n.kind, a.info)
       for j in 0..<a.len-2:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -658,7 +658,8 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
       # the field expressions, otherwise we have to use a temp
       let useTemp = def.kind notin {nkPar, nkTupleConstr}
       if useTemp:
-        tmpTuple = newSym(skLet, getIdent(c.cache, "tmpTuple"), nextSymId c.idgen, getCurrOwner(c), n.info)
+        # symkind here should be skLet but generic code doesn't like it if it doesn't match
+        tmpTuple = newSym(symkind, getIdent(c.cache, "tmpTuple"), nextSymId c.idgen, getCurrOwner(c), n.info)
         tmpTuple.typ = typ
         tmpTuple.flags.incl(sfGenSym)
         b = newNodeI(nkIdentDefs, a.info)
@@ -687,7 +688,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           tupleField[0] = name
         tupleField[^2] = c.graph.emptyNode
         if useTemp:
-          tupleField[^1] = newTreeI(nkBracketExpr, name.info, newSymNode(tmpTuple), newIntNode(nkIntLit, j))
+          tupleField[^1] = newTreeIT(nkBracketExpr, name.info, tup[j], newSymNode(tmpTuple), newIntNode(nkIntLit, j))
         else:
           var val = def[j]
           if val.kind == nkExprColonExpr: val = val[1]
@@ -854,7 +855,7 @@ proc semConst(c: PContext, n: PNode): PNode =
           tupleField[0] = name
         tupleField[^2] = c.graph.emptyNode
         if useTemp:
-          tupleField[^1] = newTreeI(nkBracketExpr, name.info, newSymNode(tmpTuple), newIntNode(nkIntLit, j))
+          tupleField[^1] = newTreeIT(nkBracketExpr, name.info, typ[j], newSymNode(tmpTuple), newIntNode(nkIntLit, j))
         else:
           var val = def[j]
           if val.kind == nkExprColonExpr: val = val[1]

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -187,7 +187,8 @@ conceptDecl = 'concept' conceptParam ^* ',' (pragma)? ('of' typeDesc ^* ',')?
               &IND{>} stmt
 typeDef = identVisDot genericParamList? pragma '=' optInd typeDefValue
             indAndComment?
-varTuple = '(' optInd identWithPragma ^+ comma optPar ')' '=' optInd expr
+varTupleLhs = '(' optInd (identWithPragma / varTupleLhs) ^+ comma optPar ')'
+varTuple = varTupleLhs '=' optInd expr
 colonBody = colcom stmt postExprBlocks?
 variable = (varTuple / identColonEquals) colonBody? indAndComment
 constant = (varTuple / identWithPragma) (colon typeDesc)? '=' optInd expr indAndComment

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -3101,7 +3101,7 @@ This is treated as syntax sugar for roughly the following:
 For `var` or `let` statements, if the value expression is a tuple literal,
 each expression is directly expanded into an assignment without the use of
 a temporary variable.
-  
+
   ```nim
   let (x, y, z) = (1, 2, 3)
   # becomes

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -3109,6 +3109,7 @@ a temporary variable.
     x = 1
     y = 2
     z = 3
+  ```
 
 Tuple unpacking can also be nested:
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -3080,8 +3080,8 @@ value is expected to come from native code, typically a C/C++ `const`.
 Tuple unpacking
 ---------------
 
-In a `var` or `let` statement tuple unpacking can be performed. The special
-identifier `_` can be used to ignore some parts of the tuple:
+In a `var`, `let` or `const` statement tuple unpacking can be performed.
+The special identifier `_` can be used to ignore some parts of the tuple:
 
   ```nim
   proc returnsTuple(): (int, int, int) = (4, 2, 3)
@@ -3089,6 +3089,34 @@ identifier `_` can be used to ignore some parts of the tuple:
   let (x, _, z) = returnsTuple()
   ```
 
+This is treated as syntax sugar for roughly the following:
+
+  ```nim
+  let
+    tmpTuple = returnsTuple()
+    x = tmpTuple[0]
+    z = tmpTuple[2]
+  ```
+
+For `var` or `let` statements, if the value expression is a tuple literal,
+each expression is directly expanded into an assignment without the use of
+a temporary variable.
+  
+  ```nim
+  let (x, y, z) = (1, 2, 3)
+  # becomes
+  let
+    x = 1
+    y = 2
+    z = 3
+
+Tuple unpacking can also be nested:
+
+  ```nim
+  proc returnsNestedTuple(): (int, (int, int), int, int) = (4, (5, 7), 2, 3)
+
+  let (x, (_, y), _, z) = returnsNestedTuple()
+  ```
 
 
 Const section

--- a/tests/arc/t19364.nim
+++ b/tests/arc/t19364.nim
@@ -1,0 +1,30 @@
+discard """
+  cmd: '''nim c --gc:arc --expandArc:fooLeaks $file'''
+  nimout: '''
+--expandArc: fooLeaks
+
+var
+  tmpTuple_cursor
+  a_cursor
+  b_cursor
+  c_cursor
+tmpTuple_cursor = refTuple
+a_cursor = tmpTuple_cursor[0]
+b_cursor = tmpTuple_cursor[1]
+c_cursor = tmpTuple_cursor[2]
+-- end of expandArc ------------------------
+'''
+"""
+
+func fooLeaks(refTuple: tuple[a,
+                              b,
+                              c: seq[float]]): float =
+  let (a, b, c) = refTuple
+
+let refset = (a: newSeq[float](25_000_000),
+              b: newSeq[float](25_000_000),
+              c: newSeq[float](25_000_000))
+
+var res = newSeq[float](1_000_000)
+for i in 0 .. res.high:
+  res[i] = fooLeaks(refset)

--- a/tests/macros/tastrepr.nim
+++ b/tests/macros/tastrepr.nim
@@ -8,7 +8,9 @@ for i, d in pairs(data):
   discard
 for i, (x, y) in pairs(data):
   discard
-var (a, b) = (1, 2)
+var
+  a = 1
+  b = 2
 
 var data = @[(1, "one"), (2, "two")]
 for (i, d) in pairs(data):

--- a/tests/misc/t11634.nim
+++ b/tests/misc/t11634.nim
@@ -1,8 +1,5 @@
 discard """
   action: reject
-  nimout: '''
-t11634.nim(20, 7) Error: cannot destructure to compile time variable
-'''
 """
 
 type Foo = ref object

--- a/tests/parser/ttupleunpack.nim
+++ b/tests/parser/ttupleunpack.nim
@@ -27,3 +27,46 @@ proc main() =
 
 main()
 main2()
+
+block: # nested unpacking
+  block: # simple let
+    let (a, (b, c), d) = (1, (2, 3), 4)
+    doAssert (a, b, c, d) == (1, 2, 3, 4)
+    let foo = (a, (b, c), d)
+    let (a2, (b2, c2), d2) = foo
+    doAssert (a, b, c, d) == (a2, b2, c2, d2)
+
+  block: # var and assignment
+    var (x, (y, z), t) = ('a', (true, @[123]), "abc")
+    doAssert (x, y, z, t) == ('a', true, @[123], "abc")
+    (x, (y, z), t) = ('b', (false, @[456]), "def")
+    doAssert (x, y, z, t) == ('b', false, @[456], "def")
+
+  block: # very nested
+    let (_, (_, (_, (_, (_, a))))) = (1, (2, (3, (4, (5, 6)))))
+    doAssert a == 6
+
+  block: # const
+    const (a, (b, c), d) = (1, (2, 3), 4)
+    doAssert (a, b, c, d) == (1, 2, 3, 4)
+    const foo = (a, (b, c), d)
+    const (a2, (b2, c2), d2) = foo
+    doAssert (a, b, c, d) == (a2, b2, c2, d2)
+  
+  block: # evaluation semantics preserved between literal and not literal
+    var s: seq[string]
+    block:
+      let (a, (b, c), d) = ((s.add("a"); 1), ((s.add("b"); 2), (s.add("c"); 3)), (s.add("d"); 4))
+      doAssert (a, b, c, d) == (1, 2, 3, 4)
+      doAssert s == @["a", "b", "c", "d"]
+    block:
+      s = @[]
+      let foo = ((s.add("a"); 1), ((s.add("b"); 2), (s.add("c"); 3)), (s.add("d"); 4))
+      let (a, (b, c), d) = foo
+      doAssert (a, b, c, d) == (1, 2, 3, 4)
+      doAssert s == @["a", "b", "c", "d"]
+
+block: # unary assignment unpacking
+  var a: int
+  (a,) = (1,)
+  doAssert a == 1

--- a/tests/parser/ttupleunpack.nim
+++ b/tests/parser/ttupleunpack.nim
@@ -55,11 +55,16 @@ block: # nested unpacking
   
   block: # evaluation semantics preserved between literal and not literal
     var s: seq[string]
-    block:
+    block: # literal
       let (a, (b, c), d) = ((s.add("a"); 1), ((s.add("b"); 2), (s.add("c"); 3)), (s.add("d"); 4))
       doAssert (a, b, c, d) == (1, 2, 3, 4)
       doAssert s == @["a", "b", "c", "d"]
-    block:
+    block: # underscore
+      s = @[]
+      let (a, (_, c), _) = ((s.add("a"); 1), ((s.add("b"); 2), (s.add("c"); 3)), (s.add("d"); 4))
+      doAssert (a, c) == (1, 3)
+      doAssert s == @["a", "b", "c", "d"]
+    block: # temp
       s = @[]
       let foo = ((s.add("a"); 1), ((s.add("b"); 2), (s.add("c"); 3)), (s.add("d"); 4))
       let (a, (b, c), d) = foo

--- a/tests/tuples/mnimsconstunpack.nim
+++ b/tests/tuples/mnimsconstunpack.nim
@@ -1,0 +1,4 @@
+proc foo(): tuple[a, b: string] =
+  result = ("a", "b")
+
+const (a, b*) = foo()

--- a/tests/tuples/tnimsconstunpack.nim
+++ b/tests/tuples/tnimsconstunpack.nim
@@ -1,0 +1,8 @@
+discard """
+  action: compile
+  cmd: "nim e $file"
+"""
+
+import mnimsconstunpack
+
+doAssert b == "b"


### PR DESCRIPTION
refs https://github.com/nim-lang/RFCs/issues/194, fixes #19364

Treats tuple unpacking for variables as in-place sugar that directly transforms `let (a, b, ...) = foo` into:

* When `foo` is a tuple literal like `(expr1, expr2, ...)` or `(field1: expr1, field2: expr2, ...)`, multiple assignments like `let a = expr1; let b = expr2; ...`
* When `foo` is not a tuple literal, an assignment of `foo` to a temporary variable `tmpTuple` and then assignments of the fields of `tmpTuple` to `a`, `b` etc like `let tmpTuple = foo; let a = tmpTuple[0]; let b = tmpTuple[1]; ...`

Benefits:

* This allows a very simple implementation of nested tuple unpacking for variable definitions (note that this already existed for variable assignments but was untested)
* Makes so much special casing for the `nkVarTuple` node kind in the backends unnecessary (not removed in this PR yet)
* Makes the code for normal `nkIdentDefs` simpler
* Easier logic to reason about in general

Caveats:

* Docgen for variables that are tuple unpacked from non-literals will be obscured, i.e. `let (a, b) = foo` will show the definition of `a` as `tmpTuple[0]` (although currently the definition of `a` would be `nil`, the docgen would just show `(a, b) = foo` and get away with it)
* Temp generation logic is added in the early `sem` phase
* Overall such a transformation is done earlier than may be desired, but any later is not really possible
* `{.compileTime.}` error message is worse but still legible (at least it's not special cased)

In my opinion the change is worth it if it works. Didn't make an RFC because I didn't know for sure if it would work.

Notes for this PR:

* Nothing has been done about `for` loop unpacking. `for` loops do support nested unpacking up to a second level as long as parentheses aren't used for the first level which makes me think the logic is easy for more nesting, but as it is it seems complex to me and I don't know how to adapt it.