### PR TITLE
Enable range checks for `uint` & `uint64`

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -120,21 +120,6 @@ proc ordinalValToString*(a: PNode; g: ModuleGraph): string =
   else:
     result = $x
 
-proc isFloatRange(t: PType): bool {.inline.} =
-  result = t.kind == tyRange and t[0].kind in {tyFloat..tyFloat128}
-
-proc isIntRange(t: PType): bool {.inline.} =
-  result = t.kind == tyRange and t[0].kind in {
-      tyInt..tyInt64, tyUInt8..tyUInt32}
-
-proc pickIntRange(a, b: PType): PType =
-  if isIntRange(a): result = a
-  elif isIntRange(b): result = b
-  else: result = a
-
-proc isIntRangeOrLit(t: PType): bool =
-  result = isIntRange(t) or isIntLit(t)
-
 proc evalOp(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
   # b and c may be nil
   result = nil

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -416,7 +416,7 @@ proc handleRange(c: PContext, f, a: PType, min, max: TTypeKind): TTypeRelation =
     elif a.kind == tyRange and
       # Make sure the conversion happens between types w/ same signedness
       (f.kind in {tyInt..tyInt64} and a[0].kind in {tyInt..tyInt64} or
-       f.kind in {tyUInt8..tyUInt32} and a[0].kind in {tyUInt8..tyUInt32}) and
+       f.kind in {tyUInt..tyUInt64} and a[0].kind in {tyUInt..tyUInt64}) and
       a.n[0].intVal >= firstOrd(nil, f) and a.n[1].intVal <= lastOrd(nil, f):
       # passing 'nil' to firstOrd/lastOrd here as type checking rules should
       # not depend on the target integer size configurations!

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -523,7 +523,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
   var dest = skipTypes(n.typ, abstractVarRange)
   var source = skipTypes(n[1].typ, abstractVarRange)
   case dest.kind
-  of tyInt..tyInt64, tyEnum, tyChar, tyUInt8..tyUInt32:
+  of tyInt..tyInt64, tyUInt..tyUInt64, tyEnum, tyChar:
     # we don't include uint and uint64 here as these are no ordinal types ;-)
     if not isOrdinalType(source):
       # float -> int conversions. ugh.
@@ -535,7 +535,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
       result = transformSons(c, n)
     else:
       # generate a range check:
-      if dest.kind == tyInt64 or source.kind == tyInt64:
+      if dest.kind in {tyInt64, tyUInt64} or source.kind in {tyInt64, tyUInt64}:
         result = newTransNode(nkChckRange64, n, 3)
       else:
         result = newTransNode(nkChckRange, n, 3)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -277,6 +277,16 @@ proc regToNode(x: TFullReg): PNode =
   of rkRegisterAddr: result = regToNode(x.regAddr[])
   of rkNodeAddr: result = x.nodeAddr[]
 
+proc regToNodeU(x: TFullReg): PNode =
+  ## Like `regToNode`, but convert int registers to unsigned int literals.
+  case x.kind
+  of rkNone: result = newNode(nkEmpty)
+  of rkInt: result = newNode(nkUIntLit); result.intVal = x.intVal
+  of rkFloat: result = newNode(nkFloatLit); result.floatVal = x.floatVal
+  of rkNode: result = x.node
+  of rkRegisterAddr: result = regToNode(x.regAddr[])
+  of rkNodeAddr: result = x.nodeAddr[]
+
 template getstr(a: untyped): untyped =
   (if a.kind == rkNode: a.node.strVal else: $chr(int(a.intVal)))
 
@@ -1352,14 +1362,16 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcRangeChck, opcURangeChck, opcRangeChckU, opcURangeChckU:
       let rb = instr.regB
       let rc = instr.regC
-      var raNode = regs[ra].regToNode
-      if instr.opcode in {opcRangeChckU, opcURangeChckU}:
-        raNode.kind = nkUIntLit
-      var rbNode = regs[rb].regToNode
-      var rcNode = regs[rc].regToNode
-      if instr.opcode in {opcURangeChck, opcURangeChckU}:
-        rbNode.kind = nkUIntLit
-        rcNode.kind = nkUIntLit
+      var raNode =
+        if instr.opcode in {opcRangeChckU, opcURangeChckU}:
+          regs[ra].regToNodeU
+        else:
+          regs[ra].regToNode
+      var (rbNode, rcNode) =
+        if instr.opcode in {opcURangeChck, opcURangeChckU}:
+          (regs[rb].regToNodeU, regs[rc].regToNodeU)
+        else:
+          (regs[rb].regToNode, regs[rc].regToNode)
       if not (leValueConv(rbNode, raNode) and
               leValueConv(raNode, rcNode)):
         stackTrace(c, tos, pc,

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -111,7 +111,7 @@ type
     opcAddStrCh,
     opcAddStrStr,
     opcAddSeqElem,
-    opcRangeChck,
+    opcRangeChck, opcURangeChck, opcRangeChckU, opcURangeChckU
 
     opcNAdd,
     opcNAddMultiple,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2207,7 +2207,20 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       tmp0 = c.genx(n[0])
       tmp1 = c.genx(n[1])
       tmp2 = c.genx(n[2])
-    c.gABC(n, opcRangeChck, tmp0, tmp1, tmp2)
+    let srcUnsigned = skipTypes(n[0].typ, abstractVarRange).kind in {tyUInt..tyUInt64}
+    let destUnsigned = skipTypes(n.typ, abstractVarRange).kind in {tyUInt..tyUInt64}
+    let opcode =
+      if destUnsigned:
+        if srcUnsigned:
+          opcURangeChckU
+        else:
+          opcURangeChck
+      else:
+        if srcUnsigned:
+          opcRangeChckU
+        else:
+          opcRangeChck
+    c.gABC(n, opcode, tmp0, tmp1, tmp2)
     c.freeTemp(tmp1)
     c.freeTemp(tmp2)
     if dest >= 0:

--- a/tests/int/tunsignedconv.nim
+++ b/tests/int/tunsignedconv.nim
@@ -108,6 +108,7 @@ block:
   doAssert a.uint32 == uint32.high
   doAssert a.uint16 == uint16.high
   doAssert a.uint8 == uint8.high
+  doAssert a.uint == uint.high
 
   doAssert b.uint64 == b
   doAssert b.uint32 == b

--- a/tests/vm/chckRange/tinttouint.nim
+++ b/tests/vm/chckRange/tinttouint.nim
@@ -1,0 +1,9 @@
+discard """
+  nimout: '''
+tinttouint.nim(9, 17) Error: illegal conversion from '-1' to '[0'u..18446744073709551615'u]'
+'''
+"""
+
+static:
+  let a = -1
+  discard uint64(a)

--- a/tests/vm/chckRange/tuinttoint.nim
+++ b/tests/vm/chckRange/tuinttoint.nim
@@ -1,0 +1,9 @@
+discard """
+  nimout: '''
+touinttoint.nim(9, 16) Error: illegal conversion from '18446744073709551615'u' to '[-9223372036854775808..9223372036854775807]'
+'''
+"""
+
+static:
+  let a = uint64.high
+  discard int64(a)


### PR DESCRIPTION
`uint` and `uint64` are currently not considered for range checks (which means masking for unsigned ints, except for the VM). This is usually not a problem, since they're the biggest unsigned types, however this is not the case when `uint` is 32 bits (which is also the case for the JS backend).

With this and #22330, the following won't fail anymore:
```nim
let a = uint64.high
doAssert a.uint == uint.high
```

For this, I had to modify the VM. Ints are stored as `int64` (e.g. `uint64.high` is stored as -1), so I added `opcRangeChckU`, `opcURangeChck` and `opcURangeChckU` opcodes to interpret the values as unsigned (the `U` before `Range` indicates that the range/destination is unsigned, the `U` at the end indicates that the source is unsigned).

I also removed some unused functions in semfold.