### PR TITLE
Debug mismatching base type addresses

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1451,7 +1451,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     let rootf = f.skipGenericAlias
 
     if a.kind == tyGenericInst:
-      if roota.base == rootf.base:
+      if roota.base.itemId == rootf.base.itemId:
         let nextFlags = flags + {trNoCovariance}
         var hasCovariance = false
         # YYYY


### PR DESCRIPTION
fix #22119
fix #21093

No idea why the addresses for base fields are different
Actual segfault happens at https://github.com/nim-lang/Nim/blob/7d9fe106ecd70bf99b9f3224430debfe10060ce1/compiler/sempass2.nim#L1090 when it tries to access typ.kind where typ is nil