### PR TITLE
modernize compiler/reorder, which exposes yet another strictdefs bug

### DIFF
--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -25,17 +25,11 @@ when defined(nimDebugReorder):
   var idNames = newTable[int, string]()
 
 proc newDepN(id: int, pnode: PNode): DepN =
-  new(result)
-  result.id = id
-  result.pnode = pnode
-  result.idx = -1
-  result.lowLink = -1
-  result.onStack = false
-  result.kids = @[]
-  result.hAQ = -1
-  result.hIS = -1
-  result.hB = -1
-  result.hCmd = -1
+  result = DepN(id: id, pnode: pnode, idx: -1,
+                lowLink: -1, onStack: false,
+                kids: @[], hAQ: -1, hIS: -1,
+                hB: -1, hCmd: -1
+  )
   when defined(nimDebugReorder):
     result.expls = @[]
 
@@ -114,7 +108,7 @@ proc computeDeps(cache: IdentCache; n: PNode, declares, uses: var IntSet; topLev
     # XXX: for callables, this technically adds the return type dep before args
     for i in 0..<n.safeLen: deps(n[i])
 
-proc hasIncludes(n:PNode): bool =
+proc hasIncludes(n: PNode): bool =
   result = false
   for a in n:
     if a.kind == nkIncludeStmt:
@@ -235,8 +229,9 @@ proc hasImportStmt(n: PNode): bool =
   # i it contains one
   case n.kind
   of nkImportStmt, nkFromStmt, nkImportExceptStmt:
-    return true
+    result = true
   of nkStmtList, nkStmtListExpr, nkWhenStmt, nkElifBranch, nkElse, nkStaticStmt:
+    result = false
     for a in n:
       if a.hasImportStmt:
         return true


### PR DESCRIPTION
```nim
{.experimental: "strictdefs".}

type
  NodeKind = enum
    nkImportStmt
    nkStmtList
    nkNone

  PNode = ref object
    kind: NodeKind

proc hasImportStmt(n: PNode): bool =
  # Checks if the node is an import statement or
  # i it contains one
  case n.kind
  of nkImportStmt:
    return true
  of nkStmtList:
    if false:
      return true
  else:
    result = false

var n = PNode()
echo hasImportStmt(n)
```
It compiles without warnings, but shouldn't. As a contrast, 

```nim
{.experimental: "strictdefs".}

type
  NodeKind = enum
    nkImportStmt
    nkStmtList
    nkNone

  PNode = ref object
    kind: NodeKind

proc hasImportStmt(n: PNode): bool =
  # Checks if the node is an import statement or
  # i it contains one
  case n.kind
  of nkImportStmt:
    result = true
  of nkStmtList:
    if false:
      return true
  else:
    result = false

var n = PNode()
echo hasImportStmt(n)
```
This gives a proper warning.