### PR TITLE
Fix #22366 by making nimlf_/nimln_ part of the same line 

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -312,10 +312,10 @@ proc genLineDir(p: BProc, t: PNode) =
       (p.prc == nil or sfPure notin p.prc.flags) and t.info.fileIndex != InvalidFileIdx:
       if freshLine:
         if lastFileIndex == t.info.fileIndex:
-          linefmt(p, cpsStmts, "nimln_($1);\n",
+          linefmt(p, cpsStmts, "nimln_($1);",
               [line])
         else:
-          linefmt(p, cpsStmts, "nimlf_($1, $2);\n",
+          linefmt(p, cpsStmts, "nimlf_($1, $2);",
               [line, quotedFilename(p.config, t.info)])
 
 proc accessThreadLocalVar(p: BProc, s: PSym)


### PR DESCRIPTION
Make nimlf_/nimln_ part of the same line so the debugger doesn't advance to the next line before executing it.

Back when it was working correctly, the code looked like this (I trimmed the paths for clarity and privacy):

    #line 8 "bug.nim"
	    nimln_(8, "bug.nim");
    #line 8 "bug.nim"
	    hello__bug_u1();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;
    #line 9 "bug.nim"
	    nimln_(9, "bug.nim");
    #line 9 "bug.nim"
	    world__bug_u2();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;

Note the redundant line directives. Commit 91abf35442d6f0861db659c5332b481bd24dfedb set to fix it (as well as cleaning it up by removing the unnecessary file paths and other things). The result was something like this:

    #line 8 "bug.nim"
	    nimlf_(8, "bug.nim");
	    hello__bug_u1();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;
    #line 9
	    nimln_(9);
	    world__bug_u2();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;

But the problem is that if `nimlf_` was the line 8, hello__bug_u1(); was the line 9. It seems the compiler was using *both* line directives, breaking before the first one, and advancing all the lines that were the same number at once. So one solution is to put back the "redundant" line directives. Another solution I've found that is probably better is to just eliminate the line break, so both statements are the same line.

    #line 8 "bug.nim"
	    nimlf_(8, "bug.nim"); 	hello__bug_u1();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;
    #line 9
	    nimln_(9); 	world__bug_u2();
	    if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;

The `if(*nimErr_)` line doesn't seem to appear in the debugger as an extra line when stepping (at least with this simple example), so we probably don't need to give it the same treatment.

The solution that I was going to use initially is to put the line directive just after the `nimlf_`/`nimln_`, but it seems that messes things up in other ways, in addition to being more confusing.