### PR TITLE
build documentation for `checksums/md5` and `checksums/sha1` 

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -13,7 +13,7 @@ const
   NimbleStableCommit = "168416290e49023894fc26106799d6f1fc964a2d" # master
   # examples of possible values: #head, #ea82b54, 1.2.3
   FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
-  ChecksumsStableCommit = "3fa15df7d27ecef624ed932d60f63d6a8949618d"
+  ChecksumsStableCommit = "b4c73320253f78e3a265aec6d9e8feb83f97c77b"
   HeadHash = "#head"
 when not defined(windows):
   const

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -62,7 +62,7 @@ runnableExamples:
 ## ========
 ## * `md5 module <md5.html>`_ for the MD5 checksum algorithm
 ## * `base64 module <base64.html>`_ for a Base64 encoder and decoder
-## * `std/sha1 module <sha1.html>`_ for the SHA-1 checksum algorithm
+## * `sha1 module <sha1.html>`_ for the SHA-1 checksum algorithm
 ## * `tables module <tables.html>`_ for hash tables
 
 import std/private/since

--- a/lib/pure/md5.nim
+++ b/lib/pure/md5.nim
@@ -14,7 +14,7 @@
 ## See also
 ## ========
 ## * `base64 module<base64.html>`_ for a Base64 encoder and decoder
-## * `std/sha1 module <sha1.html>`_ for the SHA-1 checksum algorithm
+## * `sha1 module <sha1.html>`_ for the SHA-1 checksum algorithm
 ## * `hashes module<hashes.html>`_ for efficient computations of hash values
 ##   for diverse Nim types
 

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -150,6 +150,8 @@ lib/posix/posix_other_consts.nim
 lib/posix/posix_freertos_consts.nim
 lib/posix/posix_openbsd_amd64.nim
 lib/posix/posix_haiku.nim
+lib/pure/md5.nim
+lib/std/sha1.nim
 """.splitWhitespace()
 
   officialPackagesList = """
@@ -161,6 +163,8 @@ pkgs/db_connector/src/db_connector/db_mysql.nim
 pkgs/db_connector/src/db_connector/db_odbc.nim
 pkgs/db_connector/src/db_connector/db_postgres.nim
 pkgs/db_connector/src/db_connector/db_sqlite.nim
+pkgs/checksums/src/checksums/md5.nim
+pkgs/checksums/src/checksums/sha1.nim
 """.splitWhitespace()
 
   officialPackagesListWithoutIndex = """
@@ -335,7 +339,7 @@ proc buildJS(): string =
 proc buildDocsDir*(args: string, dir: string) =
   let args = nimArgs & " " & args
   let docHackJsSource = buildJS()
-  gitClonePackages(@["asyncftpclient", "punycode", "smtp", "db_connector"])
+  gitClonePackages(@["asyncftpclient", "punycode", "smtp", "db_connector", "checksums"])
   createDir(dir)
   buildDocSamples(args, dir)
 


### PR DESCRIPTION
I have added ".. note:: In order to use this module, run `nimble install checksums`." to the source code of `checksums/sha1` and `checksums/md5`. If needed, I can add documentation for other modules such as bcrypto, sha2, etc when it's the right time.