### PR TITLE
lib: pure: asyncdispatch: unregister signalfd after process terminate…

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1436,6 +1436,8 @@ else:
         if (customSet * events) != {}:
           isCustomEvent = true
           processCustomCallbacks(p, fd)
+          if events.contains(Event.Process):
+            p.selector.unregister(fd.int)
           result = true
 
       # because state `data` can be modified in callback we need to update


### PR DESCRIPTION
Fixed leakage of signalfd created by addProcess() when asyncproc of asynctools is used and waitForExit() is called.

See here.
https://forum.nim-lang.org/t/10302