### PR TITLE
bugfixs browsers.nim. make `openDefaultBrowser()` open default page

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -81,8 +81,7 @@ proc openDefaultBrowser*(url: string) =
   openDefaultBrowserImpl(url)
 
 proc openDefaultBrowser*() {.since: (1, 1).} =
-  ## Opens the user's default browser without any `url` (blank page). This does not block.
-  ## Implements IETF RFC-6694 Section 3, "about:blank" must be reserved for a blank page.
+  ## Opens the user's default browser without any `url` (default page). This does not block.
   ##
   ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
   ## command is used. Under Unix, it is checked if `xdg-open` exists and
@@ -94,8 +93,4 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ##   ```nim
   ##   block: openDefaultBrowser()
   ##   ```
-  ##
-  ## **See also:**
-  ##
-  ## * https://tools.ietf.org/html/rfc6694#section-3
-  openDefaultBrowserImplPrep("about:blank")  # See IETF RFC-6694 Section 3.
+  openDefaultBrowserImplPrep("http://")

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -65,7 +65,7 @@ proc openDefaultBrowserImpl(url: string) =
 
 proc openDefaultBrowser*(url: string) =
   ## Opens `url` with the user's default browser. This does not block.
-  ## The URL must not be empty string, to open on a blank page see `openDefaultBrowser()`.
+  ## The URL must not be empty string, to open on a page without url see `openDefaultBrowser()`.
   ##
   ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
   ## command is used. Under Unix, it is checked if `xdg-open` exists and


### PR DESCRIPTION
In the previous implementations, none can manage to open a blank page.   
 Also, it's hard and unnecessary to implement opening blank page.
Opening default page is not only more useful but also easy to implement.  
For details, see <https://github.com/nim-lang/Nim/issues/22250>.