### PR TITLE
avoid pragmaLine cause os error

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -99,6 +99,9 @@ proc fileInfoKnown*(conf: ConfigRef; filename: AbsoluteFile): bool =
   result = conf.m.filenameToIndexTbl.hasKey(canon.string)
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool): FileIndex =
+  result = conf.fileIdxTbl.getOrDefault(filename.string, InvalidFileIdx)
+  if result != InvalidFileIdx:
+    return
   var
     canon: AbsoluteFile
     pseudoPath = false
@@ -123,6 +126,7 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
     conf.m.fileInfos.add(newFileInfo(canon, if pseudoPath: RelativeFile filename
                                             else: relativeTo(canon, conf.projectPath)))
     conf.m.filenameToIndexTbl[canon2] = result
+  conf.fileIdxTbl[filename.string] = result
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile): FileIndex =
   var dummy: bool

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -417,6 +417,7 @@ type
     expandLevels*: int
     expandNodeResult*: string
     expandPosition*: TLineInfo
+    fileIdxTbl*: Table[string, FileIndex]
 
 
 proc parseNimVersion*(a: string): NimVer =
@@ -582,6 +583,7 @@ proc newConfigRef*(): ConfigRef =
     maxLoopIterationsVM: 10_000_000,
     vmProfileData: newProfileData(),
     spellSuggestMax: spellSuggestSecretSauce,
+    fileIdxTbl: initTable[string, FileIndex](),
   )
   initConfigRefCommon(result)
   setTargetFromSystem(result.target)

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -107,7 +107,7 @@ since (1, 5):
     const
       loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
       msg = getMsg(loc, astToStr(assertion)).cstring
-    {.line: loc.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       {.emit: ["console.assert(", assertion, ", ", msg, ");"].}
 
   func dir*(console: Console; obj: auto) {.importcpp.}

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -47,7 +47,7 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
       ploc = $loc
     bind instantiationInfo
     mixin failedAssertImpl
-    {.line: loc.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       if not cond:
         failedAssertImpl(ploc & " `" & expr & "` " & msg)
 


### PR DESCRIPTION
avoid `pragmaLine` cause os error, when input is basic filename, eg. `assert` used in iterators.nim

every time run `koch` I get several errors, I found this by echo exception in `excpt.nim`

<s>the `instantiationInfo` do file index -> filename convert, then `pragmaLine`  do filename -> file index convert, which is not needed when the line info is provided through `instantiationInfo`</s>

full log:

```
/Users/bung/nim-works/Nim/compiler/nim.nim(167) nim
/Users/bung/nim-works/Nim/compiler/nim.nim(122) handleCmdLine
/Users/bung/nim-works/Nim/compiler/main.nim(307) mainCommand
/Users/bung/nim-works/Nim/compiler/main.nim(276) compileToBackend
/Users/bung/nim-works/Nim/compiler/main.nim(138) commandCompileToC
/Users/bung/nim-works/Nim/compiler/pipelines.nim(298) compilePipelineProject
/Users/bung/nim-works/Nim/compiler/pipelines.nim(279) compilePipelineSystemModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(229) compilePipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(176) processPipelineModule
/Users/bung/nim-works/Nim/compiler/sem.nim(809) semWithPContext
/Users/bung/nim-works/Nim/compiler/sem.nim(778) semStmtAndGenerateGenerics
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2610) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3273) semExpr
/Users/bung/nim-works/Nim/compiler/importer.nim(355) evalImport
/Users/bung/nim-works/Nim/compiler/importer.nim(323) impMod
/Users/bung/nim-works/Nim/compiler/importer.nim(294) myImportModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(258) importPipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(229) compilePipelineModule
/Users/bung/nim-works/Nim/compiler/pipelines.nim(176) processPipelineModule
/Users/bung/nim-works/Nim/compiler/sem.nim(809) semWithPContext
/Users/bung/nim-works/Nim/compiler/sem.nim(778) semStmtAndGenerateGenerics
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2610) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3257) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2401) semIterator
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2348) semProcAux
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1951) semProcBody
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3247) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(110) semWhile
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3121) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1148) semDirectOp
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1027) afterCallActions
/Users/bung/nim-works/Nim/compiler/semexprs.nim(40) semTemplateExpr
/Users/bung/nim-works/Nim/compiler/sem.nim(443) semAfterMacroCall
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3121) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1148) semDirectOp
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1027) afterCallActions
/Users/bung/nim-works/Nim/compiler/semexprs.nim(40) semTemplateExpr
/Users/bung/nim-works/Nim/compiler/sem.nim(443) semAfterMacroCall
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2665) semStmt
/Users/bung/nim-works/Nim/compiler/semexprs.nim(1166) semExprNoType
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3166) semExpr
/Users/bung/nim-works/Nim/compiler/semexprs.nim(2525) semWhen
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3240) semExpr
/Users/bung/nim-works/Nim/lib/system.nim(938) semStmtList
/Users/bung/nim-works/Nim/compiler/semexprs.nim(3291) semExpr
/Users/bung/nim-works/Nim/compiler/semstmts.nim(2531) semPragmaBlock
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1357) pragma
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1351) pragmaRec
/Users/bung/nim-works/Nim/compiler/pragmas.nim(1230) singlePragma
/Users/bung/nim-works/Nim/compiler/pragmas.nim(676) pragmaLine
/Users/bung/nim-works/Nim/compiler/msgs.nim(129) fileInfoIdx
/Users/bung/nim-works/Nim/compiler/msgs.nim(107) fileInfoIdx
/Users/bung/nim-works/Nim/compiler/options.nim(755) canonicalizePath
/Users/bung/nim-works/Nim/lib/pure/os.nim(451) expandFilename
/Users/bung/nim-works/Nim/lib/std/oserrors.nim(92) raiseOSError

 {.line: loc`gensym24.}:
  if not (len(a) == L):
    failedAssertImpl(ploc`gensym24 & " `" & "len(a) == L" & "` " &
        "the length of the string changed while iterating over it")
line: (filename: "iterators.nim", line: 273, column: 10)
expandFilename:iterators.nim
```