### PR TITLE
Fix searchExtPos so that it returns -1 when the path is not a file ext

### DIFF
--- a/lib/std/private/ospaths2.nim
+++ b/lib/std/private/ospaths2.nim
@@ -606,7 +606,7 @@ proc searchExtPos*(path: string): int =
   for j in countdown(i - 1, stop - 1):
     if path[j] in {DirSep, AltSep}:
       return -1
-    elif not (path[j] == ExtSep):
+    elif path[j] != ExtSep:
       result = i
       break
 

--- a/lib/std/private/ospaths2.nim
+++ b/lib/std/private/ospaths2.nim
@@ -590,21 +590,18 @@ proc searchExtPos*(path: string): int =
 
   # Unless there is any char that is not `ExtSep` before last `ExtSep` in the file name,
   # it is not a file extension.
+  const DirSeps = when doslikeFileSystem: {DirSep, AltSep, ':'} else: {DirSep, AltSep}
   result = -1
-  let stop = when doslikeFileSystem:
-      splitDrive(path).drive.len + 1
-    else:
-      1
   var i = path.high
-  while i >= stop:
+  while i >= 1:
     if path[i] == ExtSep:
       break
-    elif path[i] in {DirSep, AltSep}:
+    elif path[i] in DirSeps:
       return -1 # do not skip over path
     dec i
 
-  for j in countdown(i - 1, stop - 1):
-    if path[j] in {DirSep, AltSep}:
+  for j in countdown(i - 1, 0):
+    if path[j] in DirSeps:
       return -1
     elif path[j] != ExtSep:
       result = i

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -830,3 +830,35 @@ block:  # isValidFilename
   doAssert isValidFilename("ux.bat")
   doAssert isValidFilename("nim.nim")
   doAssert isValidFilename("foo.log")
+
+block: # searchExtPos
+  doAssert "foo.nim".searchExtPos == 3
+  doAssert "/foo.nim".searchExtPos == 4
+  doAssert "".searchExtPos == -1
+  doAssert "/".searchExtPos == -1
+  doAssert "a.b/foo".searchExtPos == -1
+  doAssert ".".searchExtPos == -1
+  doAssert "foo.".searchExtPos == 3
+  doAssert "foo..".searchExtPos == 4
+  doAssert "..".searchExtPos == -1
+  doAssert "...".searchExtPos == -1
+  doAssert "./".searchExtPos == -1
+  doAssert "../".searchExtPos == -1
+  doAssert "/.".searchExtPos == -1
+  doAssert "/..".searchExtPos == -1
+  doAssert ".b".searchExtPos == -1
+  doAssert "..b".searchExtPos == -1
+  doAssert "/.b".searchExtPos == -1
+  doAssert "a/.b".searchExtPos == -1
+  doAssert ".a.b".searchExtPos == 2
+  doAssert "a/.b.c".searchExtPos == 4
+  doAssert "a/..b".searchExtPos == -1
+  doAssert "a/b..c".searchExtPos == 4
+
+  when doslikeFileSystem:
+    doAssert "c:a.b".searchExtPos == 3
+    doAssert "c:.a".searchExtPos == -1
+    doAssert r"c:\.a".searchExtPos == -1
+    doAssert "c:..a".searchExtPos == -1
+    doAssert r"c:\..a".searchExtPos == -1
+    doAssert "c:.a.b".searchExtPos == 4


### PR DESCRIPTION
Following paths do not contain file extensions but `searchExtPos` doesn't return -1:
- ".."
- "..."
- "/."
- "/.."
- "..b"