### PR TITLE
Atlas: avoid segfault on failed Github search

### DIFF
--- a/tools/atlas/packagesjson.nim
+++ b/tools/atlas/packagesjson.nim
@@ -86,6 +86,8 @@ proc singleGithubSearch(term: string): JsonNode =
 proc githubSearch(seen: var HashSet[string]; terms: seq[string]) =
   for term in terms:
     let results = singleGithubSearch(term)
+    if results.isNil:
+      return
     for j in items(results.getOrDefault("items")):
       let p = Package(
         name: j.getOrDefault("name").getStr,
@@ -101,6 +103,8 @@ proc githubSearch(seen: var HashSet[string]; terms: seq[string]) =
 
 proc getUrlFromGithub*(term: string): string =
   let results = singleGithubSearch(term)
+  if results.isNil:
+    return ""
   var matches = 0
   result = ""
   for j in items(results.getOrDefault("items")):

--- a/tools/atlas/packagesjson.nim
+++ b/tools/atlas/packagesjson.nim
@@ -79,15 +79,13 @@ proc singleGithubSearch(term: string): JsonNode =
     let x = client.getContent("https://api.github.com/search/repositories?q=" & encodeUrl(term) & "+language:nim")
     result = parseJson(x)
   except:
-    discard "it's a failed search, ignore"
+    result = parseJson("{\"items\": []}")
   finally:
     client.close()
 
 proc githubSearch(seen: var HashSet[string]; terms: seq[string]) =
   for term in terms:
     let results = singleGithubSearch(term)
-    if results.isNil:
-      return
     for j in items(results.getOrDefault("items")):
       let p = Package(
         name: j.getOrDefault("name").getStr,
@@ -103,8 +101,6 @@ proc githubSearch(seen: var HashSet[string]; terms: seq[string]) =
 
 proc getUrlFromGithub*(term: string): string =
   let results = singleGithubSearch(term)
-  if results.isNil:
-    return ""
   var matches = 0
   result = ""
   for j in items(results.getOrDefault("items")):


### PR DESCRIPTION
`items` causes a segfault when `results` is nil without this patch.