### PR TITLE
Update browsers.nim, fix openDefaultBrowser()'s bug

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -40,15 +40,17 @@ proc prepare(s: string): string =
   else:
     result = "file://" & absolutePath(s)
 
-proc openDefaultBrowserImpl(url: string) =
+proc openDefaultBrowserImplPrep(url: string) =
+  ## note the url argument should be alreadly prepared, i.e. the url is passed "AS IS"
+
   when defined(windows):
     var o = newWideCString(osOpenCmd)
-    var u = newWideCString(prepare url)
+    var u = newWideCString(url)
     discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
   elif defined(macosx):
-    discard execShellCmd(osOpenCmd & " " & quoteShell(prepare url))
+    discard execShellCmd(osOpenCmd & " " & quoteShell(url))
   else:
-    var u = quoteShell(prepare url)
+    var u = quoteShell(url)
     if execShellCmd(osOpenCmd & " " & u) == 0: return
     for b in getEnv("BROWSER").split(PathSep):
       try:
@@ -57,6 +59,9 @@ proc openDefaultBrowserImpl(url: string) =
         return
       except OSError:
         discard
+
+proc openDefaultBrowserImpl(url: string) =
+  openDefaultBrowserImplPrep(prepare url)
 
 proc openDefaultBrowser*(url: string) =
   ## Opens `url` with the user's default browser. This does not block.
@@ -93,4 +98,4 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ## **See also:**
   ##
   ## * https://tools.ietf.org/html/rfc6694#section-3
-  openDefaultBrowserImpl("http:about:blank")  # See IETF RFC-6694 Section 3.
+  openDefaultBrowserImplPrep("about:blank")  # See IETF RFC-6694 Section 3.


### PR DESCRIPTION
Fix it that the [`openDefaultBrowser()`](https://github.com/nim-lang/Nim/blob/devel/lib/pure/browsers.nim#L78-L96) proc  doesn't open a blank page as expected.


The previous implementation uses "http:about:blank",<br> which will 
- be processed by [`prepare`](https://github.com/nim-lang/Nim/blob/devel/lib/pure/browsers.nim#L37-L41) proc 
- thus be considered as a file path, turning to "file://...".


All in all, there are two mistakes:
1. the url pointing to a blank page shouldn't be "http:about:blank"
2. the above url shouldn't be treated as a file path and passed to the `prepare` function


To fix it:
1. the "about:blank" is used instead. 
2. a new `openDefaultBrowserImplPrep` proc is added, which will not pass its `url` parameter to `prepare`
3. `openDefaultBrowserImpl` proc is modified but remains its functionality unchanged