### PR TITLE
osproc/execProcess: check process exitcode, catch inner exception, co…

### DIFF
--- a/changelogs/changelog_2_0_0.md
+++ b/changelogs/changelog_2_0_0.md
@@ -364,6 +364,8 @@
 
 - Removed deprecated `posix.CLONE_STOPPED`.
 
+- `osproc.execProcess` now raises `OSError`, which comes from inner usage of `orproc.startProcess` or 
+  when invoked process exited with non-zero exit code. -- issue[#21568](https://github.com/nim-lang/Nim/issues/21568)
 
 ## Language changes
 


### PR DESCRIPTION
…nvert CRLF to LF

resolves #21568.