### PR TITLE
macros: Extend treeTraverse intVal range to nnkUInt64Lit

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -945,7 +945,7 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
   case n.kind
   of nnkEmpty, nnkNilLit:
     discard # same as nil node in this representation
-  of nnkCharLit .. nnkInt64Lit:
+  of nnkCharLit .. nnkUInt64Lit:
     res.add(" " & $n.intVal)
   of nnkFloatLit .. nnkFloat64Lit:
     res.add(" " & $n.floatVal)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -945,8 +945,10 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
   case n.kind
   of nnkEmpty, nnkNilLit:
     discard # same as nil node in this representation
-  of nnkCharLit .. nnkUInt64Lit:
+  of nnkCharLit .. nnkInt64Lit:
     res.add(" " & $n.intVal)
+  of nnkUIntLit .. nnkUInt64Lit:
+    res.add(" " & $cast[uint64](n.intVal))
   of nnkFloatLit .. nnkFloat64Lit:
     res.add(" " & $n.floatVal)
   of nnkStrLit .. nnkTripleStrLit, nnkCommentStmt, nnkIdent, nnkSym:

--- a/tests/macros/t21593.nim
+++ b/tests/macros/t21593.nim
@@ -1,0 +1,13 @@
+discard """
+nimout: '''
+StmtList
+  UIntLit 18446744073709551615
+  IntLit -1'''
+"""
+
+import macros
+
+dumpTree:
+  0xFFFFFFFF_FFFFFFFF'u
+  0xFFFFFFFF_FFFFFFFF
+


### PR DESCRIPTION
Fixes #21593 by including unsigned integers in dumpTree output.