### PR TITLE
custom pragmas: correct error condition, remove outdated symkind whitelist

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1261,7 +1261,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
     elif comesFromPush and whichKeyword(ident) != wInvalid:
       discard "ignore the .push pragma; it doesn't apply"
     else:
-      # semCustomPragma still gives appropriate error for invalid pragmas
+      # semCustomPragma gives appropriate error for invalid pragmas
       n[i] = semCustomPragma(c, it, sym)
 
 proc overwriteLineInfo(n: PNode; info: TLineInfo) =

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1248,11 +1248,9 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
     elif comesFromPush and whichKeyword(ident) != wInvalid:
       discard "ignore the .push pragma; it doesn't apply"
     else:
-      if sym == nil or (sym.kind in {skVar, skLet, skConst, skParam, skIterator,
-                        skField, skProc, skFunc, skConverter, skMethod, skType}):
+      if sym != nil:
+        # semCustomPragma still gives appropriate error for invalid pragmas
         n[i] = semCustomPragma(c, it)
-      elif sym != nil:
-        illegalCustomPragma(c, it, sym)
       else:
         invalidPragma(c, it)
 

--- a/tests/pragmas/t8741.nim
+++ b/tests/pragmas/t8741.nim
@@ -1,7 +1,7 @@
 discard """
   cmd: "nim check --hint:processing:off $file"
   errormsg: "3 is not two"
-  nimout: '''t8741.nim(13, 9) Error: cannot attach a custom pragma to 'a'
+  nimout: '''t8741.nim(13, 9) Error: invalid pragma: foobar
 t8741.nim(29, 15) template/generic instantiation of `onlyTwo` from here
 t8741.nim(25, 12) Error: 3 is not two
 '''

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -399,12 +399,39 @@ block:
 
   discard Hello(a: 1.0, b: 12)
 
-# custom pragma on iterators
+# test routines
+block:
+  template prag {.pragma.}
+  proc hello {.prag.} = discard
+  iterator hello2: int {.prag.} = discard
+  template hello3(x: int): int {.prag.} = x
+  macro hello4(x: int): int {.prag.} = x
+  func hello5(x: int): int {.prag.} = x
+  doAssert hello.hasCustomPragma(prag)
+  doAssert hello2.hasCustomPragma(prag)
+  doAssert hello3.hasCustomPragma(prag)
+  doAssert hello4.hasCustomPragma(prag)
+  doAssert hello5.hasCustomPragma(prag)
+
+# test push doesn't break
 block:
   template prag {.pragma.}
   {.push prag.}
   proc hello = discard
   iterator hello2: int = discard
+  template hello3(x: int): int = x
+  macro hello4(x: int): int = x
+  func hello5(x: int): int = x
+  type
+    Foo = enum a
+    Bar[T] = ref object of RootObj
+      x: T
+      case y: bool
+      of false: discard
+      else:
+        when true: discard
+  for a in [1]: discard a
+  {.pop.}
 
 # issue #11511
 when false:

--- a/tests/pragmas/tinvalidcustompragma.nim
+++ b/tests/pragmas/tinvalidcustompragma.nim
@@ -1,0 +1,23 @@
+discard """
+  cmd: "nim check $file"
+"""
+
+# issue #21652
+type Foo = object
+template foo() {.tags:[Foo].} = #[tt.Error
+                     ^ invalid pragma: tags: [Foo]]#
+  discard
+
+{.foobar.} #[tt.Error
+  ^ invalid pragma: foobar]#
+type A = enum a {.foobar.} #[tt.Error
+                  ^ invalid pragma: foobar]#
+for b {.foobar.} in [1]: discard #[tt.Error
+        ^ invalid pragma: foobar]#
+template foobar {.pragma.}
+{.foobar.} #[tt.Error
+  ^ cannot attach a custom pragma to 'tinvalidcustompragma'; custom pragmas are not supported for modules]#
+type A = enum a {.foobar.} #[tt.Error
+                  ^ cannot attach a custom pragma to 'a'; custom pragmas are not supported for enum fields]#
+for b {.foobar.} in [1]: discard #[tt.Error
+        ^ cannot attach a custom pragma to 'b'; custom pragmas are not supported for `for` loop variables]#

--- a/tests/pragmas/ttemplateinvalidpragma.nim
+++ b/tests/pragmas/ttemplateinvalidpragma.nim
@@ -1,0 +1,8 @@
+# issue #21652
+
+type
+  Foo = object
+
+template foo() {.tags:[Foo].} = #[tt.Error
+                     ^ invalid pragma: tags: [Foo]]#
+  discard

--- a/tests/pragmas/ttemplateinvalidpragma.nim
+++ b/tests/pragmas/ttemplateinvalidpragma.nim
@@ -1,8 +1,0 @@
-# issue #21652
-
-type
-  Foo = object
-
-template foo() {.tags:[Foo].} = #[tt.Error
-                     ^ invalid pragma: tags: [Foo]]#
-  discard

--- a/tests/stdlib/tsince.nim
+++ b/tests/stdlib/tsince.nim
@@ -27,7 +27,6 @@ doAssert ok
 since (99, 3):
   doAssert false
 
-when false:
-  # pending bug #15920
-  # Error: cannot attach a custom pragma to 'fun3'
-  template fun3(): int {.since: (1, 3).} = 12
+template fun3(): int {.since: (1, 3).} = 12
+
+doAssert declared(fun3)


### PR DESCRIPTION
fixes #21652

Along with fixing the error message, instead of using a whitelist of symbol kinds for custom pragmas, use a blacklist of ones that do not work, so we don't have to keep maintaining this list as much (a symbol kind that does not support custom pragmas silently accepts it in the worst case). Currently this is enum fields, `for` loop variables (both because they do not retain pragma AST after semcheck) and module symbols (as it's not handled). We can also whitelist `PragmaApplicableSymKinds - {skEnumField, skForVar, skModule}` instead to make it more restrictive, but again in the worst case with the blacklist it is just silently accepted.

<details>
<summary>Description for previous patch in this PR</summary>

The symbol kinds you could previously not apply custom pragmas to were:

```
skModule
skMacro
skTemplate
skEnumField
skForVar

probably cannot attach pragmas to but still not checked for:
skGenericParam, skResult
skTemp, skUnknown, skConditional, skDynLib, skLabel, skStub, skPackage
```

Now trying to apply a nonexistant pragma to these symbols will give a proper "invalid pragma" error instead of the "cannot attach custom pragma" error.

This way of doing it will attempt to "attach" existing custom pragmas to these symbol kinds, which should not be a problem for macros and templates, but just swallow the custom pragmas without erroring likely as semchecking removes the pragma AST down the line.

```nim
import macros

template prag {.pragma.}

type Foo = enum
  a {.prag.}

echo hasCustomPragma(a, prag) # false
for b {.prag.} in [123]:
  echo hasCustomPragma(b, prag) # false

template c(x: int): int {.prag.} = x
echo hasCustomPragma(c, prag) # true

macro d(x: int): int {.prag.} = x
echo hasCustomPragma(d, prag) # true

# this just has no way of working
{.prag.}
echo hasCustomPragma(modulename, prag) # false
```

We don't have to fix #21652 this way, there is an easy patch of delaying the "cannot attach custom pragma" error until we succeed in finding the custom pragma in `semCustomPragma`, but I want to test this "swallowing" behavior against CI first to see if it breaks anything.
</details>