### PR TITLE
fixes #21632; enforce deref for `wasMoved` in ORC

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2339,7 +2339,7 @@ proc genWasMoved(p: BProc; n: PNode) =
   if p.withinBlockLeaveActions > 0 and notYetAlive(n1):
     discard
   else:
-    initLocExpr(p, n1, a)
+    initLocExpr(p, n1, a, {lfEnforceDeref})
     resetLoc(p, a)
     #linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
     #  [addrLoc(p.config, a), getTypeDesc(p.module, a.t)])

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -61,12 +61,12 @@ proc findPendingModule(m: BModule, s: PSym): BModule =
     var ms = getModule(s)
     result = m.g.modules[ms.position]
 
-proc initLoc(result: var TLoc, k: TLocKind, lode: PNode, s: TStorageLoc) =
+proc initLoc(result: var TLoc, k: TLocKind, lode: PNode, s: TStorageLoc, flags: TLocFlags = {}) =
   result.k = k
   result.storage = s
   result.lode = lode
   result.r = ""
-  result.flags = {}
+  result.flags = flags
 
 proc fillLoc(a: var TLoc, k: TLocKind, lode: PNode, r: Rope, s: TStorageLoc) {.inline.} =
   # fills the loc if it is not already initialized
@@ -698,8 +698,8 @@ proc genLiteral(p: BProc, n: PNode; result: var Rope)
 proc genOtherArg(p: BProc; ri: PNode; i: int; typ: PType; result: var Rope; argsCounter: var int)
 proc raiseExit(p: BProc)
 
-proc initLocExpr(p: BProc, e: PNode, result: var TLoc) =
-  initLoc(result, locNone, e, OnUnknown)
+proc initLocExpr(p: BProc, e: PNode, result: var TLoc, flags: TLocFlags = {}) =
+  initLoc(result, locNone, e, OnUnknown, flags)
   expr(p, e, result)
 
 proc initLocExprSingleUse(p: BProc, e: PNode, result: var TLoc) =

--- a/tests/stdlib/tpegs.nim
+++ b/tests/stdlib/tpegs.nim
@@ -328,7 +328,16 @@ call()
       doAssert program.len == program.rawMatch(grammar, 0, c)
       doAssert c.ml == 1
 
+    block:
+      # bug #21632
+
+      let p = peg"""
+        atext <- \w / \d
+      """
+
+      doAssert "a".match(p)
+      doAssert "1".match(p)
+
   pegsTest()
   static:
     pegsTest()
-


### PR DESCRIPTION
fixes #21632

`wasMoved(ref.set[])` can cause leaks. It doesn't work for `ref array` types. You cannot reset the value of `ref array` type. Otherwise the pointer is lost, the destructor cannot function properly.

`wasMoved(ref.set[])` is wrong because the deref is ignored for in the backend,
which means `wasMoved(ref.set[])` becomes `wasMoved(ref.set)` since it is ctPtrArray
we can simply not generate destructorCall for sets.

As mentioned in the issue, this example shows why it can cause leaks.
```nim
type
  Peg = object
    data: ref set[char]

proc foo =
  var x = Peg()
  new x.data
  x.data[] = {'1', '2'}
  wasMoved(x.data[])

foo()
```
`wasMoved(x.data[])` becomes `wasMoved(x.data)` in the backend. The destructor cannot destroy `x.data` since the pointer to `x.data` has been lost.
```
==6980== 40 bytes in 1 blocks are definitely lost in loss record 1 of 1
==6980==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==6980==    by 0x10AAD9: alloc0Impl__system_1770 (malloc.nim:11)
==6980==    by 0x10AAEB: allocShared0Impl__system_1783 (malloc.nim:37)
==6980==    by 0x10D0C8: alignedAlloc0__system_1942 (memalloc.nim:351)
==6980==    by 0x10C07B: nimNewObj (arc.nim:66)
==6980==    by 0x110775: foo__test5048_3 (test20.nim:13)
==6980==    by 0x1108B3: NimMainModule (test20.nim:17)
==6980==    by 0x110901: NimMainInner (test20.nim:34)
==6980==    by 0x110918: NimMain (test20.nim:45)
==6980==    by 0x11093E: main (test20.nim:53)
```