### PR TITLE
fixes nightlies regression

### DIFF
--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -194,7 +194,7 @@ elif defined(linux) and not defined(nimNoGetRandom) and not defined(emscripten):
       elif readBytes > 0:
         inc(result, readBytes)
       else:
-        if osLastError().int in [EINTR, EAGAIN]: discard
+        if osLastError().cint in [EINTR, EAGAIN]: discard
         else:
           result = -1
           break

--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -194,8 +194,7 @@ elif defined(linux) and not defined(nimNoGetRandom) and not defined(emscripten):
       elif readBytes > 0:
         inc(result, readBytes)
       else:
-        case osLastError().int
-        of EINTR, EAGAIN: discard
+        if osLastError().int in [EINTR, EAGAIN]: discard
         else:
           result = -1
           break


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/21659
ref https://github.com/nim-lang/nightlies/actions/runs/4727252660/jobs/8387899690

> /home/runner/work/nightlies/nightlies/nim-1.9.3/lib/std/sysrand.nim(198, 12) Error: cannot evaluate at compile time: EINTR

Because EINTR is not a const on i386