### PR TITLE
fix #21501 by making --app:lib and --app:staticLib imply --noMain

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1490,9 +1490,9 @@ proc genMainProc(m: BModule) =
 
   var posixCmdLine: Rope
   if optNoMain notin m.config.globalOptions:
-    posixCmdLine.add "\tN_LIB_PRIVATE int cmdCount;\L"
-    posixCmdLine.add "\tN_LIB_PRIVATE char** cmdLine;\L"
-    posixCmdLine.add "\tN_LIB_PRIVATE char** gEnv;\L"
+    posixCmdLine.add "N_LIB_PRIVATE int cmdCount;\L"
+    posixCmdLine.add "N_LIB_PRIVATE char** cmdLine;\L"
+    posixCmdLine.add "N_LIB_PRIVATE char** gEnv;\L"
 
   const
     # The use of a volatile function pointer to call Pre/NimMainInner
@@ -1517,7 +1517,7 @@ proc genMainProc(m: BModule) =
       "}$N$N"
 
     MainProcs =
-      "\t\t$^NimMain();$N"
+      "\t$^NimMain();$N"
 
     MainProcsWithResult =
       MainProcs & ("\treturn $1nim_program_result;$N")
@@ -1633,7 +1633,7 @@ proc genMainProc(m: BModule) =
     appcg(m, m.s[cfsProcs], nimMain,
         [m.g.mainModInit, initStackBottomCall, m.labels, preMainCode, m.config.nimMainPrefix, isVolatile])
 
-  if optNoMain notin m.config.globalOptions:
+  if optNoMain notin m.config.globalOptions or optGenDynLib in m.config.globalOptions:
     if m.config.cppCustomNamespace.len > 0:
       closeNamespaceNim(m.s[cfsProcs])
       m.s[cfsProcs].add "using namespace " & m.config.cppCustomNamespace & ";\L"
@@ -1940,8 +1940,6 @@ proc genModule(m: BModule, cfile: Cfile): Rope =
     openNamespaceNim(m.config.cppCustomNamespace, result)
   if m.s[cfsFrameDefines].len > 0:
     result.add(m.s[cfsFrameDefines])
-  else:
-    result.add("#define nimfr_(x, y)\n#define nimln_(x)\n\n#define nimlf_(x, y)\n")
 
   for i in cfsForwardTypes..cfsProcs:
     if m.s[i].len > 0:

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -799,11 +799,13 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       defineSymbol(conf.symbols, "consoleapp")
     of "lib":
       incl(conf.globalOptions, optGenDynLib)
+      incl(conf.globalOptions, optNoMain)
       excl(conf.globalOptions, optGenGuiApp)
       defineSymbol(conf.symbols, "library")
       defineSymbol(conf.symbols, "dll")
     of "staticlib":
       incl(conf.globalOptions, optGenStaticLib)
+      incl(conf.globalOptions, optNoMain)
       excl(conf.globalOptions, optGenGuiApp)
       defineSymbol(conf.symbols, "library")
       defineSymbol(conf.symbols, "staticlib")

--- a/doc/backends.md
+++ b/doc/backends.md
@@ -300,7 +300,7 @@ Instead of depending on the generation of the individual ``.c`` files you can
 also ask the Nim compiler to generate a statically linked library:
 
   ```cmd
-  nim c --app:staticLib --noMain fib.nim
+  nim c --app:staticLib fib.nim
   gcc -o m -Inimcache -Ipath/to/nim/lib maths.c libfib.nim.a
   ```
 


### PR DESCRIPTION
fixes #21501 

AFAIK, a main entry function passing command line arguments is generally not part of either a static or a shared library, and Nim provides its own main entry points with `NimMain()`, which is to be taken into account for external code accessing Nim code in order to have a proper setup (https://nim-lang.org/docs/backends.html#backend-code-calling-nim-nim-invocation-example-from-c).

I therefore suggest having the `--app:lib` and `--app:staticLib` switches imply `--noMain`, and will also update the docs accordingly.
I have also added some minor adjustments to code formatting in `cgen.nim` in this regard.

Many thanks to @metagn and @beef331 for the groundwork!