### PR TITLE
fixes #21708; skip colons for tuples in VM

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -20,7 +20,7 @@ import
 
 when defined(nimPreviewSlimSystem):
   import std/formatfloat
-
+import astalgo
 import ast except getstr
 from semfold import leValueConv, ordinalValToString
 from evaltempl import evalTemplate
@@ -845,7 +845,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         let n = src[rc + 1].skipColon
         regs[ra].node = n
       of nkTupleConstr:
-        let n = src[rc].skipColon
+        let n = if tfTriggersCompileTime in src.typ.flags:
+            src[rc]
+          else:
+            src[rc].skipColon
         regs[ra].node = n
       else:
         let n = src[rc]

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -844,6 +844,9 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       of nkObjConstr:
         let n = src[rc + 1].skipColon
         regs[ra].node = n
+      of nkTupleConstr:
+        let n = src[rc].skipColon
+        regs[ra].node = n
       else:
         let n = src[rc]
         regs[ra].node = n

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -845,7 +845,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         let n = src[rc + 1].skipColon
         regs[ra].node = n
       of nkTupleConstr:
-        let n = if tfTriggersCompileTime in src.typ.flags:
+        let n = if src.typ != nil and tfTriggersCompileTime in src.typ.flags:
             src[rc]
           else:
             src[rc].skipColon

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -688,3 +688,13 @@ block: # bug #7590
   # const c=(foo:(bar1: 0.0))
   const c=(foo:(bar1:"foo1"))
   fun2(c)
+
+block: # bug #21708
+  type
+    Tup = tuple[name: string]
+
+  const X: array[2, Tup] = [(name: "foo",), (name: "bar",)]
+
+  static:
+    let s = X[0]
+    doAssert s[0] == "foo"


### PR DESCRIPTION
fixes #21708

It skips a colon in a named parameter in a tuple when accessing an element from a tuple
