### PR TITLE
fixes nightlies regressions; disable `build-id=none` on macos

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -335,7 +335,7 @@ tcc.options.always = "-w"
    clang_cl.options.always%= "${clang_cl.options.always} -flto=thin"
    clang_cl.cpp.options.always%= "${clang.cpp.options.always} -flto=thin"
    clang.options.always%= "${clang.options.always} -flto=thin"
-   clang.cpp.options.always%= "${clang.cpp.options.always} -flto=thin"
+   clang.cpp.options.always%= clangmacos"${clang.cpp.options.always} -flto=thin"
    clang.options.linker %= "${clang.options.linker} -flto=thin"
    clang.cpp.options.linker %= "${clang.cpp.options.linker} -flto=thin"
   @else:
@@ -366,6 +366,8 @@ tcc.options.always = "-w"
 
 # Linker: Skip "Build-ID metadata strings" in binaries when build for release.
 @if release or danger:
-  gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
-  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"
+  @if not macosx:
+    gcc.options.linker %= "${gcc.options.linker} -Wl,--build-id=none"
+    gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -Wl,--build-id=none"
+  @end
 @end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -335,7 +335,7 @@ tcc.options.always = "-w"
    clang_cl.options.always%= "${clang_cl.options.always} -flto=thin"
    clang_cl.cpp.options.always%= "${clang.cpp.options.always} -flto=thin"
    clang.options.always%= "${clang.options.always} -flto=thin"
-   clang.cpp.options.always%= clangmacos"${clang.cpp.options.always} -flto=thin"
+   clang.cpp.options.always%= "${clang.cpp.options.always} -flto=thin"
    clang.options.linker %= "${clang.options.linker} -flto=thin"
    clang.cpp.options.linker %= "${clang.cpp.options.linker} -flto=thin"
   @else:


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/21808
@juancarlospaco Hey, do you happen to know why it failed on macOS?

https://github.com/nim-lang/nightlies/actions/runs/4942653459

> /Users/runner/work/nightlies/nightlies/external/lib/libsqlite3.a -Wl,--build-id=none -ldl -lm
2023-05-11T01:06:20.3187100Z ld: unknown option: --build-id=none