### PR TITLE
remove useVersion

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -1065,29 +1065,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "expandarc":
     expectArg(conf, switch, arg, pass, info)
     conf.arcToExpand[arg] = "T"
-  of "useversion":
-    expectArg(conf, switch, arg, pass, info)
-    case arg
-    of "1.0":
-      defineSymbol(conf.symbols, "NimMajor", "1")
-      defineSymbol(conf.symbols, "NimMinor", "0")
-      # old behaviors go here:
-      defineSymbol(conf.symbols, "nimOldRelativePathBehavior")
-      undefSymbol(conf.symbols, "nimDoesntTrackDefects")
-      ast.eqTypeFlags.excl {tfGcSafe, tfNoSideEffect}
-      conf.globalOptions.incl optNimV1Emulation
-    of "1.2":
-      defineSymbol(conf.symbols, "NimMajor", "1")
-      defineSymbol(conf.symbols, "NimMinor", "2")
-      conf.globalOptions.incl optNimV12Emulation
-    of "1.6":
-      defineSymbol(conf.symbols, "NimMajor", "1")
-      defineSymbol(conf.symbols, "NimMinor", "6")
-      conf.globalOptions.incl optNimV16Emulation
-    else:
-      localError(conf, info, "unknown Nim version; currently supported values are: `1.0`, `1.2`")
-    # always be compatible with 1.x.100:
-    defineSymbol(conf.symbols, "NimPatch", "100")
   of "benchmarkvm":
     processOnOffSwitchG(conf, {optBenchmarkVM}, arg, pass, info)
   of "profilevm":

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -102,9 +102,6 @@ type                          # please make sure we have under 32 options
     optBenchmarkVM            # Enables cpuTime() in the VM
     optProduceAsm             # produce assembler code
     optPanics                 # turn panics (sysFatal) into a process termination
-    optNimV1Emulation         # emulate Nim v1.0
-    optNimV12Emulation        # emulate Nim v1.2
-    optNimV16Emulation        # emulate Nim v1.6
     optSourcemap
     optProfileVM              # enable VM profiler
     optEnableDeepCopy         # ORC specific: enable 'deepcopy' for all types.

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -396,7 +396,7 @@ proc addRaiseEffect(a: PEffects, e, comesFrom: PNode) =
     if sameType(a.graph.excType(aa[i]), a.graph.excType(e)): return
 
   if e.typ != nil:
-    if optNimV1Emulation in a.config.globalOptions or not isDefectException(e.typ):
+    if not isDefectException(e.typ):
       throws(a.exc, e, comesFrom)
 
 proc addTag(a: PEffects, e, comesFrom: PNode) =

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -130,8 +130,8 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     e.typ = result
     e.position = int(counter)
     let symNode = newSymNode(e)
-    if optNimV1Emulation notin c.config.globalOptions and identToReplace != nil and
-        c.config.cmd notin cmdDocLike: # A hack to produce documentation for enum fields.
+    if identToReplace != nil and c.config.cmd notin cmdDocLike:
+      # A hack to produce documentation for enum fields.
       identToReplace[] = symNode
     if e.position == 0: hasNull = true
     if result.sym != nil and sfExported in result.sym.flags:
@@ -1398,8 +1398,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       addParamOrResult(c, arg, kind)
       styleCheckDef(c, a[j].info, arg)
       onDef(a[j].info, arg)
-      if {optNimV1Emulation, optNimV12Emulation} * c.config.globalOptions == {}:
-        a[j] = newSymNode(arg)
+      a[j] = newSymNode(arg)
 
   var r: PType
   if n[0].kind != nkEmpty:
@@ -1761,7 +1760,7 @@ proc semProcTypeWithScope(c: PContext, n: PNode,
   if n[1].kind != nkEmpty and n[1].len > 0:
     pragma(c, s, n[1], procTypePragmas)
     when useEffectSystem: setEffectsForProcType(c.graph, result, n[1])
-  elif c.optionStack.len > 0 and optNimV1Emulation notin c.config.globalOptions:
+  elif c.optionStack.len > 0:
     # we construct a fake 'nkProcDef' for the 'mergePragmas' inside 'implicitPragmas'...
     s.ast = newTree(nkProcDef, newNodeI(nkEmpty, n.info), newNodeI(nkEmpty, n.info),
         newNodeI(nkEmpty, n.info), newNodeI(nkEmpty, n.info), newNodeI(nkEmpty, n.info))

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1295,7 +1295,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     of tyNil: result = isNone
     else: discard
   of tyOrdinal:
-    if isOrdinalType(a, allowEnumWithHoles = optNimV1Emulation in c.c.config.globalOptions):
+    if isOrdinalType(a):
       var x = if a.kind == tyOrdinal: a[0] else: a
       if f[0].kind == tyNone:
         result = isGeneric

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -169,7 +169,6 @@ Advanced options:
                             enable experimental language feature
   --legacy:$2
                             enable obsolete/legacy language feature
-  --useVersion:1.0|1.2|1.6  emulate Nim version X of the Nim compiler, for testing
   --benchmarkVM:on|off      turn benchmarking of VM code with cpuTime() on|off
   --profileVM:on|off        turn compile time VM profiler on|off
   --sinkInference:on|off    turn sink parameter inference on|off (default: off)

--- a/lib/std/private/since.nim
+++ b/lib/std/private/since.nim
@@ -1,5 +1,5 @@
 ##[
-`since` is used to emulate older versions of nim stdlib with `--useVersion`,
+`since` is used to emulate older versions of nim stdlib,
 see `tuse_version.nim`.
 
 If a symbol `foo` is added in version `(1,3,5)`, use `{.since: (1.3.5).}`, not

--- a/tests/system/tuse_version.nim
+++ b/tests/system/tuse_version.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--useVersion:1.0"
+  matrix: "-d:NimMajor=1 -d:NimMinor=0 -d:NimPatch=100"
 """
 
 {.warning[UnusedImport]: off.}

--- a/tests/system/tuse_version16.nim
+++ b/tests/system/tuse_version16.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--useVersion:1.6"
+  matrix: "-d:NimMajor=1 -d:NimMinor=6 -d:NimPatch=100"
 """
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
originally discussed in https://github.com/nim-lang/Nim/pull/21472

This feature did 2 things: 1. changed the `NimMajor`, `NimMinor` etc constants to the given version, 2. activate some legacy features (mostly for 1.0) which could probably be behind the `--legacy` flag. The first one can be done with `-d:NimMajor=1 -d:NimMinor=6` etc which I guess might not be stable but I can't really think of a use case for it. The second one doesn't seem to have any legacy features worth keeping as an option (the only notable one to me is defect tracking), but if there is we could port them to `--legacy`.