### PR TITLE
Ignore pkgs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ htmldocs
 nimdoc.out.css
 # except here:
 !/nimdoc/testproject/expected/*
+pkgs/


### PR DESCRIPTION
When running `koch boot`, The workspace endup with untracked files.