### PR TITLE
Fix #22281

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -580,7 +580,7 @@ proc getCompileCFileCmd*(conf: ConfigRef; cfile: Cfile,
 
     compilePattern = joinPath(conf.cCompilerPath, exe)
   else:
-    compilePattern = getCompilerExe(conf, c, isCpp)
+    compilePattern = exe
 
   includeCmd.add(join([CC[c].includeCmd, quoteShell(conf.projectPath.string)]))
 


### PR DESCRIPTION
Respect `--gcc.exe` and similar options when `--genScript:on` is used.

Fixes #22281