### PR TITLE
Document about size pragma

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7513,7 +7513,7 @@ so that one can get the size of it at compile time even if it was declared witho
       echo sizeof(AtomicFlag)
   ```
 
-The `size pragma` accepts only the value 1, 2, 4 or 8.
+The `size pragma` accepts only the values 1, 2, 4 or 8.
 
 
 Align pragma

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7487,8 +7487,8 @@ generates:
 
 size pragma
 -----------
-Nim automatically determine the size of an enum.
-But when wrapping a C enum type, it need to be specific size.
+Nim automatically determines the size of an enum.
+But when wrapping a C enum type, it needs to be a specific size.
 `size pragma` allows specifying the size of the enum type.
 
   ```Nim
@@ -7501,7 +7501,7 @@ But when wrapping a C enum type, it need to be specific size.
   doAssert sizeof(EventType) == sizeof(uint32)
   ```
 
-`size pragma` can also specifys the size of importc incomplete object type
+`size pragma` can also specify the size of importc incomplete object type
 so that you can get the size of it at compile time even if it was declared without fields.
 
   ```Nim

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7485,6 +7485,37 @@ generates:
   ```
 
 
+size pragma
+-----------
+Nim automatically determine the size of an enum.
+But when wrapping a C enum type, it need to be specific size.
+`size pragma` allows specifying the size of the enum type.
+
+  ```Nim
+  type
+    EventType* {.size: sizeof(uint32).} = enum
+      QuitEvent,
+      AppTerminating,
+      AppLowMemory
+
+  doAssert sizeof(EventType) == sizeof(uint32)
+  ```
+
+`size pragma` can also specifys the size of importc incomplete object type
+so that you can get the size of it at compile time even if it was declared without fields.
+
+  ```Nim
+    type
+      AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
+
+    static:
+      # if AtomicFlag didn't have size pragma, this code result in compile error.
+      echo sizeof(AtomicFlag)
+  ```
+
+size pragma accepts only 1, 2, 4 or 8.
+
+
 Align pragma
 ------------
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7488,8 +7488,8 @@ generates:
 size pragma
 -----------
 Nim automatically determines the size of an enum.
-But when wrapping a C enum type, it needs to be a specific size.
-`size pragma` allows specifying the size of the enum type.
+But when wrapping a C enum type, it needs to be of a specific size.
+The `size pragma` allows specifying the size of the enum type.
 
   ```Nim
   type
@@ -7501,19 +7501,19 @@ But when wrapping a C enum type, it needs to be a specific size.
   doAssert sizeof(EventType) == sizeof(uint32)
   ```
 
-`size pragma` can also specify the size of importc incomplete object type
-so that you can get the size of it at compile time even if it was declared without fields.
+The `size pragma` can also specify the size of an `importc` incomplete object type
+so that one can get the size of it at compile time even if it was declared without fields.
 
   ```Nim
     type
       AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
 
     static:
-      # if AtomicFlag didn't have size pragma, this code result in compile error.
+      # if AtomicFlag didn't have the size pragma, this code would result in a compile time error.
       echo sizeof(AtomicFlag)
   ```
 
-size pragma accepts only 1, 2, 4 or 8.
+The `size pragma` accepts only the value 1, 2, 4 or 8.
 
 
 Align pragma


### PR DESCRIPTION
size pragma is not documented in Nim manual while it is often used for wrapping C libraries.