### PR TITLE
properly disallow unresolved generic proc values

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -116,7 +116,7 @@ proc ambiguousSymChoice(c: PContext, orig, n: PNode): PNode =
     result = n
 
 proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode =
-  result = semExprCheck(c, n, flags, expectedType)
+  result = semExprCheck(c, n, flags-{efTypeAllowed}, expectedType)
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
   elif (result.typ == nil or result.typ.kind == tyNone) and

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -132,6 +132,7 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType
     result.typ = errorType(c)
   elif efTypeAllowed in flags and result.typ.kind == tyProc and
       hasUnresolvedParams(result, {}):
+    # mirrored with semOperand but only on efTypeAllowed
     let owner = result.typ.owner
     let err =
       # consistent error message with evaltempl/semMacroExpr

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -680,6 +680,15 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           typ = typ.lastSon
         if hasEmpty(typ):
           localError(c.config, def.info, errCannotInferTypeOfTheLiteral % typ.kind.toHumanStr)
+        elif typ.kind == tyProc and def.kind == nkSym and isGenericRoutine(def.sym.ast):
+          let owner = typ.owner
+          let err =
+            # consistent error message with evaltempl/semMacroExpr
+            if owner != nil and owner.kind in {skTemplate, skMacro}:
+              errMissingGenericParamsForTemplate % def.renderTree
+            else:
+              errProcHasNoConcreteType % def.renderTree
+          localError(c.config, def.info, err)
         when false:
           # XXX This typing rule is neither documented nor complete enough to
           # justify it. Instead use the newer 'unowned x' until we figured out

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -680,16 +680,6 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           typ = typ.lastSon
         if hasEmpty(typ):
           localError(c.config, def.info, errCannotInferTypeOfTheLiteral % typ.kind.toHumanStr)
-        elif typ.kind == tyProc and def.kind == nkSym and isGenericRoutine(def.sym.ast):
-          # tfUnresolved in typ.flags:
-          let owner = typ.owner
-          let err =
-            # consistent error message with evaltempl/semMacroExpr
-            if owner != nil and owner.kind in {skTemplate, skMacro}:
-              errMissingGenericParamsForTemplate % def.renderTree
-            else:
-              errProcHasNoConcreteType % def.renderTree
-          localError(c.config, def.info, err)
         when false:
           # XXX This typing rule is neither documented nor complete enough to
           # justify it. Instead use the newer 'unowned x' until we figured out

--- a/tests/errmsgs/tunresolvedinnerproc.nim
+++ b/tests/errmsgs/tunresolvedinnerproc.nim
@@ -1,16 +1,10 @@
-discard """
-  errormsg: "instantiate 'notConcrete' explicitly"
-  line: 12
-  disabled: "true"
-"""
-
 proc wrap[T]() =
   proc notConcrete[T](x, y: int): int =
     var dummy: T
     result = x - y
 
   var x: proc (x, y: T): int
-  x = notConcrete
-
+  x = notConcrete #[tt.Error
+      ^ 'notConcrete' doesn't have a concrete type, due to unspecified generic parameters.]#
 
 wrap[int]()


### PR DESCRIPTION
This fixes and renames the `tnoinst` test which was disabled since https://github.com/nim-lang/Nim/commit/f73938218ec39209ef1d898e26350e4828e1248c and gave an error like `proc has no result symbol` (now gives a proper error). Couldn't find an issue for this.