### PR TITLE
fix `jsondoc` not getting `showNonExports` flag

### DIFF
--- a/compiler/docgen2.nim
+++ b/compiler/docgen2.nim
@@ -56,7 +56,7 @@ proc processNodeJson*(c: PPassContext, n: PNode): PNode =
   result = n
   var g = PGen(c)
   if shouldProcess(g):
-    generateJson(g.doc, n, false)
+    generateJson(g.doc, n, g.config, false)
 
 template myOpenImpl(ext: untyped) {.dirty.} =
   var g: PGen


### PR DESCRIPTION
Given an example like
```nim
type
  X* = object
    l: string
```
`jsondoc` wouldn't show the `l` field with `--showNonExports` passed. This fixes that by adding `renderNonExportedFields` flag to token renderer if `--showNonExports` is passed