### PR TITLE
Fixed `window.find` return

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1503,7 +1503,7 @@ proc confirm*(w: Window, msg: cstring): bool
 proc disableExternalCapture*(w: Window)
 proc enableExternalCapture*(w: Window)
 proc find*(w: Window, text: cstring, caseSensitive = false,
-           backwards = false)
+           backwards = false): bool
 proc focus*(w: Window)
 proc forward*(w: Window)
 proc getComputedStyle*(w: Window, e: Node, pe: Node = nil): Style


### PR DESCRIPTION
The `window.find` returns a boolean value, and it is needed to make something like this works:
```nim
while window.find "text":
  echo "found!"
```

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Window/find#return_value