### PR TITLE
fixes #20232；indices now use `copyMem` and `moveMem`; much faster slicing and slicing assignments

### DIFF
--- a/lib/system/indices.nim
+++ b/lib/system/indices.nim
@@ -93,10 +93,10 @@ proc `[]`*[T, U: Ordinal](s: string, x: HSlice[T, U]): string {.inline, systemRa
   else:
     when notJSnotNims:
       if L > 0:
-        if b < s.len:
+        if b <= s.len:
           copyMem(addr result[0], addr s[a], L)
         else:
-          raiseIndexError3(b, 0, s.high)
+          raiseIndexError3(b, 0, s.len-1)
     else:
       impl()
 
@@ -122,12 +122,12 @@ proc `[]=`*[T, U: Ordinal](s: var string, x: HSlice[T, U], b: string) {.systemRa
     else:
       when notJSnotNims:
         if L > 0:
-          if xb < s.len:
+          if xb <= s.len:
             when defined(nimSeqsV2):
               prepareMutation(s)
             copyMem(addr s[a], addr b[0], L)
           else:
-            raiseIndexError3(xb, 0, s.high)
+            raiseIndexError3(xb, 0, s.len-1)
       else:
         impl()
   else:
@@ -151,10 +151,10 @@ proc `[]`*[Idx, T; U, V: Ordinal](a: array[Idx, T], x: HSlice[U, V]): seq[T] {.s
   else:
     when notJSnotNims and supportsCopyMem(T):
       if L > 0:
-        if xb < a.len:
+        if xb <= a.len:
           copyMem(addr result[0], addr a[Idx(xa)], sizeof(T) * L)
         else:
-          raiseIndexError3(xb, 0, a.high)
+          raiseIndexError3(xb, 0, a.len-1)
     else:
       impl()
 
@@ -176,10 +176,10 @@ proc `[]=`*[Idx, T; U, V: Ordinal](a: var array[Idx, T], x: HSlice[U, V], b: ope
     else:
       when notJSnotNims and supportsCopyMem(T):
         if L > 0:
-          if xb < a.len:
+          if xb <= a.len:
             moveMem(addr a[Idx(xa)], addr b[0], sizeof(T) * L)
           else:
-            raiseIndexError3(xb, 0, a.high)
+            raiseIndexError3(xb, 0, a.len-1)
       else:
         impl()
   else:
@@ -204,10 +204,10 @@ proc `[]`*[T; U, V: Ordinal](s: openArray[T], x: HSlice[U, V]): seq[T] {.systemR
   else:
     when notJSnotNims and supportsCopyMem(T):
       if L > 0:
-        if xb < s.len:
+        if xb <= s.len:
           copyMem(addr result[0], addr s[a], sizeof(T) * L)
         else:
-          raiseIndexError3(xb, 0, s.high)
+          raiseIndexError3(xb, 0, s.len-1)
     else:
       impl()
 
@@ -231,10 +231,10 @@ proc `[]=`*[T; U, V: Ordinal](s: var seq[T], x: HSlice[U, V], b: openArray[T]) {
     else:
       when notJSnotNims and supportsCopyMem(T):
         if L > 0:
-          if xb < s.len:
+          if xb <= s.len:
             moveMem(addr s[a], addr b[0], sizeof(T) * L)
           else:
-            raiseIndexError3(xb, 0, s.high)
+            raiseIndexError3(xb, 0, s.len-1)
       else:
         impl()
   else:


### PR DESCRIPTION
fixes #20232

```nim
import benchy

template `^^`(s, i: untyped): untyped =
  (when i is BackwardsIndex: s.len - int(i) else: int(i))

proc assign1*[T, U: Ordinal](s: var string, x: HSlice[T, U], b: string) =
  var a = s ^^ x.a
  var xb = s ^^ x.b
  var L = (xb) - a + 1
  if L == b.len:
    if L > 0:
      if xb <= s.len:
        when defined(nimSeqsV2):
          prepareMutation(s)
        copyMem(addr s[a], addr b[0], L)
      else:
        raise newException(IndexDefect, "defect")


proc assign2*[T, U: Ordinal](s: var string, x: HSlice[T, U], b: string) =
  var a = s ^^ x.a
  var L = (s ^^ x.b) - a + 1

  if L == b.len:
    if L > 0:
      for i in 0..<L: s[i+a] = b[i]

timeIt "copyMem":
  var s = "abcdefgh"
  for i in 0..1000000:
    assign1(s, 1 .. 3, "xyz")

timeIt "old":
  var s = "abcdefgh"
  for i in 0..1000000:
    assign2(s, 1 .. 3, "xyz")
```

A simple benchmark for string slice

`-d:release`

```
   min time    avg time  std dv   runs name
   0.545 ms    0.603 ms  ±0.017  x1000 copyMem
   1.594 ms    1.754 ms  ±0.256  x1000 old
```

`-d:danger`

```
   0.541 ms    0.591 ms  ±0.021  x1000 copyMem
   0.932 ms    0.957 ms  ±0.040  x1000 old
```

It uses `moveMem` for array and seq slice assignment because there is a possibility that the memory overlaps using toOpenArray, for example. I don't see it is probable for strings, isn't it?