### PR TITLE
fixes AddressSanitizer: global-buffer-overflow in getAppFilename on windows 10

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -638,14 +638,14 @@ proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noW
   # /proc/<pid>/path/a.out (complete pathname)
   when defined(windows):
     var bufsize = int32(MAX_PATH)
-    var buf = newWideCString("", bufsize)
+    var buf = newWideCString(bufsize)
     while true:
       var L = getModuleFileNameW(0, buf, bufsize)
       if L == 0'i32:
         result = "" # error!
         break
       elif L > bufsize:
-        buf = newWideCString("", L)
+        buf = newWideCString(L)
         bufsize = L
       else:
         result = buf$L


### PR DESCRIPTION
This fixes AddressSanitizer: global-buffer-overflow in getAppFilename on windows 10
```
=================================================================
==6892==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7ff76fd552e1 at pc 0x7ff76fd23910 bp 0x00cf95d9e9b0 sp 0x00cf95d9e9f8
READ of size 1 at 0x7ff76fd552e1 thread T0
    #0 0x7ff76fd2390f in newWideCString__stdZwidestrs_u280 D:\vscode\vscode_nim\nim-2.0.0\lib\std/widestrs.nim:106:19
    #1 0x7ff76fd3c0be in nosgetAppFilename D:\vscode\vscode_nim\nim-2.0.0\lib\pure/os.nim:641:8
    #2 0x7ff76fd44b21 in help__fcrypt_u249 C:\Users\norrath\.nimble\pkgs2\argparse-4.0.1-e80475be8755b74e6c4a2a7b09b5537dca91bc16\argparse/backend.nim:817:18
    #3 0x7ff76fd45ae1 in parse__fcrypt_u253 C:\Users\norrath\.nimble\pkgs2\argparse-4.0.1-e80475be8755b74e6c4a2a7b09b5537dca91bc16\argparse/backend.nim:374:20
    #4 0x7ff76fd47c18 in parse__fcrypt_u620 C:\Users\norrath\.nimble\pkgs2\argparse-4.0.1-e80475be8755b74e6c4a2a7b09b5537dca91bc16\argparse/backend.nim:625:2
    #5 0x7ff76fd48b5e in NimMainModule D:\vscode\vscode_nim\projects\fcrypt\src/fcrypt.nim:40:74
    #6 0x7ff76fd4a5b6 in NimMainInner D:\vscode\vscode_nim\nim-2.0.0\lib\std/assertions.nim:61:2
    #7 0x7ff76fd4a5b6 in NimMain D:\vscode\vscode_nim\nim-2.0.0\lib\std/assertions.nim:72:2
    #8 0x7ff76fd4a5b6 in main D:\vscode\vscode_nim\nim-2.0.0\lib\std/assertions.nim:80:2
    #9 0x7ff76fd21314 in __tmainCRTStartup /home/runner/work/llvm-mingw/llvm-mingw/mingw-w64/mingw-w64-crt/build-x86_64/../crt/crtexe.c:267:15    
    #10 0x7ff76fd21365 in .l_start /home/runner/work/llvm-mingw/llvm-mingw/mingw-w64/mingw-w64-crt/build-x86_64/../crt/crtexe.c:188:9
    #11 0x7ffb448c7613  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017613)
    #12 0x7ffb468a26b0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800526b0)

0x7ff76fd552e1 is located 63 bytes before global variable 'TM__yu6cxgKBBXbNsTkT9cyMd4g_2' defined in 'D:\vscode\vscode_nim\projects\fcrypt\x64\release\@m..@s..@s..@snim-2.0.0@slib@spure@sos.nim.c' (0x7ff76fd55320) of size 16
0x7ff76fd552e1 is located 31 bytes before global variable 'TM__yu6cxgKBBXbNsTkT9cyMd4g_3' defined in 'D:\vscode\vscode_nim\projects\fcrypt\x64\release\@m..@s..@s..@snim-2.0.0@slib@spure@sos.nim.c' (0x7ff76fd55300) of size 16
0x7ff76fd552e1 is located 0 bytes after global variable '.str' defined in 'D:\vscode\vscode_nim\projects\fcrypt\x64\release\@m..@s..@s..@snim-2.0.0@slib@spure@sos.nim.c' (0x7ff76fd552e0) of size 1
  '.str' is ascii string ''
SUMMARY: AddressSanitizer: global-buffer-overflow D:\vscode\vscode_nim\nim-2.0.0\lib\std/widestrs.nim:106:19 in newWideCString__stdZwidestrs_u280 
Shadow bytes around the buggy address:
  0x7ff76fd55000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7ff76fd55280: 00 00 00 00 00 00 00 00 00 00 00 00[01]f9 f9 f9
  0x7ff76fd55300: 00 00 f9 f9 00 00 f9 f9 00 00 00 00 00 00 00 00
  0x7ff76fd55380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7ff76fd55480: 00 00 00 00 00 00 00 00 00 04 f9 f9 00 f9 f9 f9
  0x7ff76fd55500: 00 00 f9 f9 00 04 f9 f9 00 04 f9 f9 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==6892==ABORTING
```