### PR TITLE
Add anti-regression for #21958

### DIFF
--- a/tests/generics/t21958.nim
+++ b/tests/generics/t21958.nim
@@ -1,0 +1,11 @@
+discard """
+  action: compile
+"""
+
+type
+  Ct*[T: SomeUnsignedInt] = distinct T
+
+template `shr`*[T: Ct](x: T, y: SomeInteger): T = T(T.T(x) shr y)
+
+var x: Ct[uint64]
+let y {.used.} = x shr 2


### PR DESCRIPTION
Apparently #21958 was coincidentally solved on devel after its introduction. This ensures it doesn't reappear.

Besides that, we might need to revert the backport of https://github.com/nim-lang/Nim/commit/42ff3aa75a3c352c2b6bcb2301538f25ee8006e8 to the 1.6.13 branch