### PR TITLE
when T is both a type symbol and a routine symbol in scope of a generic proc do not account for the type symbol when doing `a.T()`

### DIFF
--- a/tests/generics/mdotlookup.nim
+++ b/tests/generics/mdotlookup.nim
@@ -23,3 +23,6 @@ proc doStrip*[T](a: T): string =
 type Foo = int32
 proc baz2*[T](y: int): auto =
   result = y.Foo
+
+proc set*(x: var int, a, b: string) =
+  x = a.len + b.len

--- a/tests/generics/timports.nim
+++ b/tests/generics/timports.nim
@@ -40,6 +40,12 @@ block tdotlookup:
   doAssert doStrip(123) == "123"
   # bug #14254
   doAssert baz2[float](1'i8) == 1
+  # bug #21883
+  proc abc[T: not not int](x: T): T =
+    var x = x
+    x.set("hello", "world")
+    result = x
+  doAssert abc(5) == 10
 
 block tmodule_same_as_proc:
   # bug #1965


### PR DESCRIPTION
fixes #21883

I thought about this case while writing #21837 but it was lost during a rewrite, `a.T()` should only check for routines named `T` and not types, but `a.T` should still check for types as it may be a type conversion

Original test case was tested manually to work