### PR TITLE
Remove declared and not used variable in packedsets.bitincl

### DIFF
--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -109,7 +109,6 @@ proc intSetPut[A](t: var PackedSet[A], key: int): Trunk =
   t.data[h] = result
 
 proc bitincl[A](s: var PackedSet[A], key: int) {.inline.} =
-  var ret: Trunk
   var t = intSetPut(s, key shr TrunkShift)
   var u = key and TrunkMask
   t.bits[u shr IntShift] = t.bits[u shr IntShift] or


### PR DESCRIPTION
When compiling code that uses PackedSet with warnings enabled, `var ret` in `bitincl` emits a "XDeclaredButNotUsed" warning.