### PR TITLE
fixes #7002; do subtype checking for derived object assignments in ORC; make it consistent with refc

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -371,6 +371,11 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
     if ty.isImportedCppType:
       linefmt(p, cpsStmts, "$1 = $2;$n", [rdLoc(dest), rdLoc(src)])
     elif not isObjLackingTypeField(ty):
+      if optSeqDestructors in p.config.globalOptions:
+        linefmt(p, cpsStmts, "#chckObjAsgn($1, $2);$n",
+              [genTypeInfoV2(p.module, dest.t, dest.lode.info),
+               addrLoc(p.config, src)
+              ])
       genGenericAsgn(p, dest, src, flags)
     elif containsGarbageCollectedRef(ty):
       if ty[0].isNil and asgnComplexity(ty.n) <= 4:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -371,7 +371,9 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
     if ty.isImportedCppType:
       linefmt(p, cpsStmts, "$1 = $2;$n", [rdLoc(dest), rdLoc(src)])
     elif not isObjLackingTypeField(ty):
-      if optSeqDestructors in p.config.globalOptions:
+      if optSeqDestructors in p.config.globalOptions and
+          not (needToCopy notin flags and
+                 dest.storage == OnStack):
         linefmt(p, cpsStmts, "#chckObjAsgn($1, $2);$n",
               [genTypeInfoV2(p.module, dest.t, dest.lode.info),
                addrLoc(p.config, src)

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -194,7 +194,7 @@ proc GC_ref*[T](x: ref T) =
   ## New runtime only supports this operation for 'ref T'.
   if x != nil: nimIncRef(cast[pointer](x))
 
-proc chckObjAsgn(dest: PNimTypeV2, src: pointer) {.compilerproc, systemRaisesDefect.} =
+proc chckObjAsgn(dest: PNimTypeV2, src: pointer) {.compilerproc, systemRaisesDefect, inline.} =
   let srcTyp = cast[ptr PNimTypeV2](src)[]
   if srcTyp != nil and dest != srcTyp:
     sysFatal(ObjectAssignmentDefect, "invalid object assignment")

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -194,6 +194,11 @@ proc GC_ref*[T](x: ref T) =
   ## New runtime only supports this operation for 'ref T'.
   if x != nil: nimIncRef(cast[pointer](x))
 
+proc chckObjAsgn(dest: PNimTypeV2, src: pointer) {.compilerproc, systemRaisesDefect.} =
+  let srcTyp = cast[ptr PNimTypeV2](src)[]
+  if srcTyp != nil and dest != srcTyp:
+    sysFatal(ObjectAssignmentDefect, "invalid object assignment")
+
 when not defined(gcOrc):
   template GC_fullCollect* =
     ## Forces a full garbage collection pass. With `--gc:arc` a nop.

--- a/tests/objects/tobj_asgn_dont_slice.nim
+++ b/tests/objects/tobj_asgn_dont_slice.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:refc; --matrix:arc"
+  matrix: "--mm:refc; --mm:arc"
 """
 
 # bug #7637

--- a/tests/objects/tobj_asgn_dont_slice.nim
+++ b/tests/objects/tobj_asgn_dont_slice.nim
@@ -1,7 +1,5 @@
 discard """
-  matrix: "--mm:refc"
-  outputsub: '''ObjectAssignmentDefect'''
-  exitcode: "1"
+  matrix: "--mm:refc; --matrix:arc"
 """
 
 # bug #7637
@@ -20,6 +18,28 @@ method eat(f: Apple) =
 method eat(f: Pear) =
   echo "juicy"
 
-let basket = [Apple(name:"a"), Pear(name:"b")]
+doAssertRaises(ObjectAssignmentDefect):
+  proc foo =
+    let basket = [Apple(name:"a"), Pear(name:"b")]
+  foo()
 
-eat(basket[0])
+
+# bug #7002
+type
+    BaseObj = object of RootObj
+    DerivedObj = object of BaseObj
+
+method `$`(bo: BaseObj): string {.base.} =
+    return "Base"
+
+method `$`(dob: DerivedObj): string =
+    return "Derived"
+
+type Container = object
+    inner: BaseObj
+
+doAssertRaises(ObjectAssignmentDefect):
+  proc foo =
+    var dob = DerivedObj()
+    var cont = Container(inner: dob)
+  foo()


### PR DESCRIPTION
fixes #7002

As reported by @PhilippMDoerner on Discord
```nim
type 
  A = object of RootObj
    name: string

  B = object of A
    id: int

method i(x: A): int {.base.} = -3
method i(x: B): int = x.id

let x = B(id: 5, name: "Potato")
let y: A = x

echo x.i # 5
echo y.i # 1
```
Gives `5 1` in ORC, but it should give the `ObjectAssignmentDefect` error as refc.

Without subtype checking for objects, it might yield surprising results.