### PR TITLE
retain forced open undeclared ident information

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -64,7 +64,7 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
   template maybeDotChoice(c: PContext, n: PNode, s: PSym, fromDotExpr: bool) =
     if fromDotExpr:
       result = symChoice(c, n, s, scForceOpen)
-      if result.len == 1:
+      if result.kind == nkOpenSymChoice and result.len == 1:
         result.transitionSonsKind(nkClosedSymChoice)
     else:
       result = symChoice(c, n, s, scOpen)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -70,6 +70,9 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
       onUse(info, s)
     else:
       result = n
+  elif i == 0:
+    # forced open but symbol not in scope, retain information
+    result = n
   else:
     # semantic checking requires a type; ``fitNode`` deals with it
     # appropriately
@@ -110,14 +113,10 @@ proc semBindStmt(c: PContext, n: PNode, toBind: var IntSet): PNode =
 
 proc semMixinStmt(c: PContext, n: PNode, toMixin: var IntSet): PNode =
   result = copyNode(n)
-  var count = 0
   for i in 0..<n.len:
     toMixin.incl(considerQuotedIdent(c, n[i]).id)
     let x = symChoice(c, n[i], nil, scForceOpen)
-    inc count, x.len
     result.add x
-  if count == 0:
-    result = newNodeI(nkEmpty, n.info)
 
 proc replaceIdentBySym(c: PContext; n: var PNode, s: PNode) =
   case n.kind

--- a/tests/lookups/tundeclaredmixin.nim
+++ b/tests/lookups/tundeclaredmixin.nim
@@ -1,0 +1,17 @@
+discard """
+  nimout: '''
+  mixin nothing, add
+'''
+"""
+
+# issue #22012
+
+import macros
+
+expandMacros:
+  proc foo[T](): int =
+    # `nothing` is undeclared, `add` is declared
+    mixin nothing, add
+    123
+
+  doAssert foo[int]() == 123


### PR DESCRIPTION
fixes #22012, refs #18968

When `scForceOpen` encounters an undeclared/non-overloadable (?) symbol, keep the original node instead of creating an empty sym choice, to retain the information of the original identifier used. This is needed for templates/generic procs that `mixin` undeclared symbols and undergo multiple semchecks (i.e. as a forwarded `typed` macro param).

Cannot directly backport due to the `semgnrc` diff being incompatible, we would need to add `if choice.kind == nkOpenSymChoice:` [here](https://github.com/nim-lang/Nim/blob/eaf89777236d939e5c21c5daee9cf96423dc11bc/compiler/semgnrc.nim#L178) instead.