### PR TITLE
Fix doc comment rendering for concepts

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -440,7 +440,7 @@ proc genRecCommentAux(d: PDoc, n: PNode): PRstNode =
   if n == nil: return nil
   result = genComment(d, n)
   if result == nil:
-    if n.kind in {nkStmtList, nkStmtListExpr, nkTypeDef, nkConstDef,
+    if n.kind in {nkStmtList, nkStmtListExpr, nkTypeDef, nkConstDef, nkTypeClassTy,
                   nkObjectTy, nkRefTy, nkPtrTy, nkAsgn, nkFastAsgn, nkSinkAsgn, nkHiddenStdConv}:
       # notin {nkEmpty..nkNilLit, nkEnumTy, nkTupleTy}:
       for i in 0..<n.len:

--- a/tests/concepts/t20237.nim
+++ b/tests/concepts/t20237.nim
@@ -1,3 +1,3 @@
-type Foo = concept
+type Foo* = concept
   ## doc comment
   proc foo(x: Self)


### PR DESCRIPTION
Using `t20237.nim` as an example:
Before:
![before](https://github.com/nim-lang/Nim/assets/44230978/5ce0203b-3901-49d1-8d50-2051e83566f2)
After:
![after](https://github.com/nim-lang/Nim/assets/44230978/3d317c36-b7ff-4a47-95dc-ce12482b0e15)
