### PR TITLE
Update browsers.nim, fix openDefaultBrowser()'s bug for v1

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -35,15 +35,17 @@ proc prepare(s: string): string =
   else:
     result = "file://" & absolutePath(s)
 
-proc openDefaultBrowserImpl(url: string) =
+proc openDefaultBrowserImplPrep(url: string) =
+  ## note the url argument should be alreadly prepared, i.e. the url is passed "AS IS"
+
   when defined(windows):
     var o = newWideCString(osOpenCmd)
-    var u = newWideCString(prepare url)
+    var u = newWideCString(url)
     discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
   elif defined(macosx):
-    discard execShellCmd(osOpenCmd & " " & quoteShell(prepare url))
+    discard execShellCmd(osOpenCmd & " " & quoteShell(url))
   else:
-    var u = quoteShell(prepare url)
+    var u = quoteShell(url)
     if execShellCmd(osOpenCmd & " " & u) == 0: return
     for b in getEnv("BROWSER").split(PathSep):
       try:
@@ -52,6 +54,9 @@ proc openDefaultBrowserImpl(url: string) =
         return
       except OSError:
         discard
+
+proc openDefaultBrowserImpl(url: string) =
+  openDefaultBrowserImplPrep(prepare url)
 
 proc openDefaultBrowser*(url: string) =
   ## Opens `url` with the user's default browser. This does not block.
@@ -86,4 +91,4 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ##
   ## .. code-block:: nim
   ##   block: openDefaultBrowser()
-  openDefaultBrowserImpl("http:about:blank")  # See IETF RFC-6694 Section 3.
+  openDefaultBrowserImplPrep("about:blank")   # See IETF RFC-6694 Section 3.


### PR DESCRIPTION
For details see [the PR for v2](https://github.com/nim-lang/Nim/pull/22052), but this one is specific to v1