### PR TITLE
hot code reloading: fix regression? and PreMain with arc/orc

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1158,6 +1158,8 @@ proc genProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool = false)
   # (instead of forward declaration) or header for function body with "_actual" postfix
   let asPtrStr = rope(if asPtr: "_PTR" else: "")
   var name = prc.loc.r
+  if not asPtr and isReloadable(m, prc):
+    name.add("_actual")
   # careful here! don't access ``prc.ast`` as that could reload large parts of
   # the object graph!
   if prc.constraint.isNil:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1479,12 +1479,15 @@ proc genMainProc(m: BModule) =
                        [handle, strLit])
 
     preMainCode.add(loadLib("hcr_handle", "hcrGetProc"))
-    preMainCode.add("\tvoid* rtl_handle;\L")
-    preMainCode.add(loadLib("rtl_handle", "nimGC_setStackBottom"))
-    preMainCode.add(hcrGetProcLoadCode(m, "nimGC_setStackBottom", "nimrtl_", "rtl_handle", "nimGetProcAddr"))
-    preMainCode.add("\tinner = PreMain;\L")
-    preMainCode.add("\tinitStackBottomWith_actual((void *)&inner);\L")
-    preMainCode.add("\t(*inner)();\L")
+    if m.config.selectedGC in {gcArc, gcAtomicArc, gcOrc}:
+      preMainCode.add("\t$1PreMain();\L" % [rope m.config.nimMainPrefix])
+    else:
+      preMainCode.add("\tvoid* rtl_handle;\L")
+      preMainCode.add(loadLib("rtl_handle", "nimGC_setStackBottom"))
+      preMainCode.add(hcrGetProcLoadCode(m, "nimGC_setStackBottom", "nimrtl_", "rtl_handle", "nimGetProcAddr"))
+      preMainCode.add("\tinner = $1PreMain;\L" % [rope m.config.nimMainPrefix])
+      preMainCode.add("\tinitStackBottomWith_actual((void *)&inner);\L")
+      preMainCode.add("\t(*inner)();\L")
   else:
     preMainCode.add("\t$1PreMain();\L" % [rope m.config.nimMainPrefix])
 

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -80,9 +80,12 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string, isOrc =
   testSpec r, makeTest("tests/dll/client.nim", options & " --threads:on" & rpath, cat)
   testSpec r, makeTest("tests/dll/nimhcr_unit.nim", options & " --threads:off" & rpath, cat)
   testSpec r, makeTest("tests/dll/visibility.nim", options & " --threads:off" & rpath, cat)
-  testSpec r, makeTest("tests/dll/nimhcr_basic.nim", options & " --threads:off" & rpath, cat)
 
-  if "boehm" notin options:
+  if "boehm" notin options and not isOrc:
+    # hcr tests
+    
+    testSpec r, makeTest("tests/dll/nimhcr_basic.nim", options & " --threads:off --forceBuild --hotCodeReloading:on " & rpath, cat)
+
     # force build required - see the comments in the .nim file for more details
     var hcri = makeTest("tests/dll/nimhcr_integration.nim",
                                    options & " --threads:off --forceBuild --hotCodeReloading:on" & rpath, cat)


### PR DESCRIPTION
addresses the issues mentioned in https://github.com/nim-lang/Nim/issues/21885#issuecomment-1565626696 and https://github.com/nim-lang/Nim/issues/21885#issuecomment-1565656336 (implied)

At some point in recent devel (after #21814?) `_actual` started not getting added to HCR proc definitions, which gave a duplicate definition error on the C compiler. This made hello world not work. This was not caught in #21915 because the hello world test did not enable --hotcodereloading, which is now fixed.

Additionally, the PreMain generated by hot code reloading is updated to work for arc/orc (no need to load functions for stack bottom, or use a volatile load) as well as adapting main prefixes. This does not make hot code reloading work with arc/orc (the current immediate error is destructor proc pointers in static constructors) and more issues are likely to come up