### PR TITLE
Fix regression in `std/times`

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1529,11 +1529,11 @@ proc getClockStr*(dt = now()): string {.rtl, extern: "nt$1", tags: [TimeEffect].
 proc initDateTime*(weekday: WeekDay, isoweek: IsoWeekRange, isoyear: IsoYear,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    nanosecond: NanosecondRange,
-                   zone: Timezone = local()): DateTime {.raises: [], tags: [], since: (1, 5).}
+                   zone: Timezone = local()): DateTime {.gcsafe, raises: [], tags: [], since: (1, 5).}
 
 proc initDateTime*(weekday: WeekDay, isoweek: IsoWeekRange, isoyear: IsoYear,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   zone: Timezone = local()): DateTime {.raises: [], tags: [], since: (1, 5).}
+                   zone: Timezone = local()): DateTime {.gcsafe, raises: [], tags: [], since: (1, 5).}
 
 #
 # TimeFormat

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -766,3 +766,7 @@ block: # ttimes
     check dt.format("GGGG") == "2023"
     check dt.format("dddd 'KW'V GGGG") == "Thursday KW1 2023"
 
+  block: # Can be used inside gcsafe proc
+    proc test(): DateTime {.gcsafe.} =
+      result = "1970".parse("yyyy")
+    doAssert test().year == 1970


### PR DESCRIPTION
This snippet works on stable but fails on devel
```nim
import times

proc main() {.gcsafe.} =
  discard "2023".parse("yyyy")
```

Issue was `initDateTime` was moved to be forward declared but wasn't marked as `gcsafe`