### PR TITLE
strictly typecheck expressions in bracketed `emit`

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -629,7 +629,7 @@ proc pragmaEmit(c: PContext, n: PNode) =
     if n1.kind == nkBracket:
       var b = newNodeI(nkBracket, n1.info, n1.len)
       for i in 0..<n1.len:
-        b[i] = c.semExpr(c, n1[i])
+        b[i] = c.semExprWithType(c, n1[i], {efTypeAllowed})
       n[1] = b
     else:
       n[1] = c.semConstExpr(c, n1)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -678,6 +678,7 @@ proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PCo
   if result.p != nil: internalError(graph.config, module.info, "sem.preparePContext")
   result.semConstExpr = semConstExpr
   result.semExpr = semExpr
+  result.semExprWithType = semExprWithType
   result.semTryExpr = tryExpr
   result.semTryConstExpr = tryConstExpr
   result.computeRequiresInit = computeRequiresInit

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -126,6 +126,7 @@ type
     libs*: seq[PLib]           # all libs used by this module
     semConstExpr*: proc (c: PContext, n: PNode; expectedType: PType = nil): PNode {.nimcall.} # for the pragmas
     semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode {.nimcall.}
+    semExprWithType*: proc (c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode {.nimcall.}
     semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
     semTryConstExpr*: proc (c: PContext, n: PNode; expectedType: PType = nil): PNode {.nimcall.}
     computeRequiresInit*: proc (c: PContext, t: PType): bool {.nimcall.}

--- a/tests/lookups/tambiguousemit.nim
+++ b/tests/lookups/tambiguousemit.nim
@@ -1,3 +1,8 @@
+discard """
+  cmd: "nim check $options $file" # use check to assure error is pre-codegen
+  matrix: "; --backend:js" # backend shouldn't matter but at least check js
+"""
+
 proc foo(x: int) = discard
 proc foo(x: float) = discard
 

--- a/tests/lookups/tambiguousemit.nim
+++ b/tests/lookups/tambiguousemit.nim
@@ -1,0 +1,7 @@
+proc foo(x: int) = discard
+proc foo(x: float) = discard
+
+{.emit: ["// ", foo].} #[tt.Error
+                ^ ambiguous identifier 'foo' -- use one of the following:
+  tambiguousemit.foo: proc (x: int){.noSideEffect, gcsafe.}
+  tambiguousemit.foo: proc (x: float){.noSideEffect, gcsafe.}]#


### PR DESCRIPTION
closes #22068

As mentioned in https://github.com/nim-lang/Nim/issues/22068#issuecomment-1586157899, ``{.emit: "// `foo`".}`` does not fail, as it ignores symbols being ambiguous. This is untouched but there is no way to get the same behavior in the bracket version. We could leave it like this, or we could allow the quoted version to be mixed in the bracket version or add some `disambiguate(foo)` to emulate the behavior of the quoted version.