### PR TITLE
cheap fix for #10853 + better tuple subscript error message

### DIFF
--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -132,7 +132,7 @@ proc lowerTupleUnpackingForAsgn*(g: ModuleGraph; n: PNode; idgen: IdGenerator; o
 
   var vpart = newNodeI(nkIdentDefs, tempAsNode.info, 3)
   vpart[0] = tempAsNode
-  vpart[1] = newNodeI(nkEmpty, value.info)
+  vpart[1] = newNodeI(nkTupleClassTy, value.info)
   vpart[2] = value
   v.add vpart
   result.add(v)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1646,7 +1646,10 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags): PNode =
         {tyInt..tyInt64}:
       let idx = getOrdValue(n[1])
       if idx >= 0 and idx < arr.len: n.typ = arr[toInt(idx)]
-      else: localError(c.config, n.info, "invalid index value for tuple subscript")
+      else:
+        localError(c.config, n.info,
+          "invalid index $1 in subscript for tuple of length $2" %
+            [$idx, $arr.len])
       result = n
     else:
       result = nil

--- a/tests/errmsgs/tassignunpack.nim
+++ b/tests/errmsgs/tassignunpack.nim
@@ -1,0 +1,3 @@
+var a, b = 0
+(a, b) = 1 #[tt.Error
+         ^ type mismatch: got <int literal(1)> but expected 'tuple']#

--- a/tests/errmsgs/ttupleindexoutofbounds.nim
+++ b/tests/errmsgs/ttupleindexoutofbounds.nim
@@ -1,0 +1,2 @@
+let a = (1, 2)[4] #[tt.Error
+              ^ invalid index 4 in subscript for tuple of length 2]#

--- a/tests/types/tassignemptytuple.nim
+++ b/tests/types/tassignemptytuple.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "cannot infer the type of the tuple"
+  errormsg: "invalid type: 'empty' in this context: '(seq[empty], (seq[empty], set[empty]))' for let"
   file: "tassignemptytuple.nim"
   line: 11
 """


### PR DESCRIPTION
fixes #10853?

Not very sophisticated. For `(a, b) = foo()` the compiler normally generates:

```nim
let tmp = foo()
let a = tmp[0]
let b = tmp[1]
```

Hence the subscript error when `foo()` is not a tuple.

Now it generates:

```nim
let tmp: tuple = foo()
...
```

The real solution is to refactor `lowerTupleUnpackingForAsgn` to be more like variable sections now which type check the RHS first, then give an error for `typ.kind != tyTuple`. However this would warrant merging `lowerTupleUnpackingForAsgn` with `makeVarTupleSection` which is a bigger refactor than necessary for now.

Also the error message `invalid index value for tuple subscript` now gives index and length information.