### PR TITLE
fixes :idx: index in  in modules (2.0 regression) and in markdown files (persistent issues since 0.20.2)

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -591,10 +591,16 @@ proc readIndexDir*(dir: string):
     if path.endsWith(IndexExt):
       var (fileEntries, title) = parseIdxFile(path)
       # Depending on type add this to the list of symbols or table of APIs.
-      if title.kind == ieNimTitle:
+      if title.kind in {ieNimTitle, ieIdxRole}:
         for i in 0 ..< fileEntries.len:
-          if fileEntries[i].kind != ieNim:
-            continue
+          if title.kind == ieIdxRole:
+            # Don't add to symbols TOC entries (they start with a whitespace).
+            let toc = fileEntries[i].linkTitle
+            if toc.len > 0 and toc[0] == ' ':
+              continue
+          else:
+            if fileEntries[i].kind != ieNim:
+              continue
           # Ok, non TOC entry, add it.
           setLen(result.symbols, L + 1)
           result.symbols[L] = fileEntries[i]

--- a/lib/packages/docutils/rstidx.nim
+++ b/lib/packages/docutils/rstidx.nim
@@ -109,16 +109,19 @@ proc parseIdxFile*(path: string):
     result.fileEntries[f].kind = parseIndexEntryKind(cols[0])
     result.fileEntries[f].keyword = cols[1]
     result.fileEntries[f].link = cols[2]
-    if result.title.keyword.len == 0:
+    if result.fileEntries[f].kind == ieIdxRole:
       result.fileEntries[f].module = base
     else:
-      result.fileEntries[f].module = result.title.keyword
+      if result.title.keyword.len == 0:
+        result.fileEntries[f].module = base
+      else:
+        result.fileEntries[f].module = result.title.keyword
 
     result.fileEntries[f].linkTitle = cols[3].unquoteIndexColumn
     result.fileEntries[f].linkDesc = cols[4].unquoteIndexColumn
     result.fileEntries[f].line = parseInt(cols[5])
 
-    if result.fileEntries[f].kind in {ieNimTitle, ieMarkupTitle}:
+    if result.fileEntries[f].kind in {ieNimTitle, ieMarkupTitle, ieIdxRole}:
       result.title = result.fileEntries[f]
     inc f
 


### PR DESCRIPTION
![image](https://github.com/nim-lang/Nim/assets/43030857/09bfcb80-f878-4f11-a59e-ba57d7e1bafb)

ref https://gist.github.com/ringabout/29fb71956bcd31579743d15084924ae2