### PR TITLE
added new experimental API isUniqueRef

### DIFF
--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -120,7 +120,7 @@ proc isUniqueRef*[T](x: ref T): bool {.inline.} =
   ## the object which is subject to lots of optimizations! In other words
   ## the value of `isUniqueRef` can depend on the used compiler version and
   ## optimizer setting.
-  ## Nevertheless it can be used  is a very valuable debugging tool and can
+  ## Nevertheless it can be used as a very valuable debugging tool and can
   ## be used to specify the constraints of a threading related API
   ## via `assert isUniqueRef(x)`.
   head(cast[pointer](x)).rc == 0

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -113,6 +113,18 @@ proc nimNewObjUninit(size, alignment: int): pointer {.compilerRtl.} =
 proc nimDecWeakRef(p: pointer) {.compilerRtl, inl.} =
   decrement head(p)
 
+proc isUniqueRef*[T](x: ref T): bool {.inline.} =
+  ## Returns true if the object `x` points to is uniquely referenced. Such
+  ## an object can potentially be passed over to a different thread safely,
+  ## if great care is taken. This queries the internal reference count of
+  ## the object which is subject to lots of optimizations! In other words
+  ## the value of `isUniqueRef` can depend on the used compiler version and
+  ## optimizer setting.
+  ## Nevertheless it can be used  is a very valuable debugging tool and can
+  ## be used to specify the constraints of a threading related API
+  ## via `assert isUniqueRef(x)`.
+  head(cast[pointer](x)).rc == 0
+
 proc nimIncRef(p: pointer) {.compilerRtl, inl.} =
   when defined(nimArcDebug):
     if head(p).refId == traceId:


### PR DESCRIPTION
Example code that helgrind is happy with:

```nim

import std / [os, locks, atomics]

type
  DatabaseConnection = ref object ## unique, but refers to a shared object
    x: ptr int

  MyList {.acyclic.} = ref object
    data: string
    next: MyList
    other: DatabaseConnection

template withMyLock*(a: Lock, body: untyped) =
  acquire(a)
  {.gcsafe.}:
    try:
      body
    finally:
      release(a)

var head: MyList
var headL: Lock

var shouldStop: Atomic[bool]

initLock headL

proc send(x: sink string; replyTo: sink DatabaseConnection) =
  #                                ^ remove this 'sink' and watch the asserts complain
  assert isUniqueRef(replyTo)
  withMyLock headL:
    head = MyList(data: x, next: head, other: replyTo)
    assert isUniqueRef(head.other)

proc worker() {.thread.} =
  var workItem = MyList(nil)
  var echoed = 0
  while true:
    withMyLock headL:
      var h = head
      if h != nil:
        workItem = h
        # workitem is now isolated:
        head = h.next
      else:
        workItem = nil
    # workItem is isolated, so we can access it outside
    # the lock:
    if workItem.isNil:
      if shouldStop.load:
        break
      else:
        # give producer time to breath:
        #os.sleep 1
        discard
    else:
      if echoed < 100:
        echo workItem.data, workItem.other.x[]
      inc echoed

var id = 23

var thr: Thread[void]
createThread(thr, worker)

send "abc", DatabaseConnection(x: addr id)
send "def", DatabaseConnection(x: addr id)
for i in 0 ..< 10_000:
  send "xzy", DatabaseConnection(x: addr id)
  send "zzz", DatabaseConnection(x: addr id)
shouldStop.store true

joinThread(thr)


```