### PR TITLE
js -r defines nodejs & program result undeclared if unavailable

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -250,7 +250,7 @@
   to simply remove these statements.
 
 - `getProgramResult` and `setProgramResult` in `std/exitprocs` are no longer
-  defined when they are not available on the backend. Previously it would call
+  declared when they are not available on the backend. Previously it would call
   `doAssert false` at runtime despite the condition being compile-time.
 
 ## Standard library additions and changes

--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -249,6 +249,10 @@
   these deprecated aliases are likely not used anymore and it may make sense
   to simply remove these statements.
 
+- `getProgramResult` and `setProgramResult` in `std/exitprocs` are no longer
+  defined when they are not available on the backend. Previously it would call
+  `doAssert false` at runtime despite the condition being compile-time.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -654,6 +654,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if backend == TBackend.default: localError(conf, info, "invalid backend: '$1'" % arg)
     if backend == backendJs: # bug #21209
       conf.globalOptions.excl {optThreadAnalysis, optThreads}
+      if optRun in conf.globalOptions:
+        # for now, -r uses nodejs, so define nodejs
+        defineSymbol(conf.symbols, "nodejs")
     conf.backend = backend
   of "doccmd": conf.docCmd = arg
   of "define", "d":
@@ -864,6 +867,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       setTarget(conf.target, conf.target.targetOS, cpu)
   of "run", "r":
     processOnOffSwitchG(conf, {optRun}, arg, pass, info)
+    if conf.backend == backendJs:
+      # for now, -r uses nodejs, so define nodejs
+      defineSymbol(conf.symbols, "nodejs")
   of "maxloopiterationsvm":
     expectArg(conf, switch, arg, pass, info)
     conf.maxLoopIterationsVM = parseInt(arg)

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -519,6 +519,12 @@ proc exceptionTypeName(e: ref Exception): string {.inline.} =
   if e == nil: "<foreign exception>"
   else: $e.name
 
+when not declared(setProgramResult):
+  {.warning: "setProgramResult not available on platform, unittest will not" &
+    " give failing exit code on test failure".}
+  template setProgramResult(a: int) =
+    discard
+
 template test*(name, body) {.dirty.} =
   ## Define a single test case identified by `name`.
   ##

--- a/lib/std/exitprocs.nim
+++ b/lib/std/exitprocs.nim
@@ -69,7 +69,7 @@ proc addExitProc*(cl: proc() {.noconv.}) =
     fun()
     gFuns.add Fun(kind: kNoconv, fun2: cl)
 
-when not defined(nimscript) or not (defined(js) and not defined(nodejs)):
+when not defined(nimscript) and (not defined(js) or defined(nodejs)):
   proc getProgramResult*(): int =
     when defined(js) and defined(nodejs):
       asm """

--- a/lib/std/exitprocs.nim
+++ b/lib/std/exitprocs.nim
@@ -69,23 +69,19 @@ proc addExitProc*(cl: proc() {.noconv.}) =
     fun()
     gFuns.add Fun(kind: kNoconv, fun2: cl)
 
-when not defined(nimscript):
+when not defined(nimscript) or not (defined(js) and not defined(nodejs)):
   proc getProgramResult*(): int =
     when defined(js) and defined(nodejs):
       asm """
 `result` = process.exitCode;
 """
-    elif not defined(js):
-      result = programResult
     else:
-      doAssert false
+      result = programResult
 
   proc setProgramResult*(a: int) =
     when defined(js) and defined(nodejs):
       asm """
 process.exitCode = `a`;
 """
-    elif not defined(js):
-      programResult = a
     else:
-      doAssert false
+      programResult = a


### PR DESCRIPTION
fixes #16985, fixes #16074

Whatever -r could mean in the future for JS, it calls nodejs now, so define nodejs when it's used.

On top of this, just don't offer `setProgramResult` at compile time when we can't provide it instead of `doAssert false`, and still allow unittest to work when it doesn't exist, giving a warning.

Would add test but testament `exitcode` doesn't work with custom `cmd`. Custom `cmd` is needed because testament automatically appends `-d:nodejs`.