### PR TITLE
.inheritable fix for 1.6

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1275,6 +1275,7 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
     if s.magic == mNone and a[2].kind == nkEmpty:
       localError(c.config, a.info, errImplOfXexpected % s.name.s)
     if s.magic != mNone: processMagicType(c, s)
+    let oldFlags = s.typ.flags
     if a[1].kind != nkEmpty:
       # We have a generic type declaration here. In generic types,
       # symbol lookup needs to be done here.
@@ -1302,6 +1303,13 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       if body != nil:
         body.sym = s
         body.size = -1 # could not be computed properly
+        if body.kind == tyObject:
+          # add flags applied to generic type to object (nominal) type
+          incl(body.flags, oldFlags)
+          # {.inheritable, final.} is already disallowed, but
+          # object might have been assumed to be final
+          if tfInheritable in oldFlags and tfFinal in body.flags:
+            excl(body.flags, tfFinal)
         s.typ[^1] = body
         if tfCovariant in s.typ.flags:
           checkCovariantParamsUsages(c, s.typ)
@@ -1353,6 +1361,13 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       internalAssert c.config, st.kind in {tyPtr, tyRef}
       internalAssert c.config, st.lastSon.sym == nil
       incl st.flags, tfRefsAnonObj
+      let objTy = st.lastSon
+      # add flags for `ref object` etc to underlying `object`
+      incl(objTy.flags, oldFlags)
+      # {.inheritable, final.} is already disallowed, but
+      # object might have been assumed to be final
+      if tfInheritable in oldFlags and tfFinal in objTy.flags:
+        excl(objTy.flags, tfFinal)
       let obj = newSym(skType, getIdent(c.cache, s.name.s & ":ObjectType"),
                        nextSymId c.idgen, getCurrOwner(c), s.info)
       let symNode = newSymNode(obj)
@@ -1368,8 +1383,8 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       obj.ast[2] = a[2][0]
       if sfPure in s.flags:
         obj.flags.incl sfPure
-      obj.typ = st.lastSon
-      st.lastSon.sym = obj
+      obj.typ = objTy
+      objTy.sym = obj
 
 proc checkForMetaFields(c: PContext; n: PNode) =
   proc checkMeta(c: PContext; n: PNode; t: PType) =

--- a/tests/assign/tassign.nim
+++ b/tests/assign/tassign.nim
@@ -80,7 +80,7 @@ block tcopy:
 
 block tgenericassign:
   type
-    TAny = object {.pure.}
+    TAny {.pure.} = object
       value: pointer
       rawType: pointer
 

--- a/tests/ast_pattern_matching.nim
+++ b/tests/ast_pattern_matching.nim
@@ -561,7 +561,7 @@ when isMainModule:
         echo "got the ident m"
 
     testRecCase:
-      type Obj[T] = object {.inheritable.}
+      type Obj[T] {.inheritable.} = object
         name: string
         case isFat: bool
         of true:

--- a/tests/ccgbugs/targ_lefttoright.nim
+++ b/tests/ccgbugs/targ_lefttoright.nim
@@ -29,7 +29,7 @@ template test =
   var b = 1
   say (b += 1; b), (b += 1; b) #2,3
 
-  type C = object {.byRef.}
+  type C {.byRef.} = object
     i: int
 
   proc say(a, b: C) =

--- a/tests/ccgbugs/tccgen1.nim
+++ b/tests/ccgbugs/tccgen1.nim
@@ -7,7 +7,7 @@ type
     Features: seq[Feature] # Read-Only
 
   PNode* = ref Node
-  Node = object {.inheritable.}
+  Node {.inheritable.} = object
     attributes*: seq[PAttr]
     childNodes*: seq[PNode]
     FLocalName: string # Read-only

--- a/tests/ccgbugs/tmissingbracket.nim
+++ b/tests/ccgbugs/tmissingbracket.nim
@@ -11,7 +11,7 @@ type
     className* : string
   TClassOfTobj = object of TClassOfTCustomObject
     nil
-  TCustomObject = ref object {.inheritable.}
+  TCustomObject {.inheritable.} = ref object
     class* : ptr TClassOfTCustomObject
   TObj = ref object of TCustomObject
     data: int

--- a/tests/effects/teffects2.nim
+++ b/tests/effects/teffects2.nim
@@ -4,7 +4,7 @@ discard """
 """
 {.push warningAsError[Effect]: on.}
 type
-  TObj = object {.pure, inheritable.}
+  TObj {.pure, inheritable.} = object
   TObjB = object of TObj
     a, b, c: string
 

--- a/tests/effects/teffects3.nim
+++ b/tests/effects/teffects3.nim
@@ -4,7 +4,7 @@ discard """
 """
 
 type
-  TObj = object {.pure, inheritable.}
+  TObj {.pure, inheritable.} = object
   TObjB = object of TObj
     a, b, c: string
     fn: proc (): int {.tags: [].}

--- a/tests/effects/teffects4.nim
+++ b/tests/effects/teffects4.nim
@@ -4,7 +4,7 @@ discard """
 """
 
 type
-  TObj = object {.pure, inheritable.}
+  TObj {.pure, inheritable.} = object
   TObjB = object of TObj
     a, b, c: string
     fn: proc (): int {.tags: [ReadIOEffect].}

--- a/tests/generics/module_with_generics.nim
+++ b/tests/generics/module_with_generics.nim
@@ -1,5 +1,5 @@
 type
-  Base[T] = ref object {.inheritable.}
+  Base[T] {.inheritable.} = ref object
     value*: T
 
   Derived[T] = ref object of Base[T]

--- a/tests/generics/tcan.nim
+++ b/tests/generics/tcan.nim
@@ -31,7 +31,7 @@ block tinherit:
 
 block tspecialise:
   type
-    TGen[T] = object {.inheritable.}
+    TGen[T] {.inheritable.} = object
     TSpef = object of TGen[string]
 
 

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -191,14 +191,14 @@ template myAttr3() {.pragma.}
 template serializationKey(key: string) {.pragma.}
 
 type
-  MyObj = object {.packed,myAttr,serializationKey: "one".}
+  MyObj {.packed,myAttr,serializationKey: "one".} = object
     myField {.myAttr2,serializationKey: "two".}: int
     myField2 {.myAttr3,serializationKey: "three".}: float
 
 # field pragmas not currently supported
 test(MyObj):
   type
-    _ = object {.packed,myAttr,serializationKey: "one".}
+    _ {.packed,myAttr,serializationKey: "one".} = object
       myField: int
       myField2: float
 

--- a/tests/macros/tvtable.nim
+++ b/tests/macros/tvtable.nim
@@ -18,7 +18,7 @@ type
   # it's also possible to use a strongly typed tuple here
   VTable = array[0..1, pointer]
 
-  TBase = object {.inheritable.}
+  TBase {.inheritable.} = object
     vtbl: ptr VTable
 
   TUserObject1 = object of TBase

--- a/tests/method/tmethod_issues.nim
+++ b/tests/method/tmethod_issues.nim
@@ -10,7 +10,7 @@ type B
 
 
 # bug #1659
-type Animal = ref object {.inheritable.}
+type Animal {.inheritable.} = ref object
 type Dog = ref object of Animal
 
 method say(a: Animal): auto {.base.} = "wat!"

--- a/tests/method/tmultim.nim
+++ b/tests/method/tmultim.nim
@@ -16,7 +16,7 @@ do nothing
 
 # tmultim2
 type
-  TThing = object {.inheritable.}
+  TThing {.inheritable.} = object
   TUnit = object of TThing
     x: int
   TParticle = object of TThing
@@ -49,7 +49,7 @@ staticCollide(a, b)
 
 # tmultim6
 type
-  Thing = object {.inheritable.}
+  Thing {.inheritable.} = object
   Unit[T] = object of Thing
     x: T
   Particle = object of Thing
@@ -81,7 +81,7 @@ method somethin(obj: RootObj) {.base.} =
   echo "do nothing"
 
 type
-  TNode* = object {.inheritable.}
+  TNode* {.inheritable.} = object
   PNode* = ref TNode
 
   PNodeFoo* = ref object of TNode

--- a/tests/objects/tobjconstr2.nim
+++ b/tests/objects/tobjconstr2.nim
@@ -15,8 +15,8 @@ echo s[0].x
 
 # bug #563
 type
-  Foo =
-    object {.inheritable.}
+  Foo {.inheritable.} =
+    object
       x: int
 
   Bar =

--- a/tests/stdlib/tstrset.nim
+++ b/tests/stdlib/tstrset.nim
@@ -3,7 +3,7 @@
 type
   TRadixNodeKind = enum rnLinear, rnFull, rnLeaf
   PRadixNode = ref TRadixNode
-  TRadixNode = object {.inheritable.}
+  TRadixNode {.inheritable.} = object
     kind: TRadixNodeKind
   TRadixNodeLinear = object of TRadixNode
     len: int8

--- a/tests/typerel/tcommontype.nim
+++ b/tests/typerel/tcommontype.nim
@@ -1,5 +1,5 @@
 type
-  TAnimal=object {.inheritable.}
+  TAnimal {.inheritable.}=object
   PAnimal=ref TAnimal
 
   TDog=object of TAnimal

--- a/tests/types/tfinalobj.nim
+++ b/tests/types/tfinalobj.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 type
-  TA = object {.pure, final.}
+  TA {.pure, final.} = object
     x: string
 
 var

--- a/tests/types/tinheritref.nim
+++ b/tests/types/tinheritref.nim
@@ -11,11 +11,11 @@ ob = T[int](elem: 23)
 doAssert ob.elem == 23
 
 type
-  TTreeIteratorA* = ref object {.inheritable.}
+  TTreeIteratorA* {.inheritable.} = ref object
 
   TKeysIteratorA* = ref object of TTreeIteratorA  #compiles
 
-  TTreeIterator* [T,D] = ref object {.inheritable.}
+  TTreeIterator* [T,D] {.inheritable.} = ref object
 
   TKeysIterator* [T,D] = ref object of TTreeIterator[T,D]  #this not
 


### PR DESCRIPTION
Partial backport of #20199 to 1.6, fixing #4651 and #16653 for 1.6 as well.

Biggest reason is that the old workaround gives a parser error on 2.0 instead of a compile error, meaning shimming for older versions needs a macro or conditional `include`.