### PR TITLE
Fix example code in Nim manual that causes warning

### DIFF
--- a/doc/sets_fragment.txt
+++ b/doc/sets_fragment.txt
@@ -78,12 +78,12 @@ Enum, sets and casting can be used together as in:
 
   ```nim
   type
-    MyFlag* {.size: sizeof(cint).} = enum
+    MyFlag* = enum
       A
       B
       C
       D
-    MyFlags = set[MyFlag]
+    MyFlags {.size: sizeof(cint).} = set[MyFlag]
 
   proc toNum(f: MyFlags): int = cast[cint](f)
   proc toFlags(v: int): MyFlags = cast[MyFlags](v)


### PR DESCRIPTION
Fixed example code that cause `Warning: target type is larger than source type`.