### PR TITLE
Update the Nim Manual compile pragma with the second tuple form

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7597,7 +7597,7 @@ Compile pragma
 The `compile` pragma can be used to compile and link a C/C++ source file
 with the project:
 
-This pragma can take two forms. The first is a simple file input:
+This pragma can take three forms. The first is a simple file input:
   ```Nim
   {.compile: "myfile.cpp".}
   ```

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7597,8 +7597,14 @@ Compile pragma
 The `compile` pragma can be used to compile and link a C/C++ source file
 with the project:
 
+This pragma can take two forms. The first is a simple file input:
   ```Nim
   {.compile: "myfile.cpp".}
+  ```
+
+The second form is a tuple where the second arg is the output name strutils formatter:
+  ```Nim
+  {.compile: ("file.c", "$1.o").}
   ```
 
 **Note**: Nim computes a SHA1 checksum and only recompiles the file if it


### PR DESCRIPTION
There's nothing in the manual that outlines the tuple usage of the .compile. pragma. 
It's got a total of three forms

1. {.compile: "myfile.cpp".}
2. {.compile: ("myfile.cpp", "$1.o").}
3. {.compile("myfile.cpp", "custom_arguments").}