### PR TITLE
fixes #20155; repr range with distinct types is broken in ORC

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -210,6 +210,11 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
       arg = arg.base.skipTypes(skippedTypes + {tyGenericInst})
       if not rec: break
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
+  of "rangeBase":
+    # return the base type of a range type
+    var arg = operand.skipTypes({tyGenericInst})
+    assert arg.kind == tyRange
+    result = getTypeDescNode(c, arg.base, operand.owner, traitCall.info)
   else:
     localError(c.config, traitCall.info, "unknown trait: " & s)
     result = newNodeI(nkEmpty, traitCall.info)

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -9,6 +9,9 @@ proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
 proc distinctBase(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".}
   ## imported from typetraits
 
+proc rangeBase(T: typedesc): typedesc {.magic: "TypeTrait".}
+  # skip one level of range; return the base type of a range type
+
 proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}
 
 proc repr*(x: int): string =
@@ -95,8 +98,13 @@ proc repr*(p: proc): string =
   ## repr of a proc as its address
   repr(cast[ptr pointer](unsafeAddr p)[])
 
-template repr*(x: distinct): string =
-  repr(distinctBase(typeof(x))(x))
+template repr*[T: distinct|range](x: T): string =
+  when T is range: # add a branch to handle range
+    repr(rangeBase(typeof(x))(x))
+  elif T is distinct:
+    repr(distinctBase(typeof(x))(x))
+  else:
+    {.error: "cannot happen".}
 
 template repr*(t: typedesc): string = $t
 

--- a/tests/metatype/tmetatype_various.nim
+++ b/tests/metatype/tmetatype_various.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:refc"
+  matrix: "--mm:refc; --mm:refc"
   output: '''[1, 0, 0, 0, 0, 0, 0, 0] CTBool[Ct[system.uint32]]'''
 """
 


### PR DESCRIPTION
fixes #20155
supersades https://github.com/nim-lang/Nim/pull/20158

```nim
type
  Distinct = distinct int
  Range = range[Distinct(1)..Distinct(10)]

proc foo(x: distinct) =
  doAssert $typeOf(x) == "Range"

var x: Range = Distinct(3)
foo(x)
```
For a range type with a distinct base type, it matches a function with a `distinct` typedesc parameter.

```nim
template repr*(x: distinct): string =
  repr(distinctBase(typeof(x))(x))
```

In the case of `repr`, the range type of a distinct base type matches the repr template, which causes the infinite match since the `distinctBase` of a range type is still a range type. So we need to skip the range type and `repr` the base type.

