### PR TITLE
fixes #21989; lift `=dup` from a custom `=copy` for objects to keep backward compatibilities 

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -430,7 +430,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
   if hasDestructor(c, n.typ):
     let typ = n.typ.skipTypes({tyGenericInst, tyAlias, tySink})
     let op = getAttachedOp(c.graph, typ, attachedDup)
-    if op != nil and (sfOverriden in op.flags or typ.kind == tyRef):
+    if op != nil and tfHasOwned notin typ.flags:
       if sfError in op.flags:
         c.checkForErrorPragma(n.typ, n, "=dup")
       else:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -430,7 +430,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
   if hasDestructor(c, n.typ):
     let typ = n.typ.skipTypes({tyGenericInst, tyAlias, tySink})
     let op = getAttachedOp(c.graph, typ, attachedDup)
-    if op != nil and sfOverriden in op.flags:
+    if op != nil and (sfOverriden in op.flags or typ.kind == tyRef):
       if sfError in op.flags:
         c.checkForErrorPragma(n.typ, n, "=dup")
       else:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -430,7 +430,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
   if hasDestructor(c, n.typ):
     let typ = n.typ.skipTypes({tyGenericInst, tyAlias, tySink})
     let op = getAttachedOp(c.graph, typ, attachedDup)
-    if op != nil and tfHasOwned notin typ.flags:
+    if op != nil and sfOverriden in op.flags and tfHasOwned notin typ.flags:
       if sfError in op.flags:
         c.checkForErrorPragma(n.typ, n, "=dup")
       else:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -430,7 +430,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
   if hasDestructor(c, n.typ):
     let typ = n.typ.skipTypes({tyGenericInst, tyAlias, tySink})
     let op = getAttachedOp(c.graph, typ, attachedDup)
-    if op != nil and sfOverriden in op.flags and tfHasOwned notin typ.flags:
+    if op != nil and sfOverriden in op.flags:
       if sfError in op.flags:
         c.checkForErrorPragma(n.typ, n, "=dup")
       else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -979,7 +979,16 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         else:
           fillBodyObjT(c, t, body, x, y)
       else:
-        fillBodyObjT(c, t, body, x, y)
+        if c.kind == attachedDup:
+          var op2 = getAttachedOp(c.g, t, attachedAsgn)
+          if op2 != nil and sfOverriden in op2.flags:
+            #markUsed(c.g.config, c.info, op, c.g.usageSym)
+            onUse(c.info, op2)
+            body.add newHookCall(c, t.assignment, x, y)
+          else:
+            fillBodyObjT(c, t, body, x, y)
+        else:
+          fillBodyObjT(c, t, body, x, y)
   of tyDistinct:
     if not considerUserDefinedOp(c, t, body, x, y):
       fillBody(c, t[0], body, x, y)


### PR DESCRIPTION
fixes #21989