### PR TITLE
fixes #22197; Distinct ref objects + destructor cause C++ codegen error

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -609,6 +609,14 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
     let op = getAttachedOp(c.graph, t, attachedDestructor)
     if op != nil:
       result[0] = newSymNode(op)
+
+      if op.typ != nil and op.typ.len == 2 and op.typ[1].kind != tyVar and
+          skipAddr(n[1]).typ.kind == tyDistinct:
+        if n[1].kind == nkSym and n[1].sym.kind == skParam and
+            n[1].typ.kind == tyVar:
+          result[1] = genDeref(n[1])
+        else:
+          result[1] = skipAddr(n[1])
   of mTrace:
     result = n
     let t = n[1].typ.skipTypes(abstractVar)

--- a/tests/destructor/tnonvardestructor.nim
+++ b/tests/destructor/tnonvardestructor.nim
@@ -193,3 +193,28 @@ block:
 
   # bug #11705
   foo()
+
+block: # bug #22197
+  type
+    H5IdObj = object
+    H5Id = ref H5IdObj
+
+    FileID = distinct H5Id
+
+    H5GroupObj = object
+      file_id: FileID
+    H5Group = ref H5GroupObj
+
+  ## This would make it work!
+  #proc `=destroy`*(x: FileID) = `=destroy`(cast[H5Id](x))
+  ## If this does not exist, it also works!
+  proc newFileID(): FileID = FileID(H5Id())
+
+  proc `=destroy`(grp: var H5GroupObj) =
+    ## Closes the group and resets all references to nil.
+    if cast[pointer](grp.fileId) != nil:
+      `=destroy`(grp.file_id)
+
+  var grp = H5Group()
+  reset(grp.file_id)
+  reset(grp)


### PR DESCRIPTION
fixes #22197

I cannot make an overload for distinct that takes more precedence than the overload takes the `var T` parameter. I have to remove the `hiddenAddr` when replacing the magic with generated destructors.