### PR TITLE
fix #22218 copy generated for non-copyable type

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1270,7 +1270,6 @@ proc extractPragma*(s: PSym): PNode =
       result = nil
   else:
     result = nil
-  assert result == nil or result.kind == nkPragma
 
 proc skipPragmaExpr*(n: PNode): PNode =
   ## if pragma expr, give the node the pragmas are applied to,

--- a/tests/arc/t22218.nim
+++ b/tests/arc/t22218.nim
@@ -1,0 +1,24 @@
+discard """
+  cmd: "nim c --gc:arc $file"
+  errormsg: "A channel cannot be copied; usage of '=copy' is an {.error.} defined at t22218.nim(9, 1)"
+"""
+
+type Obj[T] = object
+  v: T
+
+proc `=copy`[T](
+    dest: var Obj[T],
+    source: Obj[T]
+  ) {.error: "A channel cannot be copied".}
+
+from system/ansi_c import c_calloc
+
+proc test() =
+    var v: bool = true
+    var chan = cast[ptr Obj[int]](c_calloc(1, csize_t sizeof(Obj[int])))
+    var copy = chan[]
+
+    echo chan.v
+    echo v
+
+test()


### PR DESCRIPTION
deleted `assert` fails when I run testament locally.