### PR TITLE
fixes #6499; disallow built-in procs used as procvars

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1223,6 +1223,7 @@ proc track(tracked: PEffects, n: PNode) =
   of nkTupleConstr:
     for i in 0..<n.len:
       track(tracked, n[i])
+      notNilCheck(tracked, n[i].skipColon, n[i].typ)
       if tracked.owner.kind != skMacro:
         if n[i].kind == nkExprColonExpr:
           createTypeBoundOps(tracked, n[i][0].typ, n.info)

--- a/tests/errmsgs/t6499.nim
+++ b/tests/errmsgs/t6499.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "'chr' is a built-in and cannot be used as a first-class procedure"
+"""
+
+# bug #6499
+let x = (chr, 0)

--- a/tests/system/tmagics.nim
+++ b/tests/system/tmagics.nim
@@ -57,10 +57,6 @@ block t9442:
   GC_ref(v3)
   GC_unref(v3)
 
-block: # bug #6499
-  let x = (chr, 0)
-  doAssert x[1] == 0
-
 block: # bug #12229
   proc foo(T: typedesc) = discard
   foo(ref)


### PR DESCRIPTION
fixes #6499