### PR TITLE
avoid pragmaLine cause os error, when input is basic filename, eg. as…

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -672,8 +672,9 @@ proc pragmaLine(c: PContext, n: PNode) =
       elif y.kind != nkIntLit:
         localError(c.config, n.info, errIntLiteralExpected)
       else:
-        n.info.fileIndex = fileInfoIdx(c.config, AbsoluteFile(x.strVal))
-        n.info.line = uint16(y.intVal)
+        if x.strVal.isAbsolute:
+          n.info.fileIndex = fileInfoIdx(c.config, AbsoluteFile(x.strVal))
+          n.info.line = uint16(y.intVal)
     else:
       localError(c.config, n.info, "tuple expected")
   else:


### PR DESCRIPTION
…sert used in iterators.nim

every time run `koch` I get several errors, I found this by echo exception in `excpt.nim`, maybe give a warning is better, I don't know, for now avoid this.

full log:

```
/Users/bung/nim-works/Nim/compiler/nim.nim(167) nim
/Users/bung/nim-works/Nim/compiler/nim.nim(122) handleCmdLine
/Users/bung/nim-works/Nim/compiler/main.nim(307) mainCommand
/Users/bung/nim-works/Nim/compiler/main.nim(276) compileToBackend
/Users/bung/nim-works/Nim/compiler/main.nim(138) commandCompileToC
/Users/bung/nim-works/Nim/compiler/pipelines.nim(298) compilePipelineProject
/Users/bung/nim-works/Nim/compiler/pipelines.nim(279) compilePipelineSystemModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(229) compilePipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(176) processPipelineModule
/Users/bung/nim-works/Nim/compiler/sem.nim(809) semWithPContext
/Users/bung/nim-works/Nim/compiler/sem.nim(778) semStmtAndGenerateGenerics
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2610) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3273) semExpr
/Users/bung/nim-works/Nim/compiler/importer.nim(355) evalImport
/Users/bung/nim-works/Nim/compiler/importer.nim(323) impMod
/Users/bung/nim-works/Nim/compiler/importer.nim(294) myImportModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(258) importPipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(229) compilePipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(176) processPipelineModule
/Users/bung/nim-works/Nim/compiler/sem.nim(809) semWithPContext
/Users/bung/nim-works/Nim/compiler/sem.nim(778) semStmtAndGenerateGenerics
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2610) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3257) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2401) semIterator
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2348) semProcAux
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1951) semProcBody
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3247) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(110) semWhile
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3121) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1148) semDirectOp
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1027) afterCallActions
/Users/bung/nim-works/Nim/compiler/semexprs.nim(40) semTemplateExpr
/Users/bung/nim-works/Nim/compiler/sem.nim(443) semAfterMacroCall
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3121) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1148) semDirectOp
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1027) afterCallActions
/Users/bung/nim-works/Nim/compiler/semexprs.nim(40) semTemplateExpr
/Users/bung/nim-works/Nim/compiler/sem.nim(443) semAfterMacroCall
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3166) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(2525) semWhen
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3291) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2531) semPragmaBlock
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1357) pragma
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1351) pragmaRec
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1230) singlePragma
/Users/bung/nim-works/Nim/compiler/pragmas.nim(676) pragmaLine
/Users/bung/nim-works/Nim/compiler/msgs.nim(129) fileInfoIdx
/Users/bung/nim-works/Nim/compiler/msgs.nim(107) fileInfoIdx
/Users/bung/nim-works/Nim/compiler/options.nim(755) canonicalizePath
/Users/bung/nim-works/Nim/lib/pure/os.nim(451) expandFilename
/Users/bung/nim-works/Nim/lib/std/oserrors.nim(92) raiseOSError

 {.line: loc`gensym24.}:
  if not (len(a) == L):
    failedAssertImpl(ploc`gensym24 & " `" & "len(a) == L" & "` " &
        "the length of the string changed while iterating over it")
line: (filename: "iterators.nim", line: 273, column: 10)
expandFilename:iterators.nim
```