### PR TITLE
block ambiguous type conversion dotcalls in generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -167,6 +167,17 @@ proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
       elif s.isMixedIn:
         result = newDot(result, symChoice(c, n, s, scForceOpen))
       else:
+        if s.kind == skType and candidates.len > 1:
+          var ambig = false
+          let s2 = searchInScopes(c, ident, ambig) 
+          if ambig:
+            # this is a type conversion like a.T where T is ambiguous with
+            # other types or routines
+            # in regular code, this never considers a type conversion and
+            # skips to routine overloading
+            # so symchoices are used which behave similarly with type symbols
+            result = newDot(result, symChoice(c, n, s, scForceOpen))
+            return
         let syms = semGenericStmtSymbol(c, n, s, ctx, flags, fromDotExpr=true)
         result = newDot(result, syms)
 

--- a/tests/generics/m22373a.nim
+++ b/tests/generics/m22373a.nim
@@ -1,0 +1,7 @@
+# module a for t22373
+
+# original:
+type LightClientHeader* = object
+
+# simplified:
+type TypeOrTemplate* = object

--- a/tests/generics/m22373b.nim
+++ b/tests/generics/m22373b.nim
@@ -1,0 +1,18 @@
+# module b for t22373
+
+import m22373a
+
+# original:
+type
+  LightClientDataFork* {.pure.} = enum
+    None = 0,
+    Altair = 1
+template LightClientHeader*(kind: static LightClientDataFork): auto =
+  when kind == LightClientDataFork.Altair:
+    typedesc[m22373a.LightClientHeader]
+  else:
+    static: raiseAssert "Unreachable"
+
+# simplified:
+template TypeOrTemplate*(num: int): untyped =
+  typedesc[m22373a.TypeOrTemplate]

--- a/tests/generics/t22373.nim
+++ b/tests/generics/t22373.nim
@@ -1,0 +1,16 @@
+# issue #22373
+
+import m22373a
+import m22373b
+
+# original:
+template lazy_header(name: untyped): untyped {.dirty.} =
+  var `name _ ptr`: ptr[data_fork.LightClientHeader]  # this data_fork.Foo part seems required to reproduce
+proc createLightClientUpdates(data_fork: static LightClientDataFork) =
+  lazy_header(attested_header)
+createLightClientUpdates(LightClientDataFork.Altair)
+
+# simplified:
+proc generic[T](abc: T) =
+  var x: abc.TypeOrTemplate
+generic(123)

--- a/tests/generics/timports.nim
+++ b/tests/generics/timports.nim
@@ -46,6 +46,11 @@ block tdotlookup:
     x.set("hello", "world")
     result = x
   doAssert abc(5) == 10
+  block: # ensure normal call is consistent with dot call 
+    proc T(x: int): float = x.float
+    proc foo[T](x: int) =
+      doAssert typeof(T(x)) is typeof(x.T)
+    foo[uint](123)
 
 block tmodule_same_as_proc:
   # bug #1965


### PR DESCRIPTION
fixes #22373

In normal code, when an ambiguous type symbol is called, a type conversion is not considered and routine overloading is done instead:

https://github.com/nim-lang/Nim/blob/b40da812f7aa590ed16df54a492684c228320549/compiler/semexprs.nim#L3113-L3115

For the same situation in generic code with dotcalls, replace the ambiguous type symbol with a sym choice, which similarly ignores type conversions and performs normal routine overloading.