### PR TITLE
getImpl now can get ast from a generic instance and type

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -244,6 +244,8 @@ proc floatVal*(n: NimNode): BiggestFloat {.magic: "NFloatVal", noSideEffect.}
 proc symKind*(symbol: NimNode): NimSymKind {.magic: "NSymKind", noSideEffect.}
 proc getImpl*(symbol: NimNode): NimNode {.magic: "GetImpl", noSideEffect.}
   ## Returns a copy of the declaration of a symbol or `nil`.
+  ## **Note**: When used on generic types with `when` the returned branches will not be flattened.
+
 proc strVal*(n: NimNode): string  {.magic: "NStrVal", noSideEffect.}
   ## Returns the string value of an identifier, symbol, comment, or string literal.
   ##

--- a/tests/macros/tgetimpl.nim
+++ b/tests/macros/tgetimpl.nim
@@ -98,3 +98,36 @@ check(typeof(z2[]))
 var z3: TireRef2
 check(typeof(z3[]))
 check(TireRef3)
+
+
+# get ast of generic instantiations
+block:
+  template jsonName(s: string) {.pragma.}
+
+
+  type 
+    MyType[T] = object
+      a {.jsonName: "hello".}: T
+    MyOtherType = object
+      b {.jsonName: "hmm".}: int
+
+  macro dumpType(typ: typed): untyped =
+    discard typ.getTypeInst().getImpl()
+
+  macro dumpType2(typ: typedesc): untyped =
+    discard typ.getImpl()
+
+  var 
+    a = MyType[int]()
+    b = MyOtherType()
+
+  dumpType(a)
+  dumpType(b)
+  static:
+    assert a.a.hasCustomPragma(jsonName)
+    assert b.b.hasCustomPragma(jsonName)
+    assert MyType[float]().a.hasCustomPragma(jsonName)
+
+  dumpType2(MyType[int])
+  dumpType2(MyType[float])
+  dumpType2(MyOtherType)


### PR DESCRIPTION
This is very adhoc solution, but it does enable querying an approximation of the AST on generic instance/types.