### PR TITLE
add getDataDir to std/appdirs.nim

### DIFF
--- a/lib/std/appdirs.nim
+++ b/lib/std/appdirs.nim
@@ -17,6 +17,30 @@ proc getHomeDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## * `getTempDir proc`_
   result = Path(osappdirs.getHomeDir())
 
+proc getDataDir*(): string {.rtl, extern: "nos$1"
+  tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the data directory of the current user for applications.
+  ## 
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_DATA_HOME` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("~/.local/share" or "~/Library/Application Support" on macOS).
+  ## 
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
+  when defined(windows):
+    result = getEnv("APPDATA")
+  elif defined(macosx):
+    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / "Library" / "Application Support")
+  else:
+    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local" / "share")
+  result.normalizePathEnd(trailingSep = true)
+
 proc getConfigDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the config directory of the current user for applications.
   ##

--- a/lib/std/appdirs.nim
+++ b/lib/std/appdirs.nim
@@ -33,13 +33,7 @@ proc getDataDir*(): string {.rtl, extern: "nos$1"
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_
   ## * `setCurrentDir proc`_
-  when defined(windows):
-    result = getEnv("APPDATA")
-  elif defined(macosx):
-    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / "Library" / "Application Support")
-  else:
-    result = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local" / "share")
-  result.normalizePathEnd(trailingSep = true)
+  result = Path(osappdirs.getDataDir())
 
 proc getConfigDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the config directory of the current user for applications.

--- a/lib/std/appdirs.nim
+++ b/lib/std/appdirs.nim
@@ -17,8 +17,7 @@ proc getHomeDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## * `getTempDir proc`_
   result = Path(osappdirs.getHomeDir())
 
-proc getDataDir*(): string {.rtl, extern: "nos$1"
-  tags: [ReadEnvEffect, ReadIOEffect].} =
+proc getDataDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the data directory of the current user for applications.
   ## 
   ## On non-Windows OSs, this proc conforms to the XDG Base Directory


### PR DESCRIPTION
This PR extends #21408 by adding the `getDataDir` proc to the file `lib/std/appdirs.nim`