### PR TITLE
static link pthread correctly

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -179,6 +179,9 @@ nimblepath="$home/.nimble/pkgs/"
 # Configuration for the GNU C/C++ compiler:
 @if windows:
   #gcc.path = r"$nim\dist\mingw\bin"
+  @if gcc:
+    gcc.options.linker %= "-Wl,-Bstatic -lpthread"
+  @end
   @if tcc:
     tlsEmulation:on
   @end

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -35,8 +35,6 @@
 ##  deinitLock(L)
 
 
-when defined(windows) and defined(gcc) and (not compileOption("tlsEmulation")):
-  {.passl: "-Wl,-Bstatic -lpthread -Wl,-Bdynamic".}
 
 import std/private/[threadtypes]
 export Thread


### PR DESCRIPTION
I add it to `nim.cfg`, which will be appended to the link parameters without affecting user configs.

follow up https://github.com/nim-lang/Nim/pull/21668

`tlsEmulation:on` needs to pay for static linking on windows with mingw. I haven't figure out a better solution. The default works, which way more important than other options.