### PR TITLE
fix build on haiku

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -2035,7 +2035,7 @@ when defined(posix):
   import posix
 
 when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
-       defined(solaris) or defined(zephyr) or defined(freertos) or defined(nuttx):
+       defined(solaris) or defined(zephyr) or defined(freertos) or defined(nuttx) or defined(haiku):
   proc maxDescriptors*(): int {.raises: OSError.} =
     ## Returns the maximum number of active file descriptors for the current
     ## process. This involves a system call. For now `maxDescriptors` is

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -328,7 +328,7 @@ else:
     doAssert(timeout >= -1, "Cannot select with a negative value, got: " & $timeout)
 
   when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
-       defined(solaris) or defined(zephyr) or defined(freertos) or defined(nuttx):
+       defined(solaris) or defined(zephyr) or defined(freertos) or defined(nuttx) or defined(haiku):
     template maxDescriptors*(): int =
       ## Returns the maximum number of active file descriptors for the current
       ## process. This involves a system call. For now `maxDescriptors` is


### PR DESCRIPTION
hello!

the following update fixes when building on a haiku host. sample of the error shown below:

```bash
> ./build_all.sh 
bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e exists.

cmd: rm -f bin/nim

cmd: cp bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e bin/nim

cmd: bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e -v
Nim Compiler Version 1.9.1 [Haiku: amd64]
Compiled at 2023-01-02
Copyright (c) 2006-2022 by Andreas Rumpf

git hash: 7f6681b4c4ccc0dc43fd256280be4c3ad3c773e5
active boot switches: -d:release -d:danger

cmd: bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch

cmd: ./koch boot -d:release --skipUserCfg --skipParentCfg --hints:off
iteration: 1
bin/nim c  --skipUserCfg --skipParentCfg -d:nimKochBootstrap --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
bin/nim jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
iteration: 2
compiler/nim1 c  --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
compiler/nim1 jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
iteration: 3
compiler/nim2 c  --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
compiler/nim2 jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
executables are equal: SUCCESS!

cmd: ./koch tools --skipUserCfg --skipParentCfg --hints:off
bin/nim c -o:bin/nimsuggest -d:danger --skipUserCfg --skipParentCfg --hints:off nimsuggest/nimsuggest.nim
bin/nim c -o:bin/nimgrep -d:release --skipUserCfg --skipParentCfg --hints:off tools/nimgrep.nim
bin/nim c -o:bin/nimpretty -d:release --skipUserCfg --skipParentCfg --hints:off nimpretty/nimpretty.nim
bin/nim c -o:bin/testament -d:release --skipUserCfg --skipParentCfg --hints:off testament/testament.nim
/boot/home/src/git/Nim/lib/pure/ioselects/ioselectors_poll.nim(62, 29) Error: undeclared identifier: 'maxDescriptors'
FAILURE

> uname -a
Haiku shredder 1 hrev56949+2 Apr 28 2023 06:34:2 x86_64 x86_64 Haiku

```