### PR TITLE
partially fixes #20787 by having a char dummy member prepended to objs only containing an UncheckedArray (i.e. C FAM)

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -774,8 +774,15 @@ proc getRecordDesc(m: BModule; typ: PType, name: Rope,
     result = structOrUnion & " " & name
     result.add(getRecordDescAux(m, typ, name, baseType, check, hasField))
     let desc = getRecordFields(m, typ, check)
-    if desc == "" and not hasField:
-      result.addf("char dummy;$n", [])
+    if not hasField:
+      if desc == "":
+        result.add("\tchar dummy;\n")
+      elif typ.len == 1 and typ.n[0].kind == nkSym:
+        let field = typ.n[0].sym
+        let fieldType = field.typ.skipTypes(abstractInst)
+        if fieldType.kind == tyUncheckedArray:
+          result.add("\tchar dummy;\n")
+      result.add(desc)
     else:
       result.add(desc)
     result.add("};\L")

--- a/tests/ccgbugs/t20787.nim
+++ b/tests/ccgbugs/t20787.nim
@@ -1,0 +1,4 @@
+type
+  Obj = object
+    f: UncheckedArray[byte]
+let o = new Obj


### PR DESCRIPTION
partial fix for #20787 by making the `char dummy` insertion workaround already prepared in `ccgtypes` work for the respective case.

This will have the snippet offered in #20787 compile, though note that there are some further restrictions concerning C flexible array members (like disallowing their use in nested structs) that should be reflected in the future on the Nim side as well.