### PR TITLE
fix VM uint conversion size bug, stricter int gen on JS

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2513,8 +2513,10 @@ proc genConv(p: PProc, n: PNode, r: var TCompRes) =
     elif src.kind == tyUInt64:
       r.res = "BigInt.asIntN(64, $1)" % [r.res]
   elif dest.kind == tyUInt64 and optJsBigInt64 in p.config.globalOptions:
-    if fromInt or fromUint:
+    if fromUint or src.kind in {tyBool, tyChar, tyEnum}:
       r.res = "BigInt($1)" % [r.res]
+    elif fromInt: # could be negative
+      r.res = "BigInt.asUintN(64, BigInt($1))" % [r.res]
     elif src.kind in {tyFloat..tyFloat64}:
       r.res = "BigInt(Math.trunc($1))" % [r.res]
     elif src.kind == tyInt64:
@@ -2755,8 +2757,10 @@ proc genCast(p: PProc, n: PNode, r: var TCompRes) =
     elif src.kind == tyUInt64:
       r.res = "BigInt.asIntN(64, $1)" % [r.res]
   elif dest.kind == tyUInt64 and optJsBigInt64 in p.config.globalOptions:
-    if fromInt or fromUint:
+    if fromUint or src.kind in {tyBool, tyChar, tyEnum}:
       r.res = "BigInt($1)" % [r.res]
+    elif fromInt: # could be negative
+      r.res = "BigInt.asUintN(64, BigInt($1))" % [r.res]
     elif src.kind in {tyFloat..tyFloat64}:
       r.res = "BigInt(Math.trunc($1))" % [r.res]
     elif src.kind == tyInt64:
@@ -2790,11 +2794,17 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       if optJsBigInt64 in p.config.globalOptions:
         r.res.add('n')
     of tyInt64:
-      r.res = rope(n.intVal)
+      let wrap = n.intVal < 0 # wrap negative integers with parens
+      if wrap: r.res.add '('
+      r.res.addInt n.intVal
       if optJsBigInt64 in p.config.globalOptions:
         r.res.add('n')
+      if wrap: r.res.add ')'
     else:
-      r.res = rope(n.intVal)
+      let wrap = n.intVal < 0 # wrap negative integers with parens
+      if wrap: r.res.add '('
+      r.res.addInt n.intVal
+      if wrap: r.res.add ')'
     r.kind = resExpr
   of nkNilLit:
     if isEmptyType(n.typ):

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2518,7 +2518,7 @@ proc genConv(p: PProc, n: PNode, r: var TCompRes) =
     elif fromInt: # could be negative
       r.res = "BigInt.asUintN(64, BigInt($1))" % [r.res]
     elif src.kind in {tyFloat..tyFloat64}:
-      r.res = "BigInt(Math.trunc($1))" % [r.res]
+      r.res = "BigInt.asUintN(64, BigInt(Math.trunc($1)))" % [r.res]
     elif src.kind == tyInt64:
       r.res = "BigInt.asUintN(64, $1)" % [r.res]
   elif toUint or dest.kind in tyFloat..tyFloat64:
@@ -2762,7 +2762,7 @@ proc genCast(p: PProc, n: PNode, r: var TCompRes) =
     elif fromInt: # could be negative
       r.res = "BigInt.asUintN(64, BigInt($1))" % [r.res]
     elif src.kind in {tyFloat..tyFloat64}:
-      r.res = "BigInt(Math.trunc($1))" % [r.res]
+      r.res = "BigInt.asUintN(64, BigInt(Math.trunc($1)))" % [r.res]
     elif src.kind == tyInt64:
       r.res = "BigInt.asUintN(64, $1)" % [r.res]
   elif dest.kind in tyFloat..tyFloat64:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -447,8 +447,9 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
         let destSize = getSize(c.config, desttyp)
         let srcDist = (sizeof(src.intVal) - srcSize) * 8
         let destDist = (sizeof(dest.intVal) - destSize) * 8
-        var value = cast[BiggestUInt](src.intVal)
-        value = (value shl srcDist) shr srcDist
+        var srcVal = src.intVal
+        srcVal = (srcVal shl srcDist) shr srcDist
+        var value = cast[BiggestUInt](srcVal)
         value = (value shl destDist) shr destDist
         dest.intVal = cast[BiggestInt](value)
     of tyBool:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -448,7 +448,8 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
         let srcDist = (sizeof(src.intVal) - srcSize) * 8
         let destDist = (sizeof(dest.intVal) - destSize) * 8
         var srcVal = src.intVal
-        srcVal = (srcVal shl srcDist) shr srcDist
+        when false: # this needs to use unsigned right shift, but shouldn't be needed anyway
+          srcVal = (srcVal shl srcDist) shr srcDist
         var value = cast[BiggestUInt](srcVal)
         value = (value shl destDist) shr destDist
         dest.intVal = cast[BiggestInt](value)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -443,14 +443,16 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
       of tyFloat..tyFloat64:
         dest.intVal = int(src.floatVal)
       else:
-        let srcSize = getSize(c.config, styp)
         let destSize = getSize(c.config, desttyp)
-        let srcDist = (sizeof(src.intVal) - srcSize) * 8
         let destDist = (sizeof(dest.intVal) - destSize) * 8
-        var srcVal = src.intVal
-        when false: # this needs to use unsigned right shift, but shouldn't be needed anyway
-          srcVal = (srcVal shl srcDist) shr srcDist
-        var value = cast[BiggestUInt](srcVal)
+        var value = cast[BiggestUInt](src.intVal)
+        when false:
+          # this would make uint64(-5'i8) evaluate to 251
+          # but at runtime, uint64(-5'i8) is 18446744073709551611
+          # so don't do it
+          let srcSize = getSize(c.config, styp)
+          let srcDist = (sizeof(src.intVal) - srcSize) * 8
+          value = (value shl srcDist) shr srcDist
         value = (value shl destDist) shr destDist
         dest.intVal = cast[BiggestInt](value)
     of tyBool:

--- a/tests/js/tneginthash.nim
+++ b/tests/js/tneginthash.nim
@@ -1,0 +1,21 @@
+# issue #19929
+
+import std/[tables, hashes]
+
+type Foo = object
+  a: int
+
+proc hash(f: Foo): Hash =
+  var h: Hash = 0
+  h = h !& hash(f.a)
+  result = !$h
+
+proc transpose[T, S](data: array[T, S]): Table[S, T] =
+  for i, x in data:
+    result[x] = i
+
+const xs = [Foo(a: 5), Foo(a: -5)]
+const x = transpose(xs)
+
+doAssert x[Foo(a: -5)] == 1
+doAssert x[Foo(a: 5)] == 0

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -29,6 +29,9 @@ block hashes:
     const wy123 = hashWangYi1(123)
     doAssert wy123 != 0
     doAssert hashWangYi1(123) == wy123
+    const wyNeg123 = hashWangYi1(-123)
+    doAssert wyNeg123 != 0
+    doAssert hashWangYi1(-123) == wyNeg123
 
 
   # "hashIdentity value incorrect at 456"

--- a/tests/vm/ttouintconv.nim
+++ b/tests/vm/ttouintconv.nim
@@ -75,3 +75,10 @@ macro foo2() =
 
 foo()
 foo2()
+
+block:
+  const neg5VM = block:
+    let x = -5'i8
+    uint64(x)
+  let y = -5'i8
+  doAssert uint64(y) == neg5VM


### PR DESCRIPTION
fixes #19929

The diff for `vm.nim` fixes this (introduced by #3654):

```nim
# compile for JS or 32-bit platform
static:
  let x = -5
  echo uint64(x) # 4294967291
  echo cast[uint64](x) # 18446744073709551611
```

On the VM, the *output* of integer conversions was restricted to the source type size as well as the destination type size, so when we converted `int` to `uint64` when `sizeof(int) == 4` we actually got a `uint32`. This made the hash of negative integers different between compile time and runtime on 32 bit platforms (because hashing integers converts to `uint64`). Now the input is ~~restricted to the source type size~~ left alone, and the output is restricted to the destination type size. Hopefully no code depended on this behavior (it's really annoying to fix when this happens).

`jsgen` has the following changes:

* Conversion to `uint64` from negative integers or floats with `--jsbigint64:on` is fixed by using `asUintN`. Previously `cast[uint64](-5)` (and similarly `let x = -5; uint64(x)`) would give `-5n`, now it gives `18446744073709551611n`.
  - Although this is inconsistent with `--jsbigint64:off` and `uint8`/`uint16`/`uint32` etc which still give an invalid `-5`. It might not be necessary to fix #19929 given the new negative integer hash test in `thashes` passes with `jsbigint64` both on and off.
* Negative integers are always generated wrapped in parentheses. This is unrelated but is such a common pitfall and has caused many bugs up to this point (that have generally been fixed individually). Can be moved out of this PR, I just initially thought this was causing #19929.