### PR TITLE
fixes #21674; `lent` can be used in the fields or the cast type as a parameter

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -261,7 +261,7 @@ proc isCastable(c: PContext; dst, src: PType, info: TLineInfo): bool =
     return false
   elif srcSize < 0:
     return false
-  elif typeAllowed(dst, skParam, c) != nil:
+  elif typeAllowed(dst, skParam, c, {taIsCastable}) != nil:
     return false
   elif dst.kind == tyProc and dst.callConv == ccClosure:
     return src.kind == tyProc and src.callConv == ccClosure

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -25,6 +25,7 @@ type
     taNoUntyped
     taIsTemplateOrMacro
     taProcContextIsNotMacro
+    taIsCastable
 
   TTypeAllowedFlags* = set[TTypeAllowedFlag]
 
@@ -63,7 +64,8 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif taIsOpenArray in flags:
       result = t
     elif t.kind == tyLent and ((kind != skResult and views notin c.features) or
-                              kind == skParam): # lent can't be used as parameters.
+      (kind == skParam and {taIsCastable, taField} * flags == {})): # lent cannot be used as parameters.
+                                                       # but it is valid in the cast environment and as the field of an object
       result = t
     elif isOutParam(t) and kind != skParam:
       result = t

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -65,7 +65,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
       result = t
     elif t.kind == tyLent and ((kind != skResult and views notin c.features) or
       (kind == skParam and {taIsCastable, taField} * flags == {})): # lent cannot be used as parameters.
-                                                       # but it is valid in the cast environment and as the field of an object
+                                                       # except in the cast environment and as the field of an object
       result = t
     elif isOutParam(t) and kind != skParam:
       result = t

--- a/tests/views/tviews1.nim
+++ b/tests/views/tviews1.nim
@@ -85,11 +85,11 @@ block: # bug #21674
 
   proc foo(s: Lent) =
     var m = 12
-    var x: lent int = cast[lent int](m)
+    discard cast[lent int](m)
 
   proc main =
-    var m = 123
-    var x = Lent(data: m)
+    var m1 = 123
+    var x = Lent(data: m1)
     foo(x)
 
   main()

--- a/tests/views/tviews1.nim
+++ b/tests/views/tviews1.nim
@@ -77,3 +77,19 @@ type Inner = object
 var o = Outer(value: 1234)
 var v = Inner(owner: o).owner.value
 doAssert v == 1234
+
+block: # bug #21674
+  type
+    Lent = object
+      data: lent int
+
+  proc foo(s: Lent) =
+    var m = 12
+    var x: lent int = cast[lent int](m)
+
+  proc main =
+    var m = 123
+    var x = Lent(data: m)
+    foo(x)
+
+  main()


### PR DESCRIPTION
fixes #21674