### PR TITLE
fixes #21540; deref block at transf phase to make injectdestructors function properly

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -753,7 +753,7 @@ proc isCppRef(p: BProc; typ: PType): bool {.inline.} =
       tfVarIsPtr notin skipTypes(typ, abstractInstOwned).flags
 
 proc genDeref(p: BProc, e: PNode, d: var TLoc) =
-  assert e[0].kind notin {nkBlockExpr, nkBlockStmt}, "it should be transformed in transf"
+  assert e[0].kind notin {nkBlockExpr, nkBlockStmt}, "it should have been transformed in transf"
 
   let mt = mapType(p.config, e[0].typ, mapTypeChooser(e[0]))
   if mt in {ctArray, ctPtrToArray} and lfEnforceDeref notin d.flags:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -752,21 +752,8 @@ proc isCppRef(p: BProc; typ: PType): bool {.inline.} =
       skipTypes(typ, abstractInstOwned).kind in {tyVar} and
       tfVarIsPtr notin skipTypes(typ, abstractInstOwned).flags
 
-proc derefBlock(p: BProc, e: PNode, d: var TLoc) =
-  # We transform (block: x)[] to (block: x[])
-  let e0 = e[0]
-  var n = shallowCopy(e0)
-  n.typ = e.typ
-  for i in 0 ..< e0.len - 1:
-    n[i] = e0[i]
-  n[e0.len-1] = newTreeIT(nkHiddenDeref, e.info, e.typ, e0[e0.len-1])
-  expr p, n, d
-
 proc genDeref(p: BProc, e: PNode, d: var TLoc) =
-  if e.kind == nkHiddenDeref and e[0].kind in {nkBlockExpr, nkBlockStmt}:
-    # bug #20107. Watch out to not deref the pointer too late.
-    derefBlock(p, e, d)
-    return
+  assert e[0].kind notin {nkBlockExpr, nkBlockStmt}, "it should be transformed in transf"
 
   let mt = mapType(p.config, e[0].typ, mapTypeChooser(e[0]))
   if mt in {ctArray, ctPtrToArray} and lfEnforceDeref notin d.flags:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -1021,6 +1021,7 @@ proc transform(c: PTransf, n: PNode): PNode =
     result = transformAddrDeref(c, n, {nkDerefExpr, nkHiddenDeref})
   of nkDerefExpr, nkHiddenDeref:
     if n[0].kind in {nkBlockExpr, nkBlockStmt}:
+      # bug #20107 bug #21540. Watch out to not deref the pointer too late.
       let e = transformDerefBlock(c, n)
       result = transformAddrDeref(c, e, {nkAddr, nkHiddenAddr})
     else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -945,6 +945,7 @@ proc transformDerefBlock(c: PTransf, n: PNode): PNode =
   # We transform (block: x)[] to (block: x[])
   let e0 = n[0]
   result = shallowCopy(e0)
+  result.typ = n.typ
   for i in 0 ..< e0.len - 1:
     result[i] = e0[i]
   result[e0.len-1] = newTreeIT(nkHiddenDeref, n.info, n.typ, e0[e0.len-1])

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -1024,7 +1024,7 @@ proc transform(c: PTransf, n: PNode): PNode =
     if n[0].kind in {nkBlockExpr, nkBlockStmt}:
       # bug #20107 bug #21540. Watch out to not deref the pointer too late.
       let e = transformDerefBlock(c, n)
-      result = transformAddrDeref(c, e, {nkAddr, nkHiddenAddr})
+      result = transformBlock(c, e)
     else:
       result = transformAddrDeref(c, n, {nkAddr, nkHiddenAddr})
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:

--- a/tests/ccgbugs/tderefblock.nim
+++ b/tests/ccgbugs/tderefblock.nim
@@ -1,6 +1,5 @@
 discard """
-  cmd: "nim c -d:release -d:danger $file"
-  matrix: ";--gc:orc"
+  matrix: "--mm:refc -d:release -d:danger;--mm:orc -d:useMalloc -d:release -d:danger"
   output: "42"
 """
 
@@ -23,3 +22,44 @@ proc m() =
   echo $f.a
 
 m()
+
+# bug #21540
+
+type
+  Option = object
+    val: string
+    has: bool
+
+proc some(val: string): Option =
+  result.has = true
+  result.val = val
+
+# Remove lent and it works
+proc get(self: Option): lent string =
+  result = self.val
+
+type
+  StringStream = ref object
+    data: string
+    pos: int
+
+proc readAll(s: StringStream): string =
+  result = newString(s.data.len)
+  copyMem(addr(result[0]), addr(s.data[0]), s.data.len)
+
+proc newStringStream(s: string = ""): StringStream =
+  new(result)
+  result.data = s
+
+proc parseJson(s: string): string =
+  let stream = newStringStream(s)
+  result = stream.readAll()
+
+proc main =
+  let initialFEN = block:
+    let initialFEN = some parseJson("startpos")
+    initialFEN.get
+
+  doAssert initialFEN == "startpos"
+
+main()

--- a/tests/ccgbugs/tderefblock.nim
+++ b/tests/ccgbugs/tderefblock.nim
@@ -23,43 +23,54 @@ proc m() =
 
 m()
 
-# bug #21540
+block: # bug #21540
+  type
+    Option = object
+      val: string
+      has: bool
 
-type
-  Option = object
-    val: string
-    has: bool
+  proc some(val: string): Option =
+    result.has = true
+    result.val = val
 
-proc some(val: string): Option =
-  result.has = true
-  result.val = val
+  # Remove lent and it works
+  proc get(self: Option): lent string =
+    result = self.val
 
-# Remove lent and it works
-proc get(self: Option): lent string =
-  result = self.val
+  type
+    StringStream = ref object
+      data: string
+      pos: int
 
-type
-  StringStream = ref object
-    data: string
-    pos: int
+  proc readAll(s: StringStream): string =
+    result = newString(s.data.len)
+    copyMem(addr(result[0]), addr(s.data[0]), s.data.len)
 
-proc readAll(s: StringStream): string =
-  result = newString(s.data.len)
-  copyMem(addr(result[0]), addr(s.data[0]), s.data.len)
+  proc newStringStream(s: string = ""): StringStream =
+    new(result)
+    result.data = s
 
-proc newStringStream(s: string = ""): StringStream =
-  new(result)
-  result.data = s
+  proc parseJson(s: string): string =
+    let stream = newStringStream(s)
+    result = stream.readAll()
 
-proc parseJson(s: string): string =
-  let stream = newStringStream(s)
-  result = stream.readAll()
+  proc main =
+    let initialFEN = block:
+      let initialFEN = some parseJson("startpos")
+      initialFEN.get
 
-proc main =
-  let initialFEN = block:
-    let initialFEN = some parseJson("startpos")
+    doAssert initialFEN == "startpos"
+
+  main()
+
+import std/[
+    json,
+    options
+]
+
+block: # bug #21540
+  let cheek = block:
+    let initialFEN = some("""{"initialFen": "startpos"}""".parseJson{"initialFen"}.getStr)
     initialFEN.get
 
-  doAssert initialFEN == "startpos"
-
-main()
+  doAssert cheek == "startpos"


### PR DESCRIPTION
fixes #21540

If the deref block happens at the codegen phase, injectdestructors cannot know the transformation in advance.