### PR TITLE
Cpp Vfunctions draft

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -231,7 +231,7 @@ type
   TNodeKinds* = set[TNodeKind]
 
 type
-  TSymFlag* = enum    # 49 flags!
+  TSymFlag* = enum    # 50 flags!
     sfUsed,           # read access of sym (for warnings) or simply used
     sfExported,       # symbol is exported from module
     sfFromGeneric,    # symbol is instantiation of a generic; this is needed

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -930,7 +930,7 @@ type
       cname*: string          # resolved C declaration name in importc decl, e.g.:
                               # proc fun() {.importc: "$1aux".} => cname = funaux
     constraint*: PNode        # additional constraints like 'lit|result'; also
-                              # misused for the codegenDecl pragma in the hope
+                              # misused for the codegenDecl and virtual pragmas in the hope
                               # it won't cause problems
                               # for skModule the string literal to output for
                               # deprecated modules.

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -312,6 +312,7 @@ type
                       #
                       # This is disallowed but can cause the typechecking to go into
                       # an infinite loop, this flag is used as a sentinel to stop it.
+    sfVirtual         # proc is a C++ virtual function
 
   TSymFlags* = set[TSymFlag]
 

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -574,7 +574,6 @@ proc getRecordFields(m: BModule; typ: PType, check: var IntSet): Rope =
   if typ.itemId in m.g.graph.virtualProcsPerType:
     let procs = m.g.graph.virtualProcsPerType[typ.itemId]
     for prc in procs:
-      if "#->" in prc.loc.r or "#." in prc.loc.r: continue # already generated     
       var header: Rope
       genVirtualProcHeader(m, prc, header, false, true)
       result.add "\t" & header & ";\n"
@@ -621,7 +620,7 @@ proc getRecordDescAux(m: BModule; typ: PType, name, baseType: Rope,
     result.addf(" {\n", [name])
 
 proc getRecordDesc(m: BModule; typ: PType, name: Rope,
-                   check: var IntSet): Rope =             
+                   check: var IntSet): Rope =
   # declare the record:
   var hasField = false
   var structOrUnion: string
@@ -1019,16 +1018,16 @@ proc genVirtualProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool =
   let asPtrStr = rope(if asPtr: "_PTR" else: "")
   var name, declParams, userRetTyp: string
   var isFnConst, isOverride: bool
-  parseVFunctionDecl(prc.loc.r, name, declParams, userRetTyp, isFnConst, isOverride)
+  parseVFunctionDecl(prc.constraint.strVal, name, declParams, userRetTyp, isFnConst, isOverride)
   #first we format the name to get rid of the $
   template `%`(s: string, args: openArray[string]): string = runtimeFormat(s, args)
   declParams = declParams.replace("#", "$") % nimParams.pairs.toSeq.mapIt(it[0] & " " & it[1])
-  declParams = declParams.replace("%", "$") %  nimParams.keys.toSeq
+  declParams = declParams.replace("%", "$") % nimParams.keys.toSeq
   declParams = declParams.replace("^", "$") % nimParams.values.toSeq
   params = "($1)" % [declParams]
   if userRetTyp != "":
     rettype = userRetTyp.replace("%0", "$1") % [rettype]
-  var fnConst, override : string
+  var fnConst, override: string
   if isFnConst:
     fnConst = " const"
   if isFwdDecl:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -12,7 +12,7 @@
 # ------------------------- Name Mangling --------------------------------
 
 import sighashes, modulegraphs
-import strscans
+import strscans, sequtils
 import ../dist/checksums/src/checksums/md5
 
 proc isKeyword(w: PIdent): bool =
@@ -997,7 +997,7 @@ proc parseExistingParams(params:string, parsedParams: var OrderedTable[string, s
     var pair = p.split(" ")
     if pair.len == 2:
       parsedParams[pair[0].strip()] = pair[1].strip()
-import std/sequtils
+
 proc genVirtualProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool = false, isFwdDecl : bool = false) =
   assert sfVirtual in prc.flags
   # using static is needed for inline procs
@@ -1017,7 +1017,7 @@ proc genVirtualProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool =
   # handle the 2 options for hotcodereloading codegen - function pointer
   # (instead of forward declaration) or header for function body with "_actual" postfix
   let asPtrStr = rope(if asPtr: "_PTR" else: "")
-  var name, declParams, userRetTyp : string
+  var name, declParams, userRetTyp: string
   var isFnConst, isOverride: bool
   parseVFunctionDecl(prc.loc.r, name, declParams, userRetTyp, isFnConst, isOverride)
   #first we format the name to get rid of the $
@@ -1025,7 +1025,7 @@ proc genVirtualProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool =
   declParams = declParams.replace("#", "$") % nimParams.pairs.toSeq.mapIt(it[0] & " " & it[1])
   declParams = declParams.replace("%", "$") %  nimParams.keys.toSeq
   declParams = declParams.replace("^", "$") % nimParams.values.toSeq
-  params = "(" & declParams & ")"
+  params = "($1)" % [declParams]
   if userRetTyp != "":
     rettype = userRetTyp.replace("%0", "$1") % [rettype]
   var fnConst, override : string

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -574,7 +574,7 @@ proc getRecordFields(m: BModule; typ: PType, check: var IntSet): Rope =
   if typ.itemId in m.g.graph.virtualProcsPerType:
     let procs = m.g.graph.virtualProcsPerType[typ.itemId]
     for prc in procs:
-      if "#->" in prc.loc.r or "#." in prc.loc.r: continue     
+      if "#->" in prc.loc.r or "#." in prc.loc.r: continue # already generated     
       var header: Rope
       genVirtualProcHeader(m, prc, header, false, true)
       result.add "\t" & header & ";\n"

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1177,7 +1177,10 @@ proc genProcAux*(m: BModule, prc: PSym) =
         res.loc.storage = OnUnknown
   if isVirtual:
     var thisParam = prc.typ.n[1].sym 
-    thisParam.loc.r = "this" #the user first param becomes the C++ this
+    if thisParam.typ.kind == tyPtr:
+      thisParam.loc.r = "this"
+    else:
+      thisParam.loc.r = "(*this)"
 
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1176,11 +1176,11 @@ proc genProcAux*(m: BModule, prc: PSym) =
         #incl(res.loc.flags, lfIndirect)
         res.loc.storage = OnUnknown
   if isVirtual:
-    var thisParam = prc.typ.n[1].sym 
-    if thisParam.typ.kind == tyPtr:
-      thisParam.loc.r = "this"
+    var this = prc.typ.n[1].sym 
+    if this.typ.kind == tyPtr:
+      this.loc.r = "this"
     else:
-      thisParam.loc.r = "(*this)"
+      this.loc.r = "(*this)"
 
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1129,8 +1129,7 @@ proc isNoReturn(m: BModule; s: PSym): bool {.inline.} =
 proc genProcAux*(m: BModule, prc: PSym) =
   var p = newProc(prc, m)
   var header = newRopeAppender()
-  let isVirtual = m.config.backend == backendCpp and sfVirtual in prc.flags
-  if isVirtual:
+  if m.config.backend == backendCpp and sfVirtual in prc.flags:
     genVirtualProcHeader(m, prc, header)
   else:
     genProcHeader(m, prc, header)
@@ -1175,12 +1174,6 @@ proc genProcAux*(m: BModule, prc: PSym) =
       if skipTypes(res.typ, abstractInst).kind == tyArray:
         #incl(res.loc.flags, lfIndirect)
         res.loc.storage = OnUnknown
-  if isVirtual:
-    var this = prc.typ.n[1].sym 
-    if this.typ.kind == tyPtr:
-      this.loc.r = "this"
-    else:
-      this.loc.r = "(*this)"
 
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1172,6 +1172,12 @@ proc genProcAux*(m: BModule, prc: PSym) =
         #incl(res.loc.flags, lfIndirect)
         res.loc.storage = OnUnknown
 
+  if sfVirtual in prc.flags: #not sure if I should put this check somewhere else
+    let thisParam = prc.typ.n[1].sym 
+    var check: IntSet
+    p.s(cpsLocals).addf("\t$1 $2 = this; $n",
+      [getTypeDescWeak(m, thisParam.typ, check, skParam), thisParam.loc.r])
+   
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
     if param.typ.isCompileTimeOnly: continue
@@ -1231,6 +1237,10 @@ proc requiresExternC(m: BModule; sym: PSym): bool {.inline.} =
 proc genProcPrototype(m: BModule, sym: PSym) =
   useHeader(m, sym)
   if lfNoDecl in sym.loc.flags: return
+  if sfVirtual in sym.flags:
+      echo " genProcPrototype ", sym.name.s
+      # echo m.s[cfsTypes]
+      return
   if lfDynamicLib in sym.loc.flags:
     if sym.itemId.module != m.module.position and
         not containsOrIncl(m.declaredThings, sym.id):

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1236,11 +1236,7 @@ proc requiresExternC(m: BModule; sym: PSym): bool {.inline.} =
 
 proc genProcPrototype(m: BModule, sym: PSym) =
   useHeader(m, sym)
-  if lfNoDecl in sym.loc.flags: return
-  if sfVirtual in sym.flags:
-      echo " genProcPrototype ", sym.name.s
-      # echo m.s[cfsTypes]
-      return
+  if lfNoDecl in sym.loc.flags or sfVirtual in sym.flags: return
   if lfDynamicLib in sym.loc.flags:
     if sym.itemId.module != m.module.position and
         not containsOrIncl(m.declaredThings, sym.id):

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1172,12 +1172,12 @@ proc genProcAux*(m: BModule, prc: PSym) =
         #incl(res.loc.flags, lfIndirect)
         res.loc.storage = OnUnknown
 
-  if sfVirtual in prc.flags: #not sure if I should put this check somewhere else
+  if m.config.backend == backendCpp and sfVirtual in prc.flags:
     let thisParam = prc.typ.n[1].sym 
     var check: IntSet
     p.s(cpsLocals).addf("\t$1 $2 = this; $n",
       [getTypeDescWeak(m, thisParam.typ, check, skParam), thisParam.loc.r])
-   
+
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
     if param.typ.isCompileTimeOnly: continue

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -79,6 +79,7 @@ type
     procInstCache*: Table[ItemId, seq[LazyInstantiation]] # A symbol's ItemId.
     attachedOps*: array[TTypeAttachedOp, Table[ItemId, LazySym]] # Type ID, destructors, etc.
     methodsPerType*: Table[ItemId, seq[(int, LazySym)]] # Type ID, attached methods
+    virtualProcsPerType*: Table[ItemId, seq[PSym]] # Type ID, attached virtual procs
     enumToStringProcs*: Table[ItemId, LazySym]
     emittedTypeInfo*: Table[string, FileIndex]
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1264,8 +1264,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         sym.flags.incl sfSystemRaisesDefect
       of wVirtual:
         noVal(c, it)
-        incl(sym.flags, sfVirtual)
-        incl(sym.flags, sfInfixCall)
+        sym.flags.incl {sfVirtual, sfInfixCall}
+      
       else: invalidPragma(c, it)
     elif comesFromPush and whichKeyword(ident) != wInvalid:
       discard "ignore the .push pragma; it doesn't apply"

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1265,6 +1265,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wVirtual:
         noVal(c, it)
         incl(sym.flags, sfVirtual)
+        incl(sym.flags, sfInfixCall)
       else: invalidPragma(c, it)
     elif comesFromPush and whichKeyword(ident) != wInvalid:
       discard "ignore the .push pragma; it doesn't apply"

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -34,7 +34,7 @@ const
     wAsmNoStackFrame, wDiscardable, wNoInit, wCodegenDecl,
     wGensym, wInject, wRaises, wEffectsOf, wTags, wForbids, wLocks, wDelegator, wGcSafe,
     wConstructor, wLiftLocals, wStackTrace, wLineTrace, wNoDestroy,
-    wRequires, wEnsures, wEnforceNoRaises, wSystemRaisesDefect}
+    wRequires, wEnsures, wEnforceNoRaises, wSystemRaisesDefect, wVirtual}
   converterPragmas* = procPragmas
   methodPragmas* = procPragmas+{wBase}-{wImportCpp}
   templatePragmas* = {wDeprecated, wError, wGensym, wInject, wDirty,
@@ -1262,6 +1262,9 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         sym.flags.incl sfNeverRaises
       of wSystemRaisesDefect:
         sym.flags.incl sfSystemRaisesDefect
+      of wVirtual:
+        noVal(c, it)
+        incl(sym.flags, sfVirtual)
       else: invalidPragma(c, it)
     elif comesFromPush and whichKeyword(ident) != wInvalid:
       discard "ignore the .push pragma; it doesn't apply"

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1265,6 +1265,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wVirtual:
         noVal(c, it)
         sym.flags.incl {sfVirtual, sfInfixCall}
+        sym.typ.callConv = ccNoConvention
       
       else: invalidPragma(c, it)
     elif comesFromPush and whichKeyword(ident) != wInvalid:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -246,7 +246,7 @@ proc getOptionalStr(c: PContext, n: PNode, defaultStr: string): string =
 
 proc processVirtual(c: PContext, n: PNode, s: PSym) =
   s.constraint = newEmptyStrNode(c, n, getOptionalStr(c, n, "$1"))
-  s.constraint.strVal = s.constraint.strVal % s.name.s #TODO dont do this, move it into the parser
+  s.constraint.strVal = s.constraint.strVal % s.name.s
   s.flags.incl {sfVirtual, sfInfixCall, sfExportc, sfMangleCpp}
   
   s.typ.callConv = ccNoConvention

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -202,6 +202,15 @@ proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
     incl(m.flags, sfCompileToCpp)
   incl c.config.globalOptions, optMixedMode
 
+
+proc processVirtual(c: PContext; s: PSym, extname: string, info: TLineInfo) =
+  setExternName(c, s, extname, info)
+  s.flags.incl {sfVirtual, sfInfixCall}
+  s.flags.excl {sfExportc}
+  s.typ.callConv = ccNoConvention
+  incl c.config.globalOptions, optMixedMode
+
+
 proc processImportObjC(c: PContext; s: PSym, extname: string, info: TLineInfo) =
   setExternName(c, s, extname, info)
   incl(s.flags, sfImportc)
@@ -1263,9 +1272,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wSystemRaisesDefect:
         sym.flags.incl sfSystemRaisesDefect
       of wVirtual:
-        noVal(c, it)
-        sym.flags.incl {sfVirtual, sfInfixCall}
-        sym.typ.callConv = ccNoConvention
+          processVirtual(c, sym, getOptionalStr(c, it, "$1"), it.info)
       
       else: invalidPragma(c, it)
     elif comesFromPush and whichKeyword(ident) != wInvalid:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -833,7 +833,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
       # and it's not a recursive call:
       if not (a.kind == nkSym and a.sym == tracked.owner):
         markSideEffect(tracked, a, n.info)
-
+         
   # p's effects are ours too:
   var a = n[0]
   #if canRaise(a):

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -833,7 +833,6 @@ proc trackCall(tracked: PEffects; n: PNode) =
       # and it's not a recursive call:
       if not (a.kind == nkSym and a.sym == tracked.owner):
         markSideEffect(tracked, a, n.info)
-         
   # p's effects are ours too:
   var a = n[0]
   #if canRaise(a):

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2181,7 +2181,9 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   
   if sfVirtual in s.flags:
     if c.config.backend == backendCpp:
-      let typ = s.typ.sons[1][0] #TODO error if not a ptr or should we allow ref/objects?
+      var typ = s.typ.sons[1] #TODO error on ref and on generics
+      if typ.kind == tyPtr:
+        typ = typ[0]
       if typ.owner.id == s.owner.id and c.module.id == s.owner.id:
         c.graph.virtualProcsPerType.mgetOrPut(typ.itemId, @[]).add s
       else:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2178,6 +2178,13 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
 
   if sfBorrow in s.flags and c.config.cmd notin cmdDocLike:
     result[bodyPos] = c.graph.emptyNode
+  
+  if sfVirtual in s.flags:
+    if c.config.backend == backendCpp:
+      let typ = s.typ.sons[1][0] #TODO error if not a ptr or should we allow ref/objects?
+      c.graph.virtualProcsPerType.mgetOrPut(typ.itemId, @[]).add s
+    else:
+      localError(c.config, n.info, "virtual procs are only supported in C++")
 
   if n[bodyPos].kind != nkEmpty and sfError notin s.flags:
     # for DLL generation we allow sfImportc to have a body, for use in VM

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2182,7 +2182,11 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if sfVirtual in s.flags:
     if c.config.backend == backendCpp:
       let typ = s.typ.sons[1][0] #TODO error if not a ptr or should we allow ref/objects?
-      c.graph.virtualProcsPerType.mgetOrPut(typ.itemId, @[]).add s
+      if typ.owner.id == s.owner.id and c.module.id == s.owner.id:
+        c.graph.virtualProcsPerType.mgetOrPut(typ.itemId, @[]).add s
+      else:
+        localError(c.config, n.info, 
+          "virtual procs must be defined in the same scope as the type they are virtual for and it must be a top level scope")
     else:
       localError(c.config, n.info, "virtual procs are only supported in C++")
 

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2181,9 +2181,15 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   
   if sfVirtual in s.flags:
     if c.config.backend == backendCpp:
-      var typ = s.typ.sons[1] #TODO error on ref and on generics
+      for son in s.typ.sons:
+        if son!=nil and son.isMetaType:
+          localError(c.config, n.info, "virtual unsupported for generic routine")
+
+      var typ = s.typ.sons[1]
       if typ.kind == tyPtr:
         typ = typ[0]
+      if typ.kind != tyObject:
+        localError(c.config, n.info, "virtual must be a non ref object type")
       if typ.owner.id == s.owner.id and c.module.id == s.owner.id:
         c.graph.virtualProcsPerType.mgetOrPut(typ.itemId, @[]).add s
       else:

--- a/tests/cpp/tvirtual.nim
+++ b/tests/cpp/tvirtual.nim
@@ -1,0 +1,68 @@
+discard """
+  targets: "cpp"
+  cmd: "nim cpp $file"
+  output: '''
+hello foo
+hello boo
+hello boo
+Const Message: hello world
+NimPrinter: hello world
+NimPrinterConstRef: hello world
+'''
+"""
+
+{.emit:"""/*TYPESECTION*/
+#include <iostream>
+  class CppPrinter {
+  public:
+    
+    virtual void printConst(char* message) const {
+        std::cout << "Const Message: " << message << std::endl;
+    }
+    virtual void printConstRef(char* message, const int& flag) const {
+        std::cout << "Const Ref Message: " << message << std::endl;
+    }  
+};
+""".}
+
+proc newCpp*[T](): ptr T {.importcpp:"new '*0()".}
+type 
+  Foo = object of RootObj
+  FooPtr = ptr Foo
+  Boo = object of Foo
+  BooPtr = ptr Boo
+  CppPrinter {.importcpp, inheritable.} = object
+  NimPrinter {.exportc.} = object of CppPrinter
+
+proc salute(self:FooPtr) {.virtual.} = 
+  echo "hello foo"
+
+proc salute(self:BooPtr) {.virtual.} =
+  echo "hello boo"
+
+let foo = newCpp[Foo]()
+let boo = newCpp[Boo]()
+let booAsFoo = cast[FooPtr](newCpp[Boo]())
+
+#polymorphism works
+foo.salute()
+boo.salute()
+booAsFoo.salute()
+let message = "hello world".cstring
+
+proc printConst(self:CppPrinter, message:cstring) {.importcpp.}
+CppPrinter().printConst(message)
+
+#notice override is optional. 
+#Will make the cpp compiler to fail if not virtual function with the same signature if found in the base type
+proc printConst(self:NimPrinter, message:cstring) {.virtual:"$1(#2) const override".} =
+  echo "NimPrinter: " & $message
+
+proc printConstRef(self:NimPrinter, message:cstring, flag:int32) {.virtual:"$1(#2, const %3& ^3 ) const override".} =
+  echo "NimPrinterConstRef: " & $message
+
+NimPrinter().printConst(message)
+var val : int32 = 10
+NimPrinter().printConstRef(message, val)
+
+

--- a/tests/cpp/tvirtual.nim
+++ b/tests/cpp/tvirtual.nim
@@ -55,10 +55,10 @@ CppPrinter().printConst(message)
 
 #notice override is optional. 
 #Will make the cpp compiler to fail if not virtual function with the same signature if found in the base type
-proc printConst(self:NimPrinter, message:cstring) {.virtual:"$1(#2) const override".} =
+proc printConst(self:NimPrinter, message:cstring) {.virtual:"$1('2 #2) const override".} =
   echo "NimPrinter: " & $message
 
-proc printConstRef(self:NimPrinter, message:cstring, flag:int32) {.virtual:"$1(#2, const %3& ^3 ) const override".} =
+proc printConstRef(self:NimPrinter, message:cstring, flag:int32) {.virtual:"$1('2 #2, const '3& #3 ) const override".} =
   echo "NimPrinterConstRef: " & $message
 
 NimPrinter().printConst(message)


### PR DESCRIPTION
Initial work on vfunctions. 
It introduces the keyword virtual that allows to mark a proc as virtual so it:
1) Forwards declare the proc in the type definition

```nim
type
  Boo {.exportc.} = object of Foo
      a: int32
    BooPtr = ptr Boo
  proc getFieldB(self : BooPtr) : int32 {. exportc, virtual .} =
    result = self.b + 220.int32

proc anotherVirtual(self : BooPtr, otro:string) {. exportc, virtual .} =
  echo otro 
  
 ```
 
```nim
struct Boo : public Foo {
	NI32 a;
	N_LIB_PRIVATE N_NIMCALL(virtual NI, getFieldB)(void);
	N_LIB_PRIVATE N_NIMCALL(virtual void, anotherVirtual)(NimStringV2 otro_p1);
};
```
 

2) Transform the body so the first parameter is treated as this and its name is qualified with the struct name:
```c

N_LIB_PRIVATE N_NIMCALL(NI32, Boo::getFieldB)(void) {
	NI32 result;
	Boo* self_p0 = this; 
	
```

3) Change the way the calls are done to use:`(#->fn)`  instead of `fn(#)`. ~~It also deals with a go to jumping the declaration issue, reason why we need to detect the usage of a virtual function and mark the proc as `sfUseVirtual`~~

Worth it mentioning that it's compatible with the current forms of `codegenDecl`

Next steps:
1) Once this is approved, explore if expanding the support of `codegenDecl` will allow to introduce `constCpp` as a macro rather than as another pragma.

2) Support generics (probably using the same mechanism as importcpp) where the user types the shape: `virtual:"getSubsystem<'*0>(@)"`

3) Based on 2 remove the need for exportc to keep the name unmangled (no needed since it's already qualified by the struct/class)

Decide if we are supporting something else beside pointers, which Im not sure it make sense since `this` is a pointer.

Decide if we want to be able to autogen call base/super or we left that up to the user

Document it via manual/rfc
