### PR TITLE
uint arithmetic for pointers

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -1139,7 +1139,7 @@ template instantiateForRegion(allocator: untyped) {.dirty.} =
   proc realloc0Impl(p: pointer, oldSize, newSize: Natural): pointer =
     result = realloc(allocator, p, newSize)
     if newSize > oldSize:
-      zeroMem(cast[pointer](cast[int](result) + oldSize), newSize - oldSize)
+      zeroMem(cast[pointer](cast[uint](result) + uint(oldSize)), newSize - oldSize)
 
   when false:
     proc countFreeMem(): int =

--- a/lib/system/mm/malloc.nim
+++ b/lib/system/mm/malloc.nim
@@ -22,7 +22,7 @@ proc reallocImpl(p: pointer, newSize: Natural): pointer =
 proc realloc0Impl(p: pointer, oldsize, newSize: Natural): pointer =
   result = realloc(p, newSize.csize_t)
   if newSize > oldSize:
-    zeroMem(cast[pointer](cast[int](result) + oldSize), newSize - oldSize)
+    zeroMem(cast[pointer](cast[uint](result) + uint(oldSize)), newSize - oldSize)
 
 proc deallocImpl(p: pointer) =
   c_free(p)


### PR DESCRIPTION
pointers are not signed and arithmetic may correctly cross int.max threshold

this PR only fixes 2 occurances - there are plenty however in the std lib