### PR TITLE
make runnableExamples a special word

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1933,7 +1933,7 @@ proc isCompileTimeProc*(s: PSym): bool {.inline.} =
 proc isRunnableExamples*(n: PNode): bool =
   # Templates and generics don't perform symbol lookups.
   result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
-    n.kind == nkIdent and n.ident.s == "runnableExamples"
+    n.kind == nkIdent and n.ident.id == ord(wRunnableExamples)
 
 proc hasPattern*(s: PSym): bool {.inline.} =
   result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1930,11 +1930,6 @@ proc isCompileTimeProc*(s: PSym): bool {.inline.} =
   result = s.kind == skMacro or
            s.kind in {skProc, skFunc} and sfCompileTime in s.flags
 
-proc isRunnableExamples*(n: PNode): bool =
-  # Templates and generics don't perform symbol lookups.
-  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
-    n.kind == nkIdent and n.ident.id == ord(wRunnableExamples)
-
 proc hasPattern*(s: PSym): bool {.inline.} =
   result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty
 

--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -10,7 +10,7 @@
 ## Template evaluation engine. Now hygienic.
 
 import
-  strutils, options, ast, astalgo, msgs, renderer, lineinfos, idents
+  strutils, options, ast, astalgo, msgs, renderer, lineinfos, idents, trees
 
 type
   TemplCtx = object

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -214,3 +214,8 @@ proc dontInlineConstant*(orig, cnst: PNode): bool {.inline.} =
   result = orig.kind != cnst.kind and
            cnst.kind in {nkCurly, nkPar, nkTupleConstr, nkBracket, nkObjConstr} and
            cnst.len > ord(cnst.kind == nkObjConstr)
+
+proc isRunnableExamples*(n: PNode): bool =
+  # Templates and generics don't perform symbol lookups.
+  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
+    n.kind == nkIdent and n.ident.id == ord(wRunnableExamples)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -37,7 +37,7 @@ type
     wMemTracker = "memtracker", wObjChecks = "objchecks",
     wIntDefine = "intdefine", wStrDefine = "strdefine", wBoolDefine = "booldefine",
     wCursor = "cursor", wNoalias = "noalias", wEffectsOf = "effectsOf",
-    wUncheckedAssign = "uncheckedAssign",
+    wUncheckedAssign = "uncheckedAssign", wRunnableExamples = "runnableExamples",
 
     wImmediate = "immediate", wConstructor = "constructor", wDestructor = "destructor",
     wDelegator = "delegator", wOverride = "override", wImportCpp = "importcpp",


### PR DESCRIPTION
Slight performance improvement given `isRunnableExamples` is called on every call expression in templates.