### PR TITLE
fix #18846 Typechecking can be bypassed for descendant of generics wh…

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1596,9 +1596,6 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
 
       if depth >= 0:
         c.inheritancePenalty += depth
-        # bug #4863: We still need to bind generic alias crap, so
-        # we cannot return immediately:
-        result = if depth == 0: isGeneric else: isSubtype
   of tyAnd:
     considerPreviousT:
       result = isEqual

--- a/tests/generics/t18846.nim
+++ b/tests/generics/t18846.nim
@@ -1,0 +1,28 @@
+type
+  Either[T, U] = object of RootObj
+    t: T
+    u: U
+
+  E = object of Either[float, string]
+
+proc test(T: typedesc, e: Either[T, T]) =
+  echo "matched ", typeof(e)
+  echo e
+
+proc test1[T](e: Either[T, auto]) =
+  echo "matched ", typeof(e)
+  echo e
+
+proc test2[T](e: Either[T, T]) =
+  echo "matched ", typeof(e)
+  echo e
+
+proc makeE(): E =
+  result.t = -1.0
+  result.u = "string"
+
+doAssert false == compiles(test(int, makeE()))
+doAssert false == compiles(test1[int](makeE()))
+
+# This doesn't compile as expected
+doAssert false == compiles(test2[int](makeE()))


### PR DESCRIPTION
…en a typedesc parameter or auto is used

fix #18846