### PR TITLE
Adding info to manual

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2652,16 +2652,33 @@ to think of the below as a comparison between two candidates because of this alg
 
 
 There are two major methods of selecting the best matching candidate, namely 
-counting and type comparison. Counting takes precedence to type comparison since
+counting and disambiguation. Counting takes precedence to disambiguation since
 it is simpler, more efficient and necessary in some situations. In counting,
 each parameter is given a category and the number of parameters in each category is counted.
 The categories are listed above and are in order of precedence. For example, if
 a candidate with one exact match is compared to a candidate with multiple generic matches 
 and zero exact matches, the candidate with an exact match will win.
 
+In the following, `count(p, m)` counts the number of matches of the matching category `m`
+for the routine `p`.
 
-When counting is not enough to select an overload, type comparison begins. Parameters are iterated 
-by position (or index) and these parameter pairs are compared for their type relation. The general goal
+A routine `p` matches better than a routine `q` if the following
+algorithm returns true:
+
+  ```nim
+  for each matching category m in ["exact match", "literal match",
+                                  "generic match", "subtype match",
+                                  "integral match", "conversion match"]:
+    if count(p, m) > count(q, m): return true
+    elif count(p, m) == count(q, m):
+      discard "continue with next category m"
+    else:
+      return false
+  return "ambiguous"
+  ```
+
+When counting is ambiguous, disambiguation begins. Parameters are iterated 
+by position and these parameter pairs are compared for their type relation. The general goal
 of this comparison is to determine which parameter is more specific. The "rules" for this comparison are
 not meant to be be completely exhaustive. It is crucial to understand that the parameters are not 
 compared with the types of inputs from the callsite, but with the parameters of competing candidates.

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -5413,49 +5413,6 @@ Generics are Nim's means to parametrize procs, iterators or types with
 `type parameters`:idx:. Depending on the context, the brackets are used either to
 introduce type parameters or to instantiate a generic proc, iterator, or type.
 
-
-Generic Procs
----------------
-
-Let's consider the anatomy of a generic `proc` to agree on defined terminology.
-
-```nim
-p[T: t](arg1: f): y
-```
-
-- `p`: Callee symbol
-- `[...]`: Generic parameters
-- `T: t`: Generic constraint
-- `T`: Type variable
-- `[T: t](arg1: f): y`: Formal signature
-- `arg1: f`: Formal parameter
-- `f`: Formal parameter type
-- `y`: Formal return type
-
-The use of the word "formal" here is to denote the symbols as they are defined by the programmer, 
-not as they may be at compile time contextually. Since generics may be instantiated and
-types bound, we have more than one entity to think about when generics are involved.
-
-The usage of a generic will resolve the formally defined expression into an instance of that
-expression bound to only concrete types. This process is called "instantiation".
-
-Brackets at the sight of a generic's formal definition specify the "constraints" as in:
-
-```nim
-type Foo[T] = object
-proc p[H;T: Foo[H]](param: T): H
-```
-
-A constraint definition may have more than one symbol defined by seperating each definition by 
-a `;`. Notice how `T` is composed of `H` and the return  type of `p` is defined as `H`. When this 
-generic proc is instantiated `H` will be bound to a concrete type, thus making `T` concrete and 
-the return type of `p` will be bound to the same concrete type used to define `H`.
-
-Brackets at the sight of usage can be used to supply concrete types to instantiate the generic in the same
-order that the symbols are defined in the constraint. Alternatively, type bindings may be inferred by the compiler
-in some situations, allowing for cleaner code.
-
-
 The following example shows how a generic binary tree can be modeled:
 
   ```nim  test = "nim c $1"
@@ -5516,6 +5473,49 @@ The following example shows how a generic binary tree can be modeled:
 
 The `T` is called a `generic type parameter`:idx: or
 a `type variable`:idx:.
+
+
+Generic Procs
+---------------
+
+Let's consider the anatomy of a generic `proc` to agree on defined terminology.
+
+```nim
+p[T: t](arg1: f): y
+```
+
+- `p`: Callee symbol
+- `[...]`: Generic parameters
+- `T: t`: Generic constraint
+- `T`: Type variable
+- `[T: t](arg1: f): y`: Formal signature
+- `arg1: f`: Formal parameter
+- `f`: Formal parameter type
+- `y`: Formal return type
+
+The use of the word "formal" here is to denote the symbols as they are defined by the programmer, 
+not as they may be at compile time contextually. Since generics may be instantiated and
+types bound, we have more than one entity to think about when generics are involved.
+
+The usage of a generic will resolve the formally defined expression into an instance of that
+expression bound to only concrete types. This process is called "instantiation".
+
+Brackets at the sight of a generic's formal definition specify the "constraints" as in:
+
+```nim
+type Foo[T] = object
+proc p[H;T: Foo[H]](param: T): H
+```
+
+A constraint definition may have more than one symbol defined by seperating each definition by 
+a `;`. Notice how `T` is composed of `H` and the return  type of `p` is defined as `H`. When this 
+generic proc is instantiated `H` will be bound to a concrete type, thus making `T` concrete and 
+the return type of `p` will be bound to the same concrete type used to define `H`.
+
+Brackets at the sight of usage can be used to supply concrete types to instantiate the generic in the same
+order that the symbols are defined in the constraint. Alternatively, type bindings may be inferred by the compiler
+in some situations, allowing for cleaner code.
+
 
 Is operator
 -----------

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -5500,7 +5500,7 @@ types bound, we have more than one entity to think about when generics are invol
 The usage of a generic will resolve the formally defined expression into an instance of that
 expression bound to only concrete types. This process is called "instantiation".
 
-Brackets at the sight of a generic's formal definition specify the "constraints" as in:
+Brackets at the site of a generic's formal definition specify the "constraints" as in:
 
 ```nim
 type Foo[T] = object
@@ -5512,7 +5512,7 @@ a `;`. Notice how `T` is composed of `H` and the return  type of `p` is defined 
 generic proc is instantiated `H` will be bound to a concrete type, thus making `T` concrete and 
 the return type of `p` will be bound to the same concrete type used to define `H`.
 
-Brackets at the sight of usage can be used to supply concrete types to instantiate the generic in the same
+Brackets at the site of usage can be used to supply concrete types to instantiate the generic in the same
 order that the symbols are defined in the constraint. Alternatively, type bindings may be inferred by the compiler
 in some situations, allowing for cleaner code.
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2642,18 +2642,9 @@ of the argument.
 6. Conversion match: `a` is convertible to `f`, possibly via a user
    defined `converter`.
 
-It is important to note that overload resolution concerns itself with the 
-category of each parameter and not the category of callable.
-
-Nim will compare two candidates at a time and pick the "best" candidate to 
-to continue through the resolution process, if at the end the best candidate is 
-is proven "better" then the rest, it is chosen as an unambiguous match. I may help 
-to think of the below as a comparison between two candidates because of this algorithm. 
-
 
 There are two major methods of selecting the best matching candidate, namely 
-counting and disambiguation. Counting takes precedence to disambiguation since
-it is simpler, more efficient and necessary in some situations. In counting,
+counting and disambiguation. Counting takes precedence to disambiguation. In counting,
 each parameter is given a category and the number of parameters in each category is counted.
 The categories are listed above and are in order of precedence. For example, if
 a candidate with one exact match is compared to a candidate with multiple generic matches 
@@ -2679,9 +2670,8 @@ algorithm returns true:
 
 When counting is ambiguous, disambiguation begins. Parameters are iterated 
 by position and these parameter pairs are compared for their type relation. The general goal
-of this comparison is to determine which parameter is more specific. The "rules" for this comparison are
-not meant to be be completely exhaustive. It is crucial to understand that the parameters are not 
-compared with the types of inputs from the callsite, but with the parameters of competing candidates.
+of this comparison is to determine which parameter is more specific. The types considered are 
+not of the inputs from the callsite, but of the competing candidates' parameters.
 
 
 Some examples:


### PR DESCRIPTION
To be clear, this does not have anything relating to my other PRs. Most of the manual adjustments for those are clarifications that may be helpful on their own.

My justification for replacing the pseudo-code in "Overload Resolution" is that I think it was harder to parse and less telling then just spelling it out in words.