### PR TITLE
Fix concepts with doc comments

### DIFF
--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -62,7 +62,7 @@ proc semConceptDecl(c: PContext; n: PNode): PNode =
       result[i] = n[i]
     result[^1] = semConceptDecl(c, n[^1])
   of nkCommentStmt:
-    discard
+    result = n
   else:
     localError(c.config, n.info, "unexpected construct in the new-styled concept: " & renderTree(n))
     result = n
@@ -286,8 +286,8 @@ proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool =
   ## can be matched with the current scope.
   case n.kind
   of nkStmtList, nkStmtListExpr:
-    for node in n:
-      if node != nil and not conceptMatchNode(c, node, m):
+    for i in 0..<n.len:
+      if not conceptMatchNode(c, n[i], m):
         return false
     return true
   of nkProcDef, nkFuncDef:
@@ -306,6 +306,8 @@ proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool =
     result = matchSyms(c, n, {skMethod}, m)
   of nkIteratorDef:
     result = matchSyms(c, n, {skIterator}, m)
+  of nkCommentStmt:
+    result = true
   else:
     # error was reported earlier.
     result = false

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -286,8 +286,8 @@ proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool =
   ## can be matched with the current scope.
   case n.kind
   of nkStmtList, nkStmtListExpr:
-    for i in 0..<n.len:
-      if not conceptMatchNode(c, n[i], m):
+    for node in n:
+      if node != nil and not conceptMatchNode(c, node, m):
         return false
     return true
   of nkProcDef, nkFuncDef:

--- a/tests/concepts/tconcepts.nim
+++ b/tests/concepts/tconcepts.nim
@@ -31,6 +31,7 @@ e
 20
 10
 5
+9
 '''
 """
 
@@ -438,3 +439,13 @@ import mvarconcept
 block tvar:
   # bug #2346, bug #2404
   echo randomInt(5)
+
+block tcomment:
+  type
+    Foo = concept
+      ## Some comment
+      proc bar(x: Self)
+
+  proc bar(x: int) = echo x
+  proc foo(x: Foo) = x.foo
+  foo(9)

--- a/tests/concepts/tconcepts.nim
+++ b/tests/concepts/tconcepts.nim
@@ -447,5 +447,5 @@ block tcomment:
       proc bar(x: Self)
 
   proc bar(x: int) = echo x
-  proc foo(x: Foo) = x.foo
+  proc foo(x: Foo) = x.bar
   foo(9)


### PR DESCRIPTION
Currently trying to use a concept with a doc comment in it results in a segfault

**Example**
```nim
type Foo = concept
  ## Helpful comment
  proc bar(y: Self)

proc bar(x: int) = discard
proc something(x: Foo) = x.bar()
something 9 # Segfaults when the compiler tries to match against the concept
```

The fix is semming comment statements and then ignoring them when checking if a concept matches. The alternative was to just ignore `nil` nodes but felt that would allow future problems to be silently ignored
