### PR TITLE
reuse `ansi_c/CFilePtr` in std/syncio

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -16,10 +16,11 @@ when defined(windows):
   import std/widestrs
 
 # ----------------- IO Part ------------------------------------------------
+
+from system/ansi_c import CFilePtr
+
 type
-  CFile {.importc: "FILE", header: "<stdio.h>",
-          incompleteStruct.} = object
-  File* = ptr CFile ## The type representing a file handle.
+  File* = CFilePtr ## The type representing a file handle.
 
   FileMode* = enum       ## The file mode when opening a file.
     fmRead,              ## Open the file for read access only.

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -77,9 +77,7 @@ elif defined(haiku):
     SIGPIPE* = cint(7)
     SIG_DFL* = CSighandlerT(nil)
 else:
-  when defined(nimscript):
-    {.error: "SIGABRT not ported to your platform".}
-  else:
+  when not defined(nimscript):
     var
       SIGINT* {.importc: "SIGINT", nodecl.}: cint
       SIGSEGV* {.importc: "SIGSEGV", nodecl.}: cint


### PR DESCRIPTION
this avoids creating two nim types for the same C type (avoiding a little bloat)