### PR TITLE
tweak spellsuggest; three counts for equal distances candidates by default

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -490,12 +490,8 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
     let e = list.pop()
     if c.config.spellSuggestMax == spellSuggestSecretSauce:
       const
-        smallThres = 2
-        maxCountForSmall = 4
-        # avoids ton of operator matches when mis-matching short symbols such as `i`
-        # other heuristics could be devised, such as only suggesting operators if `name0`
-        # is an operator (likewise with non-operators).
-      if e.dist > e0.dist or (name0.len <= smallThres and count >= maxCountForSmall): break
+        maxCount = 3 # avoids ton of matches; three counts for equal distances
+      if e.dist > e0.dist or count >= maxCount: break
     elif count >= c.config.spellSuggestMax: break
     if count == 0:
       result.add "\ncandidates (edit distance, scope distance); see '--spellSuggest': "

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -490,8 +490,9 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
     let e = list.pop()
     if c.config.spellSuggestMax == spellSuggestSecretSauce:
       const
+        minLengthForSuggestion = 4
         maxCount = 3 # avoids ton of matches; three counts for equal distances
-      if e.dist > e0.dist or count >= maxCount: break
+      if e.dist > e0.dist or count >= maxCount or name0.len < minLengthForSuggestion: break
     elif count >= c.config.spellSuggestMax: break
     if count == 0:
       result.add "\ncandidates (edit distance, scope distance); see '--spellSuggest': "

--- a/tests/misc/tspellsuggest2.nim
+++ b/tests/misc/tspellsuggest2.nim
@@ -1,6 +1,6 @@
 discard """
   # pending bug #16521 (bug 12) use `matrix`
-  cmd: "nim c --spellsuggest --hints:off $file"
+  cmd: "nim c --spellsuggest:12 --hints:off $file"
   action: "reject"
   nimout: '''
 tspellsuggest2.nim(45, 13) Error: undeclared identifier: 'fooBar'


### PR DESCRIPTION
The spellsuggest works well for a variable with an one-word typo, which tends to obtain the best grade and is the only one suggested. However, for a real undeclared symbol, it spits tons of garbages that are confusing and pollute the command line. In this PR, it drops the max count to three instead of infinty.