### PR TITLE
osproc/execProcess: check process exitcode, catch inner exception, convert CRLF to LF

### DIFF
--- a/changelogs/changelog_2_0_0_details.md
+++ b/changelogs/changelog_2_0_0_details.md
@@ -303,6 +303,9 @@
 
   This is necessary to pass when building Nim on kernel versions < 3.17 in particular to avoid an error of "SYS_getrandom undeclared" during the build process for the stdlib (sysrand in particular).
 
+- `osproc.execProcess` now raises `OSError`, which comes from inner usage of `orproc.startProcess` or 
+  when invoked process exited with non-zero exit code. -- issue[#21568](https://github.com/nim-lang/Nim/issues/21568)
+
 [//]: # "Additions:"
 - Added ISO 8601 week date utilities in `times`:
   - Added `IsoWeekRange`, a range type for weeks in a week-based year.

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -516,19 +516,35 @@ when not defined(useNimRtl):
           poEvalCommand}):
     string =
 
-    var p = startProcess(command, workingDir = workingDir, args = args,
-        env = env, options = options)
-    var outp = outputStream(p)
-    result = ""
-    var line = newStringOfCap(120)
-    # consider `p.lines(keepNewLines=true)` to circumvent `running` busy-wait
-    while true:
-      # FIXME: converts CR-LF to LF.
-      if outp.readLine(line):
-        result.add(line)
-        result.add("\n")
-      elif not running(p): break
-    close(p)
+    proc convertCRLF(s: var string): string {.inline.} =
+      s.replace("\r\n", "\n")
+
+    var 
+      p: Process
+      outp: Stream
+    try:
+      p = startProcess(command, workingDir = workingDir, args = args,
+          env = env, options = options)
+      outp = outputStream(p) # This stream will be closed when `p` is closed.
+      result = ""
+      var line = newStringOfCap(120)
+      # consider `p.lines(keepNewLines=true)` to circumvent `running` busy-wait
+      while true:
+        if outp.readLine(line):
+          result.add(convertCRLF(line))
+          result.add("\n")
+        elif not running(p): break
+      # Check exit code issue[#21568](https://github.com/nim-lang/Nim/issues/21568)
+      let
+        exitCode = p.exitStatus # As process has exited, using exitStatus is just fine.
+        pid = p.processID
+      if exitCode != 0:
+        raise newException(OSError, "process " & $pid & " exit with error code: " & $exitCode)
+    except OSError as e:
+      raise e
+    finally:
+      # `p` will never be nil due to proc `startProcess`.
+      close(p)
 
 template streamAccess(p) =
   assert poParentStreams notin p.options, "API usage error: stream access not allowed when you use poParentStreams"


### PR DESCRIPTION
resolves #21568.