### PR TITLE
fix #22173 `sink` paramers not moved into closure (refc)

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -342,12 +342,15 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
       if (dest.storage == OnStack and p.config.selectedGC != gcGo) or not usesWriteBarrier(p.config):
         linefmt(p, cpsStmts, "$1 = #copyString($2);$n", [dest.rdLoc, src.rdLoc])
       elif dest.storage == OnHeap:
-        # we use a temporary to care for the dreaded self assignment:
-        var tmp: TLoc
-        getTemp(p, ty, tmp)
-        linefmt(p, cpsStmts, "$3 = $1; $1 = #copyStringRC1($2);$n",
-                [dest.rdLoc, src.rdLoc, tmp.rdLoc])
-        linefmt(p, cpsStmts, "if ($1) #nimGCunrefNoCycle($1);$n", [tmp.rdLoc])
+        if dest.lode.typ.kind == tySink:
+          genRefAssign(p, dest, src)
+        else:
+          # we use a temporary to care for the dreaded self assignment:
+          var tmp: TLoc
+          getTemp(p, ty, tmp)
+          linefmt(p, cpsStmts, "$3 = $1; $1 = #copyStringRC1($2);$n",
+                  [dest.rdLoc, src.rdLoc, tmp.rdLoc])
+          linefmt(p, cpsStmts, "if ($1) #nimGCunrefNoCycle($1);$n", [tmp.rdLoc])
       else:
         linefmt(p, cpsStmts, "#unsureAsgnRef((void**) $1, #copyString($2));$n",
                [addrLoc(p.config, dest), rdLoc(src)])

--- a/tests/gc/t22173.nim
+++ b/tests/gc/t22173.nim
@@ -1,0 +1,20 @@
+discard """
+  cmd: '''nim c --gc:refc -r $file'''
+"""
+const Memo = 100 * 1024
+
+proc fff(v: sink string): iterator(): char =
+  return iterator(): char =
+    for c in v:
+      yield c
+
+var tmp = newString(Memo)
+
+let iter = fff(move(tmp))
+
+while true:
+  let v = iter()
+  if finished(iter):
+    break
+
+doAssert getOccupiedMem() < Memo * 3


### PR DESCRIPTION
fix #22173