### PR TITLE
Let inferGenericTypes continue if a param is already bound

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -562,10 +562,6 @@ proc getCallLineInfo(n: PNode): TLineInfo =
     discard
   result = n.info
 
-proc semOverloadedCall(c: PContext, n, nOrig: PNode,
-                       filter: TSymKinds, flags: TExprFlags;
-                       expectedType: PType = nil): PNode
-
 proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType): bool =
   ## Helper proc to inherit bound generic parameters from expectedType into x.
   ## Does nothing if 'inferGenericTypes' isn't in c.features.
@@ -611,7 +607,7 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType): bool 
         stackPut(t[i], u[i])
     of tyGenericParam:
       var prebound = x.bindings.idTableGet(t).PType
-      if prebound != nil:
+      if prebound != nil and prebound != u:
         # The generic parameter is already bound.
         # If it's not compatible it's a mismatch and we return
         let tm = typeRel(x, u, prebound)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -605,11 +605,7 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType) =
         stackPut(t[i], u[i])
     of tyGenericParam:
       let prebound = x.bindings.idTableGet(t).PType
-      if prebound != nil and prebound != u:
-        # The generic parameter is already bound.
-        # If it's not compatible it's a mismatch and we return
-        let tm = typeRel(x, u, prebound)
-        if tm != isConvertible: return
+      if prebound != nil:
         continue # Skip param, already bound
 
       # fully reduced generic param, bind it

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -606,8 +606,9 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType): bool 
         if t[i] == nil or u[i] == nil: return
         stackPut(t[i], u[i])
     of tyGenericParam:
-      var prebound = x.bindings.idTableGet(t).PType
+      let prebound = x.bindings.idTableGet(t).PType
       if prebound != nil and prebound != u:
+        if prebound.kind == tyProc: return # Don't attempt proc conversions
         # The generic parameter is already bound.
         # If it's not compatible it's a mismatch and we return
         let tm = typeRel(x, u, prebound)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -565,7 +565,7 @@ proc getCallLineInfo(n: PNode): TLineInfo =
 proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType) =
   ## Helper proc to inherit bound generic parameters from expectedType into x.
   ## Does nothing if 'inferGenericTypes' isn't in c.features.
-  #if inferGenericTypes notin c.features: return
+  if inferGenericTypes notin c.features: return
   if expectedType == nil or x.callee[0] == nil: return # required for inference
 
   var
@@ -587,7 +587,6 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType) =
 
   stackPut(x.callee[0], expectedType)
 
-  var requireConversion = false
   while typeStack.len() > 0:
     let (t, u) = typeStack.pop()
     if t == u or t == nil or u == nil or t.kind == tyAnything or u.kind == tyAnything:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -580,7 +580,7 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType): bool 
     ## skips types and puts the skipped version on stack
     # It might make sense to skip here one by one. It's not part of the main
     #  type reduction because the right side normally won't be skipped
-    const toSkip = { tyVar, tyLent, tyStatic, tyCompositeTypeClass }
+    const toSkip = { tyVar, tyLent, tyStatic, tyCompositeTypeClass, tySink }
     let
       x = a.skipTypes(toSkip)
       y = if a.kind notin toSkip: b

--- a/tests/generics/treturn_inference.nim
+++ b/tests/generics/treturn_inference.nim
@@ -137,3 +137,25 @@ block:
 
   let a = Foo(x: initTable())
   doAssert a.x is Table[int, float]
+
+# partial binding and conversion
+block:
+  type
+    ResultKind = enum
+      Ok, Error
+
+    Result[T, E] = object
+      case kind: ResultKind
+      of Ok:
+        okVal: T
+      of Error:
+        errVal: E
+
+  proc err[T, E](myParam: E): Result[T, E] =
+    Result[T, E](kind : Error, errVal : myParam)
+
+  proc doStuff(): Result[int, cstring] = 
+    # string is compatible with cstring, so it can be inferred with conversion
+    err("Error")
+
+  discard doStuff()

--- a/tests/generics/treturn_inference.nim
+++ b/tests/generics/treturn_inference.nim
@@ -138,7 +138,7 @@ block:
   let a = Foo(x: initTable())
   doAssert a.x is Table[int, float]
 
-# partial binding and conversion
+# partial binding
 block:
   type
     ResultKind = enum
@@ -154,8 +154,7 @@ block:
   proc err[T, E](myParam: E): Result[T, E] =
     Result[T, E](kind : Error, errVal : myParam)
 
-  proc doStuff(): Result[int, cstring] = 
-    # string is compatible with cstring, so it can be inferred with conversion
+  proc doStuff(): Result[int, string] = 
     err("Error")
 
   let res = doStuff()

--- a/tests/generics/treturn_inference.nim
+++ b/tests/generics/treturn_inference.nim
@@ -158,4 +158,6 @@ block:
     # string is compatible with cstring, so it can be inferred with conversion
     err("Error")
 
-  discard doStuff()
+  let res = doStuff()
+  doAssert res.kind == Error
+  doAssert res.errVal == "Error"


### PR DESCRIPTION
The current inference does not support code like below as `T` or `E` will be bound already which causes an early return. Originally this PR was gonna try to convert the types for `string` to `cstring` conversion, but that causes more problems than it solves, so now it simply lets the inference continue instead of returning.


```nim
{.experimental: "inferGenericTypes".}

type
  ResultKind = enum
    Ok, Error

  Result[T, E] = object
    case kind: ResultKind
    of Ok:
      okVal: T
    of Error:
      errVal: E

proc ok[T, E](x: T): Result[T, E] =
  Result[T, E](kind : Ok, okVal : x)

proc err[T, E](x: E): Result[T, E] =
  Result[T, E](kind : Error, errVal : x)

proc doStuff(): Result[int, string] = 
  err("Error")
```