### PR TITLE
fix cursor

### DIFF
--- a/compiler/varpartitions.nim
+++ b/compiler/varpartitions.nim
@@ -984,9 +984,9 @@ proc computeCursors*(s: PSym; n: PNode; g: ModuleGraph) =
         v.sym.flags * {sfThread, sfGlobal} == {} and hasDestructor(v.sym.typ) and
         v.sym.typ.skipTypes({tyGenericInst, tyAlias}).kind != tyOwned:
       let rid = root(par, i)
-      if par.s[rid].con.kind == isRootOf and dangerousMutation(par.graphs[par.s[rid].con.graphIndex], par.s[i]):
+      if preventCursor in par.s[rid].flags or par.s[rid].con.kind == isRootOf and dangerousMutation(par.graphs[par.s[rid].con.graphIndex], par.s[i]):
         discard "cannot cursor into a graph that is mutated"
       else:
         v.sym.flags.incl sfCursor
         when false:
-          echo "this is now a cursor ", v.sym, " ", par.s[rid].flags, " ", g.config $ v.sym.info
+          echo "this is now a cursor ", v.sym, " ", v.sym.typ, " ", par.s[rid].flags, " ", g.config $ v.sym.info


### PR DESCRIPTION
ref: #22357, not a proper fix, just for inspiration.

local test in main branch

permlink: https://github.com/vsajip/nim-cfg-lib/blob/b013bde1ef16357db306fce9ade8a5346c213b10/src/config.nim

buggy cursor log:
```
ln@1979737836 ListNode {ownsData, preventCursor} nim-cfg-lib/src/config.nim(2204, 9)
t@1979734184 Token {ownsData, preventCursor, isReassigned} nim-cfg-lib/src/config.nim(1767, 9)
_@1979738022 (TokenKind, ASTNode) {ownsData, preventCursor, isReassigned} nim-cfg-lib/src/config.nim(2331, 27)
```