### PR TITLE
fixes #21564; std/bitops: Add explicit type masking for the JS target

### DIFF
--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -72,7 +72,7 @@ func typeMask[T: SomeInteger](): auto {.inline.} =
   else:
     cast[T](0xffffffff_ffffffff'u).castToUnsigned
 
-proc bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1, 3).} =
+func bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1, 3).} =
   ## Returns an extracted (and shifted) slice of bits from `v`.
   runnableExamples:
     doAssert 0b10111.bitsliced(2 .. 4) == 0b101

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -63,14 +63,11 @@ macro bitxor*[T: SomeInteger](x, y: T; z: varargs[T]): T =
 type BitsRange*[T] = range[0..sizeof(T)*8-1]
   ## A range with all bit positions for type `T`.
 
-func typeMask[T: SomeInteger](): auto {.inline.} =
-  # We can't rely on the JavaScript interpreter to cut off our bits when
-  # left-shifting i.e. a uint8 into the range of a uint16, so we have to
-  # mask out the valid range in the JS target. For C, we can simply downcast.
+template typeMasked[T: SomeInteger](x: T): T =
   when defined(js):
-    ((0xffffffff_ffffffff'u shr (64 - sizeof(T) * 8))).castToUnsigned
+    x and ((0xffffffff_ffffffff'u shr (64 - sizeof(T) * 8)))
   else:
-    cast[T](0xffffffff_ffffffff'u).castToUnsigned
+    x
 
 func bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1, 3).} =
   ## Returns an extracted (and shifted) slice of bits from `v`.
@@ -82,7 +79,7 @@ func bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1,
   let
     upmost = sizeof(T) * 8 - 1
     uv     = v.castToUnsigned
-  ((uv shl (upmost - slice.b) and typeMask[T]()) shr (upmost - slice.b + slice.a)).T
+  ((uv shl (upmost - slice.b)).typeMasked shr (upmost - slice.b + slice.a)).T
 
 proc bitslice*[T: SomeInteger](v: var T; slice: Slice[int]) {.inline, since: (1, 3).} =
   ## Mutates `v` into an extracted (and shifted) slice of bits from `v`.
@@ -94,7 +91,7 @@ proc bitslice*[T: SomeInteger](v: var T; slice: Slice[int]) {.inline, since: (1,
   let
     upmost = sizeof(T) * 8 - 1
     uv     = v.castToUnsigned
-  v = ((uv shl (upmost - slice.b) and typeMask[T]()) shr (upmost - slice.b + slice.a)).T
+  v = ((uv shl (upmost - slice.b)).typeMasked shr (upmost - slice.b + slice.a)).T
 
 func toMask*[T: SomeInteger](slice: Slice[int]): T {.inline, since: (1, 3).} =
   ## Creates a bitmask based on a slice of bits.
@@ -105,7 +102,7 @@ func toMask*[T: SomeInteger](slice: Slice[int]): T {.inline, since: (1, 3).} =
   let
     upmost = sizeof(T) * 8 - 1
     bitmask = bitnot(0.T).castToUnsigned
-  ((bitmask shl (upmost - slice.b + slice.a) and typeMask[T]()) shr (upmost - slice.b)).T
+  ((bitmask shl (upmost - slice.b + slice.a)).typeMasked shr (upmost - slice.b)).T
 
 proc masked*[T: SomeInteger](v, mask :T): T {.inline, since: (1, 3).} =
   ## Returns `v`, with only the `1` bits from `mask` matching those of

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -63,7 +63,16 @@ macro bitxor*[T: SomeInteger](x, y: T; z: varargs[T]): T =
 type BitsRange*[T] = range[0..sizeof(T)*8-1]
   ## A range with all bit positions for type `T`.
 
-func bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1, 3).} =
+func typeMask[T: SomeInteger](): auto {.inline.} =
+  # We can't rely on the JavaScript interpreter to cut off our bits when
+  # left-shifting i.e. a uint8 into the range of a uint16, so we have to
+  # mask out the valid range in the JS target. For C, we can simply downcast.
+  when defined(js):
+    ((0xffffffff_ffffffff'u shr (64 - sizeof(T) * 8))).castToUnsigned
+  else:
+    cast[T](0xffffffff_ffffffff'u).castToUnsigned
+
+proc bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1, 3).} =
   ## Returns an extracted (and shifted) slice of bits from `v`.
   runnableExamples:
     doAssert 0b10111.bitsliced(2 .. 4) == 0b101
@@ -73,7 +82,7 @@ func bitsliced*[T: SomeInteger](v: T; slice: Slice[int]): T {.inline, since: (1,
   let
     upmost = sizeof(T) * 8 - 1
     uv     = v.castToUnsigned
-  (uv shl (upmost - slice.b) shr (upmost - slice.b + slice.a)).T
+  ((uv shl (upmost - slice.b) and typeMask[T]()) shr (upmost - slice.b + slice.a)).T
 
 proc bitslice*[T: SomeInteger](v: var T; slice: Slice[int]) {.inline, since: (1, 3).} =
   ## Mutates `v` into an extracted (and shifted) slice of bits from `v`.
@@ -85,7 +94,7 @@ proc bitslice*[T: SomeInteger](v: var T; slice: Slice[int]) {.inline, since: (1,
   let
     upmost = sizeof(T) * 8 - 1
     uv     = v.castToUnsigned
-  v = (uv shl (upmost - slice.b) shr (upmost - slice.b + slice.a)).T
+  v = ((uv shl (upmost - slice.b) and typeMask[T]()) shr (upmost - slice.b + slice.a)).T
 
 func toMask*[T: SomeInteger](slice: Slice[int]): T {.inline, since: (1, 3).} =
   ## Creates a bitmask based on a slice of bits.
@@ -96,7 +105,7 @@ func toMask*[T: SomeInteger](slice: Slice[int]): T {.inline, since: (1, 3).} =
   let
     upmost = sizeof(T) * 8 - 1
     bitmask = bitnot(0.T).castToUnsigned
-  (bitmask shl (upmost - slice.b + slice.a) shr (upmost - slice.b)).T
+  ((bitmask shl (upmost - slice.b + slice.a) and typeMask[T]()) shr (upmost - slice.b)).T
 
 proc masked*[T: SomeInteger](v, mask :T): T {.inline, since: (1, 3).} =
   ## Returns `v`, with only the `1` bits from `mask` matching those of

--- a/tests/stdlib/t21564.nim
+++ b/tests/stdlib/t21564.nim
@@ -1,8 +1,4 @@
 discard """
-nimout: "OK"
-output: '''
-OK
-'''
 targets: "c js"
 """
 
@@ -10,21 +6,21 @@ import bitops
 import std/assertions
 
 proc main() =
-  # tesk bitops.bitsliced patch
-  doAssert(0x17.bitsliced(4..7) == 0x01)
-  doAssert(0x17.bitsliced(0..3) == 0x07)
+  block: # bug #21564
+    # tesk `bitops.bitsliced` patch
+    doAssert(0x17.bitsliced(4..7) == 0x01)
+    doAssert(0x17.bitsliced(0..3) == 0x07)
 
-  # test in-place bitops.bitslice
-  var t = 0x12F4
-  t.bitslice(4..7)
+  block:
+    # test in-place `bitops.bitslice`
+    var t = 0x12F4
+    t.bitslice(4..7)
 
-  doAssert(t == 0xF)
+    doAssert(t == 0xF)
 
-  # test bitops.toMask patch via bitops.masked
-  doAssert(0x12FFFF34.masked(8..23) == 0x00FFFF00)
-
-
-  echo "OK"
+  block:
+    # test `bitops.toMask` patch via bitops.masked
+    doAssert(0x12FFFF34.masked(8..23) == 0x00FFFF00)
 
 main()
 

--- a/tests/stdlib/t21564.nim
+++ b/tests/stdlib/t21564.nim
@@ -1,0 +1,31 @@
+discard """
+nimout: "OK"
+output: '''
+OK
+'''
+"""
+
+import bitops
+import std/assertions
+
+proc main() =
+  # tesk bitops.bitsliced patch
+  doAssert(0x17.bitsliced(4..7) == 0x01)
+  doAssert(0x17.bitsliced(0..3) == 0x07)
+
+  # test in-place bitops.bitslice
+  var t = 0x12F4
+  t.bitslice(4..7)
+
+  doAssert(t == 0xF)
+
+  # test bitops.toMask patch via bitops.masked
+  doAssert(0x12FFFF34.masked(8..23) == 0x00FFFF00)
+
+
+  echo "OK"
+
+main()
+
+static:
+  main()

--- a/tests/stdlib/t21564.nim
+++ b/tests/stdlib/t21564.nim
@@ -3,6 +3,7 @@ nimout: "OK"
 output: '''
 OK
 '''
+targets: "c js"
 """
 
 import bitops


### PR DESCRIPTION
Typecasts on the JavaScript backend do not function the same way as they do on C and C++ backends, so for bitwise operations we may need to mask them back down into their allowed range when they get shifted outside it. This is done by shifting a 1111... bitmask into the size of the target type and masking left shifted values down. For other backends, the value is passed through untouched.

This fixes #21564 (bitops.bitsliced) and two other related but unreported bugs in bitops.bitslice and bitops.toMask (which in turn affects bitops.masked, bitops.setMasked and maybe others).

~~I'm not sure how to explicitely instruct Koch to test for the JS backend if it's possible, but manually verifying the testcase via NodeJS works as expected.~~