### PR TITLE
Bootstrap: Allow to override number of CPUs

### DIFF
--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -58,7 +58,11 @@ _nimNumCpu(){
   # FreeBSD | macOS: $(sysctl -n hw.ncpu)
   # OpenBSD: $(sysctl -n hw.ncpuonline)
   # windows: $NUMBER_OF_PROCESSORS ?
-  echo $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
+  if env | grep -q '^NCPU='; then
+    echo $NCPU
+  else
+    echo $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
+  fi
 }
 
 _nimBuildCsourcesIfNeeded(){

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -58,8 +58,8 @@ _nimNumCpu(){
   # FreeBSD | macOS: $(sysctl -n hw.ncpu)
   # OpenBSD: $(sysctl -n hw.ncpuonline)
   # windows: $NUMBER_OF_PROCESSORS ?
-  if env | grep -q '^NCPU='; then
-    echo $NCPU
+  if env | grep -q '^NIMCORES='; then
+    echo $NIMCORES
   else
     echo $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
   fi


### PR DESCRIPTION
Currently the bootstrap process always uses the max amount of CPU, which is not always desired

With this PR, it becomes possible to override it by doing `NIMCORES=1 ./build_all.sh` for instance