### PR TITLE
remove `seq[T]` `setLen` undefined behavior

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1947,7 +1947,7 @@ proc genSetLengthSeq(p: BProc, e: PNode, d: var TLoc) =
 
   initLoc(call, locCall, e, OnHeap)
   if not p.module.compileToCpp:
-    const setLenPattern = "($3) #setLengthSeqV2(&($1)->Sup, $4, $2)"
+    const setLenPattern = "($3) #setLengthSeqV2(($1)?&($1)->Sup:NIM_NIL, $4, $2)"
     call.r = ropecg(p.module, setLenPattern, [
       rdLoc(a), rdLoc(b), getTypeDesc(p.module, t),
       genTypeInfoV1(p.module, t.skipTypes(abstractInst), e.info)])


### PR DESCRIPTION
Fix https://github.com/nim-lang/Nim/issues/21509

Make https://github.com/nim-lang/Nim/pull/21520 more feasible

Because arithmetic of any sort of `NULL` pointers is UB.

[Godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:5,endLineNumber:13,positionColumn:5,positionLineNumber:13,selectionStartColumn:5,selectionStartLineNumber:13,startColumn:5,startLineNumber:13),source:'%23include+%3Cstdio.h%3E%0A%0Astruct+Bar+%7B%0A++++int+*Sup%3B%0A++++int+y%3B%0A%7D%3B%0A%0Avoid+callee(int+**x)+%7B%0A++++printf(%22%25p%5Cn%22,+(void+*)x)%3B%0A%7D%0A%0Avoid+caller(struct+Bar+**x)+%7B%0A++++callee(%26((*x))-%3ESup)%3B+//+Nim+status+quo%0A++++callee((*x)%3F(%26((*x))-%3ESup):NULL)%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:vcpp_v19_latest_x64,deviceViewOpen:'1',filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-O1',selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x64+msvc+v19.latest+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) shows that on `-O1` and higher optimization levels, across gcc, clang, and MSVC, it generates exactly the same code, which makes sense because specific pointer types aside, it's an identity function -- there aren't any new conditional instructions, jumps, or comparisons. The underlying bit patterns are identical.

As a broader note, this setup is kind of broken anyway, but this PR doesn't break it any further:
https://github.com/nim-lang/Nim/blob/2315b01ae691e5e9e54fdfdfb4642c8fbc559e48/lib/system/sysstr.nim#L307-L316
compares the incoming pointer against `nil`, but that only works when `offsetof(TypedSeq, Sup) == 0`, which happens to be true but then, sort of defeats the point of many of these pseudo-`offsetof`s scattered around Nim for these `Sup` fields in the C codegen, because it'd just break entirely if those `offsetof`s were truly used.