### PR TITLE
make binary `not` not parse complex expressions on right side

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1396,7 +1396,7 @@ proc binaryNot(p: var Parser; a: PNode): PNode =
     let notOpr = newIdentNodeP(p.tok.ident, p)
     getTok(p)
     optInd(p, notOpr)
-    let b = simpleExpr(p, pmTypeDesc)
+    let b = primary(p, pmTypeDesc)
     result = newNodeP(nkInfix, p)
     result.add notOpr
     result.add a
@@ -1407,8 +1407,8 @@ proc binaryNot(p: var Parser; a: PNode): PNode =
 proc parseTypeDesc(p: var Parser, fullExpr = false): PNode =
   #| rawTypeDesc = (tupleType | routineType | 'enum' | 'object' |
   #|                 ('var' | 'out' | 'ref' | 'ptr' | 'distinct') typeDesc?)
-  #|                 ('not' simpleExpr)?
-  #| typeDescExpr = (routineType / simpleExpr) ('not' simpleExpr)?
+  #|                 ('not' primary)?
+  #| typeDescExpr = (routineType / simpleExpr) ('not' primary)?
   #| typeDesc = rawTypeDesc / typeDescExpr
   newlineWasSplitting(p)
   if fullExpr:
@@ -1445,7 +1445,7 @@ proc parseTypeDefValue(p: var Parser): PNode =
   #| typeDefValue = ((tupleDecl | enumDecl | objectDecl | conceptDecl |
   #|                  ('ref' | 'ptr' | 'distinct') (tupleDecl | objectDecl))
   #|                / (simpleExpr (exprEqExpr ^+ comma postExprBlocks?)?))
-  #|                ('not' simpleExpr)?
+  #|                ('not' primary)?
   case p.tok.tokType
   of tkTuple: result = parseTuple(p, true)
   of tkRef: result = parseTypeDescKAux(p, nkRefTy, pmTypeDef)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1396,7 +1396,7 @@ proc binaryNot(p: var Parser; a: PNode): PNode =
     let notOpr = newIdentNodeP(p.tok.ident, p)
     getTok(p)
     optInd(p, notOpr)
-    let b = parseExpr(p)
+    let b = simpleExpr(p, pmTypeDesc)
     result = newNodeP(nkInfix, p)
     result.add notOpr
     result.add a
@@ -1407,8 +1407,8 @@ proc binaryNot(p: var Parser; a: PNode): PNode =
 proc parseTypeDesc(p: var Parser, fullExpr = false): PNode =
   #| rawTypeDesc = (tupleType | routineType | 'enum' | 'object' |
   #|                 ('var' | 'out' | 'ref' | 'ptr' | 'distinct') typeDesc?)
-  #|                 ('not' expr)?
-  #| typeDescExpr = (routineType / simpleExpr) ('not' expr)?
+  #|                 ('not' simpleExpr)?
+  #| typeDescExpr = (routineType / simpleExpr) ('not' simpleExpr)?
   #| typeDesc = rawTypeDesc / typeDescExpr
   newlineWasSplitting(p)
   if fullExpr:
@@ -1445,7 +1445,7 @@ proc parseTypeDefValue(p: var Parser): PNode =
   #| typeDefValue = ((tupleDecl | enumDecl | objectDecl | conceptDecl |
   #|                  ('ref' | 'ptr' | 'distinct') (tupleDecl | objectDecl))
   #|                / (simpleExpr (exprEqExpr ^+ comma postExprBlocks?)?))
-  #|                ('not' expr)?
+  #|                ('not' simpleExpr)?
   case p.tok.tokType
   of tkTuple: result = parseTuple(p, true)
   of tkRef: result = parseTypeDescKAux(p, nkRefTy, pmTypeDef)

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -104,13 +104,13 @@ primary = simplePrimary (commandStart expr (doBlock extraPostExprBlock*)?)?
         / prefixOperator primary
 rawTypeDesc = (tupleType | routineType | 'enum' | 'object' |
                 ('var' | 'out' | 'ref' | 'ptr' | 'distinct') typeDesc?)
-                ('not' expr)?
-typeDescExpr = (routineType / simpleExpr) ('not' expr)?
+                ('not' simpleExpr)?
+typeDescExpr = (routineType / simpleExpr) ('not' simpleExpr)?
 typeDesc = rawTypeDesc / typeDescExpr
 typeDefValue = ((tupleDecl | enumDecl | objectDecl | conceptDecl |
                  ('ref' | 'ptr' | 'distinct') (tupleDecl | objectDecl))
                / (simpleExpr (exprEqExpr ^+ comma postExprBlocks?)?))
-               ('not' expr)?
+               ('not' simpleExpr)?
 extraPostExprBlock = ( IND{=} doBlock
                      | IND{=} 'of' exprList ':' stmt
                      | IND{=} 'elif' expr ':' stmt

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -104,13 +104,13 @@ primary = simplePrimary (commandStart expr (doBlock extraPostExprBlock*)?)?
         / prefixOperator primary
 rawTypeDesc = (tupleType | routineType | 'enum' | 'object' |
                 ('var' | 'out' | 'ref' | 'ptr' | 'distinct') typeDesc?)
-                ('not' simpleExpr)?
-typeDescExpr = (routineType / simpleExpr) ('not' simpleExpr)?
+                ('not' primary)?
+typeDescExpr = (routineType / simpleExpr) ('not' primary)?
 typeDesc = rawTypeDesc / typeDescExpr
 typeDefValue = ((tupleDecl | enumDecl | objectDecl | conceptDecl |
                  ('ref' | 'ptr' | 'distinct') (tupleDecl | objectDecl))
                / (simpleExpr (exprEqExpr ^+ comma postExprBlocks?)?))
-               ('not' simpleExpr)?
+               ('not' primary)?
 extraPostExprBlock = ( IND{=} doBlock
                      | IND{=} 'of' exprList ':' stmt
                      | IND{=} 'elif' expr ':' stmt

--- a/tests/notnil/tparse.nim
+++ b/tests/notnil/tparse.nim
@@ -1,0 +1,18 @@
+# issue #16324
+
+{.push experimental: "notnil".}
+
+block:
+  type Foo = ref object
+    value: int
+    
+  proc newFoo1(): Foo not nil =               # This compiles
+    return Foo(value: 1)
+    
+  proc newFoo2(): Foo not nil {.inline.} =    # This does not
+    return Foo(value: 1)
+
+  doAssert newFoo1().value == 1
+  doAssert newFoo2().value == 1
+
+{.pop.}


### PR DESCRIPTION
fixes #16324

This fixes the pragma issue, and is consistent with `not` normally having higher precedence than any infix operator. However the left hand side still parses anything.

The issue mentions this:

```nim
type FooBar = Foo not nil | Bar
```

which no longer parses, because of how binary `not` is special cased in type parsing. Meanwhile `Foo | Bar not nil` becomes `(Foo | Bar) not nil` which presumably wouldn't be implemented. Maybe in the future we can remove the special parsing and the compiler can handle `Foo(not nil)`?