### PR TITLE
Fix crash when using uninstantiated generic

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1536,6 +1536,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     if x.kind == tyGenericInvocation:
       if f[0] == x[0]:
         for i in 1..<f.len:
+          # Handle when checking against a generic that isn't fully instantiated
+          if i >= x.len: return
           let tr = typeRel(c, f[i], x[i], flags)
           if tr <= isSubtype: return
         result = isGeneric

--- a/tests/generics/tuninstantiated_failure.nim
+++ b/tests/generics/tuninstantiated_failure.nim
@@ -1,0 +1,16 @@
+discard """
+cmd: "nim check $file"
+"""
+
+type
+  Test[T, K] = object
+    name: string
+  Something = Test[int]
+
+func `[]`[T, K](x: var Test[T, K], idx: int): var Test[T, K] =
+  x
+
+var b: Something
+# Should give a type-mismatch since Something isn't a valid Test
+b[0].name = "Test" #[tt.Error
+            ^  type mismatch]#


### PR DESCRIPTION
Currently when running `nim check` on the test case you get 
```
fatal.nim(53)            sysFatal
Error: unhandled exception: index 1 not in 0 .. 0 [IndexDefect]
```
since `Something` is not fully instantiated.

Causes problems when using nimsuggest since it crashes when you haven't fully instantiated a generic and try to use it