### PR TITLE
Add staticFileExists and staticDirExists

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -264,6 +264,10 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop getCurrentException
     registerCallback c, "stdlib.osdirs.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
+    registerCallback c, "stdlib.staticos.staticDirExists", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, dirExists(getString(a, 0)))
+    registerCallback c, "stdlib.staticos.staticFileExists", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, fileExists(getString(a, 0)))
     registerCallback c, "stdlib.compilesettings.querySetting", proc (a: VmArgs) =
       setResult(a, querySettingImpl(c.config, getInt(a, 0)))
     registerCallback c, "stdlib.compilesettings.querySettingSeq", proc (a: VmArgs) =

--- a/lib/std/staticos.nim
+++ b/lib/std/staticos.nim
@@ -1,0 +1,13 @@
+## This module implements path handling like os module but works at only compile-time.
+## This module works even when cross compiling to OS that is not supported by os module.
+
+proc staticFileExists*(filename: string): bool {.compileTime.} =
+  ## Returns true if `filename` exists and is a regular file or symlink.
+  ##
+  ## Directories, device files, named pipes and sockets return false.
+  discard
+
+proc staticDirExists*(dir: string): bool {.compileTime.} =
+  ## Returns true if the directory `dir` exists. If `dir` is a file, false
+  ## is returned. Follows symlinks.
+  discard

--- a/tests/stdlib/tstaticos.nim
+++ b/tests/stdlib/tstaticos.nim
@@ -1,0 +1,8 @@
+import std/[assertions, staticos, os]
+
+block:
+  static:
+    doAssert staticDirExists("MISSINGFILE") == false
+    doAssert staticFileExists("MISSINGDIR") == false
+    doAssert staticDirExists(currentSourcePath().parentDir)
+    doAssert staticFileExists(currentSourcePath())

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -82,6 +82,8 @@ block:
 
     doAssert fileExists("MISSINGFILE") == false
     doAssert dirExists("MISSINGDIR") == false
+    doAssert fileExists(currentSourcePath())
+    doAssert dirExists(currentSourcePath().parentDir)
 
 # bug #7210
 block:


### PR DESCRIPTION
This PR partly fix https://github.com/nim-lang/Nim/issues/19414 .

In previus PR https://github.com/nim-lang/Nim/pull/22203, I tried to make `fileExists` and `dirExists` in std/private/oscommon works at compile-time even when --os:any option is set.
This PR adds staticos module that contains `staticFileExists` and `staticDirExists` that works like `fileExists` or `dirExists` but works only at compile-time even when `--os:any` option is set.

But I cannot make calling `staticFileExists` at runtime result in compile error even if I add compileTime pragma.
When I use `when nimvm` like this, error pragma is always cause error even if `staticFileExists` is called at compile-time.
```nim
proc staticFileExists*(filename: string): bool =
  when nimvm:
    discard
  else:
    {.error: "Don't run at runtime".}
```