### PR TITLE
prevent spamming of thread local forward declarations in C/C++ output

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1387,10 +1387,10 @@ proc genVarPrototype(m: BModule, n: PNode) =
   if sym.owner.id != m.module.id:
     # else we already have the symbol generated!
     assert(sym.loc.r != "")
+    incl(m.declaredThings, sym.id)
     if sfThread in sym.flags:
       declareThreadVar(m, sym, true)
     else:
-      incl(m.declaredThings, sym.id)
       if sym.kind in {skLet, skVar, skField, skForVar} and sym.alignment > 0:
         m.s[cfsVars].addf "NIM_ALIGN($1) ", [rope(sym.alignment)]
       m.s[cfsVars].add(if m.hcrOn: "static " else: "extern ")


### PR DESCRIPTION
I noticed
```nim
extern NIM_THREADVAR TFrame* framePtr__system_u...;
```
output several times in C/C++. This happens due to global thread local vars escaping a check for thread local vars already being declared. By putting those under that scrutiny, less redundant work in context of thread local vars is to be done in the compilation and the code emission steps.