### PR TITLE
stdlib tests now check refc too

### DIFF
--- a/tests/ccgbugs/t21116.nim
+++ b/tests/ccgbugs/t21116.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c cpp"
+  targets: "c cpp"
   disabled: windows
 """
 # bug #21116

--- a/tests/ccgbugs/tderefblock.nim
+++ b/tests/ccgbugs/tderefblock.nim
@@ -1,6 +1,5 @@
 discard """
-  cmd: "nim c -d:release -d:danger $file"
-  matrix: ";--gc:orc"
+  matrix: "--mm:refc -d:release -d:danger;--mm:orc -d:release -d:danger"
   output: "42"
 """
 

--- a/tests/coroutines/tgc.nim
+++ b/tests/coroutines/tgc.nim
@@ -1,6 +1,6 @@
 discard """
   matrix: "--gc:refc; --gc:arc; --gc:orc"
-  target: "c"
+  targets: "c"
 """
 
 when compileOption("gc", "refc") or not defined(openbsd):

--- a/tests/coroutines/twait.nim
+++ b/tests/coroutines/twait.nim
@@ -1,7 +1,7 @@
 discard """
   output: "Exit 1\nExit 2"
   matrix: "--gc:refc; --gc:arc; --gc:orc"
-  target: "c"
+  targets: "c"
 """
 
 when compileOption("gc", "refc") or not defined(openbsd):

--- a/tests/js/tsourcemap.nim
+++ b/tests/js/tsourcemap.nim
@@ -1,6 +1,6 @@
 discard """
   action: "run"
-  target: "js"
+  targets: "js"
   cmd: "nim js -r -d:nodejs $options --sourceMap:on $file"
 """
 import std/[os, json, strutils, sequtils, algorithm, assertions, paths, compilesettings]

--- a/tests/parallel/t10913.nim
+++ b/tests/parallel/t10913.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:rec; --mm:orc"
+  matrix: "--mm:refc; --mm:orc"
   errormsg: "'spawn'ed function cannot have a 'typed' or 'untyped' parameter"
 """
 

--- a/tests/parallel/t10913.nim
+++ b/tests/parallel/t10913.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:rec; --mm:orc"
   errormsg: "'spawn'ed function cannot have a 'typed' or 'untyped' parameter"
 """
 

--- a/tests/parallel/t7535.nim
+++ b/tests/parallel/t7535.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:refc; --mm:orc"
   errormsg: "'spawn' takes a call expression; got: proc (x: uint32) = echo [x]"
 """
 

--- a/tests/parallel/t9691.nim
+++ b/tests/parallel/t9691.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:refc; --mm:orc"
   errormsg: "'spawn'ed function cannot have a 'typed' or 'untyped' parameter"
 """
 

--- a/tests/specialops/terrmsgs.nim
+++ b/tests/specialops/terrmsgs.nim
@@ -1,7 +1,7 @@
 discard """
 action: reject
 cmd: '''nim check $options $file'''
-matrix: "; -d:testWithout"
+matrix: "; -d:testWithout; --mm:refc"
 """
 
 when not defined(testWithout): # test for same errors before and after

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -22,7 +22,7 @@ heyho
 Val1
 Val1
 '''
-matrix: "--hints:off"
+matrix: "--hints:off --mm:orc; --hints:off --mm:refc"
 """
 
 import macros

--- a/tests/stdlib/concurrency/tatomic_import.nim
+++ b/tests/stdlib/concurrency/tatomic_import.nim
@@ -1,7 +1,3 @@
-discard """
-  matrix: "--mm:orc"
-"""
-
 import atomicSample
 
 block crossFileObjectContainingAGenericWithAComplexObject:

--- a/tests/stdlib/concurrency/tatomic_import.nim
+++ b/tests/stdlib/concurrency/tatomic_import.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import atomicSample
 
 block crossFileObjectContainingAGenericWithAComplexObject:

--- a/tests/stdlib/concurrency/tatomic_import.nim
+++ b/tests/stdlib/concurrency/tatomic_import.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:refc; --mm:orc"
+  matrix: "--mm:orc"
 """
 
 import atomicSample

--- a/tests/stdlib/concurrency/tatomics.nim
+++ b/tests/stdlib/concurrency/tatomics.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 # test atomic operations
 
 import std/[atomics, bitops]

--- a/tests/stdlib/concurrency/tatomics_size.nim
+++ b/tests/stdlib/concurrency/tatomics_size.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp"
 """
 import std/atomics

--- a/tests/stdlib/talgorithm.nim
+++ b/tests/stdlib/talgorithm.nim
@@ -1,5 +1,6 @@
 discard """
   targets: "c js"
+  matrix: "--mm:refc; --mm:orc"
   output:'''@["3", "2", "1"]
 '''
 """

--- a/tests/stdlib/tarithmetics.nim
+++ b/tests/stdlib/tarithmetics.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 import std/assertions

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:arc --threads:on; --gc:arc --threads:on -d:danger; --threads:on"
+  matrix: "--mm:arc; --mm:arc -d:danger; --mm:refc"
   disabled: "freebsd"
 """
 

--- a/tests/stdlib/tbase64.nim
+++ b/tests/stdlib/tbase64.nim
@@ -1,4 +1,5 @@
 ﻿discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 import std/assertions

--- a/tests/stdlib/tbitops.nim
+++ b/tests/stdlib/tbitops.nim
@@ -1,5 +1,6 @@
 discard """
   nimout: "OK"
+  matrix: "--mm:refc; --mm:orc"
   output: '''
 OK
 '''

--- a/tests/stdlib/tbitops_utils.nim
+++ b/tests/stdlib/tbitops_utils.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/private/bitops_utils
 import std/assertions
 

--- a/tests/stdlib/tcgi.nim
+++ b/tests/stdlib/tcgi.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/unittest
 import std/[cgi, strtabs, sugar]
 import std/assertions

--- a/tests/stdlib/tcmdline.nim
+++ b/tests/stdlib/tcmdline.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
   joinable: false
 """

--- a/tests/stdlib/tcomplex.nim
+++ b/tests/stdlib/tcomplex.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/[complex, math]
 import std/assertions
 

--- a/tests/stdlib/tcookies.nim
+++ b/tests/stdlib/tcookies.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tcritbits.nim
+++ b/tests/stdlib/tcritbits.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tcstrutils.nim
+++ b/tests/stdlib/tcstrutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tdecls.nim
+++ b/tests/stdlib/tdecls.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 import std/assertions

--- a/tests/stdlib/tdeques.nim
+++ b/tests/stdlib/tdeques.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:refc; --gc:orc"
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tdiff.nim
+++ b/tests/stdlib/tdiff.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tdochelpers.nim
+++ b/tests/stdlib/tdochelpers.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''
 
 [Suite] Integration with Nim

--- a/tests/stdlib/teditdistance.nim
+++ b/tests/stdlib/teditdistance.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/editdistance
 import std/assertions
 

--- a/tests/stdlib/tencodings.nim
+++ b/tests/stdlib/tencodings.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/encodings
 import std/assertions
 

--- a/tests/stdlib/tenumerate.nim
+++ b/tests/stdlib/tenumerate.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/enumerate
 import std/assertions
 

--- a/tests/stdlib/tenumutils.nim
+++ b/tests/stdlib/tenumutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tenvvars.nim
+++ b/tests/stdlib/tenvvars.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:refc; --mm:orc"
   joinable: false
   targets: "c js cpp"
 """

--- a/tests/stdlib/texitprocs.nim
+++ b/tests/stdlib/texitprocs.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 targets: "c cpp js"
 output: '''
 ok4

--- a/tests/stdlib/tfdleak.nim
+++ b/tests/stdlib/tfdleak.nim
@@ -1,7 +1,7 @@
 discard """
   exitcode: 0
   output: ""
-  matrix: "; -d:nimInheritHandles"
+  matrix: "; -d:nimInheritHandles; --mm:refc"
   joinable: false
 """
 

--- a/tests/stdlib/tfrexp1.nim
+++ b/tests/stdlib/tfrexp1.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "js c cpp"
 """
 

--- a/tests/stdlib/tgetaddrinfo.nim
+++ b/tests/stdlib/tgetaddrinfo.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   exitcode: 0
   output: ""
 """

--- a/tests/stdlib/tgetfileinfo.nim
+++ b/tests/stdlib/tgetfileinfo.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: "pcDir\npcFile\npcLinkToDir\npcLinkToFile\n"
   joinable: false
 """

--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import nativesockets
 import std/assertions
 

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/private/globs
 import std/assertions
 

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "; --backend:cpp; --backend:js --jsbigint64:on; --backend:js --jsbigint64:off"
+  matrix: "--mm:refc; --mm:orc; --backend:cpp; --backend:js --jsbigint64:on; --backend:js --jsbigint64:off"
 """
 
 import std/hashes

--- a/tests/stdlib/theapqueue.nim
+++ b/tests/stdlib/theapqueue.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/heapqueue
 import std/assertions
 

--- a/tests/stdlib/thighlite.nim
+++ b/tests/stdlib/thighlite.nim
@@ -1,3 +1,6 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
 
 import unittest, strutils
 import ../../lib/packages/docutils/highlite

--- a/tests/stdlib/thtmlparser.nim
+++ b/tests/stdlib/thtmlparser.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
   output: '''
 true

--- a/tests/stdlib/thttpcore.nim
+++ b/tests/stdlib/thttpcore.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import httpcore, strutils
 import std/assertions
 

--- a/tests/stdlib/timportutils.nim
+++ b/tests/stdlib/timportutils.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/[importutils, assertions]
 import stdtest/testutils
 import mimportutils

--- a/tests/stdlib/tio.nim
+++ b/tests/stdlib/tio.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 # xxx move to here other tests that belong here; io is a proper module
 
 import std/os

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -1,5 +1,6 @@
 discard """
   output: ""
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tlocks.nim
+++ b/tests/stdlib/tlocks.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp js"
-  matrix: "--threads:on"
+  matrix: "--mm:refc; --mm:orc"
 """
 
 #bug #6049

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 #[
 xxx macros tests need to be reorganized to makes sure each API is tested once
 See also:

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp js"
-  matrix:"; -d:danger"
+  matrix:"; -d:danger; --mm:refc"
 """
 
 # xxx: there should be a test with `-d:nimTmathCase2 -d:danger --passc:-ffast-math`,

--- a/tests/stdlib/tmd5.nim
+++ b/tests/stdlib/tmd5.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tmget.nim
+++ b/tests/stdlib/tmget.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''Can't access 6
 10
 11

--- a/tests/stdlib/tmimetypes.nim
+++ b/tests/stdlib/tmimetypes.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tmisc_issues.nim
+++ b/tests/stdlib/tmisc_issues.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tmitems.nim
+++ b/tests/stdlib/tmitems.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''@[11, 12, 13]
 @[11, 12, 13]
 @[1, 3, 5]

--- a/tests/stdlib/tmonotimes.nim
+++ b/tests/stdlib/tmonotimes.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tnativesockets.nim
+++ b/tests/stdlib/tnativesockets.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/nativesockets
 import stdtest/testutils
 import std/assertions

--- a/tests/stdlib/tnet.nim
+++ b/tests/stdlib/tnet.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 outputsub: ""
 """
 

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -1,5 +1,6 @@
 discard """
   action: run
+  matrix: "--mm:refc; --mm:orc"
   output: '''
 
 [Suite] inet_ntop tests

--- a/tests/stdlib/tnetbind.nim
+++ b/tests/stdlib/tnetbind.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 joinable: false
 """
 

--- a/tests/stdlib/tnre.nim
+++ b/tests/stdlib/tnre.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 # Since the tests for nre are all bundled together we treat failure in one test as an nre failure
 # When running 'testament/tester' a failed check() in the test suite will cause the exit
 # codes to differ and be reported as a failure

--- a/tests/stdlib/tntpath.nim
+++ b/tests/stdlib/tntpath.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/private/ntpath
 import std/assertions
 

--- a/tests/stdlib/topenssl.nim
+++ b/tests/stdlib/topenssl.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/wordwrap
 import openssl
 import std/assertions

--- a/tests/stdlib/toptions.nim
+++ b/tests/stdlib/toptions.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -22,6 +22,7 @@ __really_obscure_dir_name/test
 Raises
 Raises
 '''
+  matrix: "--mm:refc; --mm:orc"
   joinable: false
 """
 # test os path creation, iteration, and deletion

--- a/tests/stdlib/tos_unc.nim
+++ b/tests/stdlib/tos_unc.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   disabled: "posix"
 """
 

--- a/tests/stdlib/tosenv.nim
+++ b/tests/stdlib/tosenv.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads"
+  matrix: "--mm:refc; --mm:arc"
   joinable: false
   targets: "c js cpp"
 """

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 joinable: false
 """
 

--- a/tests/stdlib/tosprocterminate.nim
+++ b/tests/stdlib/tosprocterminate.nim
@@ -1,7 +1,7 @@
 discard """
   cmd: "nim $target $options -r $file"
   targets: "c cpp"
-  matrix: "--threads:on; "
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import os, osproc, times, std / monotimes

--- a/tests/stdlib/tpackedsets.nim
+++ b/tests/stdlib/tpackedsets.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/packedsets
 import std/sets
 

--- a/tests/stdlib/tparsecfg.nim
+++ b/tests/stdlib/tparsecfg.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tparsecsv.nim
+++ b/tests/stdlib/tparsecsv.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 include parsecsv
 import strutils, os
 import std/assertions

--- a/tests/stdlib/tparseipv6.nim
+++ b/tests/stdlib/tparseipv6.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: "all ok"
 """
 

--- a/tests/stdlib/tparsesql.nim
+++ b/tests/stdlib/tparsesql.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 import parsesql

--- a/tests/stdlib/tparseuints.nim
+++ b/tests/stdlib/tparseuints.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import unittest, strutils
 
 block: # parseutils

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp"
 """
 

--- a/tests/stdlib/tpathnorm.nim
+++ b/tests/stdlib/tpathnorm.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import std/os

--- a/tests/stdlib/tpaths.nim
+++ b/tests/stdlib/tpaths.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/paths
 import std/assertions
 import pathnorm

--- a/tests/stdlib/tpegs.nim
+++ b/tests/stdlib/tpegs.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
   output: '''
 PEG AST traversal output

--- a/tests/stdlib/tposix.nim
+++ b/tests/stdlib/tposix.nim
@@ -1,5 +1,6 @@
 discard """
-outputsub: ""
+  matrix: "--mm:refc; --mm:orc"
+  disabled: windows
 """
 
 # Test Posix interface

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -1,6 +1,6 @@
 discard """
   joinable: false # to avoid messing with global rand state
-  matrix: "; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
+  matrix: "--mm:refc; --mm:orc; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
 """
 import std/[assertions, formatfloat]
 import std/[random, math, stats, sets, tables]

--- a/tests/stdlib/trationals.nim
+++ b/tests/stdlib/trationals.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/[rationals, math]
 import std/assertions
 

--- a/tests/stdlib/tre.nim
+++ b/tests/stdlib/tre.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/re
 import std/assertions
 

--- a/tests/stdlib/tregex.nim
+++ b/tests/stdlib/tregex.nim
@@ -1,5 +1,6 @@
 discard """
   output: "key: keyAYes!"
+  matrix: "--mm:refc; --mm:orc"
 """
 # Test the new regular expression module
 # which is based on the PCRE library

--- a/tests/stdlib/tregistry.nim
+++ b/tests/stdlib/tregistry.nim
@@ -1,6 +1,6 @@
 discard """
   disabled: "unix"
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--mm:refc; --mm:orc"
 """
 
 when defined(windows):

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp js"
-  matrix: ";--gc:arc"
+  matrix: "--mm:refc;--mm:arc"
 """
 
 # if excessive, could remove 'cpp' from targets

--- a/tests/stdlib/tropes.nim
+++ b/tests/stdlib/tropes.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -17,6 +17,7 @@ discard """
 
 [Suite] RST inline markup
 '''
+matrix: "--mm:refc; --mm:orc"
 """
 
 # tests for rst module

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 outputsub: ""
 """
 

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/tsha1.nim
+++ b/tests/stdlib/tsha1.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/sha1
 import std/assertions
 

--- a/tests/stdlib/tsharedlist.nim
+++ b/tests/stdlib/tsharedlist.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:orc; --mm:refc"
 """
 
 import std/sharedlist

--- a/tests/stdlib/tsharedtable.nim
+++ b/tests/stdlib/tsharedtable.nim
@@ -1,5 +1,5 @@
 discard """
-cmd: "nim $target --threads:on $options $file"
+matrix: "--mm:refc; --mm:orc"
 output: '''
 '''
 """

--- a/tests/stdlib/tsocketstreams.nim
+++ b/tests/stdlib/tsocketstreams.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''
 OM
 NIM

--- a/tests/stdlib/tsortcall.nim
+++ b/tests/stdlib/tsortcall.nim
@@ -1,5 +1,5 @@
 discard """
-outputsub: ""
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import algorithm

--- a/tests/stdlib/tsqlparser.nim
+++ b/tests/stdlib/tsqlparser.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''true'''
 """
 

--- a/tests/stdlib/tssl.nim
+++ b/tests/stdlib/tssl.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   joinable: false
   disabled: "freebsd"
   disabled: "openbsd"

--- a/tests/stdlib/tstats.nim
+++ b/tests/stdlib/tstats.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/[stats, assertions]
 import std/math
 

--- a/tests/stdlib/tstdlib_issues.nim
+++ b/tests/stdlib/tstdlib_issues.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 output: '''
 02
 1

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp js"
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import std/[strbasics, sugar, assertions]

--- a/tests/stdlib/tstreams.nim
+++ b/tests/stdlib/tstreams.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--mm:refc; --mm:orc"
   input: "Arne"
   output: '''
 Hello! What is your name?

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,4 +1,6 @@
-# xxx: test js target
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
 
 import genericstrformat
 import std/[strformat, strutils, times, tables, json]

--- a/tests/stdlib/tstrimpl.nim
+++ b/tests/stdlib/tstrimpl.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/private/strimpl
 
 import std/assertions

--- a/tests/stdlib/tstring.nim
+++ b/tests/stdlib/tstring.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tstrmiscs.nim
+++ b/tests/stdlib/tstrmiscs.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/strmisc
 import std/assertions
 

--- a/tests/stdlib/tstrscans.nim
+++ b/tests/stdlib/tstrscans.nim
@@ -1,5 +1,5 @@
 discard """
-  output: ""
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import std/[strscans, strutils, assertions]

--- a/tests/stdlib/tstrset.nim
+++ b/tests/stdlib/tstrset.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 # test a simple yet highly efficient set of strings
 
 type

--- a/tests/stdlib/tstrtabs.nim
+++ b/tests/stdlib/tstrtabs.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--mm:refc; --mm:orc"
 sortoutput: true
 output: '''
 key1: value1

--- a/tests/stdlib/tstrtabs2.nim
+++ b/tests/stdlib/tstrtabs2.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "; --backend:cpp; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
+  matrix: "--mm:refc; --mm:orc; --backend:cpp; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
 """
 
 import std/strutils

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''
 x + y = 30
 '''

--- a/tests/stdlib/tsums.nim
+++ b/tests/stdlib/tsums.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/sums
 from math import pow
 import std/assertions

--- a/tests/stdlib/tsysrand.nim
+++ b/tests/stdlib/tsysrand.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp js"
-  matrix: "--experimental:vmopsDanger"
+  matrix: "--experimental:vmopsDanger; --experimental:vmopsDanger --mm:refc"
 """
 
 import std/sysrand

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/ttables.nim
+++ b/tests/stdlib/ttables.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import tables, hashes
 import std/assertions
 

--- a/tests/stdlib/ttempfiles.nim
+++ b/tests/stdlib/ttempfiles.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   joinable: false # not strictly necessary
 """
 

--- a/tests/stdlib/tthreadpool.nim
+++ b/tests/stdlib/tthreadpool.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on --gc:arc"
+  matrix: "--mm:arc; --mm:refc"
   disabled: "freebsd"
   output: "42"
 """

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "; --backend:js --jsbigint64:on; --backend:js --jsbigint64:off"
+  matrix: "--mm:refc; --mm:orc; --backend:js --jsbigint64:on; --backend:js --jsbigint64:off"
 """
 
 import times, strutils, unittest

--- a/tests/stdlib/ttypeinfo.nim
+++ b/tests/stdlib/ttypeinfo.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/typeinfo
 import std/assertions
 

--- a/tests/stdlib/ttypetraits.nim
+++ b/tests/stdlib/ttypetraits.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/stdlib/tunicode.nim
+++ b/tests/stdlib/tunicode.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/unicode
 import std/assertions
 

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -19,6 +19,7 @@ discard """
 
 [Suite] test name filtering
 '''
+matrix: "--mm:refc; --mm:orc"
 targets: "c js"
 """
 

--- a/tests/stdlib/tunittestpass.nim
+++ b/tests/stdlib/tunittestpass.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
 

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets:  "c js"
 """
 

--- a/tests/stdlib/tuserlocks.nim
+++ b/tests/stdlib/tuserlocks.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--mm:refc; --mm:orc"
 """
 
 import std/rlocks

--- a/tests/stdlib/tvarargs.nim
+++ b/tests/stdlib/tvarargs.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c js"
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--mm:refc; --mm:orc"
 """
 import std/assertions
 

--- a/tests/stdlib/tvarints.nim
+++ b/tests/stdlib/tvarints.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/varints
 import std/assertions
 

--- a/tests/stdlib/tvmutils.nim
+++ b/tests/stdlib/tvmutils.nim
@@ -20,7 +20,6 @@ tvmutils.nim(29, 14) [opcIndCall]       vmTrace(false)
 """
 # line 20 (only showing a subset of nimout to avoid making the test rigid)
 import std/vmutils
-
 proc main() =
   for i in 0..<7:
     echo i

--- a/tests/stdlib/tvmutils.nim
+++ b/tests/stdlib/tvmutils.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   joinable: false
   nimout: '''
 0

--- a/tests/stdlib/twchartoutf8.nim
+++ b/tests/stdlib/twchartoutf8.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''OK'''
 """
 

--- a/tests/stdlib/twith.nim
+++ b/tests/stdlib/twith.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/with
 import std/[assertions, formatfloat]
 

--- a/tests/stdlib/twordwrap.nim
+++ b/tests/stdlib/twordwrap.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/wordwrap
 import std/assertions
 

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/wrapnils
 from std/options import get, isSome
 import std/assertions

--- a/tests/stdlib/txmltree.nim
+++ b/tests/stdlib/txmltree.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+"""
+
 import std/[xmltree, assertions, xmlparser]
 
 

--- a/tests/stdlib/tyield.nim
+++ b/tests/stdlib/tyield.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   targets: "c cpp js"
 """
 

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "; --backend:cpp; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
+  matrix: "--mm:refc; --mm:orc; --backend:cpp; --backend:js --jsbigint64:off; --backend:js --jsbigint64:on"
 """
 
 #[

--- a/tests/system/tslimsystem.nim
+++ b/tests/system/tslimsystem.nim
@@ -1,6 +1,6 @@
 discard """
   output: "123"
-  matrix: "-d:nimPreviewSlimSystem"
+  matrix: "-d:nimPreviewSlimSystem --mm:refc; -d:nimPreviewSlimSystem --mm:arc"
 """
 
 echo 123

--- a/tests/vm/t9622.nim
+++ b/tests/vm/t9622.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp"
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--mm:refc; --mm:arc"
 """
 
 type


### PR DESCRIPTION
target => targets typo

I added `refc` for almost every file under stdlib since they are not tested by megatest anyway because there is a separate config for stdlib tests.