### PR TITLE
Fix RST/Markdown false heading detection

### DIFF
--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -67,6 +67,45 @@ proc toAst(input: string,
       result = e.msg
 
 suite "RST parsing":
+  test "Standalone punctuation is not parsed as heading overlines":
+    check(dedent"""
+        Paragraph
+
+        !""".toAst ==
+      dedent"""
+        rnInner
+          rnParagraph
+            rnLeaf  'Paragraph'
+          rnParagraph
+            rnLeaf  '!'
+      """)
+
+    check(dedent"""
+        Paragraph1
+
+        ...
+
+        Paragraph2""".toAst ==
+      dedent"""
+        rnInner
+          rnParagraph
+            rnLeaf  'Paragraph1'
+          rnParagraph
+            rnLeaf  '...'
+          rnParagraph
+            rnLeaf  'Paragraph2'
+      """)
+
+    check(dedent"""
+        ---
+        Paragraph""".toAst ==
+      dedent"""
+        rnInner
+          rnLeaf  '---'
+          rnLeaf  ' '
+          rnLeaf  'Paragraph'
+      """)
+
   test "References are whitespace-neutral and case-insensitive":
     # refname is 'lexical-analysis', the same for all the 3 variants:
     check(dedent"""

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -617,8 +617,8 @@ context2
 This is too short to be a transition:
 
 ---
-
 context2
+---
 """
     var error2 = new string
     let output2 = input2.toHtml(error=error2)


### PR DESCRIPTION
The heading detection is rearranged a bit, more on ad-hoc basis, than on any (murky) specification. It fixes very non-intuitive parsing failures like one reported [nimforum issue here](https://github.com/nim-lang/nimforum/issues/330#issuecomment-1376039966).