### PR TITLE
adds T destructor for refs

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1069,7 +1069,7 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   let src = newSym(skParam, getIdent(g.cache, if kind == attachedTrace: "env" else: "src"),
                    idgen, result, info)
 
-  if kind == attachedDestructor and typ.kind == tyRef and isDefined(g.config, "newRefdestructor"):
+  if kind == attachedDestructor and typ.kind == tyRef:
     dest.typ = typ
   else:
     dest.typ = makeVarType(typ.owner, typ, idgen)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1069,7 +1069,7 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   let src = newSym(skParam, getIdent(g.cache, if kind == attachedTrace: "env" else: "src"),
                    idgen, result, info)
 
-  if kind == attachedDestructor and typ.kind == tyRef:
+  if kind == attachedDestructor and typ.kind == tyRef and isDefined(g.config, "newRefdestructor"):
     dest.typ = typ
   else:
     dest.typ = makeVarType(typ.owner, typ, idgen)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1068,7 +1068,12 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   let dest = newSym(skParam, getIdent(g.cache, "dest"), idgen, result, info)
   let src = newSym(skParam, getIdent(g.cache, if kind == attachedTrace: "env" else: "src"),
                    idgen, result, info)
-  dest.typ = makeVarType(typ.owner, typ, idgen)
+
+  if kind == attachedDestructor and typ.kind == tyRef:
+    dest.typ = typ
+  else:
+    dest.typ = makeVarType(typ.owner, typ, idgen)
+
   if kind == attachedTrace:
     src.typ = getSysType(g, info, tyPointer)
   else:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -609,6 +609,13 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
     let op = getAttachedOp(c.graph, t, attachedDestructor)
     if op != nil:
       result[0] = newSymNode(op)
+      if op.typ != nil and op.typ.len == 2 and op.typ[1].kind != tyVar:
+        # debug n[1]
+        if n[1].kind == nkSym and n[1].sym.kind == skParam and
+            n[1].typ.kind == tyVar:
+          result[1] = genDeref(n[1])
+        else:
+          result[1] = skipAddr(n[1])
   of mTrace:
     result = n
     let t = n[1].typ.skipTypes(abstractVar)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -609,13 +609,6 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
     let op = getAttachedOp(c.graph, t, attachedDestructor)
     if op != nil:
       result[0] = newSymNode(op)
-      if op.typ != nil and op.typ.len == 2 and op.typ[1].kind != tyVar:
-        # debug n[1]
-        if n[1].kind == nkSym and n[1].sym.kind == skParam and
-            n[1].typ.kind == tyVar:
-          result[1] = genDeref(n[1])
-        else:
-          result[1] = skipAddr(n[1])
   of mTrace:
     result = n
     let t = n[1].typ.skipTypes(abstractVar)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -365,6 +365,10 @@ proc arrGet[I: Ordinal;T](a: T; i: I): T {.
 proc arrPut[I: Ordinal;T,S](a: T; i: I;
   x: S) {.noSideEffect, magic: "ArrPut".}
 
+when defined(nimAllowNonVarDestructor):
+  proc `=destroy`*[T](x: ref T) {.inline, magic: "Destroy".} =
+    discard
+
 proc `=destroy`*[T](x: var T) {.inline, magic: "Destroy".} =
   ## Generic `destructor`:idx: implementation that can be overridden.
   discard

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -43,3 +43,4 @@ switch("define", "nimPreviewRangeDefault")
 
 switch("warningAserror", "UnnamedBreak")
 switch("legacy", "verboseTypeMismatch")
+switch("define", "newRefdestructor")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -43,4 +43,4 @@ switch("define", "nimPreviewRangeDefault")
 
 switch("warningAserror", "UnnamedBreak")
 switch("legacy", "verboseTypeMismatch")
-switch("define", "newRefdestructor")
+


### PR DESCRIPTION
```nim
type
  Ref = ref object
    id: string

var x = Ref(id: "1243")
echo x.id
```

results in

```c
N_LIB_PRIVATE N_NIMCALL(void, eqdestroy___test53_u28)(tyObject_RefcolonObjectType___5xWuskg5NFR9csf9bEoTnGvg* dest_p0) {
	{
		NIM_BOOL T3_;
		T3_ = (NIM_BOOL)0;
		T3_ = nimDecRefIsLast(dest_p0);
		if (!T3_) goto LA4_;
		eqdestroy___test53_u8(dest_p0);
		nimRawDispose(dest_p0, ((NI)8));
	}
LA4_: ;
}
```

I didn't see noticeable performance booting.