### PR TITLE
fix #21727

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -626,6 +626,8 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   onDef(n[namePos].info, s)
   # check parameter list:
   #s.scope = c.currentScope
+  # push noalias flag at first to prevent unwanted recursive calls:
+  incl(s.flags, sfNoalias)
   pushOwner(c, s)
   openScope(c)
   n[namePos] = newSymNode(s)
@@ -635,7 +637,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   setGenericParamsMisc(c, n)
   # process parameters:
   var allUntyped = true
-  var requiresParams = false
+  var nullary = true
   if n[paramsPos].kind != nkEmpty:
     semParamList(c, n[paramsPos], n[genericParamsPos], s)
     # a template's parameters are not gensym'ed even if that was originally the
@@ -648,7 +650,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
         param.flags.excl sfGenSym
       if param.typ.kind != tyUntyped: allUntyped = false
       # no default value, parameters required in call
-      if param.ast == nil: requiresParams = true
+      if param.ast == nil: nullary = false
   else:
     s.typ = newTypeS(tyProc, c)
     # XXX why do we need tyTyped as a return type again?
@@ -660,11 +662,11 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     n[genericParamsPos] = n[miscPos][1]
     n[miscPos] = c.graph.emptyNode
   if allUntyped: incl(s.flags, sfAllUntyped)
-  if requiresParams or
-      n[bodyPos].kind == nkEmpty or
-      n[genericParamsPos].kind != nkEmpty:
-    # template cannot be called with alias syntax
-    incl(s.flags, sfNoalias)
+  if nullary and
+      n[genericParamsPos].kind == nkEmpty and
+      n[bodyPos].kind != nkEmpty:
+    # template can be called with alias syntax, remove pushed noalias flag
+    excl(s.flags, sfNoalias)
 
   if n[patternPos].kind != nkEmpty:
     n[patternPos] = semPattern(c, n[patternPos], s)

--- a/tests/template/taliassyntax.nim
+++ b/tests/template/taliassyntax.nim
@@ -61,3 +61,14 @@ block: # issue #13515
     if not test:
       doAssert false
   x
+
+import macros
+
+block: # issue #21727
+  template debugAnnotation(s: typed): string =
+    astToStr s
+
+  macro cpsJump(x: int): untyped =
+    result = newLit(debugAnnotation(cpsJump))
+  
+  doAssert cpsJump(13) == "cpsJump"


### PR DESCRIPTION
fixes #21727

Pushes `sfNoalias` immediately for templates and macros to prevent unwanted recursive calls in param lists or macro bodies. The test case is minimized from the issue, might still have to confirm if cps works (and reopen the issue if it doesn't) but this should be the whole problem. The alternative solution described in the comment on the issue turned out messy so I didn't do it.

I admit this wasn't amazing logic in the first place, it might have been better to just have some `sfAlias` instead of `sfNoalias` which for some reason I fixated on reusing, but there's not really a reason to change it at this point. Beyond that though I don't know a better alternative for the implementation here if we didn't want to break any code (which is basically why this feature is still here).