### PR TITLE
privateAccess ignores non-objects

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -2008,7 +2008,7 @@ proc toObjectFromRefPtrGeneric*(typ: PType): PType =
     of tyRef, tyPtr, tyGenericInst, tyGenericInvocation, tyAlias: result = result[0]
       # automatic dereferencing is deep, refs #18298.
     else: break
-  assert result.sym != nil
+  # result does not have to be object type
 
 proc isImportedException*(t: PType; conf: ConfigRef): bool =
   assert t != nil

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -524,7 +524,9 @@ proc semNewFinalize(c: PContext; n: PNode): PNode =
 
 proc semPrivateAccess(c: PContext, n: PNode): PNode =
   let t = n[1].typ[0].toObjectFromRefPtrGeneric
-  c.currentScope.allowPrivateAccess.add t.sym
+  if t.kind == tyObject:
+    assert t.sym != nil
+    c.currentScope.allowPrivateAccess.add t.sym
   result = newNodeIT(nkEmpty, n.info, getSysType(c.graph, n.info, tyVoid))
 
 proc checkDefault(c: PContext, n: PNode): PNode =

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -277,6 +277,7 @@ proc fieldVisible*(c: PContext, f: PSym): bool {.inline.} =
       var symObj = f.owner
       if symObj.typ.skipTypes({tyGenericBody, tyGenericInst, tyGenericInvocation, tyAlias}).kind in {tyRef, tyPtr}:
         symObj = symObj.typ.toObjectFromRefPtrGeneric.sym
+        assert symObj != nil
       for scope in allScopes(c.currentScope):
         for sym in scope.allowPrivateAccess:
           if symObj.id == sym.id: return true


### PR DESCRIPTION
closes #21969

No test because the code in #21969 currently compiles but could just as easily give a proper error eventually. Maybe if there was a way to just test for no compiler error.