### PR TITLE
Fix option lists with additional indentation in Markdown

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -2447,7 +2447,9 @@ proc parseParagraph(p: var RstParser, result: PRstNode) =
           result.addIfNotNil(parseLineBlock(p))
         of rnMarkdownBlockQuote:
           result.addIfNotNil(parseMarkdownBlockQuote(p))
-        else: break
+        else:
+          dec p.idx  # allow subsequent block to be parsed as another section
+          break
       else:
         break
     of tkPunct:

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -689,6 +689,32 @@ suite "RST parsing":
                 rnLeaf  'desc2'
       """)
 
+  test "definition lists work correctly with additional indentation in Markdown":
+    check(dedent"""
+        Paragraph:
+          -c  desc1
+          -b  desc2
+        """.toAst() ==
+      dedent"""
+        rnInner
+          rnInner
+            rnLeaf  'Paragraph'
+            rnLeaf  ':'
+          rnOptionList
+            rnOptionListItem  order=1
+              rnOptionGroup
+                rnLeaf  '-'
+                rnLeaf  'c'
+              rnDescription
+                rnLeaf  'desc1'
+            rnOptionListItem  order=2
+              rnOptionGroup
+                rnLeaf  '-'
+                rnLeaf  'b'
+              rnDescription
+                rnLeaf  'desc2'
+      """)
+
   test "RST comment":
     check(dedent"""
         .. comment1


### PR DESCRIPTION
This is more Markdown-ish way to fix issue #21055, than PR #21625. It does not enable RST definition lists, instead it makes adding additional indentation (less than 4) right after a paragraph be ignored, as it's done for all block elements in Markdown. (In this case this tenet is applied to option lists that are not part of CommonMark spec by themselves).

So unlike #21625 it all won't be parsed as definition list, just 2 normal sections:
![image](https://user-images.githubusercontent.com/1299583/230759693-6364f0a6-f3bb-47c7-8689-819087c9d90e.png)
