### PR TITLE
Revert "Add `cursor` to lists iterator variables"

### DIFF
--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -286,7 +286,7 @@ iterator nodes*[T](L: SomeLinkedList[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it {.cursor.} = L.head
+  var it = L.head
   while it != nil:
     let nxt = it.next
     yield it
@@ -311,7 +311,7 @@ iterator nodes*[T](L: SomeLinkedRing[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it {.cursor.} = L.head
+  var it = L.head
   if it != nil:
     while true:
       let nxt = it.next
@@ -733,7 +733,7 @@ proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.disc
     if L.tail.next == n:
       L.tail.next = L.head # restore cycle
   else:
-    var prev {.cursor.} = L.head
+    var prev = L.head
     while prev.next != n and prev.next != nil:
       prev = prev.next
     if prev.next == nil:


### PR DESCRIPTION
Reverts nim-lang/Nim#21527

fixes CI

```
  /home/runner/work/Nim/Nim/lib/pure/unittest.nim(686) testcommonmark
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(2513) markdown
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(623) render
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(620) toStringSeq
  /home/runner/work/Nim/Nim/lib/pure/collections/sequtils.nim(389) map
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(620) :anonymous
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(475) $
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(551) $
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(620) toStringSeq
  /home/runner/work/Nim/Nim/lib/pure/collections/sequtils.nim(389) map
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(620) :anonymous
  /home/runner/work/Nim/Nim/pkgstemp/markdown/src/markdown.nim(475) $
  /home/runner/work/Nim/Nim/lib/system/arc.nim(211) isObjDisplayCheck
  SIGSEGV: Illegal storage access. (Attempt to read from nil?)
  Segmentation fault (core dumped)
```