### PR TITLE
fix server caching issue causing Theme failures

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1723,7 +1723,7 @@ proc genOutFile(d: PDoc, groupedToc = false): string =
         "moduledesc", d.modDescFinal, "date", getDateStr(), "time", getClockStr(),
         "content", content, "author", d.meta[metaAuthor],
         "version", esc(d.target, d.meta[metaVersion]), "analytics", d.analytics,
-        "deprecationMsg", d.modDeprecationMsg]
+        "deprecationMsg", d.modDeprecationMsg, "nimVersion", $NimMajor & "." & $NimMinor & "." & $NimPatch]
   else:
     code = content
   result = code
@@ -1907,7 +1907,7 @@ proc commandBuildIndex*(conf: ConfigRef, dir: string, outFile = RelativeFile"") 
       "title", "Index",
       "subtitle", "", "tableofcontents", "", "moduledesc", "",
       "date", getDateStr(), "time", getClockStr(),
-      "content", content, "author", "", "version", "", "analytics", ""]
+      "content", content, "author", "", "version", "", "analytics", "", "nimVersion", $NimMajor & "." & $NimMinor & "." & $NimPatch]
   # no analytics because context is not available
 
   try:

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -237,10 +237,10 @@ doc.file = """<?xml version="1.0" encoding="utf-8" ?>
 <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4QQQEwksSS9ZWwAAAk1JREFUWMPtll2ITVEUx39nn/O7Y5qR8f05wtCUUr6ZIS++8pEnkZInPImneaCQ5METNdOkeFBKUhMPRIkHKfEuUZSUlGlKPN2TrgfncpvmnntnmlEyq1Z7t89/rf9a6+y99oZxGZf/XeIq61EdtgKXgdXA0xrYAvBjOIF1AI9zvjcC74BSpndrJPkBWDScTF8Aa4E3wDlgHbASaANmVqlcCnwHvgDvgVfAJ+AikAAvgfVZwLnSVZHZaOuKoQi3ZOMi4NkYkpe1p4J7A8BpYAD49hfIy/oqG0+hLomiKP2L5L+1ubn5115S+3OAn4EnwBlgMzCjyt6ZAnQCJ4A7wOs88iRJHvw50HoujuPBoCKwHWiosy8MdfZnAdcHk8dxXFJ3VQbQlCTJvRBCGdRbD4M6uc5glpY3eAihpN5S5w12diSEcCCEcKUO4ljdr15T76ur1FDDLIQQ3qv71EdDOe3Kxj3leRXyk+pxdWnFWod6Wt2bY3de3aSuUHcPBVimHs7mK9WrmeOF6lR1o9qnzskh2ar2qm1qizpfXaPeVGdlmGN5pb09qMxz1Xb1kLqgzn1RyH7JUXW52lr5e/Kqi9qpto7V1atuUzfnARrV7jEib1T76gG2qxdGmXyiekkt1GswPTtek0aBfJp6YySGBfWg2tPQ0FAYgf1stUfdmdcjarbYJEniKIq6gY/Aw+zWHAC+p2labGpqiorFYgGYCEzN7oQdQClN07O1/EfDyGgC0ALMBdYAi4FyK+4H3gLPsxfR1zRNi+NP7nH5J+QntnXe5B5mpfQAAAAASUVORK5CYII=">
 
 <!-- CSS -->
-<link rel="stylesheet" type="text/css" href="$nimdoccss">
+<link rel="stylesheet" type="text/css" href="${nimdoccss}?v=$nimVersion">
 
 <!-- JS -->
-<script type="text/javascript" src="$dochackjs"></script>
+<script type="text/javascript" src="${dochackjs}?v=$nimVersion"></script>
 </head>
 <body>
   <div class="document" id="documentId">

--- a/nimdoc/rsttester.nim
+++ b/nimdoc/rsttester.nim
@@ -24,11 +24,13 @@ proc testRst2Html(fixup = false) =
     let sourceFile = expectedHtml.replace('\\', '/').replace("/expected/", "/source/").replace(".html", ".rst")
     exec("$1 rst2html $2" % [nimExe, sourceFile])
     let producedHtml = expectedHtml.replace('\\', '/').replace("/expected/", "/source/htmldocs/")
-    if readFile(expectedHtml) != readFile(producedHtml):
+    let versionCacheParam = "?v=" & $NimMajor & "." & $NimMinor & "." & $NimPatch
+    let producedFile = readFile(producedHtml).replace(versionCacheParam,"") #remove version cache param used for cache invalidation
+    if readFile(expectedHtml) != producedFile:
       echo diffFiles(expectedHtml, producedHtml).output
       inc failures
       if fixup:
-        copyFile(producedHtml, expectedHtml)
+        writeFile(expectedHtml, producedFile)
     else:
       echo "SUCCESS: files identical: ", producedHtml
     if failures == 0:

--- a/nimdoc/tester.nim
+++ b/nimdoc/tester.nim
@@ -64,12 +64,13 @@ proc testNimDoc(prjDir, docsDir: string; switches: NimSwitches; fixup = false) =
     if not fileExists(produced):
       echo "FAILURE: files not found: ", produced
       inc failures
-    elif readFile(expected) != readFile(produced).replace(versionCacheParam,""): #remove version cache param used for cache invalidation
+    let producedFile = readFile(produced).replace(versionCacheParam,"") #remove version cache param used for cache invalidation
+    if readFile(expected) != producedFile:
       echo "FAILURE: files differ: ", produced
       echo diffFiles(expected, produced).output
       inc failures
       if fixup:
-        copyFile(produced, expected)
+        writeFile(expected, producedFile)
     else:
       echo "SUCCESS: files identical: ", produced
 

--- a/nimdoc/tester.nim
+++ b/nimdoc/tester.nim
@@ -59,11 +59,12 @@ proc testNimDoc(prjDir, docsDir: string; switches: NimSwitches; fixup = false) =
     echo("$1 buildIndex $2" % [nimExe, nimBuildIndexSwitches])
 
   for expected in walkDirRec(prjDir / "expected/", checkDir=true):
+    let versionCacheParam = "?v=" & $NimMajor & "." & $NimMinor & "." & $NimPatch
     let produced = expected.replace('\\', '/').replace("/expected/", "/$1/" % [docsDir])
     if not fileExists(produced):
       echo "FAILURE: files not found: ", produced
       inc failures
-    elif readFile(expected) != readFile(produced):
+    elif readFile(expected) != readFile(produced).replace(versionCacheParam,""): #remove version cache param used for cache invalidation
       echo "FAILURE: files differ: ", produced
       echo diffFiles(expected, produced).output
       inc failures


### PR DESCRIPTION
fixes [22377](https://github.com/nim-lang/Nim/issues/22377)

invalidates server cache by changing resource url. Will update for every version.

```html
<!-- CSS -->
<link rel="stylesheet" type="text/css" href="nimdoc.out.css?v=2.1.1">

<!-- JS -->
<script type="text/javascript" src="dochack.js?v=2.1.1"></script>
```