### PR TITLE
clean up onUse, onDef, onDefResolveForward

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -353,7 +353,6 @@ proc considerAsgnOrSink(c: var TLiftCtx; t: PType; body, x, y: PNode;
         incl c.fn.flags, sfError
       #else:
       #  markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add newHookCall(c, op, x, y)
       result = true
     elif op == nil and destructorOverriden:
@@ -377,7 +376,6 @@ proc considerAsgnOrSink(c: var TLiftCtx; t: PType; body, x, y: PNode;
       incl c.fn.flags, sfError
     #else:
     #  markUsed(c.g.config, c.info, op, c.g.usageSym)
-    onUse(c.info, op)
     # We also now do generic instantiations in the destructor lifting pass:
     if op.ast.isGenericRoutine:
       op = instantiateGeneric(c, op, t, t.typeInst)
@@ -407,7 +405,6 @@ proc addDestructorCall(c: var TLiftCtx; orig: PType; body, x: PNode) =
 
   if op != nil:
     #markUsed(c.g.config, c.info, op, c.g.usageSym)
-    onUse(c.info, op)
     body.add destructorCall(c, op, x)
   elif useNoGc(c, t):
     internalError(c.g.config, c.info,
@@ -425,7 +422,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
         setAttachedOp(c.g, c.idgen.module, t, attachedDestructor, op)
 
       #markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add destructorCall(c, op, x)
       result = true
     #result = addDestructorCall(c, t, body, x)
@@ -445,7 +441,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
     let op = getAttachedOp(c.g, t, attachedDeepCopy)
     if op != nil:
       #markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add newDeepCopyCall(c, op, x, y)
       result = true
 
@@ -459,7 +454,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
         setAttachedOp(c.g, c.idgen.module, t, attachedWasMoved, op)
 
       #markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add genWasMovedCall(c, op, x)
       result = true
 

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -400,14 +400,6 @@ template getPContext(): untyped =
   when c is PContext: c
   else: c.c
 
-when defined(nimsuggest):
-  template onUse*(info: TLineInfo; s: PSym) = discard
-  template onDefResolveForward*(info: TLineInfo; s: PSym) = discard
-else:
-  template onUse*(info: TLineInfo; s: PSym) = discard
-  template onDef*(info: TLineInfo; s: PSym) = discard
-  template onDefResolveForward*(info: TLineInfo; s: PSym) = discard
-
 proc stopCompile*(g: ModuleGraph): bool {.inline.} =
   result = g.doStopCompile != nil and g.doStopCompile()
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -484,7 +484,6 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
 
   let info = getCallLineInfo(n)
   markUsed(c, info, sym)
-  onUse(info, sym)
   if sym == c.p.owner:
     globalError(c.config, info, "recursive dependency: '$1'" % sym.name.s)
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -568,7 +568,6 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   var finalCallee = x.calleeSym
   let info = getCallLineInfo(n)
   markUsed(c, info, finalCallee)
-  onUse(info, finalCallee)
   assert finalCallee.ast != nil
   if x.hasFauxMatch:
     result = x.call
@@ -659,7 +658,6 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   newInst.typ.flags.excl tfUnresolved
   let info = getCallLineInfo(n)
   markUsed(c, info, s)
-  onUse(info, s)
   result = newSymNode(newInst, info)
 
 proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -77,7 +77,6 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
   of skTemplate, skMacro:
     # alias syntax, see semSym for skTemplate, skMacro
     if sfNoalias notin s.flags and not fromDotExpr:
-      onUse(n.info, s)
       case s.kind
       of skTemplate: result = semTemplateExpr(c, n, s, {efNoSemCheck})
       of skMacro: result = semMacroExpr(c, n, n, s, {efNoSemCheck})
@@ -95,20 +94,16 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
         result = n
     else:
       result = newSymNodeTypeDesc(s, c.idgen, n.info)
-    onUse(n.info, s)
   of skParam:
     result = n
-    onUse(n.info, s)
   of skType:
     if (s.typ != nil) and
        (s.typ.flags * {tfGenericTypeParam, tfImplicitTypeParam} == {}):
       result = newSymNodeTypeDesc(s, c.idgen, n.info)
     else:
       result = n
-    onUse(n.info, s)
   else:
     result = newSymNode(s, n.info)
-    onUse(n.info, s)
 
 proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
             ctx: var GenericCtx): PNode =
@@ -236,7 +231,6 @@ proc semGenericStmt(c: PContext, n: PNode,
       of skMacro, skTemplate:
         # unambiguous macros/templates are expanded if all params are untyped
         if sfAllUntyped in s.flags and sc.safeLen <= 1:
-          onUse(fn.info, s)
           case s.kind
           of skMacro: result = semMacroExpr(c, n, n, s, {efNoSemCheck})
           of skTemplate: result = semTemplateExpr(c, n, s, {efNoSemCheck})
@@ -264,17 +258,14 @@ proc semGenericStmt(c: PContext, n: PNode,
           first = result.safeLen # see trunnableexamples.fun3
       of skGenericParam:
         result[0] = newSymNodeTypeDesc(s, c.idgen, fn.info)
-        onUse(fn.info, s)
         first = 1
       of skType:
         # bad hack for generics:
         if (s.typ != nil) and (s.typ.kind != tyGenericParam):
           result[0] = newSymNodeTypeDesc(s, c.idgen, fn.info)
-          onUse(fn.info, s)
           first = 1
       else:
         result[0] = newSymNode(s, fn.info)
-        onUse(fn.info, s)
         first = 1
     elif fn.kind == nkDotExpr:
       result[0] = fuzzyLookup(c, fn, flags, ctx, mixinContext)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -79,7 +79,6 @@ proc semBreakOrContinue(c: PContext, n: PNode): PNode =
         incl(s.flags, sfUsed)
         n[0] = x
         suggestSym(c.graph, x.info, s, c.graph.usageSym)
-        onUse(x.info, s)
       else:
         localError(c.config, n.info, errInvalidControlFlowX % s.name.s)
     else:
@@ -1042,7 +1041,6 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   if r.state == csMatch:
     var match = r.calleeSym
     markUsed(c, n[0].info, match)
-    onUse(n[0].info, match)
 
     # but pass 'n' to the `case` macro, not 'n[0]':
     r.call[1] = n
@@ -2145,9 +2143,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
         " '" & s.name.s & "' from " & c.config$s.info))
 
   styleCheckDef(c, s)
-  if hasProto:
-    onDefResolveForward(n[namePos].info, proto)
-  else:
+  if not hasProto:
     onDef(n[namePos].info, s)
 
   if hasProto:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1181,7 +1181,6 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
 
   of tyGenericParam:
     markUsed(c, paramType.sym.info, paramType.sym)
-    onUse(paramType.sym.info, paramType.sym)
     if tfWildcard in paramType.flags:
       paramType.flags.excl tfWildcard
       paramType.sym.transitionGenericParamToType()
@@ -1753,7 +1752,6 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
       result = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared})
     if result != nil:
       markUsed(c, n.info, result)
-      onUse(n.info, result)
 
       # alias syntax, see semSym for skTemplate, skMacro
       if result.kind in {skTemplate, skMacro} and sfNoalias notin result.flags:
@@ -2045,7 +2043,6 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         assignType(prev, t)
         result = prev
       markUsed(c, n.info, n.sym)
-      onUse(n.info, n.sym)
     else:
       if s.kind != skError:
         if s.typ == nil:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2311,7 +2311,6 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
     else:
       # only one valid interpretation found:
       markUsed(m.c, arg.info, arg[best].sym)
-      onUse(arg.info, arg[best].sym)
       result = paramTypesMatchAux(m, f, arg[best].typ, arg[best], argOrig)
   when false:
     if m.calleeSym != nil and m.calleeSym.name.s == "[]":

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -712,3 +712,5 @@ when defined(nimsuggest):
   template onDef*(info: TLineInfo; s: PSym) =
     let c = getPContext()
     onDef(c.graph, s, info)
+else:
+  template onDef*(info: TLineInfo; s: PSym) = discard


### PR DESCRIPTION
`onUse` and `onDefResolveForward` have been no-ops since #20250, however they were not removed from code as they could serve as some kind of comment. In this PR these are removed entirely since `onDefResolveForward` is used once and `onUse` is basically always paired with a `markUsed`/`incl(s.flags, sfUsed)` call. In the case where this is removing too much information though, instead of removing we can replace these with just comments, like `# s is used here`.

The stub definition of `onDef` is also moved next to the real definition of `onDef` instead of along with `onUse` and `onDefResolveForward`.