### PR TITLE
make `var object` match better than `object`

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -250,7 +250,9 @@ proc sumGeneric(t: PType): int =
     of tyAlias, tySink: t = t.lastSon
     of tyBool, tyChar, tyEnum, tyObject, tyPointer,
         tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
-        tyUInt..tyUInt64, tyCompositeTypeClass, tyBuiltInTypeClass:
+        tyUInt..tyUInt64, tyCompositeTypeClass:
+      return isvar + 1
+    of tyBuiltInTypeClass:
       return isvar
     else:
       return 0

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -251,7 +251,6 @@ proc sumGeneric(t: PType): int =
     of tyBool, tyChar, tyEnum, tyObject, tyPointer,
         tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
         tyUInt..tyUInt64, tyCompositeTypeClass, tyBuiltInTypeClass:
-      # todo: account for proc `tyBuiltInTypeClass` info like callconv
       return isvar
     else:
       return 0

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -250,7 +250,8 @@ proc sumGeneric(t: PType): int =
     of tyAlias, tySink: t = t.lastSon
     of tyBool, tyChar, tyEnum, tyObject, tyPointer,
         tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
-        tyUInt..tyUInt64, tyCompositeTypeClass:
+        tyUInt..tyUInt64, tyCompositeTypeClass, tyBuiltInTypeClass:
+      # todo: account for proc `tyBuiltInTypeClass` info like callconv
       return isvar
     else:
       return 0

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -215,7 +215,7 @@ proc sumGeneric(t: PType): int =
   # and Foo[T] has the value 2 so that we know Foo[Foo[T]] is more
   # specific than Foo[T].
   var t = t
-  var isvar = 1
+  var isvar = 0
   while true:
     case t.kind
     of tyGenericInst, tyArray, tyRef, tyPtr, tyDistinct, tyUncheckedArray,

--- a/tests/overload/tvartypeclass.nim
+++ b/tests/overload/tvartypeclass.nim
@@ -1,0 +1,11 @@
+# issue #13302
+
+proc foo(x: object): int = x.i*2
+proc foo(x: var object) = x.i*=2
+type Foo = object
+  i: int
+let x = Foo(i: 3)
+var y = Foo(i: 4)
+doAssert foo(x) == 6
+foo(y)
+doAssert y.i == 8


### PR DESCRIPTION
fixes #13302
