### PR TITLE
make grammar a bit more honest

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1717,9 +1717,9 @@ proc parseIfOrWhen(p: var Parser, kind: TNodeKind): PNode =
   setEndInfo()
 
 proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
-  #| condExpr = expr colcom expr optInd
-  #|         ('elif' expr colcom expr optInd)*
-  #|          'else' colcom expr
+  #| condExpr = expr colcom stmt optInd
+  #|         ('elif' expr colcom stmt optInd)*
+  #|          'else' colcom stmt
   #| ifExpr = 'if' condExpr
   #| whenExpr = 'when' condExpr
   result = newNodeP(kind, p)
@@ -1729,7 +1729,7 @@ proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
     optInd(p, branch)
     branch.add(parseExpr(p))
     colcom(p, branch)
-    branch.add(parseExpr(p))
+    branch.add(parseStmt(p))
     skipComment(p, branch)
     result.add(branch)
     if p.tok.tokType != tkElif: break
@@ -1737,7 +1737,7 @@ proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
     var branch = newNodeP(nkElseExpr, p)
     eat(p, tkElse)
     colcom(p, branch)
-    branch.add(parseExpr(p))
+    branch.add(parseStmt(p))
     result.add(branch)
   setEndInfo()
 

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -321,7 +321,7 @@ proc checkBinary(p: Parser) {.inline.} =
 #| operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
 #|          | 'or' | 'xor' | 'and'
 #|          | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from'
-#|          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
+#|          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | '..'
 #|
 #| prefixOperator = operator
 #|
@@ -1729,7 +1729,7 @@ proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
     optInd(p, branch)
     branch.add(parseExpr(p))
     colcom(p, branch)
-    branch.add(parseStmt(p))
+    branch.add(parseExpr(p))
     skipComment(p, branch)
     result.add(branch)
     if p.tok.tokType != tkElif: break
@@ -1737,7 +1737,7 @@ proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
     var branch = newNodeP(nkElseExpr, p)
     eat(p, tkElse)
     colcom(p, branch)
-    branch.add(parseStmt(p))
+    branch.add(parseExpr(p))
     result.add(branch)
   setEndInfo()
 

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -26,13 +26,14 @@ operatorB = OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9 |
             'div' | 'mod' | 'shl' | 'shr' | 'in' | 'notin' |
             'is' | 'isnot' | 'not' | 'of' | 'as' | 'from' | '..' | 'and' | 'or' | 'xor'
 symbol = '`' (KEYW|IDENT|literal|(operator|'('|')'|'['|']'|'{'|'}'|'=')+)+ '`'
-       | IDENT | KEYW
+       | IDENT | 'addr' | 'type' | 'static'
+symbolOrKeyword = symbol | KEYW
 exprColonEqExpr = expr (':'|'=' expr)?
 exprEqExpr = expr ('=' expr)?
 exprList = expr ^+ comma
 optionalExprList = expr ^* comma
 exprColonEqExprList = exprColonEqExpr (comma exprColonEqExpr)* (comma)?
-qualifiedIdent = symbol ('.' optInd symbol)?
+qualifiedIdent = symbol ('.' optInd symbolOrKeyword)?
 setOrTableConstr = '{' ((exprColonEqExpr comma)* | ':' ) '}'
 castExpr = 'cast' ('[' optInd typeDesc optPar ']' '(' optInd expr optPar ')') /
 parKeyw = 'discard' | 'include' | 'if' | 'while' | 'case' | 'try'
@@ -58,13 +59,13 @@ identOrLiteral = generalizedLit | symbol | literal
 tupleConstr = '(' optInd (exprColonEqExpr comma?)* optPar ')'
 arrayConstr = '[' optInd (exprColonEqExpr comma?)* optPar ']'
 primarySuffix = '(' (exprColonEqExpr comma?)* ')'
-      | '.' optInd symbol ('[:' exprList ']' ( '(' exprColonEqExpr ')' )?)? generalizedLit?
-      | DOTLIKEOP optInd symbol generalizedLit?
+      | '.' optInd symbolOrKeyword ('[:' exprList ']' ( '(' exprColonEqExpr ')' )?)? generalizedLit?
+      | DOTLIKEOP optInd symbolOrKeyword generalizedLit?
       | '[' optInd exprColonEqExprList optPar ']'
       | '{' optInd exprColonEqExprList optPar '}'
 pragma = '{.' optInd (exprColonEqExpr comma?)* optPar ('.}' | '}')
 identVis = symbol OPR?  # postfix position
-identVisDot = symbol '.' optInd symbol OPR?
+identVisDot = symbol '.' optInd symbolOrKeyword OPR?
 identWithPragma = identVis pragma?
 identWithPragmaDot = identVisDot pragma?
 declColonEquals = identWithPragma (comma identWithPragma)* comma?

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -135,9 +135,9 @@ condStmt = expr colcom stmt COMMENT?
            (IND{=} 'else' colcom stmt)?
 ifStmt = 'if' condStmt
 whenStmt = 'when' condStmt
-condExpr = expr colcom expr optInd
-        ('elif' expr colcom expr optInd)*
-         'else' colcom expr
+condExpr = expr colcom stmt optInd
+        ('elif' expr colcom stmt optInd)*
+         'else' colcom stmt
 ifExpr = 'if' condExpr
 whenExpr = 'when' condExpr
 whileStmt = 'while' expr colcom stmt

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -7,7 +7,7 @@ colcom = ':' COMMENT?
 operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
          | 'or' | 'xor' | 'and'
          | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from'
-         | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
+         | 'div' | 'mod' | 'shl' | 'shr' | 'not' | '..'
 prefixOperator = operator
 optInd = COMMENT? IND?
 optPar = (IND{>} | IND{=})?


### PR DESCRIPTION
refs #19802

`static` is not an operator in any capacity (maybe it was before), and `ifExpr` actually parses `stmt`.

`symbol` only allows `KEYW` when parsing the RHS of dotlike expressions, so this `KEYW` is removed from `symbol` and moved to `symbolOrKeyword`. There is also a version that allows `nil` but this is only used by `distinct with` which is not documented at all (and also basically never parses, `distinct enum with foo` works but not `distinct T with foo`).