### PR TITLE
fixes #21847; let `parseFloat` behave like `strtod`

### DIFF
--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -178,7 +178,9 @@ proc nimParseBiggestFloat(s: openArray[char], number: var BiggestFloat,
 
   # if exponent greater than can be represented: +/- zero or infinity
   if absExponent > 999:
-    if expNegative:
+    if integer == 0:
+      number = 0.0
+    elif expNegative:
       number = 0.0*sign
     else:
       number = Inf*sign

--- a/tests/float/tfloat4.nim
+++ b/tests/float/tfloat4.nim
@@ -56,8 +56,14 @@ doAssert 0.9999999999999999 == ".9999999999999999".parseFloat
 
 # bug #18400
 var s = [-13.888888'f32]
-assert $s[0] == "-13.888888"
+doAssert $s[0] == "-13.888888"
 var x = 1.23456789012345'f32
-assert $x == "1.2345679"
+doAssert $x == "1.2345679"
+
+# bug #21847
+doAssert parseFloat"0e+42" == 0.0
+doAssert parseFloat"0e+42949672969" == 0.0
+doAssert parseFloat"0e+42949672970" == 0.0
+doAssert parseFloat"0e+42949623223346323563272970" == 0.0
 
 echo("passed all tests.")


### PR DESCRIPTION
fixes #21847

https://onlinegdb.com/hBo31PrAu

```c
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>


void test(const char* s) {
  printf("\ns=\"%s\"\n", s);

  double d0 = strtod(s, NULL);
  printf("%.50g\n", d0);
}

int main(int argc, char** argv) {
  test("0e+42949672969");
  test("0e+42949672970"); 
  test("0e+429496722187734834873464312872970");
  return 0;
}
```

```
s="0e+42949672969"
0

s="0e+42949672970"
0

s="0e+429496722187734834873464312872970"
0
```