### PR TITLE
macOS `ar` doesn't support `@` syntax

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -834,7 +834,10 @@ proc linkViaResponseFile(conf: ConfigRef; cmd: string) =
   else:
     writeFile(linkerArgs, args)
   try:
-    execLinkCmd(conf, cmd.substr(0, last) & " @" & linkerArgs)
+    when defined(macosx):
+      execLinkCmd(conf, "xargs " & cmd.substr(0, last) & " < " & linkerArgs)
+    else:
+      execLinkCmd(conf, cmd.substr(0, last) & " @" & linkerArgs)
   finally:
     removeFile(linkerArgs)
 


### PR DESCRIPTION
When the linker command line is long, Nim compiler generates a file for passing the linker arguments. On `macOS`, that mechanism fails as the `@` syntax is not supported by `ar`. Use `xargs` instead to pass the linker arguments file.