### PR TITLE
Re-fix `browsers.nim`'s `openDefaultBrowser()`  with some refinement

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -81,8 +81,7 @@ proc openDefaultBrowser*(url: string) =
   openDefaultBrowserImpl(url)
 
 proc openDefaultBrowser*() {.since: (1, 1).} =
-  ## Opens the user's default browser without any `url` (blank page). This does not block.
-  ## Implements IETF RFC-6694 Section 3, "about:blank" must be reserved for a blank page.
+  ## Opens the user's default browser without any `url` (default page). This does not block.
   ##
   ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
   ## command is used. Under Unix, it is checked if `xdg-open` exists and
@@ -94,8 +93,4 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ##   ```nim
   ##   block: openDefaultBrowser()
   ##   ```
-  ##
-  ## **See also:**
-  ##
-  ## * https://tools.ietf.org/html/rfc6694#section-3
-  openDefaultBrowserImplPrep("about:blank")  # See IETF RFC-6694 Section 3.
+  openDefaultBrowserImplPrep("http://")

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -92,10 +92,7 @@ proc openDefaultBrowser*(url: string) =
   ## This proc doesn't raise an exception on error, beware.
   ##
   ##   ```nim
-  ##   block: 
-  ##     # the following two are equivalent
-  ##     openDefaultBrowser("https://nim-lang.org")
-  ##     openDefaultBrowser("nim-lang.org")
+  ##   block: openDefaultBrowser("https://nim-lang.org")
   ##   ```
   if url.len == 0:
     openDefaultBrowser()

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -48,7 +48,6 @@ proc openDefaultBrowserRaw(url: string) =
   ##
   ## This proc doesn't raise an exception on error, beware.
   ##
-
   when defined(windows):
     var o = newWideCString(osOpenCmd)
     var u = newWideCString(url)
@@ -65,6 +64,21 @@ proc openDefaultBrowserRaw(url: string) =
         return
       except OSError:
         discard
+
+proc openDefaultBrowser*() {.since: (1, 1).} =
+  ## Opens the user's default browser without any `url` (default page). This does not block.
+  ##
+  ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
+  ## command is used. Under Unix, it is checked if `xdg-open` exists and
+  ## used if it does. Otherwise the environment variable `BROWSER` is
+  ## used to determine the default browser to use.
+  ##
+  ## This proc doesn't raise an exception on error, beware.
+  ##
+  ##   ```nim
+  ##   block: openDefaultBrowser()
+  ##   ```
+  openDefaultBrowserRaw("http://")
 
 proc openDefaultBrowser*(url: string) =
   ## Opens `url` with the user's default browser. This does not block.
@@ -88,17 +102,3 @@ proc openDefaultBrowser*(url: string) =
   else: 
     openDefaultBrowserRaw(prepare url)
 
-proc openDefaultBrowser*() {.since: (1, 1).} =
-  ## Opens the user's default browser without any `url` (default page). This does not block.
-  ##
-  ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
-  ## command is used. Under Unix, it is checked if `xdg-open` exists and
-  ## used if it does. Otherwise the environment variable `BROWSER` is
-  ## used to determine the default browser to use.
-  ##
-  ## This proc doesn't raise an exception on error, beware.
-  ##
-  ##   ```nim
-  ##   block: openDefaultBrowser()
-  ##   ```
-  openDefaultBrowserRaw("http://")

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -65,7 +65,7 @@ proc openDefaultBrowserImpl(url: string) =
 
 proc openDefaultBrowser*(url: string) =
   ## Opens `url` with the user's default browser. This does not block.
-  ## The URL must not be empty string, to open on a blank page see `openDefaultBrowser()`.
+  ## The URL must not be empty string, to open on a page without url see `openDefaultBrowser()`.
   ##
   ## Under Windows, `ShellExecute` is used. Under Mac OS X the `open`
   ## command is used. Under Unix, it is checked if `xdg-open` exists and


### PR DESCRIPTION
Still due to `proc openDefaultBrowser()`, which can't work as expected in Windows.  
In case of adding huge code, I've change its behavior to open a default page rather than opening a blank page.  [^1]

## Advantage

This can also, in a more lenient way, fix <https://github.com/nim-lang/Nim/pull/13818#issue-396473868>, which <https://github.com/nim-lang/Nim/pull/13835> and <https://github.com/nim-lang/Nim/pull/22052> had tried to fix but *failed*

In addition, as I explained in <https://github.com/nim-lang/Nim/issues/22250>:  

These are backward compatibility.
What's more, in this way, the structure of this module can become simpler and better

not only will it keep every exported symbol unchanged
but also it'll remove the dependency of std/assertions, which needs importing explicitly in v2



[^1]: Because implementing its original functionality ( open a  blank page) may be hard, leading to a lot of code adding, unnecessarily