### PR TITLE
Atlas: Use copyFileWithPermissions to copy nim executable

### DIFF
--- a/tools/atlas/atlas.nim
+++ b/tools/atlas/atlas.nim
@@ -891,7 +891,7 @@ proc setupNimEnv(c: var AtlasContext; nimVersion: string) =
   let nimExe0 = ".." / csourcesVersion / "bin" / "nim".addFileExt(ExeExt)
   withDir c, c.workspace / nimDest:
     let nimExe = "bin" / "nim".addFileExt(ExeExt)
-    copyFile nimExe0, nimExe
+    copyFileWithPermissions nimExe0, nimExe
     let dep = Dependency(name: toName(nimDest), rel: normal, commit: nimVersion)
     if not nimVersion.isDevel:
       let commit = versionToCommit(c, dep)


### PR DESCRIPTION
Fixes issue where the copied nim executable may lack executable permissions