### PR TITLE
always show call convention when printing proc type

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -723,7 +723,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         if i < t.len - 1: result.add(", ")
       result.add(')')
       if t.len > 0 and t[0] != nil: result.add(": " & typeToString(t[0]))
-      var prag = if t.callConv == ccNimCall and tfExplicitCallConv notin t.flags: "" else: $t.callConv
+      var prag = $t.callConv
       if tfNoSideEffect in t.flags:
         addSep(prag)
         prag.add("noSideEffect")


### PR DESCRIPTION
refs https://forum.nim-lang.org/t/10060