### PR TITLE
`std/strutils`: `split`, `rsplit` now raise on an empty separator

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -266,6 +266,7 @@
 - Changed `mimedb` to use an `OrderedTable` instead of `OrderedTableRef` to support `const` tables.
 - `strutils.find` now uses and defaults to `last = -1` for whole string searches,
   making limiting it to just the first char (`last = 0`) valid.
+- `strutils.split` and `strutils.rsplit` now raise a `ValueError` on an empty separator.
 - `random.rand` now works with `Ordinal`s.
 - Undeprecated `os.isvalidfilename`.
 - `std/oids` now uses `int64` to store time internally (before it was int32).

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -447,7 +447,7 @@ iterator split*(s: string, sep: char, maxsplit: int = -1): string =
   splitCommon(s, sep, maxsplit, 1)
 
 iterator split*(s: string, seps: set[char] = Whitespace,
-                maxsplit: int = -1): string =
+                maxsplit: int = -1): string {.raises: [ValueError].} =
   ## Splits the string `s` into substrings using a group of separators.
   ##
   ## Substrings are separated by a substring containing only `seps`.
@@ -488,14 +488,18 @@ iterator split*(s: string, seps: set[char] = Whitespace,
   ##   "08"
   ##   "08.398990"
   ##
+  ## Raises `ValueError` for an empty separator set.
+  ##
   ## See also:
   ## * `rsplit iterator<#rsplit.i,string,set[char],int>`_
   ## * `splitLines iterator<#splitLines.i,string>`_
   ## * `splitWhitespace iterator<#splitWhitespace.i,string,int>`_
   ## * `split func<#split,string,set[char],int>`_
+  if seps.card == 0:
+    raise newException(ValueError, "Empty separator")
   splitCommon(s, seps, maxsplit, 1)
 
-iterator split*(s: string, sep: string, maxsplit: int = -1): string =
+iterator split*(s: string, sep: string, maxsplit: int = -1): string {.raises: [ValueError].} =
   ## Splits the string `s` into substrings using a string separator.
   ##
   ## Substrings are separated by the string `sep`.
@@ -512,11 +516,15 @@ iterator split*(s: string, sep: string, maxsplit: int = -1): string =
   ##   "is"
   ##   "corrupted"
   ##
+  ## Raises `ValueError` for an empty separator.
+  ##
   ## See also:
   ## * `rsplit iterator<#rsplit.i,string,string,int,bool>`_
   ## * `splitLines iterator<#splitLines.i,string>`_
   ## * `splitWhitespace iterator<#splitWhitespace.i,string,int>`_
   ## * `split func<#split,string,string,int>`_
+  if sep.len == 0:
+    raise newException(ValueError, "Empty separator")
   splitCommon(s, sep, maxsplit, sep.len)
 
 
@@ -570,7 +578,7 @@ iterator rsplit*(s: string, sep: char,
   rsplitCommon(s, sep, maxsplit, 1)
 
 iterator rsplit*(s: string, seps: set[char] = Whitespace,
-                 maxsplit: int = -1): string =
+                 maxsplit: int = -1): string {.raises: [ValueError].} =
   ## Splits the string `s` into substrings from the right using a
   ## string separator. Works exactly the same as `split iterator
   ## <#split.i,string,char,int>`_ except in reverse order.
@@ -587,15 +595,19 @@ iterator rsplit*(s: string, seps: set[char] = Whitespace,
   ##
   ## Substrings are separated from the right by the set of chars `seps`
   ##
+  ## Raises `ValueError` for an empty separator set.
+  ##
   ## See also:
   ## * `split iterator<#split.i,string,set[char],int>`_
   ## * `splitLines iterator<#splitLines.i,string>`_
   ## * `splitWhitespace iterator<#splitWhitespace.i,string,int>`_
   ## * `rsplit func<#rsplit,string,set[char],int>`_
+  if seps.card == 0:
+    raise newException(ValueError, "Empty separator")
   rsplitCommon(s, seps, maxsplit, 1)
 
 iterator rsplit*(s: string, sep: string, maxsplit: int = -1,
-                 keepSeparators: bool = false): string =
+                 keepSeparators: bool = false): string {.raises: [ValueError].} =
   ## Splits the string `s` into substrings from the right using a
   ## string separator. Works exactly the same as `split iterator
   ## <#split.i,string,string,int>`_ except in reverse order.
@@ -612,11 +624,15 @@ iterator rsplit*(s: string, sep: string, maxsplit: int = -1,
   ##
   ## Substrings are separated from the right by the string `sep`
   ##
+  ## Raises `ValueError` for an empty separator.
+  ##
   ## See also:
   ## * `split iterator<#split.i,string,string,int>`_
   ## * `splitLines iterator<#splitLines.i,string>`_
   ## * `splitWhitespace iterator<#splitWhitespace.i,string,int>`_
   ## * `rsplit func<#rsplit,string,string,int>`_
+  if sep.len == 0:
+    raise newException(ValueError, "Empty separator")
   rsplitCommon(s, sep, maxsplit, sep.len)
 
 iterator splitLines*(s: string, keepEol = false): string =
@@ -724,9 +740,11 @@ func split*(s: string, sep: char, maxsplit: int = -1): seq[string] {.rtl,
   accResult(split(s, sep, maxsplit))
 
 func split*(s: string, seps: set[char] = Whitespace, maxsplit: int = -1): seq[
-    string] {.rtl, extern: "nsuSplitCharSet".} =
+    string] {.rtl, extern: "nsuSplitCharSet", raises: [ValueError].} =
   ## The same as the `split iterator <#split.i,string,set[char],int>`_ (see its
   ## documentation), but is a func that returns a sequence of substrings.
+  ##
+  ## Raises `ValueError` for an empty separator set.
   ##
   ## See also:
   ## * `split iterator <#split.i,string,set[char],int>`_
@@ -739,11 +757,13 @@ func split*(s: string, seps: set[char] = Whitespace, maxsplit: int = -1): seq[
   accResult(split(s, seps, maxsplit))
 
 func split*(s: string, sep: string, maxsplit: int = -1): seq[string] {.rtl,
-    extern: "nsuSplitString".} =
+    extern: "nsuSplitString", raises: [ValueError].} =
   ## Splits the string `s` into substrings using a string separator.
   ##
   ## Substrings are separated by the string `sep`. This is a wrapper around the
   ## `split iterator <#split.i,string,string,int>`_.
+  ##
+  ## Raises `ValueError` for an empty separator.
   ##
   ## See also:
   ## * `split iterator <#split.i,string,string,int>`_
@@ -757,8 +777,6 @@ func split*(s: string, sep: string, maxsplit: int = -1): seq[string] {.rtl,
     doAssert "a  largely    spaced sentence".split(" ") == @["a", "", "largely",
         "", "", "", "spaced", "sentence"]
     doAssert "a  largely    spaced sentence".split(" ", maxsplit = 1) == @["a", " largely    spaced sentence"]
-  doAssert(sep.len > 0)
-
   accResult(split(s, sep, maxsplit))
 
 func rsplit*(s: string, sep: char, maxsplit: int = -1): seq[string] {.rtl,
@@ -790,7 +808,7 @@ func rsplit*(s: string, sep: char, maxsplit: int = -1): seq[string] {.rtl,
 
 func rsplit*(s: string, seps: set[char] = Whitespace,
              maxsplit: int = -1): seq[string]
-             {.rtl, extern: "nsuRSplitCharSet".} =
+             {.rtl, extern: "nsuRSplitCharSet", raises: [ValueError].} =
   ## The same as the `rsplit iterator <#rsplit.i,string,set[char],int>`_, but is a
   ## func that returns a sequence of substrings.
   ##
@@ -808,6 +826,8 @@ func rsplit*(s: string, seps: set[char] = Whitespace,
   ## .. code-block:: nim
   ##   @["Root#Object#Method", "Index"]
   ##
+  ## Raises `ValueError` for an empty separator set.
+  ##
   ## See also:
   ## * `rsplit iterator <#rsplit.i,string,set[char],int>`_
   ## * `split func<#split,string,set[char],int>`_
@@ -817,7 +837,7 @@ func rsplit*(s: string, seps: set[char] = Whitespace,
   result.reverse()
 
 func rsplit*(s: string, sep: string, maxsplit: int = -1): seq[string] {.rtl,
-    extern: "nsuRSplitString".} =
+    extern: "nsuRSplitString", raises: [ValueError].} =
   ## The same as the `rsplit iterator <#rsplit.i,string,string,int,bool>`_, but is a func
   ## that returns a sequence of substrings.
   ##
@@ -834,6 +854,8 @@ func rsplit*(s: string, sep: string, maxsplit: int = -1): seq[string] {.rtl,
   ##
   ## .. code-block:: nim
   ##   @["Root#Object#Method", "Index"]
+  ##
+  ## Raises `ValueError` for an empty separator.
   ##
   ## See also:
   ## * `rsplit iterator <#rsplit.i,string,string,int,bool>`_

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -53,6 +53,13 @@ template main() =
     doAssert s.split(maxsplit = 4) == @["", "this", "is", "an", "example  "]
     doAssert s.split(' ', maxsplit = 1) == @["", "this is an example  "]
     doAssert s.split(" ", maxsplit = 4) == @["", "this", "is", "an", "example  "]
+    # Empty string:
+    doAssert "".split() == @[""]
+    doAssert "".split(" ") == @[""]
+    doAssert "".split({' '}) == @[""]
+    # Empty separators:
+    doAssertRaises(ValueError): discard s.split({})
+    doAssertRaises(ValueError): discard s.split("")
 
   block: # splitLines
     let fixture = "a\nb\rc\r\nd"
@@ -63,12 +70,18 @@ template main() =
   block: # rsplit
     doAssert rsplit("foo bar", seps = Whitespace) == @["foo", "bar"]
     doAssert rsplit(" foo bar", seps = Whitespace, maxsplit = 1) == @[" foo", "bar"]
-    doAssert rsplit(" foo bar ", seps = Whitespace, maxsplit = 1) == @[
-        " foo bar", ""]
+    doAssert rsplit(" foo bar ", seps = Whitespace, maxsplit = 1) == @[" foo bar", ""]
     doAssert rsplit(":foo:bar", sep = ':') == @["", "foo", "bar"]
     doAssert rsplit(":foo:bar", sep = ':', maxsplit = 2) == @["", "foo", "bar"]
     doAssert rsplit(":foo:bar", sep = ':', maxsplit = 3) == @["", "foo", "bar"]
     doAssert rsplit("foothebar", sep = "the") == @["foo", "bar"]
+    # Empty string:
+    doAssert "".rsplit() == @[""]
+    doAssert "".rsplit(" ") == @[""]
+    doAssert "".rsplit({' '}) == @[""]
+    # Empty separators:
+    doAssertRaises(ValueError): discard "".rsplit({})
+    doAssertRaises(ValueError): discard "".rsplit("")
 
   block: # splitWhitespace
     let s = " this is an example  "


### PR DESCRIPTION
This PR adds a `ValueError` raise on an empty separators for `split` and `rsplit` iterators and functions. 
This fixes an infinite loop for an empty separator.

Previous code was inconsistent as only one function of all variations had a forced assertion for this case.

Raising an exception was chosen over an assertion following the behaviour of Python's [`str.split`](https://docs.python.org/3/library/stdtypes.html#str.split).

Current behaviour:
```nim
import std/[strutils, enumerate]

# returns the input string
doAssert "setsAreSpecial".split({}) == @["setsAreSpecial"]

# infinite loop
for i, _ in enumerate("nineChars".split("")):
  if i > 8:
    echo "boom"
    break
  else:
    stdout.write i+1, ","
# 1,2,3,4,5,6,7,8,9,boom
```