### PR TITLE
use out parameters for getTemp

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -96,7 +96,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
         pl.add(");\n")
         line(p, cpsStmts, pl)
       else:
-        var tmp: TLoc = default(TLoc)
+        var tmp: TLoc
         getTemp(p, typ[0], tmp, needsInit=true)
         pl.add(addrLoc(p.config, tmp))
         pl.add(");\n")
@@ -133,7 +133,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
         genAssignment(p, d, list, {}) # no need for deep copying
         if canRaise: raiseExit(p)
       else:
-        var tmp: TLoc = default(TLoc)
+        var tmp: TLoc
         getTemp(p, typ[0], tmp, needsInit=true)
         var list: TLoc = default(TLoc)
         initLoc(list, locCall, d.lode, OnUnknown)
@@ -273,14 +273,12 @@ proc withTmpIfNeeded(p: BProc, a: TLoc, needsTmp: bool): TLoc =
   # Also don't regress for non ARC-builds, too risky.
   if needsTmp and a.lode.typ != nil and p.config.selectedGC in {gcArc, gcAtomicArc, gcOrc} and
       getSize(p.config, a.lode.typ) < 1024:
-    result = default(TLoc)
     getTemp(p, a.lode.typ, result, needsInit=false)
     genAssignment(p, result, a, {})
   else:
     result = a
 
 proc literalsNeedsTmp(p: BProc, a: TLoc): TLoc =
-  result = default(TLoc)
   getTemp(p, a.lode.typ, result, needsInit=false)
   genAssignment(p, result, a, {})
 
@@ -483,7 +481,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         genCallPattern()
         if canRaise: raiseExit(p)
       else:
-        var tmp: TLoc = default(TLoc)
+        var tmp: TLoc
         getTemp(p, typ[0], tmp, needsInit=true)
         pl.add(addrLoc(p.config, tmp))
         genCallPattern()
@@ -501,7 +499,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
       genAssignment(p, d, list, {}) # no need for deep copying
       if canRaise: raiseExit(p)
     else:
-      var tmp: TLoc = default(TLoc)
+      var tmp: TLoc
       getTemp(p, typ[0], tmp)
       assert(d.t != nil)        # generate an assignment to d:
       var list: TLoc = default(TLoc)
@@ -782,7 +780,7 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
         pl.add("];\n")
         line(p, cpsStmts, pl)
       else:
-        var tmp: TLoc = default(TLoc)
+        var tmp: TLoc
         getTemp(p, typ[0], tmp, needsInit=true)
         pl.add(addrLoc(p.config, tmp))
         pl.add("];\n")

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -348,7 +348,7 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
         linefmt(p, cpsStmts, "$1 = #copyString($2);$n", [dest.rdLoc, src.rdLoc])
       elif dest.storage == OnHeap:
         # we use a temporary to care for the dreaded self assignment:
-        var tmp: TLoc = default(TLoc)
+        var tmp: TLoc
         getTemp(p, ty, tmp)
         linefmt(p, cpsStmts, "$3 = $1; $1 = #copyStringRC1($2);$n",
                 [dest.rdLoc, src.rdLoc, tmp.rdLoc])
@@ -431,7 +431,7 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
 proc genDeepCopy(p: BProc; dest, src: TLoc) =
   template addrLocOrTemp(a: TLoc): Rope =
     if a.k == locExpr:
-      var tmp: TLoc = default(TLoc)
+      var tmp: TLoc
       getTemp(p, a.t, tmp)
       genAssignment(p, tmp, a, {})
       addrLoc(p.config, tmp)
@@ -1197,7 +1197,7 @@ proc genAndOr(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
   else:
     var
       L: TLabel
-      tmp: TLoc = default(TLoc)
+      tmp: TLoc
     getTemp(p, e.typ, tmp)      # force it into a temp!
     inc p.splitDecls
     expr(p, e[1], tmp)
@@ -1276,7 +1276,8 @@ proc genStrConcat(p: BProc, e: PNode, d: var TLoc) =
   #    appendChar(tmp0, 'z');
   #    asgn(s, tmp0);
   #  }
-  var a, tmp: TLoc = default(TLoc)
+  var a = default(TLoc)
+  var tmp: TLoc
   getTemp(p, e.typ, tmp)
   var L = 0
   var appends: Rope = ""
@@ -1556,7 +1557,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
         (d.k notin {locTemp,locLocalVar,locGlobalVar,locParam,locField}) or
         (isPartOf(d.lode, e) != arNo)
 
-  var tmp: TLoc = default(TLoc)
+  var tmp: TLoc = TLoc()
   var r: Rope
   if useTemp:
     getTemp(p, t, tmp)
@@ -1604,7 +1605,8 @@ proc lhsDoesAlias(a, b: PNode): bool =
     if isPartOf(a, y) != arNo: return true
 
 proc genSeqConstr(p: BProc, n: PNode, d: var TLoc) =
-  var arr, tmp: TLoc = default(TLoc)
+  var arr = default(TLoc)
+  var tmp: TLoc = default(TLoc)
   # bug #668
   let doesAlias = lhsDoesAlias(d.lode, n)
   let dest = if doesAlias: addr(tmp) else: addr(d)
@@ -1669,7 +1671,7 @@ proc genArrToSeq(p: BProc, n: PNode, d: var TLoc) =
       arr.r = ropecg(p.module, "$1[$2]", [rdLoc(a), lit])
       genAssignment(p, elem, arr, {needToCopy})
   else:
-    var i: TLoc = default(TLoc)
+    var i: TLoc
     getTemp(p, getSysType(p.module.g.graph, unknownLineInfo, tyInt), i)
     linefmt(p, cpsStmts, "for ($1 = 0; $1 < $2; $1++) {$n",  [i.r, L])
     initLoc(elem, locExpr, lodeTyp elemType(skipTypes(n.typ, abstractInst)), OnHeap)
@@ -1986,7 +1988,8 @@ proc genSwap(p: BProc, e: PNode, d: var TLoc) =
   # b = temp
   cowBracket(p, e[1])
   cowBracket(p, e[2])
-  var a, b, tmp: TLoc = default(TLoc)
+  var a, b = default(TLoc)
+  var tmp: TLoc
   getTemp(p, skipTypes(e[1].typ, abstractVar), tmp)
   initLocExpr(p, e[1], a) # eval a
   initLocExpr(p, e[2], b) # eval b
@@ -2090,7 +2093,8 @@ proc genSetOp(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       "&",
       "|",
       "& ~"]
-  var a, b, i: TLoc = default(TLoc)
+  var a, b = default(TLoc)
+  var i: TLoc
   var setType = skipTypes(e[1].typ, abstractVar)
   var size = int(getSize(p.config, setType))
   case size
@@ -2645,7 +2649,8 @@ proc genSetConstr(p: BProc, e: PNode, d: var TLoc) =
   # nimZeroMem(tmp, sizeof(tmp)); inclRange(tmp, a, b); incl(tmp, c);
   # incl(tmp, d); incl(tmp, e); inclRange(tmp, f, g);
   var
-    a, b, idx: TLoc = default(TLoc)
+    a, b = default(TLoc)
+  var idx: TLoc
   if nfAllConst in e.flags:
     var elem = newRopeAppender()
     genSetNode(p, e, elem)
@@ -2744,7 +2749,8 @@ proc genClosure(p: BProc, n: PNode, d: var TLoc) =
     p.module.s[cfsData].add data
     putIntoDest(p, d, n, tmp, OnStatic)
   else:
-    var tmp, a, b: TLoc = default(TLoc)
+    var tmp: TLoc
+    var a, b = default(TLoc)
     initLocExpr(p, n[0], a)
     initLocExpr(p, n[1], b)
     if n[0].skipConv.kind == nkClosure:

--- a/compiler/ccgreset.nim
+++ b/compiler/ccgreset.nim
@@ -57,7 +57,7 @@ proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =
     specializeResetT(p, accessor, lastSon(typ))
   of tyArray:
     let arraySize = lengthOrd(p.config, typ[0])
-    var i: TLoc = default(TLoc)
+    var i: TLoc
     getTemp(p, getSysType(p.module.g.graph, unknownLineInfo, tyInt), i)
     linefmt(p, cpsStmts, "for ($1 = 0; $1 < $2; $1++) {$n",
             [i.r, arraySize])

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1611,7 +1611,8 @@ when false:
     expr(p, call, d)
 
 proc asgnFieldDiscriminant(p: BProc, e: PNode) =
-  var a, tmp: TLoc = default(TLoc)
+  var a = default(TLoc)
+  var tmp: TLoc
   var dotExpr = e[0]
   if dotExpr.kind == nkCheckedFieldExpr: dotExpr = dotExpr[0]
   initLocExpr(p, e[0], a)

--- a/compiler/ccgtrav.nim
+++ b/compiler/ccgtrav.nim
@@ -21,7 +21,7 @@ const
 
 proc genTraverseProc(c: TTraversalClosure, accessor: Rope, typ: PType)
 proc genCaseRange(p: BProc, branch: PNode)
-proc getTemp(p: BProc, t: PType, result: var TLoc; needsInit=false)
+proc getTemp(p: BProc, t: PType, result: out TLoc; needsInit=false)
 
 proc genTraverseProc(c: TTraversalClosure, accessor: Rope, n: PNode;
                      typ: PType) =
@@ -74,7 +74,7 @@ proc genTraverseProc(c: TTraversalClosure, accessor: Rope, typ: PType) =
     genTraverseProc(c, accessor, lastSon(typ))
   of tyArray:
     let arraySize = lengthOrd(c.p.config, typ[0])
-    var i: TLoc = default(TLoc)
+    var i: TLoc
     getTemp(p, getSysType(c.p.module.g.graph, unknownLineInfo, tyInt), i)
     var oldCode = p.s(cpsStmts)
     freeze oldCode
@@ -119,12 +119,11 @@ proc genTraverseProc(c: TTraversalClosure, accessor: Rope, typ: PType) =
 proc genTraverseProcSeq(c: TTraversalClosure, accessor: Rope, typ: PType) =
   var p = c.p
   assert typ.kind == tySequence
-  var i: TLoc = default(TLoc)
+  var i: TLoc
   getTemp(p, getSysType(c.p.module.g.graph, unknownLineInfo, tyInt), i)
   var oldCode = p.s(cpsStmts)
   freeze oldCode
-  var a: TLoc = default(TLoc)
-  a.r = accessor
+  var a: TLoc = TLoc(r: accessor)
 
   lineF(p, cpsStmts, "for ($1 = 0; $1 < $2; $1++) {$n",
       [i.r, lenExpr(c.p, a)])


### PR DESCRIPTION
`initLoc` should have received the same treatment, but a bug related to the out parameter implicates it to make it impossible to change. A reduced example for that:
```nim
proc foo(x: out int) =
  x = 1

proc bar(x: out int) =
  foo(x)

var s: int
bar(s)
```
working on it anyway.