### PR TITLE
fixes #15428 by updating deep open array copy codegen

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -450,9 +450,10 @@ proc genDeepCopy(p: BProc; dest, src: TLoc) =
               [addrLoc(p.config, dest), rdLoc(src),
               genTypeInfoV1(p.module, dest.t, dest.lode.info)])
   of tyOpenArray, tyVarargs:
+    let source = addrLocOrTemp(src)
     linefmt(p, cpsStmts,
-         "#genericDeepCopyOpenArray((void*)$1, (void*)$2, $1Len_0, $3);$n",
-         [addrLoc(p.config, dest), addrLocOrTemp(src),
+         "#genericDeepCopyOpenArray((void*)$1, (void*)$2, $2->Field1, $3);$n",
+         [addrLoc(p.config, dest), source,
          genTypeInfoV1(p.module, dest.t, dest.lode.info)])
   of tySet:
     if mapSetType(p.config, ty) == ctArray:

--- a/tests/ccgbugs/t15428.nim
+++ b/tests/ccgbugs/t15428.nim
@@ -1,0 +1,22 @@
+discard """
+    cmd: "nim $target --mm:refc $file"
+    output: '''5
+5
+[1, 2, 3, 4, 5]
+(data: [1, 2, 3, 4, 5])
+'''
+"""
+
+proc take[T](f: openArray[T]) =
+  echo f.len
+let f = @[0,1,2,3,4]
+take(f.toOpenArray(0,4))
+
+{.experimental: "views".}
+type
+  Foo = object
+    data: openArray[int]
+let f2 = Foo(data: [1,2,3,4,5])
+echo f2.data.len
+echo f2.data
+echo f2


### PR DESCRIPTION
fixes #15428 

In context of #15428, this seems to provide a working codegen for both `refc` and `ARC`/`ORC` memory management.