### PR TITLE
set module symbol type to None instead of nil for discard check

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1353,6 +1353,12 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     markUsed(c, n.info, s)
     onUse(n.info, s)
     result = newSymNode(s, n.info)
+  of skModule:
+    # make sure type is None and not nil for discard checking
+    s.typ = newTypeS(tyNone, c)
+    markUsed(c, n.info, s)
+    onUse(n.info, s)
+    result = newSymNode(s, n.info)
   else:
     let info = getCallLineInfo(n)
     #if efInCall notin flags:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1355,7 +1355,7 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     result = newSymNode(s, n.info)
   of skModule:
     # make sure type is None and not nil for discard checking
-    s.typ = newTypeS(tyNone, c)
+    if efWantStmt in flags: s.typ = newTypeS(tyNone, c)
     markUsed(c, n.info, s)
     onUse(n.info, s)
     result = newSymNode(s, n.info)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -161,18 +161,19 @@ proc discardCheck(c: PContext, result: PNode, flags: TExprFlags) =
       if result.typ.kind == tyNone:
         localError(c.config, result.info, "expression has no type: " &
                renderTree(result, {renderNoComments}))
-      var n = result
-      while n.kind in skipForDiscardable:
-        if n.kind == nkTryStmt: n = n[0]
-        else: n = n.lastSon
-      var s = "expression '" & $n & "' is of type '" &
-          result.typ.typeToString & "' and has to be used (or discarded)"
-      if result.info.line != n.info.line or
-          result.info.fileIndex != n.info.fileIndex:
-        s.add "; start of expression here: " & c.config$result.info
-      if result.typ.kind == tyProc:
-        s.add "; for a function call use ()"
-      localError(c.config, n.info, s)
+      else:
+        var n = result
+        while n.kind in skipForDiscardable:
+          if n.kind == nkTryStmt: n = n[0]
+          else: n = n.lastSon
+        var s = "expression '" & $n & "' is of type '" &
+            result.typ.typeToString & "' and has to be used (or discarded)"
+        if result.info.line != n.info.line or
+            result.info.fileIndex != n.info.fileIndex:
+          s.add "; start of expression here: " & c.config$result.info
+        if result.typ.kind == tyProc:
+          s.add "; for a function call use ()"
+        localError(c.config, n.info, s)
 
 proc semIf(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil): PNode =
   result = n

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -222,7 +222,10 @@ proc extractErrorMsg(s: string; i: int; line: var int; col: var int; spec: var T
 
   while result < s.len-1:
     if s[result] == '\n':
-      msg.add '\n'
+      if result > 0 and s[result - 1] == '\r':
+        msg[^1] = '\n'
+      else:
+        msg.add '\n'
       inc result
       inc line
       col = 1

--- a/tests/modules/tmodulesymtype.nim
+++ b/tests/modules/tmodulesymtype.nim
@@ -1,0 +1,15 @@
+discard """
+cmd: "nim check $file"
+"""
+
+# bug #19225
+import std/sequtils
+sequtils #[tt.Error
+^ expression has no type: sequtils]#
+proc foo() =
+  block: #[tt.Error
+  ^ expression has no type: block:
+  sequtils]#
+    sequtils
+
+foo()


### PR DESCRIPTION
fixes #19225, closes #20469, closes #21484

Module symbols are created with type `nil` which the compiler accepts as a valid `void` statement. To circumvent this, set their type to `tyNone` when the module symbol gets semchecked in `semSym`. To prevent the use of module symbols in cases where `tyNone` is accepted, this also is currently restricted to the expression flag `efWantStmt`.

Other changes:

Now the "expression has no type" error doesn't cascade into another "expression has type None and must be used or discarded" error with `nim check` etc.

Testament turns `\r\n` into `\n` in `tt.*` comments now as this made multiline `tt.*` comments not work on Windows. 