### PR TITLE
Make `repr(HSlice)` always available

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2395,6 +2395,16 @@ when defined(nimV2):
   import system/repr_v2
   export repr_v2
 
+proc repr*[T, U](x: HSlice[T, U]): string =
+  ## Generic `repr` operator for slices that is lifted from the components
+  ## of `x`. Example:
+  ##
+  ## .. code-block:: Nim
+  ##  $(1 .. 5) == "1 .. 5"
+  result = repr(x.a)
+  result.add(" .. ")
+  result.add(repr(x.b))
+
 when hasAlloc or defined(nimscript):
   proc insert*(x: var string, item: string, i = 0.Natural) {.noSideEffect.} =
     ## Inserts `item` into `x` at position `i`.

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -177,16 +177,6 @@ proc repr*[T](x: seq[T]): string =
   ##   $(@[23, 45]) == "@[23, 45]"
   collectionToRepr(x, "@[", ", ", "]")
 
-proc repr*[T, U](x: HSlice[T, U]): string =
-  ## Generic `repr` operator for slices that is lifted from the components
-  ## of `x`. Example:
-  ##
-  ## .. code-block:: Nim
-  ##  $(1 .. 5) == "1 .. 5"
-  result = repr(x.a)
-  result.add(" .. ")
-  result.add(repr(x.b))
-
 proc repr*[T, IDX](x: array[IDX, T]): string =
   ## Generic `repr` operator for arrays that is lifted from the components.
   collectionToRepr(x, "[", ", ", "]")

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -40,7 +40,7 @@ template main() =
   #[
   BUG:
   --gc:arc returns `"abc"`
-  regular gc returns with address, e.g. 0x1068aae60"abc", but only 
+  regular gc returns with address, e.g. 0x1068aae60"abc", but only
   for c,cpp backends (not js, vm)
   ]#
   block:
@@ -293,7 +293,7 @@ func fn2(): int =
 
       *a: b
       do: c
-    
+
     doAssert a == """foo(a, b, (c, d)):
   e
   f
@@ -321,6 +321,8 @@ else:
   b
 do:
   c"""
+
+  doAssert repr(1..2) == "1 .. 2"
 
 static: main()
 main()


### PR DESCRIPTION
Move `proc repr*[T, U](x: HSlice[T, U]): string` from `system/repr_v2` to `system`, so that it's always available. With this change, `repr` also works correctly for `HSlice` on the JS backend (before, it used the generic `object` `repr`).