### PR TITLE
test disabling fauxMatch

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -467,7 +467,6 @@ const
   tyPureObject* = tyTuple
   GcTypeKinds* = {tyRef, tySequence, tyString}
   tyError* = tyProxy # as an errornous node should match everything
-  tyUnknown* = tyFromExpr
 
   tyUnknownTypes* = {tyError, tyFromExpr}
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -573,9 +573,9 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   if x.hasFauxMatch:
     result = x.call
     result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))
-    if containsGenericType(result.typ) or x.fauxMatch == tyUnknown:
+    if containsGenericType(result.typ):
       result.typ = newTypeS(x.fauxMatch, c)
-      if result.typ.kind == tyError: incl result.typ.flags, tfCheckedForDestructor
+      incl result.typ.flags, tfCheckedForDestructor
     return
   let gp = finalCallee.ast[genericParamsPos]
   if gp.isGenericParams:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2596,7 +2596,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, expectedType: PType =
         let verdict = semConstExpr(c, n[i])
         if verdict == nil or verdict.kind != nkIntLit or verdict.intVal == 0:
           localError(c.config, result.info, "concept predicate failed")
-      of tyUnknown: continue
+      of tyFromExpr: continue
       else: discard
     if n[i].typ == c.enforceVoidContext: #or usesResult(n[i]):
       voidContext = true

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -732,7 +732,7 @@ proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
             param.typ.flags.incl tfInferrableStatic
           else:
             param.ast = typ.n
-        of tyUnknown:
+        of tyFromExpr:
           param = paramSym skVar
           param.typ = typ.exactReplica
           #copyType(typ, nextTypeId(c.idgen), typ.owner)
@@ -2221,11 +2221,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       result = implicitConv(nkHiddenSubConv, f, arg, m, c)
   of isNone:
     # do not do this in ``typeRel`` as it then can't infer T in ``ref T``:
-    if false and a.kind in {tyProxy, tyUnknown}:
-      if a.kind == tyUnknown and c.inGenericContext > 0:
-        # don't bother with fauxMatch mechanism in generic type,
-        # reject match, typechecking will be delayed to instantiation
-        return nil
+    if a.kind == tyProxy:
       inc(m.genericMatches)
       m.fauxMatch = a.kind
       return arg

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2221,7 +2221,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       result = implicitConv(nkHiddenSubConv, f, arg, m, c)
   of isNone:
     # do not do this in ``typeRel`` as it then can't infer T in ``ref T``:
-    if a.kind in {tyProxy, tyUnknown}:
+    if false and a.kind in {tyProxy, tyUnknown}:
       if a.kind == tyUnknown and c.inGenericContext > 0:
         # don't bother with fauxMatch mechanism in generic type,
         # reject match, typechecking will be delayed to instantiation


### PR DESCRIPTION
Test removing `fauxMatch` for `tyUnknown` = `tyFromExpr` as it may not be necessary anymore (#22189)

Failure in nimcrypto implies it is:

```
nimcrypto/hash.nim(52, 34) Error: cannot instantiate MDigest [type declared in nimcrypto/hash.nim(27, 3)]
got: <typeof(HashType.bits)>
but expected: <bits>
```

```nim
# in nimcrypto/hash.nim

type
  MDigest*[bits: static[int]] = object
    ## Message digest type
    data*: array[bits div 8, byte]

proc digest*(HashType: typedesc, data: ptr byte,
             ulen: uint): MDigest[HashType.bits] = # line 52
  ...

echo typeof(digest)
# proc (HashType: typedesc, data: ptr byte, ulen: uint): MDigest[typeof(HashType.bits)]
```