### PR TITLE
replaces `doAssert false` with `raiseAssert` for unreachable branches, which works better with strictdefs

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1499,7 +1499,7 @@ proc newIntTypeNode*(intVal: BiggestInt, typ: PType): PNode =
     result = newNode(nkIntLit)
   of tyStatic: # that's a pre-existing bug, will fix in another PR
     result = newNode(nkIntLit)
-  else: doAssert false, $kind
+  else: raiseAssert $kind
   result.intVal = intVal
   result.typ = typ
 

--- a/compiler/ccgreset.nim
+++ b/compiler/ccgreset.nim
@@ -95,7 +95,7 @@ proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =
     of ctInt8, ctInt16, ctInt32, ctInt64:
       lineCg(p, cpsStmts, "$1 = 0;$n", [accessor])
     else:
-      doAssert false, "unexpected set type kind"
+      raiseAssert "unexpected set type kind"
   of {tyNone, tyEmpty, tyNil, tyUntyped, tyTyped, tyGenericInvocation,
       tyGenericParam, tyOrdinal, tyRange, tyOpenArray, tyForward, tyVarargs,
       tyUncheckedArray, tyProxy, tyBuiltInTypeClass, tyUserTypeClass,

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -477,11 +477,11 @@ proc multiFormat*(frmt: var string, chars : static openArray[char], args: openAr
             if i >= frmt.len or frmt[i] notin {'0'..'9'}: break
           num = j
           if j > high(arg) + 1:
-            doAssert false, "invalid format string: " & frmt
+            raiseAssert "invalid format string: " & frmt
           else:
             res.add(arg[j-1])
         else:
-          doAssert false, "invalid format string: " & frmt
+          raiseAssert "invalid format string: " & frmt
       var start = i
       while i < frmt.len:
         if frmt[i] != c: inc(i)
@@ -847,7 +847,7 @@ proc resolveStarsInCppType(typ: PType, idx, stars: int): PType =
   # Make sure the index refers to one of the generic params of the type.
   # XXX: we should catch this earlier and report it as a semantic error.
   if idx >= typ.len:
-    doAssert false, "invalid apostrophe type parameter index"
+    raiseAssert "invalid apostrophe type parameter index"
 
   result = typ[idx]
   for i in 1..stars:

--- a/compiler/depends.nim
+++ b/compiler/depends.nim
@@ -42,8 +42,7 @@ proc toNimblePath(s: string, isStdlib: bool): string =
     let sub = "lib/"
     var start = s.find(sub)
     if start < 0:
-      result = ""
-      doAssert false
+      raiseAssert "unreachable"
     else:
       start += sub.len
       let base = s[start..^1]

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -470,7 +470,7 @@ proc gen(c: var Con; n: PNode) =
   of nkConv, nkExprColonExpr, nkExprEqExpr, nkCast, PathKinds1:
     gen(c, n[1])
   of nkVarSection, nkLetSection: genVarSection(c, n)
-  of nkDefer: doAssert false, "dfa construction pass requires the elimination of 'defer'"
+  of nkDefer: raiseAssert "dfa construction pass requires the elimination of 'defer'"
   else: discard
 
 when false:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -348,7 +348,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef,
 
   if conf.configVars.hasKey("doc.googleAnalytics") and
       conf.configVars.hasKey("doc.plausibleAnalytics"):
-    doAssert false, "Either use googleAnalytics or plausibleAnalytics"
+    raiseAssert "Either use googleAnalytics or plausibleAnalytics"
 
   if conf.configVars.hasKey("doc.googleAnalytics"):
     result.analytics = """
@@ -954,8 +954,7 @@ proc genDeprecationMsg(d: PDoc, n: PNode): string =
     else:
       result = ""
   else:
-    result = ""
-    doAssert false
+    raiseAssert "unreachable"
 
 type DocFlags = enum
   kDefault

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -218,8 +218,7 @@ proc mapType(typ: PType): TJSTypeKind =
   of tyProc: result = etyProc
   of tyCstring: result = etyString
   of tyConcept, tyIterable:
-    result = etyNone
-    doAssert false
+    raiseAssert "unreachable"
 
 proc mapType(p: PProc; typ: PType): TJSTypeKind =
   result = mapType(typ)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1024,7 +1024,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of tyOrdinal, tyRange, tyInferred,
      tyGenericInst, tyAlias, tySink:
     fillBody(c, lastSon(t), body, x, y)
-  of tyConcept, tyIterable: doAssert false
+  of tyConcept, tyIterable: raiseAssert "unreachable"
 
 proc produceSymDistinctType(g: ModuleGraph; c: PContext; typ: PType;
                             kind: TTypeAttachedOp; info: TLineInfo;

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -115,7 +115,7 @@ when not defined(leanCompiler):
       setPipeLinePass(graph, Docgen2JsonPass)
     of HtmlExt:
       setPipeLinePass(graph, Docgen2Pass)
-    else: doAssert false, $ext
+    else: raiseAssert $ext
     compilePipelineProject(graph)
 
 proc commandCompileToC(graph: ModuleGraph) =
@@ -267,7 +267,7 @@ proc mainCommand*(graph: ModuleGraph) =
         # and it has added this define implictly, so we must undo that here.
         # A better solution might be to fix system.nim
         undefSymbol(conf.symbols, "useNimRtl")
-    of backendInvalid: doAssert false
+    of backendInvalid: raiseAssert "unreachable"
 
   proc compileToBackend() =
     customizeForBackend(conf.backend)
@@ -277,7 +277,7 @@ proc mainCommand*(graph: ModuleGraph) =
     of backendCpp: commandCompileToC(graph)
     of backendObjc: commandCompileToC(graph)
     of backendJs: commandCompileToJS(graph)
-    of backendInvalid: doAssert false
+    of backendInvalid: raiseAssert "unreachable"
 
   template docLikeCmd(body) =
     when defined(leanCompiler):

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -140,7 +140,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
         # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
         if cmdPrefix.len == 0: cmdPrefix = findNodeJs().quoteShell
         cmdPrefix.add " --unhandled-rejections=strict"
-      else: doAssert false, $conf.backend
+      else: raiseAssert $conf.backend
       if cmdPrefix.len > 0: cmdPrefix.add " "
         # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:
         # `The parameter is incorrect`

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -663,7 +663,7 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
 template quitOrRaise*(conf: ConfigRef, msg = "") =
   # xxx in future work, consider whether to also intercept `msgQuit` calls
   if conf.isDefined("nimDebug"):
-    doAssert false, msg
+    raiseAssert msg
   else:
     quit(msg) # quits with QuitFailure
 

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -44,8 +44,7 @@ proc processPipeline(graph: ModuleGraph; semNode: PNode; bModule: PPassContext):
   of EvalPass, InterpreterPass:
     result = interpreterCode(bModule, semNode)
   of NonePass:
-    result = nil
-    doAssert false, "use setPipeLinePass to set a proper PipelinePass"
+    raiseAssert "use setPipeLinePass to set a proper PipelinePass"
 
 proc processImplicitImports(graph: ModuleGraph; implicits: seq[string], nodeKind: TNodeKind,
                       m: PSym, ctx: PContext, bModule: PPassContext, idgen: IdGenerator,
@@ -133,8 +132,7 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
     of SemPass:
       nil
     of NonePass:
-      doAssert false, "use setPipeLinePass to set a proper PipelinePass"
-      nil
+      raiseAssert "use setPipeLinePass to set a proper PipelinePass"
 
   if stream == nil:
     let filename = toFullPathConsiderDirty(graph.config, fileIdx)
@@ -208,7 +206,7 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
     when not defined(leanCompiler):
       discard closeJson(graph, bModule, finalNode)
   of NonePass:
-    doAssert false, "use setPipeLinePass to set a proper PipelinePass"
+    raiseAssert "use setPipeLinePass to set a proper PipelinePass"
 
   if graph.config.backend notin {backendC, backendCpp, backendObjc}:
     # We only write rod files here if no C-like backend is active.

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -76,7 +76,7 @@ proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
           if i >= frmt.len or frmt[i] notin {'0'..'9'}: break
         num = j
         if j > high(args) + 1:
-          doAssert false, "invalid format string: " & frmt
+          raiseAssert "invalid format string: " & frmt
         else:
           result.add(args[j-1])
       of '{':
@@ -88,10 +88,10 @@ proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
         num = j
         if frmt[i] == '}': inc(i)
         else:
-          doAssert false, "invalid format string: " & frmt
+          raiseAssert "invalid format string: " & frmt
 
         if j > high(args) + 1:
-          doAssert false, "invalid format string: " & frmt
+          raiseAssert "invalid format string: " & frmt
         else:
           result.add(args[j-1])
       of 'n':
@@ -101,7 +101,7 @@ proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
         result.add("\n")
         inc(i)
       else:
-        doAssert false, "invalid format string: " & frmt
+        raiseAssert "invalid format string: " & frmt
     else:
       result.add(frmt[i])
       inc(i)

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -240,7 +240,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
     of gcAtomicArc:
       defineSymbol(conf.symbols, "gcatomicarc")
     else:
-      doAssert false, "unreachable"
+      raiseAssert "unreachable"
 
   # ensure we load 'system.nim' again for the real non-config stuff!
   resetSystemArtifacts(graph)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -594,7 +594,7 @@ proc defaultFieldsForTuple(c: PContext, recNode: PNode, hasDefault: var bool, ch
       asgnExpr.typ = recNode.typ
       result.add newTree(nkExprColonExpr, recNode, asgnExpr)
   else:
-    doAssert false
+    raiseAssert "unreachable"
 
 proc defaultFieldsForTheUninitialized(c: PContext, recNode: PNode, checkDefault: bool): seq[PNode] =
   result = @[]
@@ -630,7 +630,7 @@ proc defaultFieldsForTheUninitialized(c: PContext, recNode: PNode, checkDefault:
         asgnExpr.flags.incl nfSkipFieldChecking
         result.add newTree(nkExprColonExpr, recNode, asgnExpr)
   else:
-    doAssert false
+    raiseAssert "unreachable"
 
 proc defaultNodeField(c: PContext, a: PNode, aTyp: PType, checkDefault: bool): PNode =
   let aTypSkip = aTyp.skipTypes(defaultFieldsSkipTypes)

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -408,8 +408,7 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): P
       result = a
       result.typ = n.typ
     else:
-      result = nil
-      doAssert false, $srcTyp.kind
+      raiseAssert $srcTyp.kind
   of tyInt..tyInt64, tyUInt..tyUInt64:
     case srcTyp.kind
     of tyFloat..tyFloat64:

--- a/compiler/tccgen.nim
+++ b/compiler/tccgen.nim
@@ -14,7 +14,7 @@ const tinyPrefix = "dist/nim-tinyc-archive".unixToNativePath
 const nimRoot = currentSourcePath.parentDir.parentDir
 const tinycRoot = nimRoot / tinyPrefix
 when not dirExists(tinycRoot):
-  static: doAssert false, $(tinycRoot, "requires: ./koch installdeps tinyc")
+  static: raiseAssert $(tinycRoot, "requires: ./koch installdeps tinyc")
 {.compile: tinycRoot / "tinyc/libtcc.c".}
 
 var

--- a/compiler/vmconv.nim
+++ b/compiler/vmconv.nim
@@ -16,7 +16,7 @@ proc fromLit*(a: PNode, T: typedesc): auto =
     for ai in a:
       result.incl Ti(ai.intVal)
   else:
-    static: doAssert false, "not yet supported: " & $T # add as needed
+    static: raiseAssert "not yet supported: " & $T # add as needed
 
 proc toLit*[T](a: T): PNode =
   ## generic type => PNode
@@ -43,7 +43,7 @@ proc toLit*[T](a: T): PNode =
       reti.add ai.toLit
       result.add reti
   else:
-    static: doAssert false, "not yet supported: " & $T # add as needed
+    static: raiseAssert "not yet supported: " & $T # add as needed
 
 proc toTimeLit*(a: Time, c: PCtx, obj: PNode, info: TLineInfo): PNode =
   # probably refactor it into `toLit` in the future

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -366,7 +366,7 @@ proc genBlock(c: PCtx; n: PNode; dest: var TDest) =
                                   slotTempFloat,
                                   slotTempStr,
                                   slotTempComplex}:
-          doAssert false, "leaking temporary " & $i & " " & $c.prc.regInfo[i].kind
+          raiseAssert "leaking temporary " & $i & " " & $c.prc.regInfo[i].kind
       c.prc.regInfo[i] = (inUse: false, kind: slotEmpty)
 
   c.clearDest(n, dest)
@@ -1073,7 +1073,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     case n[1].typ.skipTypes(abstractVarRange).kind
     of tyString: genUnaryABI(c, n, dest, opcLenStr)
     of tyCstring: genUnaryABI(c, n, dest, opcLenCstring)
-    else: doAssert false, $n[1].typ.kind
+    else: raiseAssert $n[1].typ.kind
   of mSlice:
     var
       d = c.genx(n[1])

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -69,9 +69,7 @@ proc getVar*(a: VmArgs; i: Natural): PNode =
   case p.kind
   of rkRegisterAddr: result = p.regAddr.node
   of rkNodeAddr: result = p.nodeAddr[]
-  else:
-    result = nil
-    doAssert false, $p.kind
+  else: raiseAssert $p.kind
 
 proc getNodeAddr*(a: VmArgs; i: Natural): PNode =
   let nodeAddr = getX(rkNodeAddr, nodeAddr)

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -243,7 +243,7 @@ proc registerAdditionalOps*(c: PCtx) =
     case n
     of 1: setResult(a, round(getFloat(a, 0)))
     of 2: setResult(a, round(getFloat(a, 0), getInt(a, 1).int))
-    else: doAssert false, $n
+    else: raiseAssert $n
 
   proc `mod Wrapper`(a: VmArgs) {.nimcall.} =
     setResult(a, `mod`(getFloat(a, 0), getFloat(a, 1)))


### PR DESCRIPTION
`raiseAssert` has the `noreturn` pragma, which works better with `strictdefs` since you don't need to specify the initialization on an unreachable branch while it's a pain for `doAssert` false. But perhaps making a new `unreachable` function serves the purpose better.