### PR TITLE
[JS] Fix casting to ints

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2727,19 +2727,14 @@ proc genCast(p: PProc, n: PNode, r: var TCompRes) =
   let fromInt = (src.kind in tyInt..tyInt32)
   let fromUint = (src.kind in tyUInt..tyUInt32)
 
-  if toUint and (fromInt or fromUint):
-    let trimmer = unsignedTrimmer(dest.size)
-    r.res = "($1 $2)" % [r.res, trimmer]
-  elif toUint and src.kind in {tyInt64, tyUInt64} and optJsBigInt64 in p.config.globalOptions:
-    r.res = "Number(BigInt.asUintN($1, $2))" % [$(dest.size * 8), r.res]
+  if toUint:
+    if fromInt or fromUint:
+      r.res = "Number(BigInt.asUintN($1, BigInt($2)))" % [$(dest.size * 8), r.res]
+    elif src.kind in {tyInt64, tyUInt64} and optJsBigInt64 in p.config.globalOptions:
+      r.res = "Number(BigInt.asUintN($1, $2))" % [$(dest.size * 8), r.res]
   elif toInt:
     if fromInt or fromUint:
-      if dest.size == 4:
-        r.res = "(($1) | 0)" % [r.res]
-      else:
-        let trimmer = unsignedTrimmer(dest.size)
-        # sign extension is done by shifting to the left and then shifting back to the right
-        r.res = "(($1 $2) << $3 >> $3)" % [r.res, trimmer, $(32 - (dest.size * 8))]
+      r.res = "Number(BigInt.asIntN($1, BigInt($2)))" % [$(dest.size * 8), r.res]
     elif src.kind in {tyInt64, tyUInt64} and optJsBigInt64 in p.config.globalOptions:
       r.res = "Number(BigInt.asIntN($1, $2))" % [$(dest.size * 8), r.res]
   elif dest.kind == tyInt64 and optJsBigInt64 in p.config.globalOptions:

--- a/tests/cast/tcast.nim
+++ b/tests/cast/tcast.nim
@@ -1,0 +1,21 @@
+discard """
+  targets: "c cpp js"
+"""
+
+proc main() =
+  block: # bug #16806
+    let
+      a = 42u16
+      b = cast[int16](a)
+    doAssert a.int16 == 42
+    doAssert b in int16.low..int16.high
+
+  block: # bug #16808
+    doAssert cast[int8](cast[uint8](int8(-12))) == int8(-12)
+    doAssert cast[int16](cast[uint16](int16(-12))) == int16(-12)
+    doAssert cast[int32](cast[uint32](int32(-12))) == int32(-12)
+
+  doAssert cast[int8](int16.high) == -1
+
+static: main()
+main()


### PR DESCRIPTION
Fixes #16806.
Fixes #16808.

Casting from ints to ints generated nothing, causing for example `doAssert cast[int8](int16.high) == -1` to fail.
Casting from uints to ints used some weird subtracting (I still have no idea how that was supposed to work), which I replaced by shifting left and then right again to sign extend.
The trick to use `| 0` to convert to `int32` also works when the source type isn't 32 bit.

I created a new folder `tests/cast/` for tests related to casting. `tcast.nim` contains tests for both fixed issues and an additional one that I found.