### PR TITLE
make borrow `.` work with aliases if not overriden

### DIFF
--- a/tests/distinct/tborrow.nim
+++ b/tests/distinct/tborrow.nim
@@ -89,3 +89,12 @@ block: # Borrow from generic alias
     e = default(E)
   assert c.i == int(0)
   assert e.i == 0d
+
+block: # issue #22069
+  type
+    Vehicle[C: static[int]] = object
+      color: array[C, int]
+    Car[C: static[int]] {.borrow: `.`.} = distinct Vehicle[C]
+    MuscleCar = Car[128]
+  var x: MuscleCar
+  doAssert x.color is array[128, int]


### PR DESCRIPTION
fixes #22069

Skip alias and generic instantiation types when checking what `tfBorrowDot` was applied to (as it might have been copied from the original distinct type), but consider if the flag in the alias/instantiation type is inconsistent with the original distinct type.