### PR TITLE
Create compiler and nimsuggest packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ nimdoc.out.css
 # except here:
 !/nimdoc/testproject/expected/*
 pkgs/
+/compiler/compiler/

--- a/compiler/compiler.nimble
+++ b/compiler/compiler.nimble
@@ -1,0 +1,28 @@
+include "../lib/system/compilation.nim"
+version = $NimMajor & "." & $NimMinor & "." & $NimPatch
+author = "Andreas Rumpf"
+description = "Compiler package providing the compiler sources as a library."
+license = "MIT"
+skipDirs = @["."]
+installDirs = @["compiler"]
+
+import os
+
+var compilerDir = ""
+
+before install:
+  rmDir("compiler")
+
+  let
+    files = listFiles(".")
+    dirs = listDirs(".")
+
+  mkDir("compiler")
+
+  for f in files:
+    cpFile(f, "compiler" / f)
+
+  for d in dirs:
+    cpDir(d, "compiler" / d)
+
+requires "nim"

--- a/nim.nimble
+++ b/nim.nimble
@@ -1,7 +1,7 @@
 include "lib/system/compilation.nim"
 version = $NimMajor & "." & $NimMinor & "." & $NimPatch
 author = "Andreas Rumpf"
-description = "Compiler package providing the compiler sources as a library."
+description = "Nim package providing the compiler binary"
 license = "MIT"
 
 bin = @["compiler/nim", "nimsuggest/nimsuggest"]

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -13,7 +13,12 @@ import algorithm
 import tables
 import times
 
-import ../dist/checksums/src/checksums/sha1
+template tryImport(module) = import module
+
+when compiles tryImport ../dist/checksums/src/checksums/sha1:
+  import ../dist/checksums/src/checksums/sha1
+else:
+  import checksums/sha1
 
 ## Nimsuggest is a tool that helps to give editors IDE like capabilities.
 

--- a/nimsuggest/nimsuggest.nimble
+++ b/nimsuggest/nimsuggest.nimble
@@ -1,8 +1,8 @@
-version       = "0.1.0"
-author        = "Andreas Rumpf"
-description   = "Tool for providing auto completion data for Nim source code."
-license       = "MIT"
-
+include "../lib/system/compilation.nim"
+version = $NimMajor & "." & $NimMinor & "." & $NimPatch
+author = "Andreas Rumpf"
+description = "Tool for providing auto completion data for Nim source code."
+license = "MIT"
 bin = @["nimsuggest"]
 
-requires "nim >= 1.1.1"
+requires "compiler >= 1.9.0" , "checksums"


### PR DESCRIPTION
I have tested it locally with the following in my local packages_official.json

```
  {
    "name": "compiler",
    "url": "https://github.com/yyoncho/Nim.git/?subdir=compiler",
    "method": "git",
    "tags": [
      "library",
      "compiler"
    ],
    "description": "Package providing the Nim compiler binaries plus all its source files that can be used as a library",
    "license": "MIT",
    "web": "https://github.com/nim-lang/Nim"
  },
  {
    "name": "nimsuggest",
    "url": "https://github.com/yyoncho/Nim.git/?nimsuggest=compiler",
    "method": "git",
    "tags": [
      "library",
      "compiler"
    ],
    "description": "Package providing the Nim compiler binaries plus all its source files that can be used as a library",
    "license": "MIT",
    "web": "https://github.com/nim-lang/Nim"
  },
```

Then `nimble install compiler`, `nimble install nimsuggest` work as expected.