### PR TITLE
Don't throw errors on RST tables in Markdown and RstMarkdown modes

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -2616,7 +2616,7 @@ proc getColumns(p: RstParser, cols: var RstCols, startIdx: int): int =
     if p.tok[result].kind != tkAdornment: break
   if p.tok[result].kind == tkIndent: inc result
 
-proc checkColumns(p: RstParser, cols: RstCols): bool =
+proc checkColumns(p: RstParser, cols: RstCols) =
   var i = p.idx
   if p.tok[i].symbol[0] != '=':
     stopOrWarn(p, meIllformedTable,
@@ -2638,8 +2638,6 @@ proc checkColumns(p: RstParser, cols: RstCols): bool =
     else:
       stopOrWarn(p, meIllformedTable,
                  "no enough table columns", p.tok[i].line, p.tok[i].col)
-      # return false
-  result = true
 
 proc getSpans(p: RstParser, nextLine: int,
               cols: RstCols, unitedCols: RstCols): seq[int] =
@@ -2732,12 +2730,12 @@ proc parseSimpleTable(p: var RstParser): PRstNode =
   result = newRstNodeA(p, rnTable)
   let startIdx = getColumns(p, cols, p.idx)
   let colChar = currentTok(p).symbol[0]
-  if not checkColumns(p, cols): return nil
+  checkColumns(p, cols)
   p.idx = startIdx
   result.colCount = cols.len
   while true:
     if currentTok(p).kind == tkAdornment:
-      if not checkColumns(p, cols): return nil
+      checkColumns(p, cols)
       p.idx = tokenAfterNewline(p)
       if currentTok(p).kind in {tkEof, tkIndent}:
         # skip last adornment line:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -585,6 +585,29 @@ proc rstMessage(p: RstParser, msgKind: MsgKind) =
                              p.col + currentTok(p).col, msgKind,
                              currentTok(p).symbol)
 
+# Functions `isPureRst` & `stopOrWarn` address differences between
+# Markdown and RST:
+# * Markdown always tries to continue working. If it is really impossible
+#   to parse a markup element, its proc just returns `nil` and parsing
+#   continues for it as for normal text paragraph.
+#   The downside is that real mistakes/typos are often silently ignored.
+#   The same applies to legacy `RstMarkdown` mode for nimforum.
+# * RST really signals errors. The downside is that it's more intrusive -
+#   the user must escape special syntax with \ explicitly.
+#
+# TODO: we need to apply this strategy to all markup elements eventually.
+
+func isPureRst(p: RstParser): bool =
+  roSupportMarkdown notin p.s.options
+
+proc stopOrWarn(p: RstParser, errorType: MsgKind, arg: string) =
+  let realMsgKind = if isPureRst(p): errorType else: mwRstStyle
+  rstMessage(p, realMsgKind, arg)
+
+proc stopOrWarn(p: RstParser, errorType: MsgKind, arg: string, line, col: int) =
+  let realMsgKind = if isPureRst(p): errorType else: mwRstStyle
+  rstMessage(p, realMsgKind, arg, line, col)
+
 proc currInd(p: RstParser): int =
   result = p.indentStack[high(p.indentStack)]
 
@@ -2593,14 +2616,14 @@ proc getColumns(p: RstParser, cols: var RstCols, startIdx: int): int =
     if p.tok[result].kind != tkAdornment: break
   if p.tok[result].kind == tkIndent: inc result
 
-proc checkColumns(p: RstParser, cols: RstCols) =
+proc checkColumns(p: RstParser, cols: RstCols): bool =
   var i = p.idx
   if p.tok[i].symbol[0] != '=':
-    rstMessage(p, mwRstStyle,
+    stopOrWarn(p, meIllformedTable,
                "only tables with `=` columns specification are allowed")
   for col in 0 ..< cols.len:
     if tokEnd(p, i) != cols[col].stop:
-      rstMessage(p, meIllformedTable,
+      stopOrWarn(p, meIllformedTable,
                  "end of table column #$1 should end at position $2" % [
                    $(col+1), $(cols[col].stop+ColRstOffset)],
                  p.tok[i].line, tokEnd(p, i))
@@ -2609,12 +2632,14 @@ proc checkColumns(p: RstParser, cols: RstCols) =
       if p.tok[i].kind == tkWhite:
         inc i
       if p.tok[i].kind notin {tkIndent, tkEof}:
-        rstMessage(p, meIllformedTable, "extraneous column specification")
+        stopOrWarn(p, meIllformedTable, "extraneous column specification")
     elif p.tok[i].kind == tkWhite:
       inc i
     else:
-      rstMessage(p, meIllformedTable, "no enough table columns",
-                 p.tok[i].line, p.tok[i].col)
+      stopOrWarn(p, meIllformedTable,
+                 "no enough table columns", p.tok[i].line, p.tok[i].col)
+      # return false
+  result = true
 
 proc getSpans(p: RstParser, nextLine: int,
               cols: RstCols, unitedCols: RstCols): seq[int] =
@@ -2669,17 +2694,18 @@ proc parseSimpleTableRow(p: var RstParser, cols: RstCols, colChar: char): PRstNo
       if tokEnd(p) <= colEnd(nCell):
         if tokStart(p) < colStart(nCell):
           if currentTok(p).kind != tkWhite:
-            rstMessage(p, meIllformedTable,
+            stopOrWarn(p, meIllformedTable,
                        "this word crosses table column from the left")
-          else:
-            inc p.idx
+            row[nCell].add(currentTok(p).symbol)
         else:
           row[nCell].add(currentTok(p).symbol)
-          inc p.idx
+        inc p.idx
       else:
         if tokStart(p) < colEnd(nCell) and currentTok(p).kind != tkWhite:
-          rstMessage(p, meIllformedTable,
+          stopOrWarn(p, meIllformedTable,
                      "this word crosses table column from the right")
+          row[nCell].add(currentTok(p).symbol)
+          inc p.idx
         inc nCell
     if currentTok(p).kind == tkIndent: inc p.idx
     if tokEnd(p) <= colEnd(0): break
@@ -2706,12 +2732,12 @@ proc parseSimpleTable(p: var RstParser): PRstNode =
   result = newRstNodeA(p, rnTable)
   let startIdx = getColumns(p, cols, p.idx)
   let colChar = currentTok(p).symbol[0]
-  checkColumns(p, cols)
+  if not checkColumns(p, cols): return nil
   p.idx = startIdx
   result.colCount = cols.len
   while true:
     if currentTok(p).kind == tkAdornment:
-      checkColumns(p, cols)
+      if not checkColumns(p, cols): return nil
       p.idx = tokenAfterNewline(p)
       if currentTok(p).kind in {tkEof, tkIndent}:
         # skip last adornment line:


### PR DESCRIPTION
Additions to RST simple tables (#19859) made their parsing more restrictive, which can introduce problems with of some old nimforum posts, which have tables with sloppily aligned columns (like this one:
https://github.com/nim-lang/nimforum/issues/330#issuecomment-1376039966). Also this strictness contradicts to Markdown style of not getting in the way (ignoring errors).

So this PR proposes a new strategy of dealing with errors:
* In Markdown and legacy (old default) RstMarkdown we try to continue parsing, emitting only warnings
* And only in pure RST mode we throw a error

I expect that this strategy will be applied to more parts of markup code in the future.