### PR TITLE
Add build-id=none for GCC when build for Release

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -454,6 +454,7 @@
   static libraries.
 
 - When compiling for Release the flag `-fno-math-errno` is used for GCC.
+- When compiling for Release the flag `--build-id=none` is used for GCC Linker.
 
 ## Docgen
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -369,6 +369,6 @@ tcc.options.always = "-w"
 @if release or danger:
   gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
   gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"
-  clang.options.linker %= "${clang.options.linker} -Wl,--build-id=none"
-  clang.cpp.options.linker %= "${clang.cpp.options.linker} -Wl,--build-id=none"
+  clang.options.linker %= "${clang.options.linker} -Wl,-z,now"
+  clang.cpp.options.linker %= "${clang.cpp.options.linker} -Wl,-z,now"
 @end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -369,6 +369,4 @@ tcc.options.always = "-w"
 @if release or danger:
   gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
   gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"
-  clang.options.linker %= "${clang.options.linker} -Wl,-z,now"
-  clang.cpp.options.linker %= "${clang.cpp.options.linker} -Wl,-z,now"
 @end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -262,15 +262,15 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
 # -fno-math-errno is default in OSX, iOS, BSD, Musl, Libm, LLVM, Clang, ICC.
 # See https://itnext.io/why-standard-c-math-functions-are-slow-d10d02554e33
 # and https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Optimize-Options.html#Optimize-Options
-gcc.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno -Wl,--build-id=none"
-gcc.options.size = "-Os -fno-ident -Wl,--build-id=none"
+gcc.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno"
+gcc.options.size = "-Os -fno-ident"
 @if windows:
   gcc.options.debug = "-g3 -Og -gdwarf-3"
 @else:
   gcc.options.debug = "-g3 -Og"
 @end
-gcc.cpp.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno -Wl,--build-id=none"
-gcc.cpp.options.size = "-Os -fno-ident -Wl,--build-id=none"
+gcc.cpp.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno"
+gcc.cpp.options.size = "-Os -fno-ident"
 gcc.cpp.options.debug = "-g3 -Og"
 #passl = "-pg"
 
@@ -363,4 +363,12 @@ tcc.options.always = "-w"
   gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -s"
   clang.options.linker %= "${clang.options.linker} -s"
   clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
+@end
+
+# Linker: Skip "Build-ID Metadata strings" in binaries when build for Release.
+@if release or danger:
+  gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
+  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"
+  clang.options.linker %= "${clang.options.linker} -Wl,--build-id=none"
+  clang.cpp.options.linker %= "${clang.cpp.options.linker} -Wl,--build-id=none"
 @end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -262,15 +262,15 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
 # -fno-math-errno is default in OSX, iOS, BSD, Musl, Libm, LLVM, Clang, ICC.
 # See https://itnext.io/why-standard-c-math-functions-are-slow-d10d02554e33
 # and https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Optimize-Options.html#Optimize-Options
-gcc.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno"
-gcc.options.size = "-Os -fno-ident"
+gcc.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno -Wl,--build-id=none"
+gcc.options.size = "-Os -fno-ident -Wl,--build-id=none"
 @if windows:
   gcc.options.debug = "-g3 -Og -gdwarf-3"
 @else:
   gcc.options.debug = "-g3 -Og"
 @end
-gcc.cpp.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno"
-gcc.cpp.options.size = "-Os -fno-ident"
+gcc.cpp.options.speed = "-O3 -fno-strict-aliasing -fno-ident -fno-math-errno -Wl,--build-id=none"
+gcc.cpp.options.size = "-Os -fno-ident -Wl,--build-id=none"
 gcc.cpp.options.debug = "-g3 -Og"
 #passl = "-pg"
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -365,7 +365,7 @@ tcc.options.always = "-w"
   clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
 @end
 
-# Linker: Skip "Build-ID Metadata strings" in binaries when build for Release.
+# Linker: Skip "Build-ID metadata strings" in binaries when build for release.
 @if release or danger:
   gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
   gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"


### PR DESCRIPTION
- When compiling for Release the flag `--build-id=none` is used for GCC Linker.
- Skip unneeded "Build-ID metadata strings" in binaries.
- Continuation of https://github.com/nim-lang/Nim/pull/20503#issue-1397942773
- C and ASM do not change, flag is link-time only, flag exists since GCC v4. Tiny diff.

Try it yourself:

```console
$ echo 'echo 42' > temp.nim
$ nim c -d:danger temp.nim
$ objdump -s -j .note.gnu.build-id temp

Contents of section .note.gnu.build-id:
 0378 04000000 14000000 03000000 474e5500  ............GNU.
 0388 2d02280d bdfee16d a8b35a44 9edcf1ce  -.(....m..ZD....
 0398 90595a1d                             .YZ.

Build ID: 2d02280dbdfee16da8b35a449edcf1ce90595a1d (unique build ID bitstring)

$ nim c -d:danger --passL:-Wl,--build-id=none temp.nim
$ objdump -s -j .note.gnu.build-id temp
objdump: section '.note.gnu.build-id' mentioned in a -j option, but not found in any input file.

$
```

Faking it with `--passL:`.
