### PR TITLE
Fix const in async regression

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -221,13 +221,11 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     procBody = newStmtList()
     let resultIdent = ident"result"
     procBody.add quote do:
-      template nimAsyncDispatchSetResult(x: `subRetType`) {.used.} =
-        # If the proc has implicit return then this will get called
-        `resultIdent` = x
-      template nimAsyncDispatchSetResult(x: untyped) {.used.} =
-        # If the proc doesn't have implicit return then this will get called
-        x
-    procBody.add newCall(ident"nimAsyncDispatchSetResult", blockStmt)
+      # Check whether there is an implicit return
+      when typeof(`blockStmt`) is void:
+        `blockStmt`
+      else:
+        `resultIdent` = `blockStmt`
     procBody.add(createFutureVarCompletions(futureVarIdents, nil))
     procBody.insert(0): quote do:
       {.push warning[resultshadowed]: off.}

--- a/tests/async/t21893.nim
+++ b/tests/async/t21893.nim
@@ -1,0 +1,13 @@
+discard """
+output: "@[97]\ntrue"
+"""
+
+import asyncdispatch
+
+proc test(): Future[bool] {.async.} =
+  const S4 = @[byte('a')]
+  echo S4
+  return true
+
+echo waitFor test()
+


### PR DESCRIPTION
Closes #21893 

While this doesn't solve the root issue that was brought up, it atleast fixes `const` inside async procs.
It does this by using `typeof` to instead check whether the code has an implicit return or not.