### PR TITLE
fold compileTime converters

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1924,7 +1924,7 @@ proc isRoutine*(s: PSym): bool {.inline.} =
 
 proc isCompileTimeProc*(s: PSym): bool {.inline.} =
   result = s.kind == skMacro or
-           s.kind in {skProc, skFunc} and sfCompileTime in s.flags
+           s.kind in {skProc, skFunc, skConverter} and sfCompileTime in s.flags
 
 proc hasPattern*(s: PSym): bool {.inline.} =
   result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -685,6 +685,7 @@ proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PCo
   result.semOperand = semOperand
   result.semConstBoolExpr = semConstBoolExpr
   result.semOverloadedCall = semOverloadedCall
+  result.afterCallActions = afterCallActions
   result.semInferredLambda = semInferredLambda
   result.semGenerateInstance = generateInstance
   result.semTypeNode = semTypeNode

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -136,6 +136,8 @@ type
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
     semOverloadedCall*: proc (c: PContext, n, nOrig: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
+    afterCallActions*: proc (c: PContext; n, orig: PNode, flags: TExprFlags;
+                             expectedType: PType = nil): PNode {.nimcall.}
     semTypeNode*: proc(c: PContext, n: PNode, prev: PType): PType {.nimcall.}
     semInferredLambda*: proc(c: PContext, pt: TIdTable, n: PNode): PNode
     semGenerateInstance*: proc (c: PContext, fn: PSym, pt: TIdTable,

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -597,7 +597,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         result = copyTree(s.astdef)
         if result != nil:
           result.info = n.info
-    of skProc, skFunc, skMethod:
+    of skProc, skFunc, skMethod, skConverter:
       result = n
     of skParam:
       if s.typ != nil and s.typ.kind == tyTypeDesc:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1993,6 +1993,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       else:
         param = copyTree(arg)
       result.add param
+      result = c.afterCallActions(c, result, arg, {})
 
       if dest.kind in {tyVar, tyLent}:
         dest.flags.incl tfVarIsPtr

--- a/tests/converter/tcompiletimeconverter.nim
+++ b/tests/converter/tcompiletimeconverter.nim
@@ -1,0 +1,13 @@
+discard """
+  nimout: '''
+abc
+'''
+"""
+
+converter foo(x: int): string {.compileTime.} = 
+  echo "abc"
+  $x
+
+const x: int = 123
+let y: string = x
+doAssert y == $x


### PR DESCRIPTION
fixes #20374

This behavior is wrong, it should only fold after the match is complete, not during the match. I can't bother figuring out how to do this so I will just keep this open for 1 CI run and close after for future reference.

Failure:

```
2023-06-16T01:55:44.8913505Z CT:megatest:processing: [176] tests\template\template_various.nim
2023-06-16T01:55:44.8913791Z template\template_various.nim(63, 5) Hint: 'Foo' is declared but not used [XDeclaredButNotUsed]
2023-06-16T01:55:44.8914054Z template\template_various.nim(71, 7) Hint: 'ret' is declared but not used [XDeclaredButNotUsed]
2023-06-16T01:55:44.8914357Z template\template_various.nim(84, 7) Hint: 'i2' is declared but not used [XDeclaredButNotUsed]
2023-06-16T01:55:44.8914661Z template\template_various.nim(95, 7) Hint: 'i3' is declared but not used [XDeclaredButNotUsed]
2023-06-16T01:55:44.8914948Z template\template_various.nim(118, 8) Hint: 'point' is declared but not used [XDeclaredButNotUsed]
2023-06-16T01:55:44.8915195Z Error: illformed AST: 
2023-06-16T01:55:44.8915255Z 
2023-06-16T01:55:46.2505412Z                      (14.56 sec)
```