### PR TITLE
fixes #21730; adds pkgs2 as well when nimbleDir is set

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -614,6 +614,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       var path = processPath(conf, arg, info, notRelativeToProj=true)
       let nimbleDir = AbsoluteDir getEnv("NIMBLE_DIR")
       if not nimbleDir.isEmpty and pass == passPP:
+        path = nimbleDir / RelativeDir"pkgs2"
+        nimblePath(conf, path, info)
         path = nimbleDir / RelativeDir"pkgs"
       nimblePath(conf, path, info)
   of "nonimblepath", "nobabelpath":


### PR DESCRIPTION
fixes #21730

It is consistent as the order of `--nimblepath` in the config.

```
nimblepath="$home/.nimble/pkgs2/"
nimblepath="$home/.nimble/pkgs/"
```

Which means `pkgs` will be searched first. 

I tested #21730 locally.