### PR TITLE
fixes #21592; create type bound operations for calls in the method dispatcher for ORC

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2140,7 +2140,7 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
 
       if m.g.forwardedProcs.len == 0:
         incl m.flags, objHasKidsValid
-      let disp = generateMethodDispatchers(graph)
+      let disp = generateMethodDispatchers(graph, m.idgen)
       for x in disp: genProcAux(m, x.sym)
 
   let mm = m

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2855,7 +2855,7 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
       var p = newInitProc(globals, m)
       attachProc(p, prc)
 
-  var disp = generateMethodDispatchers(graph)
+  var disp = generateMethodDispatchers(graph, m.idgen)
   for i in 0..<disp.len:
     let prc = disp[i].sym
     if not globals.generatedSyms.containsOrIncl(prc.id):

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -597,3 +597,14 @@ block: # bug #19857
       let res = v.toF()
 
   foo()
+
+import std/options
+
+type Event* = object
+  code*: string
+
+type App* = ref object of RootObj
+  id*: string
+
+method process*(self: App): Option[Event] {.base.} =
+  raise Exception.new_exception("not impl")


### PR DESCRIPTION
fixes #21592

Since the if dispatcher calls the original methods for sure, the compiler needs to generate type bound operations for the return type of the call.