### PR TITLE
actually fix #19015

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2393,7 +2393,9 @@ proc findFirstArgBlock(m: var TCandidate, n: PNode): int =
     # checking `nfBlockArg in n[a2].flags` wouldn't work inside templates
     if n[a2].kind != nkStmtList: break
     let formalLast = m.callee.n[m.callee.n.len - (n.len - a2)]
-    if formalLast.kind == nkSym and formalLast.sym.ast == nil:
+    # parameter has to occupy space (no default value, not void or varargs)
+    if formalLast.kind == nkSym and formalLast.sym.ast == nil and
+        formalLast.sym.typ.kind notin {tyVoid, tyVarargs}:
       result = a2
     else: break
 

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -89,6 +89,8 @@ template main =
       worked = true
     doAssert worked
     worked = false
+    hi(doAssert(not worked), doesntCompile, againDoesntCompile):
+      definitelyDoesntCompile
 
     template hi2(a: bool, b: untyped, c: varargs[untyped]): untyped =
       b
@@ -97,6 +99,8 @@ template main =
     hi2 worked:
       worked = true
     doAssert worked
+    hi2 worked, doAssert(worked), againDoesntCompile:
+      definitelyDoesntCompile
 
 static: main()
 main()

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -89,6 +89,8 @@ template main =
       worked = true
     doAssert worked
     worked = false
+    hi(doAssert(not worked)):
+      doesntCompile
     hi(doAssert(not worked), doesntCompile, againDoesntCompile):
       definitelyDoesntCompile
 
@@ -99,6 +101,10 @@ template main =
     hi2 worked:
       worked = true
     doAssert worked
+    hi2 worked, doAssert(worked):
+      doesntCompile
+    hi2 worked, doAssert(worked), doesntCompile, againDoesntCompile:
+      definitelyDoesntCompile
     hi2 worked, doAssert(worked), againDoesntCompile:
       definitelyDoesntCompile
 

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -79,6 +79,24 @@ template main =
       foobar3
       foobar4
     doAssert a2 == (1, 20, "\nfoobar1\nfoobar2", "\nfoobar3\nfoobar4")
+  
+  block: # issue #19015
+    template hi(a: untyped, b: varargs[untyped]): untyped =
+      a
+
+    var worked = false
+    hi:
+      worked = true
+    doAssert worked
+    worked = false
+
+    template hi2(a: bool, b: untyped, c: varargs[untyped]): untyped =
+      b
+      doAssert a
+
+    hi2 worked:
+      worked = true
+    doAssert worked
 
 static: main()
 main()


### PR DESCRIPTION
actually fixes #19015

The previous check here for a parameter to necessarily occupy space was just the lack of a default parameter, but `void` and `varargs` types can also not occupy space