### PR TITLE
simple micro-optimizations of ropes' runtime-formatting

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -216,13 +216,9 @@ macro ropecg(m: BModule, frmt: static[FormatStr], args: untyped): Rope =
     elif frmt[i] == '#' and frmt[i+1] == '#':
       inc(i, 2)
       strLit.add("#")
-
-    var start = i
-    while i < frmt.len:
-      if frmt[i] != '$' and frmt[i] != '#': inc(i)
-      else: break
-    if i - 1 >= start:
-      strLit.add(substr(frmt, start, i - 1))
+    else:
+      strLit.add(frmt[i])
+      inc(i)
 
   flushStrLit()
   result.add newCall(ident"rope", resVar)

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -21,8 +21,8 @@ type
                        # though it is not necessary)
   Rope* = string
 
-proc newRopeAppender*(): string {.inline.} =
-  result = newString(0)
+proc newRopeAppender*(cap = 80): string {.inline.} =
+  result = newStringOfCap(cap)
 
 proc freeze*(r: Rope) {.inline.} = discard
 
@@ -102,12 +102,9 @@ proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
         inc(i)
       else:
         doAssert false, "invalid format string: " & frmt
-    var start = i
-    while i < frmt.len:
-      if frmt[i] != '$': inc(i)
-      else: break
-    if i - 1 >= start:
-      result.add(substr(frmt, start, i - 1))
+    else:
+      result.add(frmt[i])
+      inc(i)
 
 proc `%`*(frmt: static[FormatStr], args: openArray[Rope]): Rope =
   runtimeFormat(frmt, args)


### PR DESCRIPTION
In highly artificial benchmark settings, testing for ropes to be formatted like `$1->len = 0; $1->p = NIM_NIL;$n`, `= $#;$n` etc., I consistently witnessed some small speedups for:

- a tiny adjustment of the `runtimeFormat` algo for ropes
- setting a baseline capacity for `newRopeAppender()`, following the capacity used in `cgen`'s `ropecg` macro

Currently working on a processing behemoth of a Pentium Silver N6000, I didn't bother with bootstrapping the Nim compiler that often in order to examine if the results above translate into any real-worldish differences, yet, maybe those changes help a slight bit on bigger Nim builds.

Might dig up some further build-time (micro-)optimizations the following days, if found useful and not breaking.