### PR TITLE
towards less macros in the C/C++ codegen output

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -58,8 +58,8 @@ proc genLiteral(p: BProc, n: PNode, ty: PType; result: var Rope) =
     of tyChar, tyNil:
       intLiteral(n.intVal, result)
     of tyBool:
-      if n.intVal != 0: result.add "NIM_TRUE"
-      else: result.add "NIM_FALSE"
+      if n.intVal != 0: result.add "true"
+      else: result.add "false"
     of tyInt64: int64Literal(n.intVal, result)
     of tyUInt64: uint64Literal(uint64(n.intVal), result)
     else:
@@ -3177,7 +3177,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
 proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo; result: var Rope) =
   var t = skipTypes(typ, abstractRange+{tyOwned}-{tyTypeDesc})
   case t.kind
-  of tyBool: result.add rope"NIM_FALSE"
+  of tyBool: result.add rope"false"
   of tyEnum, tyChar, tyInt..tyInt64, tyUInt..tyUInt64: result.add rope"0"
   of tyFloat..tyFloat128: result.add rope"0.0"
   of tyCstring, tyVar, tyLent, tyPointer, tyPtr, tyUntyped,

--- a/compiler/ccgliterals.nim
+++ b/compiler/ccgliterals.nim
@@ -57,7 +57,7 @@ proc genStringLiteralV1(m: BModule; n: PNode; result: var Rope) =
 
 proc genStringLiteralDataOnlyV2(m: BModule, s: string; result: Rope; isConst: bool) =
   m.s[cfsStrData].addf("static $4 struct {$n" &
-       "  NI cap; NIM_CHAR data[$2+1];$n" &
+       "  NI cap; char data[$2+1];$n" &
        "} $1 = { $2 | NIM_STRLIT_FLAG, $3 };$n",
        [result, rope(s.len), makeCString(s),
        rope(if isConst: "const" else: "")])

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -123,7 +123,7 @@ proc genVarTuple(p: BProc, n: PNode) =
     # insert the registration of the globals for the different parts of the tuple at the
     # start of the current scope (after they have been iterated) and init a boolean to
     # check if any of them is newly introduced and the initializing code has to be ran
-    lineCg(p, cpsLocals, "NIM_BOOL $1 = NIM_FALSE;$n", [hcrCond])
+    lineCg(p, cpsLocals, "NIM_BOOL $1 = false;$n", [hcrCond])
     for curr in hcrGlobals:
       lineCg(p, cpsLocals, "$1 |= hcrRegisterGlobal($4, \"$2\", sizeof($3), $5, (void**)&$2);$N",
               [hcrCond, curr.loc.r, rdLoc(curr.loc), getModuleDllPath(p.module, n[0].sym), curr.tp])
@@ -1290,7 +1290,7 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
       if i > 1: lineF(p, cpsStmts, "else", [])
       startBlock(p)
       # we handled the exception, remember this:
-      linefmt(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", [])
+      linefmt(p, cpsStmts, "*nimErr_ = false;$n", [])
       expr(p, t[i][0], d)
     else:
       var orExpr = newRopeAppender()
@@ -1308,7 +1308,7 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
       if i > 1: line(p, cpsStmts, "else ")
       startBlock(p, "if ($1) {$n", [orExpr])
       # we handled the exception, remember this:
-      linefmt(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", [])
+      linefmt(p, cpsStmts, "*nimErr_ = false;$n", [])
       expr(p, t[i][^1], d)
 
     linefmt(p, cpsStmts, "#popCurrentException();$n", [])
@@ -1328,7 +1328,7 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
     else:
       # pretend we did handle the error for the safe execution of the 'finally' section:
       p.procSec(cpsLocals).add(ropecg(p.module, "NIM_BOOL oldNimErrFin$1_;$n", [lab]))
-      linefmt(p, cpsStmts, "oldNimErrFin$1_ = *nimErr_; *nimErr_ = NIM_FALSE;$n", [lab])
+      linefmt(p, cpsStmts, "oldNimErrFin$1_ = *nimErr_; *nimErr_ = false;$n", [lab])
       genStmts(p, t[i][0])
       # this is correct for all these cases:
       # 1. finally is run during ordinary control flow

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -123,7 +123,7 @@ proc genVarTuple(p: BProc, n: PNode) =
     # insert the registration of the globals for the different parts of the tuple at the
     # start of the current scope (after they have been iterated) and init a boolean to
     # check if any of them is newly introduced and the initializing code has to be ran
-    lineCg(p, cpsLocals, "NIM_BOOL $1 = false;$n", [hcrCond])
+    lineCg(p, cpsLocals, "bool $1 = false;$n", [hcrCond])
     for curr in hcrGlobals:
       lineCg(p, cpsLocals, "$1 |= hcrRegisterGlobal($4, \"$2\", sizeof($3), $5, (void**)&$2);$N",
               [hcrCond, curr.loc.r, rdLoc(curr.loc), getModuleDllPath(p.module, n[0].sym), curr.tp])
@@ -1327,7 +1327,7 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
       genStmts(p, t[i][0])
     else:
       # pretend we did handle the error for the safe execution of the 'finally' section:
-      p.procSec(cpsLocals).add(ropecg(p.module, "NIM_BOOL oldNimErrFin$1_;$n", [lab]))
+      p.procSec(cpsLocals).add(ropecg(p.module, "bool oldNimErrFin$1_;$n", [lab]))
       linefmt(p, cpsStmts, "oldNimErrFin$1_ = *nimErr_; *nimErr_ = false;$n", [lab])
       genStmts(p, t[i][0])
       # this is correct for all these cases:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -293,8 +293,8 @@ proc getSimpleTypeDesc(m: BModule; typ: PType): Rope =
       cgsym(m, "NimStringDesc")
       result = typeNameOrLiteral(m, typ, "NimStringDesc*")
   of tyCstring: result = typeNameOrLiteral(m, typ, "NCSTRING")
-  of tyBool: result = typeNameOrLiteral(m, typ, "NIM_BOOL")
-  of tyChar: result = typeNameOrLiteral(m, typ, "NIM_CHAR")
+  of tyBool: result = typeNameOrLiteral(m, typ, "bool")
+  of tyChar: result = typeNameOrLiteral(m, typ, "char")
   of tyNil: result = typeNameOrLiteral(m, typ, "void*")
   of tyInt..tyUInt64:
     result = typeNameOrLiteral(m, typ, NumericalTypeToStr[typ.kind])

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1119,7 +1119,7 @@ proc genProcBody(p: BProc; procBody: PNode) =
   genStmts(p, procBody) # modifies p.locals, p.init, etc.
   if {nimErrorFlagAccessed, nimErrorFlagDeclared} * p.flags == {nimErrorFlagAccessed}:
     p.flags.incl nimErrorFlagDeclared
-    p.blocks[0].sections[cpsLocals].add(ropecg(p.module, "NIM_BOOL* nimErr_;$n", []))
+    p.blocks[0].sections[cpsLocals].add(ropecg(p.module, "bool* nimErr_;$n", []))
     p.blocks[0].sections[cpsInit].add(ropecg(p.module, "nimErr_ = #nimErrorFlag();$n", []))
 
 proc isNoReturn(m: BModule; s: PSym): bool {.inline.} =
@@ -1806,7 +1806,7 @@ proc genInitCode(m: BModule) =
 
   if m.hcrOn:
     prc.addf("\tint* nim_hcr_dummy_ = 0;$n" &
-              "\tNIM_BOOL nim_hcr_do_init_ = " &
+              "\bool nim_hcr_do_init_ = " &
                   "hcrRegisterGlobal($1, \"module_initialized_\", 1, NULL, (void**)&nim_hcr_dummy_);$n",
       [getModuleDllPath(m, m.module)])
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -310,28 +310,23 @@ __AVR__
 namespace USE_NIM_NAMESPACE {
 #endif
 
-// preexisting check, seems paranoid, maybe remove
-#if defined(NIM_TRUE) || defined(NIM_FALSE) || defined(NIM_BOOL)
-#error "nim reserved preprocessor macros clash"
-#endif
-
 /* bool types (C++ has it): */
-#ifdef __cplusplus
-#define NIM_BOOL bool
-#elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901)
-// see #13798: to avoid conflicts for code emitting `#include <stdbool.h>`
-#define NIM_BOOL _Bool
-#else
-typedef unsigned char NIM_BOOL; // best effort
+#ifndef __cplusplus
+#  if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901)
+#    include <stdbool.h>
+#  else
+#    define bool  unsigned char
+#    define true	1
+#    define false	0
+#  endif
 #endif
-
-NIM_STATIC_ASSERT(sizeof(NIM_BOOL) == 1, ""); // check whether really needed
+#define NIM_BOOL bool
+#define NIM_TRUE true
+#define NIM_FALSE false
+NIM_STATIC_ASSERT(sizeof(bool) == 1, ""); // check whether really needed
 NIM_STATIC_ASSERT(CHAR_BIT == 8, "");
   // fail fast for (rare) environments where this doesn't hold, as some implicit
   // assumptions would need revisiting (e.g. `uint8` or https://github.com/nim-lang/Nim/pull/18505)
-
-#define NIM_TRUE true
-#define NIM_FALSE false
 
 #ifdef __cplusplus
 #  if __cplusplus >= 201103L
@@ -346,7 +341,6 @@ NIM_STATIC_ASSERT(CHAR_BIT == 8, "");
 #    define NIM_NIL 0
 #  endif
 #else
-#  include <stdbool.h>
 #  define NIM_NIL ((void*)0) /* C's NULL is fucked up in some C compilers, so
                               the generated code does not rely on it anymore */
 #endif
@@ -474,7 +468,7 @@ typedef char* NCSTRING;
 #define STRING_LITERAL(name, str, length) \
    static const struct {                   \
      TGenericSeq Sup;                      \
-     NIM_CHAR data[(length) + 1];          \
+     char data[(length) + 1];          \
   } name = {{length, (NI) ((NU)length | NIM_STRLIT_FLAG)}, str}
 
 /* declared size of a sequence/variable length array: */

--- a/tests/ccgbugs/tnoalias.nim
+++ b/tests/ccgbugs/tnoalias.nim
@@ -1,5 +1,5 @@
 discard """
-  ccodecheck: "\\i@'NI* NIM_NOALIAS field;' @'NIM_CHAR* NIM_NOALIAS x_p0,' @'void* NIM_NOALIAS q'"
+  ccodecheck: "\\i@'NI* NIM_NOALIAS field;' @'char* NIM_NOALIAS x_p0,' @'void* NIM_NOALIAS q'"
 """
 
 type


### PR DESCRIPTION
While working on clearly far more important C/C++ codegen issues, I kept wondering if we could not simply emit C's and C++'s "native" types in the cases of `NIM_BOOL` and `NIM_CHAR` nowadays, instead of using macros/redundant typedefs possibly obscuring semantics for the C/C++ code interpreter (be it a person or an editor/IDE).

I did not encounter any problems swapping `NIM_CHAR` for `char` with both C and C++, but I might be lacking foresight here.

For `NIM_BOOL` → `bool` the story is a bit different: I suggest a slight modification to what was accomplished here #13798: we define `bool`, `true`/`false` macros if C89 support is actually (still?!) wanted. In most other cases, when C code is to be output, why not rely on the ISO C way of having `stdbool.h` take care of what `true` and `false` actually represent since C99 (see https://github.com/gcc-mirror/gcc/blob/master/gcc/ginclude/stdbool.h for reference)?