### PR TITLE
Fix: don't track Defect in proc effect compatibility

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1434,6 +1434,19 @@ proc compatibleEffectsAux(se, re: PNode): bool =
       return false
   result = true
 
+proc isDefectException*(t: PType): bool
+proc compatibleExceptions(se, re: PNode): bool =
+  if re.isNil: return false
+  for r in items(re):
+    block search:
+      if isDefectException(r.typ):
+        break search
+      for s in items(se):
+        if safeInheritanceDiff(r.typ, s.typ) <= 0:
+          break search
+      return false
+  result = true
+
 proc hasIncompatibleEffect(se, re: PNode): bool =
   if re.isNil: return false
   for r in items(re):
@@ -1472,7 +1485,7 @@ proc compatibleEffects*(formal, actual: PType): EffectsCompat =
     if not isNil(se) and se.kind != nkArgList:
       # spec requires some exception or tag, but we don't know anything:
       if real.len == 0: return efRaisesUnknown
-      let res = compatibleEffectsAux(se, real[exceptionEffects])
+      let res = compatibleExceptions(se, real[exceptionEffects])
       if not res: return efRaisesDiffer
 
     let st = spec[tagEffects]

--- a/tests/effects/teffects1.nim
+++ b/tests/effects/teffects1.nim
@@ -22,6 +22,11 @@ proc lier(): int {.raises: [IO2Error].} = #[tt.Hint
 proc forw: int =
   raise newException(IOError, "arg")
 
+block:
+  proc someProc(t: string) {.raises: [Defect].} =
+    discard
+  let vh: proc(topic: string) {.raises: [].} = someProc
+
 {.push raises: [Defect].}
 
 type


### PR DESCRIPTION
Follow up of https://github.com/nim-lang/Nim/pull/14298

This doesn't compile currently:
```nim
  proc someProc(t: string) {.raises: [Defect].} =
    discard
  let vh: proc(topic: string) {.raises: [].} = someProc
```