### PR TITLE
fixes #19502; fixes #17552; lift `{.global.}` at the transf phase

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -969,7 +969,7 @@ proc liftGlobals(c: PTransf, n: PNode, globals: PNode): PNode =
     if result.len == 0:
       result = newNode(nkEmpty)
   else:
-    result = n
+    result = newTransNode(n.kind, n, n.len)
     for i in 0..<n.len:
       result[i] = liftGlobals(c, n[i], globals)
 
@@ -995,7 +995,7 @@ proc transform(c: PTransf, n: PNode): PNode =
       # use the same node as before if still a symbol:
       if result.kind == nkSym: result = n
     else:
-      if c.isStmt and sfCompileTime notin s.flags:
+      if c.isStmt and sfCompileTime notin s.flags and n.kind in {nkProcDef, nkFuncDef, nkMethodDef}:
         let varSections = newNodeI(nkVarSection, n.info)
         let defs = liftGlobals(c, n, varSections)
         if varSections.len > 0:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -942,6 +942,8 @@ proc commonOptimizations*(g: ModuleGraph; idgen: IdGenerator; c: PSym, n: PNode)
       result = n
 
 proc liftGlobals(c: PTransf, n: PNode, globals: PNode): PNode =
+  if n == nil:
+    return
   case n.kind
   of nkEmpty..nkNilLit:
     result = n

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -32,9 +32,9 @@ copying
 123
 42
 ok
+closed
 destroying variable: 20
 destroying variable: 10
-closed
 '''
   cmd: "nim c --gc:arc --deepcopy:on -d:nimAllocPagesViaMalloc $file"
 """


### PR DESCRIPTION
- [ ] How to handle them for vm?
- [ ] generics/templates/macros?
- [ ] better error messages for cases using local variables?
- [ ] finally remove the old related logics from backends


```nim
var x = "hi"

proc foo() =
  var s {.global.} = x
  s.add "hi"
  echo s

foo()
foo()
```
=>
```nim
var x = "hi"

var s = x
proc foo() =
  s.add "hi"
  echo s

foo()
foo()

```