### PR TITLE
make the name of procs consistent with the name forwards

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -109,7 +109,7 @@ type
     data*: TIIPairSeq
 
 
-proc initIiTable*(x: var TIITable)
+proc initIITable*(x: var TIITable)
 proc iiTableGet*(t: TIITable, key: int): int
 proc iiTablePut*(t: var TIITable, key, val: int)
 


### PR DESCRIPTION
It seems that `--stylecheck:error` acts up when the name forwards is involved.


```nim
proc thisOne*(x: var int)
proc thisone(x: var int) = x = 1
```

It cannot understand this at all.