### PR TITLE
fixes #21703; moveOrCopy should consider when vm

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1054,7 +1054,8 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
     else:
       result = newTree(nkFastAsgn, dest, p(ri, c, s, normal))
   else:
-    case ri.kind
+    let ri2 = if ri.kind == nkWhen: ri[1][0] else: ri
+    case ri2.kind
     of nkCallKinds:
       result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
     of nkBracketExpr:


### PR DESCRIPTION
fixes #21703

```
--expandArc: example

result = when nimvm:
  s
else:
  @toOpenArray(s, 0, high(s))
-- end of expandArc ------------------------
```

valgrind

```
==12481== Memcheck, a memory error detector
==12481== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12481== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==12481== Command: ./test20
==12481== 
==12481== 
==12481== HEAP SUMMARY:
==12481==     in use at exit: 0 bytes in 0 blocks
==12481==   total heap usage: 2 allocs, 2 frees, 64 bytes allocated
==12481== 
==12481== All heap blocks were freed -- no leaks are possible
==12481== 
==12481== For lists of detected and suppressed errors, rerun with: -s
==12481== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Or fix the `of nkAsgn, nkFastAsgn, nkSinkAsgn:` directly.