### PR TITLE
Fix #21742: Check generic alias depth before skip

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1455,11 +1455,15 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     var prev = PType(idTableGet(c.bindings, f))
     let origF = f
     var f = if prev == nil: f else: prev
+
+    let deptha = a.genericAliasDepth()
+    let depthf = f.genericAliasDepth()
+    let skipBoth = deptha == depthf and (a.len > 0 and f.len > 0 and a.base != f.base)
+
+    let roota = if skipBoth or deptha > depthf: a.skipGenericAlias else: a
+    let rootf = if skipBoth or depthf > deptha: f.skipGenericAlias else: f
+
     if a.kind == tyGenericInst:
-      # If they are lined up skipping could lead to losing generic parameters
-      let shouldSkip = a.base != f.base
-      let roota = if shouldSkip: a.skipGenericAlias else: a
-      let rootf = if shouldSkip: f.skipGenericAlias else: f
       if roota.base == rootf.base:
         let nextFlags = flags + {trNoCovariance}
         var hasCovariance = false

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1455,11 +1455,11 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     var prev = PType(idTableGet(c.bindings, f))
     let origF = f
     var f = if prev == nil: f else: prev
-
-    let roota = a.skipGenericAlias
-    let rootf = f.skipGenericAlias
-
     if a.kind == tyGenericInst:
+      # If they are lined up skipping could lead to losing generic parameters
+      let shouldSkip = a.base != f.base
+      let roota = if shouldSkip: a.skipGenericAlias else: a
+      let rootf = if shouldSkip: f.skipGenericAlias else: f
       if roota.base == rootf.base:
         let nextFlags = flags + {trNoCovariance}
         var hasCovariance = false

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1173,8 +1173,7 @@ proc sameChildrenAux(a, b: PType, c: var TSameTypeClosure): bool =
     if not result: return
 
 proc isGenericAlias*(t: PType): bool =
-  return t.kind == tyGenericInst and t.lastSon.kind == tyGenericInst and
-    t.len() <= t.lastSon.len()
+  return t.kind == tyGenericInst and t.lastSon.kind == tyGenericInst
 
 proc skipGenericAlias*(t: PType): PType =
   return if t.isGenericAlias: t.lastSon else: t

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1175,7 +1175,15 @@ proc sameChildrenAux(a, b: PType, c: var TSameTypeClosure): bool =
 proc isGenericAlias*(t: PType): bool =
   return t.kind == tyGenericInst and t.lastSon.kind == tyGenericInst
 
+proc genericAliasDepth*(t: PType): int =
+  result = 0
+  var it = t
+  while it.isGenericAlias:
+    it = it.lastSon
+    inc result
+
 proc skipGenericAlias*(t: PType): PType =
+  # TODO: Calc alias depth
   return if t.isGenericAlias: t.lastSon else: t
 
 proc sameFlags*(a, b: PType): bool {.inline.} =

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1183,7 +1183,6 @@ proc genericAliasDepth*(t: PType): int =
     inc result
 
 proc skipGenericAlias*(t: PType): PType =
-  # TODO: Calc alias depth
   return if t.isGenericAlias: t.lastSon else: t
 
 proc sameFlags*(a, b: PType): bool {.inline.} =

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1173,7 +1173,8 @@ proc sameChildrenAux(a, b: PType, c: var TSameTypeClosure): bool =
     if not result: return
 
 proc isGenericAlias*(t: PType): bool =
-  return t.kind == tyGenericInst and t.lastSon.kind == tyGenericInst
+  return t.kind == tyGenericInst and t.lastSon.kind == tyGenericInst and
+    t.len() <= t.lastSon.len()
 
 proc skipGenericAlias*(t: PType): PType =
   return if t.isGenericAlias: t.lastSon else: t

--- a/tests/generics/t21742.nim
+++ b/tests/generics/t21742.nim
@@ -1,0 +1,10 @@
+type
+  Foo[T] = object
+    x:T
+  Bar[T,R] = Foo[T]
+  Baz = Bar[int,float]
+
+proc qux[T,R](x: Bar[T,R]) = discard
+
+var b:Baz
+b.qux()


### PR DESCRIPTION
Close #21742

Checking if there's any side-effects and if just changing typeRel is adequate for this issue before trying to look into related ones.

`skipBoth` is also not that great, it can lead to code that works sometimes but fails when the proc is instantiated with branching aliases. This is mostly an issue with error clarity though.