### PR TITLE
fix #15005; [ARC] Global variable declared in a block is destroyed too…

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1154,7 +1154,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
         result = newTree(nkStmtList, snk, c.genWasMoved(ri))
       elif ri.sym.kind != skParam and ri.sym.owner == c.owner and
           isLastRead(ri, c, s) and canBeMoved(c, dest.typ) and not isCursor(ri) and
-          {sfGlobal, sfPure} * ri.sym.flags == {}:
+          {sfGlobal, sfPure} <= ri.sym.flags == false:
         # Rule 3: `=sink`(x, z); wasMoved(z)
         let snk = c.genSink(s, dest, ri, flags)
         result = newTree(nkStmtList, snk, c.genWasMoved(ri))

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1153,7 +1153,8 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
         let snk = c.genSink(s, dest, ri, flags)
         result = newTree(nkStmtList, snk, c.genWasMoved(ri))
       elif ri.sym.kind != skParam and ri.sym.owner == c.owner and
-          isLastRead(ri, c, s) and canBeMoved(c, dest.typ) and not isCursor(ri):
+          isLastRead(ri, c, s) and canBeMoved(c, dest.typ) and not isCursor(ri) and
+          {sfGlobal, sfPure} * ri.sym.flags == {}:
         # Rule 3: `=sink`(x, z); wasMoved(z)
         let snk = c.genSink(s, dest, ri, flags)
         result = newTree(nkStmtList, snk, c.genWasMoved(ri))

--- a/tests/global/t15005.nim
+++ b/tests/global/t15005.nim
@@ -1,0 +1,18 @@
+type
+  T = ref object
+    data: string
+
+template foo(): T =
+  var a15005 {.global.}: T
+  once:
+    a15005 = T(data: "hi")
+
+  a15005
+
+proc test() =
+  var b15005 = foo()
+
+  doAssert b15005.data == "hi"
+
+test()
+test()


### PR DESCRIPTION
… early  

fix #15005. 

now expand as below.
```
--expandArc: test

var
  b15005
  a15005`gensym0
var alreadyExecuted`gensym1 = false
if not alreadyExecuted`gensym1:
  alreadyExecuted`gensym1 = true
  `=sink`(a15005`gensym0, T(data: "hi"))
`=copy`(b15005, a15005`gensym0)
const
  loc`gensym3 = (filename: "t15005.nim", line: 15, column: 2)
  ploc`gensym3 = "t15005.nim(15, 3)"
bind instantiationInfo
mixin failedAssertImpl
{.line: (filename: "t15005.nim", line: 15, column: 2).}:
  if not (b15005.data == "hi"):
    failedAssertImpl("t15005.nim(15, 3) `b15005.data == \"hi\"` ")
`=destroy`(b15005)
-- end of expandArc ------------------------
```