### PR TITLE
fixes #22357; don't sink elements of var tuple cursors

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -185,7 +185,9 @@ proc isCursor(n: PNode): bool =
 template isUnpackedTuple(n: PNode): bool =
   ## we move out all elements of unpacked tuples,
   ## hence unpacked tuples themselves don't need to be destroyed
-  (n.kind == nkSym and n.sym.kind == skTemp and n.sym.typ.kind == tyTuple)
+  ## except it's already a cursor
+  (n.kind == nkSym and n.sym.kind == skTemp and
+   n.sym.typ.kind == tyTuple and sfCursor notin n.sym.flags)
 
 proc checkForErrorPragma(c: Con; t: PType; ri: PNode; opname: string; inferredFromCopy = false) =
   var m = "'" & opname & "' is not available for type <" & typeToString(t) & ">"


### PR DESCRIPTION
fixes #22357

I haven't had figured out a small test case, but it works locally for me.

![image](https://github.com/nim-lang/Nim/assets/43030857/4733ab36-5410-4b6f-8943-ee5d122afed6)


Btw, @vsajip, I have some workarounds for you

change
```nim
(op, operand) = elements[0]
```
into 
```nim
let tmp = elements[0]
op = tmp[0]
operand = tmp[1]
```
Or just
```nim
op = elements[0][0]
operand = elements[0][1]
```