### PR TITLE
fixes #21987; don't create type bound ops for anything in a function with a `nodestroy` pragma

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -90,7 +90,9 @@ const
   errLetNeedsInit = "'let' symbol requires an initialization"
 
 proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
-  if typ == nil: return
+  if typ == nil or sfGeneratedOp in tracked.owner.flags:
+    # don't create type bound ops for anything in a function with a `nodestroy` pragma
+    return
   when false:
     let realType = typ.skipTypes(abstractInst)
     if realType.kind == tyRef and

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -92,6 +92,7 @@ const
 proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
   if typ == nil or sfGeneratedOp in tracked.owner.flags:
     # don't create type bound ops for anything in a function with a `nodestroy` pragma
+    # bug #21987
     return
   when false:
     let realType = typ.skipTypes(abstractInst)


### PR DESCRIPTION
fixes #21987