### PR TITLE
Add benchmarking based on Minimize

### DIFF
--- a/.github/workflows/ci_bench.yml
+++ b/.github/workflows/ci_bench.yml
@@ -1,0 +1,117 @@
+name: Benchmarks CI
+on:
+  pull_request:
+  push:
+    branches:
+      - 'devel'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        cpu: [amd64]
+    name: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60 # refs bug #18178
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: 'Install node.js 16.x'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: 'Install dependencies (Linux amd64)'
+        if: runner.os == 'Linux' && matrix.cpu == 'amd64'
+        run: |
+          sudo apt-fast update -qq
+          DEBIAN_FRONTEND='noninteractive' \
+            sudo apt-fast install --no-install-recommends -yq \
+              libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev \
+              valgrind libc6-dbg libblas-dev xorg-dev
+
+      - name: 'Add build binaries to PATH'
+        shell: bash
+        run: echo "${{ github.workspace }}/bin" >> "${GITHUB_PATH}"
+
+      - name: 'Build csourcesAny'
+        shell: bash
+        run: . ci/funs.sh && nimBuildCsourcesIfNeeded CC=gcc ucpu='${{ matrix.cpu }}'
+
+      - name: 'Build koch'
+        shell: bash
+        run: nim c koch
+
+      - name: 'Build Nim'
+        shell: bash
+        run: ./koch boot -d:release -d:nimStrictMode --lib:lib
+
+      - name: 'Build Nimble'
+        shell: bash
+        run: ./koch nimble
+
+      - name: 'Action'
+        shell: bash
+        run: nim c -r -d:release ci/action.nim
+
+      - name: 'Checkout minimize'
+        uses: actions/checkout@v3
+        with:
+          repository: 'FedericoCeratto/minimize'
+          path: minimize
+
+      - name: 'Run minimize benchmarks'
+        shell: bash
+        run: ./minimize/minimize ci-bench
+
+      - name: 'Restore minimize cached database'
+        id: minimize-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: minimize.sqlite
+          key: minimize-db-key
+
+      - name: 'Update minimize db'
+        shell: bash
+        run: ./minimize/minimize update-db
+
+            # - name: 'Save minimize cached database'
+            #if: |
+            #  github.event_name == 'push' && github.ref == 'refs/heads/devel' &&
+            #  matrix.target == 'linux'
+            #   id: minimize-cache
+            #   uses: actions/cache/save@v3
+            #   with:
+            #     path: minimize.sqlite
+            #     key: minimize-db-key
+
+      - name: 'Generate minimize report'
+        shell: bash
+        run: ./minimize/minimize generate-report
+
+      - name: 'Archive minimize report'
+        uses: actions/upload-artifact@v3
+        with:
+          name: minimize-report
+          path: |
+            minimize/minimize.html
+            minimize/minimize.csv
+
+      # Requires additional permissions, see:
+      # https://github.com/nim-lang/Nim/actions/runs/4778177321/jobs/8494423792?pr=21566
+      # - name: 'Publish HTML report'
+      #   uses: rossjrw/pr-preview-action@v1
+      #   with:
+      #     source-dir: minimize
+      #     umbrella-dir: minimize
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract md summary
+        run: |
+          cat minimize/summary.md  >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci_bench.yml
+++ b/.github/workflows/ci_bench.yml
@@ -62,7 +62,7 @@ jobs:
       - name: 'Checkout minimize'
         uses: actions/checkout@v3
         with:
-          repository: 'FedericoCeratto/minimize'
+          repository: 'nim-lang/ci_bench'
           path: minimize
 
       - name: 'Run minimize benchmarks'


### PR DESCRIPTION
Based on a conversation with @ringabout, this runs a set of benchmarks for each PR and merges into the devel branch. The benchmarks measure CPU and RAM load using cachegrind is a way that is very independent from the performance of each github actions VM and therefore reproducible over time.
It compares the effects of the PR with a history of past commits on the devel branch and outputs a set of charts and a CSV as a build artifact and a short summary visible in the action output in case there are significant changes.
It has a small set of benchmarks (to start with something) and they should be expanded over time.

Preview of the HTML output: https://output.jsbin.com/wuneweweju - the charts are meant to visualize long term trends.
Each bar in the chart links to the git commit that triggered the run.