### PR TITLE
Docs: Mention Source Code Filters in `lib/String handling`

### DIFF
--- a/doc/lib.md
+++ b/doc/lib.md
@@ -171,7 +171,9 @@ String handling
 
 * [strformat](strformat.html)
   Macro based standard string interpolation/formatting. Inspired by
-  Python's f-strings.
+  Python's f-strings.\
+  **Note:** if you need templating, consider using Nim
+  [Source Code Filters (SCF)](filters.html).
 
 * [strmisc](strmisc.html)
   This module contains uncommon string handling operations that do not


### PR DESCRIPTION
...as a viable solution for templating.

Currently SCFs are almost unlinked, but they work and can be very useful.
We also need to mention them somewhere outside of std lib's docs, as they aren't exactly a part. But I'm not sure what's the right place to stick the link in.