### PR TITLE
Markdown code blocks migration part 9

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -227,7 +227,7 @@ proc getNamedParamFromList*(list: PNode, ident: PIdent): PSym =
   ## Named parameters are special because a named parameter can be
   ## gensym'ed and then they have '\`<number>' suffix that we need to
   ## ignore, see compiler / evaltempl.nim, snippet:
-  ##   ```
+  ##   ```nim
   ##   result.add newIdentNode(getIdent(c.ic, x.name.s & "\`gensym" & $x.id),
   ##            if c.instLines: actual.info else: templ.info)
   ##   ```

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -576,7 +576,7 @@ proc inconsistentVarTypes(f, a: PType): bool {.inline.} =
 
 proc procParamTypeRel(c: var TCandidate, f, a: PType): TTypeRelation =
   ## For example we have:
-  ##   ```
+  ##   ```nim
   ##   proc myMap[T,S](sIn: seq[T], f: proc(x: T): S): seq[S] = ...
   ##   proc innerProc[Q,W](q: Q): W = ...
   ##   ```

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1055,7 +1055,7 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ##   ```
   ##
   ## Outputs:
-  ##   ```nim
+  ##   ```
   ##   StmtList
   ##     Command
   ##       Ident "echo"
@@ -1079,7 +1079,7 @@ macro dumpLisp*(s: untyped): untyped = echo s.lispRepr(indented = true)
   ##   ```
   ##
   ## Outputs:
-  ##   ```nim
+  ##   ```
   ##   (StmtList
   ##    (Command
   ##     (Ident "echo")
@@ -1102,7 +1102,7 @@ macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ##   ```
   ##
   ## Outputs:
-  ##   ```nim
+  ##   ```
   ##   nnkStmtList.newTree(
   ##     nnkCommand.newTree(
   ##       newIdentNode("echo"),

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -208,7 +208,7 @@ template `or`*(x, y: NimNode): NimNode =
   ## Evaluate `x` and when it is not an empty node, return
   ## it. Otherwise evaluate to `y`. Can be used to chain several
   ## expressions to get the first expression that is not empty.
-  ##   ```
+  ##   ```nim
   ##   let node = mightBeEmpty() or mightAlsoBeEmpty() or fallbackNode
   ##   ```
 
@@ -590,7 +590,7 @@ proc getAst*(macroOrTemplate: untyped): NimNode {.magic: "ExpandToAst", noSideEf
   ## Obtains the AST nodes returned from a macro or template invocation.
   ## See also `genasts.genAst`.
   ## Example:
-  ##   ```
+  ##   ```nim
   ##   macro FooMacro() =
   ##     var ast = getAst(BarTemplate())
   ##   ```
@@ -1049,13 +1049,13 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ## a certain expression/statement.
   ##
   ## For example:
-  ##   ```
+  ##   ```nim
   ##   dumpTree:
   ##     echo "Hello, World!"
   ##   ```
   ##
   ## Outputs:
-  ##   ```
+  ##   ```nim
   ##   StmtList
   ##     Command
   ##       Ident "echo"
@@ -1073,13 +1073,13 @@ macro dumpLisp*(s: untyped): untyped = echo s.lispRepr(indented = true)
   ## a certain expression/statement.
   ##
   ## For example:
-  ##   ```
+  ##   ```nim
   ##   dumpLisp:
   ##     echo "Hello, World!"
   ##   ```
   ##
   ## Outputs:
-  ##   ```
+  ##   ```nim
   ##   (StmtList
   ##    (Command
   ##     (Ident "echo")
@@ -1096,13 +1096,13 @@ macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ## outputs and then copying the snippets into the macro for modification.
   ##
   ## For example:
-  ##   ```
+  ##   ```nim
   ##   dumpAstGen:
   ##     echo "Hello, World!"
   ##   ```
   ##
   ## Outputs:
-  ##   ```
+  ##   ```nim
   ##   nnkStmtList.newTree(
   ##     nnkCommand.newTree(
   ##       newIdentNode("echo"),
@@ -1179,7 +1179,7 @@ proc newIdentDefs*(name, kind: NimNode;
   ## `let` or `var` blocks may have an empty `kind` node if the
   ## identifier is being assigned a value. Example:
   ##
-  ##   ```
+  ##   ```nim
   ##   var varSection = newNimNode(nnkVarSection).add(
   ##     newIdentDefs(ident("a"), ident("string")),
   ##     newIdentDefs(ident("b"), newEmptyNode(), newLit(3)))
@@ -1190,7 +1190,7 @@ proc newIdentDefs*(name, kind: NimNode;
   ##
   ## If you need to create multiple identifiers you need to use the lower level
   ## `newNimNode`:
-  ##   ```
+  ##   ```nim
   ##   result = newNimNode(nnkIdentDefs).add(
   ##     ident("a"), ident("b"), ident("c"), ident("string"),
   ##       newStrLitNode("Hello"))
@@ -1241,7 +1241,7 @@ proc newProc*(name = newEmptyNode();
 
 proc newIfStmt*(branches: varargs[tuple[cond, body: NimNode]]): NimNode =
   ## Constructor for `if` statements.
-  ##   ```
+  ##   ```nim
   ##   newIfStmt(
   ##     (Ident, StmtList),
   ##     ...
@@ -1258,7 +1258,7 @@ proc newEnum*(name: NimNode, fields: openArray[NimNode],
 
   ## Creates a new enum. `name` must be an ident. Fields are allowed to be
   ## either idents or EnumFieldDef:
-  ##   ```
+  ##   ```nim
   ##   newEnum(
   ##     name    = ident("Colors"),
   ##     fields  = [ident("Blue"), ident("Red")],
@@ -1429,7 +1429,7 @@ iterator children*(n: NimNode): NimNode {.inline.} =
 
 template findChild*(n: NimNode; cond: untyped): NimNode {.dirty.} =
   ## Find the first child node matching condition (or nil).
-  ##   ```
+  ##   ```nim
   ##   var res = findChild(n, it.kind == nnkPostfix and
   ##                          it.basename.ident == ident"foo")
   ##   ```
@@ -1536,7 +1536,7 @@ macro expandMacros*(body: typed): untyped =
   ##
   ## For instance,
   ##
-  ##   ```
+  ##   ```nim
   ##   import std/[sugar, macros]
   ##
   ##   let
@@ -1652,7 +1652,7 @@ macro hasCustomPragma*(n: typed, cp: typed{nkSym}): untyped =
   ##
   ## See also `getCustomPragmaVal`_.
   ##
-  ##   ```
+  ##   ```nim
   ##   template myAttr() {.pragma.}
   ##   type
   ##     MyObj = object
@@ -1677,7 +1677,7 @@ macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
   ##
   ## See also `hasCustomPragma`_.
   ##
-  ##   ```
+  ##   ```nim
   ##   template serializationKey(key: string) {.pragma.}
   ##   type
   ##     MyObj {.serializationKey: "mo".} = object
@@ -1773,7 +1773,7 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
   ## runnableExamples in `a`, stopping at the first child that is neither.
   ## Example:
   ##
-  ##   ```
+  ##   ```nim
   ##   import std/macros
   ##   macro transf(a): untyped =
   ##     result = quote do:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -108,7 +108,7 @@ proc `addr`*[T](x: T): ptr T {.magic: "Addr", noSideEffect.} =
   ##
   ## Cannot be overloaded.
   ##
-  ##   ```
+  ##   ```nim
   ##   var
   ##     buf: seq[char] = @['a','b','c']
   ##     p = buf[1].addr
@@ -194,7 +194,7 @@ proc high*[T: Ordinal|enum|range](x: T): T {.magic: "High", noSideEffect,
   ## **This proc is deprecated**, use this one instead:
   ## * `high(typedesc) <#high,typedesc[T]>`_
   ##
-  ## ```
+  ## ```nim
   ## high(2) # => 9223372036854775807
   ## ```
 
@@ -202,7 +202,7 @@ proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffe
   ## Returns the highest possible value of an ordinal or enum type.
   ##
   ## `high(int)` is Nim's way of writing `INT_MAX`:idx: or `MAX_INT`:idx:.
-  ##   ```
+  ##   ```nim
   ##   high(int) # => 9223372036854775807
   ##   ```
   ##
@@ -211,7 +211,7 @@ proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffe
 
 proc high*[T](x: openArray[T]): int {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of a sequence `x`.
-  ##   ```
+  ##   ```nim
   ##   var s = @[1, 2, 3, 4, 5, 6, 7]
   ##   high(s) # => 6
   ##   for i in low(s)..high(s):
@@ -225,7 +225,7 @@ proc high*[I, T](x: array[I, T]): I {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of an array `x`.
   ##
   ## For empty arrays, the return type is `int`.
-  ##   ```
+  ##   ```nim
   ##   var arr = [1, 2, 3, 4, 5, 6, 7]
   ##   high(arr) # => 6
   ##   for i in low(arr)..high(arr):
@@ -239,7 +239,7 @@ proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of an array type.
   ##
   ## For empty arrays, the return type is `int`.
-  ##   ```
+  ##   ```nim
   ##   high(array[7, int]) # => 6
   ##   ```
   ##
@@ -255,7 +255,7 @@ proc high*(x: cstring): int {.magic: "High", noSideEffect.}
 
 proc high*(x: string): int {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of a string `x`.
-  ##   ```
+  ##   ```nim
   ##   var str = "Hello world!"
   ##   high(str) # => 11
   ##   ```
@@ -271,7 +271,7 @@ proc low*[T: Ordinal|enum|range](x: T): T {.magic: "Low", noSideEffect,
   ## **This proc is deprecated**, use this one instead:
   ## * `low(typedesc) <#low,typedesc[T]>`_
   ##
-  ## ```
+  ## ```nim
   ## low(2) # => -9223372036854775808
   ## ```
 
@@ -279,7 +279,7 @@ proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect
   ## Returns the lowest possible value of an ordinal or enum type.
   ##
   ## `low(int)` is Nim's way of writing `INT_MIN`:idx: or `MIN_INT`:idx:.
-  ##   ```
+  ##   ```nim
   ##   low(int) # => -9223372036854775808
   ##   ```
   ##
@@ -288,7 +288,7 @@ proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect
 
 proc low*[T](x: openArray[T]): int {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of a sequence `x`.
-  ##   ```
+  ##   ```nim
   ##   var s = @[1, 2, 3, 4, 5, 6, 7]
   ##   low(s) # => 0
   ##   for i in low(s)..high(s):
@@ -302,7 +302,7 @@ proc low*[I, T](x: array[I, T]): I {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of an array `x`.
   ##
   ## For empty arrays, the return type is `int`.
-  ##   ```
+  ##   ```nim
   ##   var arr = [1, 2, 3, 4, 5, 6, 7]
   ##   low(arr) # => 0
   ##   for i in low(arr)..high(arr):
@@ -316,7 +316,7 @@ proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of an array type.
   ##
   ## For empty arrays, the return type is `int`.
-  ##   ```
+  ##   ```nim
   ##   low(array[7, int]) # => 0
   ##   ```
   ##
@@ -331,7 +331,7 @@ proc low*(x: cstring): int {.magic: "Low", noSideEffect.}
 
 proc low*(x: string): int {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of a string `x`.
-  ##   ```
+  ##   ```nim
   ##   var str = "Hello world!"
   ##   low(str) # => 0
   ##   ```
@@ -409,7 +409,7 @@ proc `..`*[T, U](a: sink T, b: sink U): HSlice[T, U] {.noSideEffect, inline, mag
   ##
   ## Slices can also be used in the set constructor and in ordinal case
   ## statements, but then they are special-cased by the compiler.
-  ##   ```
+  ##   ```nim
   ##   let a = [10, 20, 30, 40, 50]
   ##   echo a[2 .. 3] # @[30, 40]
   ##   ```
@@ -418,7 +418,7 @@ proc `..`*[T, U](a: sink T, b: sink U): HSlice[T, U] {.noSideEffect, inline, mag
 proc `..`*[T](b: sink T): HSlice[int, T]
   {.noSideEffect, inline, magic: "DotDot", deprecated: "replace `..b` with `0..b`".} =
   ## Unary `slice`:idx: operator that constructs an interval `[default(int), b]`.
-  ##   ```
+  ##   ```nim
   ##   let a = [10, 20, 30, 40, 50]
   ##   echo a[.. 2] # @[10, 20, 30]
   ##   ```
@@ -573,7 +573,7 @@ proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
   ## sizeof should fallback to the `sizeof` in the C compiler. The
   ## result isn't available for the Nim compiler and therefore can't
   ## be used inside of macros.
-  ##   ```
+  ##   ```nim
   ##   sizeof('A') # => 1
   ##   sizeof(2) # => 8
   ##   ```
@@ -604,7 +604,7 @@ proc newSeq*[T](s: var seq[T], len: Natural) {.magic: "NewSeq", noSideEffect.}
   ## Note that the sequence will be filled with zeroed entries.
   ## After the creation of the sequence you should assign entries to
   ## the sequence instead of adding them. Example:
-  ##   ```
+  ##   ```nim
   ##   var inputStrings: seq[string]
   ##   newSeq(inputStrings, 3)
   ##   assert len(inputStrings) == 3
@@ -620,7 +620,7 @@ proc newSeq*[T](len = 0.Natural): seq[T] =
   ## Note that the sequence will be filled with zeroed entries.
   ## After the creation of the sequence you should assign entries to
   ## the sequence instead of adding them.
-  ##   ```
+  ##   ```nim
   ##   var inputStrings = newSeq[string](3)
   ##   assert len(inputStrings) == 3
   ##   inputStrings[0] = "The fourth"
@@ -638,7 +638,7 @@ proc newSeqOfCap*[T](cap: Natural): seq[T] {.
   magic: "NewSeqOfCap", noSideEffect.} =
   ## Creates a new sequence of type `seq[T]` with length zero and capacity
   ## `cap`. Example:
-  ##   ```
+  ##   ```nim
   ##   var x = newSeqOfCap[int](5)
   ##   assert len(x) == 0
   ##   x.add(10)
@@ -654,7 +654,7 @@ when not defined(js):
     ## uninitialized. After the creation of the sequence you should assign
     ## entries to the sequence instead of adding them.
     ## Example:
-    ##   ```
+    ##   ```nim
     ##   var x = newSeqUninitialized[int](3)
     ##   assert len(x) == 3
     ##   x[0] = 10
@@ -748,7 +748,7 @@ include "system/setops"
 proc contains*[U, V, W](s: HSlice[U, V], value: W): bool {.noSideEffect, inline.} =
   ## Checks if `value` is within the range of `s`; returns true if
   ## `value >= s.a and value <= s.b`.
-  ##   ```
+  ##   ```nim
   ##   assert((1..3).contains(1) == true)
   ##   assert((1..3).contains(2) == true)
   ##   assert((1..3).contains(4) == false)
@@ -760,13 +760,13 @@ when not defined(nimHasCallsitePragma):
 
 template `in`*(x, y: untyped): untyped {.dirty, callsite.} = contains(y, x)
   ## Sugar for `contains`.
-  ##   ```
+  ##   ```nim
   ##   assert(1 in (1..3) == true)
   ##   assert(5 in (1..3) == false)
   ##   ```
 template `notin`*(x, y: untyped): untyped {.dirty, callsite.} = not contains(y, x)
   ## Sugar for `not contains`.
-  ##   ```
+  ##   ```nim
   ##   assert(1 notin (1..3) == false)
   ##   assert(5 notin (1..3) == true)
   ##   ```
@@ -776,7 +776,7 @@ proc `is`*[T, S](x: T, y: S): bool {.magic: "Is", noSideEffect.}
   ##
   ## For a negated version, use `isnot <#isnot.t,untyped,untyped>`_.
   ##
-  ##   ```
+  ##   ```nim
   ##   assert 42 is int
   ##   assert @[1, 2] is seq
   ##
@@ -791,7 +791,7 @@ proc `is`*[T, S](x: T, y: S): bool {.magic: "Is", noSideEffect.}
   ##   ```
 template `isnot`*(x, y: untyped): untyped {.callsite.} = not (x is y)
   ## Negated version of `is <#is,T,S>`_. Equivalent to `not(x is y)`.
-  ##   ```
+  ##   ```nim
   ##   assert 42 isnot float
   ##   assert @[1, 2] isnot enum
   ##   ```
@@ -887,7 +887,7 @@ proc cmp*[T](x, y: T): int =
   ##
   ## This is useful for writing generic algorithms without performance loss.
   ## This generic implementation uses the `==` and `<` operators.
-  ##   ```
+  ##   ```nim
   ##   import std/algorithm
   ##   echo sorted(@[4, 2, 6, 5, 8, 7], cmp[int])
   ##   ```
@@ -908,7 +908,7 @@ proc `@`* [IDX, T](a: sink array[IDX, T]): seq[T] {.magic: "ArrToSeq", noSideEff
   ## sequences with the array constructor: `@[1, 2, 3]` has the type
   ## `seq[int]`, while `[1, 2, 3]` has the type `array[0..2, int]`.
   ##
-  ##   ```
+  ##   ```nim
   ##   let
   ##     a = [1, 3, 5]
   ##     b = "foo"
@@ -950,7 +950,7 @@ proc setLen*[T](s: var seq[T], newlen: Natural) {.
   ##
   ## If the current length is greater than the new length,
   ## `s` will be truncated.
-  ##   ```
+  ##   ```nim
   ##   var x = @[10, 20]
   ##   x.setLen(5)
   ##   x[4] = 50
@@ -965,7 +965,7 @@ proc setLen*(s: var string, newlen: Natural) {.
   ##
   ## If the current length is greater than the new length,
   ## `s` will be truncated.
-  ##   ```
+  ##   ```nim
   ##   var myS = "Nim is great!!"
   ##   myS.setLen(3) # myS <- "Nim"
   ##   echo myS, " is fantastic!!"
@@ -990,25 +990,25 @@ proc newStringOfCap*(cap: Natural): string {.
 proc `&`*(x: string, y: char): string {.
   magic: "ConStrStr", noSideEffect.}
   ## Concatenates `x` with `y`.
-  ##   ```
+  ##   ```nim
   ##   assert("ab" & 'c' == "abc")
   ##   ```
 proc `&`*(x, y: char): string {.
   magic: "ConStrStr", noSideEffect.}
   ## Concatenates characters `x` and `y` into a string.
-  ##   ```
+  ##   ```nim
   ##   assert('a' & 'b' == "ab")
   ##   ```
 proc `&`*(x, y: string): string {.
   magic: "ConStrStr", noSideEffect.}
   ## Concatenates strings `x` and `y`.
-  ##   ```
+  ##   ```nim
   ##   assert("ab" & "cd" == "abcd")
   ##   ```
 proc `&`*(x: char, y: string): string {.
   magic: "ConStrStr", noSideEffect.}
   ## Concatenates `x` with `y`.
-  ##   ```
+  ##   ```nim
   ##   assert('a' & "bc" == "abc")
   ##   ```
 
@@ -1017,7 +1017,7 @@ proc `&`*(x: char, y: string): string {.
 
 proc add*(x: var string, y: char) {.magic: "AppendStrCh", noSideEffect.}
   ## Appends `y` to `x` in place.
-  ##   ```
+  ##   ```nim
   ##   var tmp = ""
   ##   tmp.add('a')
   ##   tmp.add('b')
@@ -1150,7 +1150,7 @@ when defined(nimscript) or not defined(nimSeqsV2):
     ## containers should also call their adding proc `add` for consistency.
     ## Generic code becomes much easier to write if the Nim naming scheme is
     ## respected.
-    ##   ```
+    ##   ```nim
     ##   var s: seq[string] = @["test2","test2"]
     ##   s.add("test")
     ##   assert s == @["test2", "test2", "test"]
@@ -1164,7 +1164,7 @@ when false: # defined(gcDestructors):
     ## containers should also call their adding proc `add` for consistency.
     ## Generic code becomes much easier to write if the Nim naming scheme is
     ## respected.
-    ##   ```
+    ##   ```nim
     ##   var s: seq[string] = @["test2","test2"]
     ##   s.add("test") # s <- @[test2, test2, test]
     ##   ```
@@ -1230,7 +1230,7 @@ proc del*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
 
 proc insert*[T](x: var seq[T], item: sink T, i = 0.Natural) {.noSideEffect.} =
   ## Inserts `item` into `x` at position `i`.
-  ##   ```
+  ##   ```nim
   ##   var i = @[1, 3, 5]
   ##   i.insert(99, 0) # i <- @[99, 1, 3, 5]
   ##   ```
@@ -1261,7 +1261,7 @@ when not defined(nimV2):
     ##
     ## It works even for complex data graphs with cycles. This is a great
     ## debugging tool.
-    ##   ```
+    ##   ```nim
     ##   var s: seq[string] = @["test2", "test2"]
     ##   var i = @[1, 2, 3, 4, 5]
     ##   echo repr(s) # => 0x1055eb050[0x1055ec050"test2", 0x1055ec078"test2"]
@@ -1294,7 +1294,7 @@ proc toFloat*(i: int): float {.noSideEffect, inline.} =
   ## If the conversion fails, `ValueError` is raised.
   ## However, on most platforms the conversion cannot fail.
   ##
-  ##   ```
+  ##   ```nim
   ##   let
   ##     a = 2
   ##     b = 3.7
@@ -1317,7 +1317,7 @@ proc toInt*(f: float): int {.noSideEffect.} =
   ##
   ## Note that some floating point numbers (e.g. infinity or even 1e19)
   ## cannot be accurately converted.
-  ##   ```
+  ##   ```nim
   ##   doAssert toInt(0.49) == 0
   ##   doAssert toInt(0.5) == 1
   ##   doAssert toInt(-0.5) == -1 # rounding is symmetrical
@@ -1330,7 +1330,7 @@ proc toBiggestInt*(f: BiggestFloat): BiggestInt {.noSideEffect.} =
 
 proc `/`*(x, y: int): float {.inline, noSideEffect.} =
   ## Division of integers that results in a float.
-  ##   ```
+  ##   ```nim
   ##   echo 7 / 5 # => 1.4
   ##   ```
   ##
@@ -1397,7 +1397,7 @@ proc swap*[T](a, b: var T) {.magic: "Swap", noSideEffect.}
   ## This is often more efficient than `tmp = a; a = b; b = tmp`.
   ## Particularly useful for sorting algorithms.
   ##
-  ##   ```
+  ##   ```nim
   ##   var
   ##     a = 5
   ##     b = 9
@@ -1436,7 +1436,7 @@ include "system/iterators_1"
 
 proc len*[U: Ordinal; V: Ordinal](x: HSlice[U, V]): int {.noSideEffect, inline.} =
   ## Length of ordinal slice. When x.b < x.a returns zero length.
-  ##   ```
+  ##   ```nim
   ##   assert((0..5).len == 6)
   ##   assert((5..2).len == 0)
   ##   ```
@@ -1477,7 +1477,7 @@ when defined(nimSeqsV2):
     ## Concatenates two sequences.
     ##
     ## Requires copying of the sequences.
-    ##   ```
+    ##   ```nim
     ##   assert(@[1, 2, 3, 4] & @[5, 6] == @[1, 2, 3, 4, 5, 6])
     ##   ```
     ##
@@ -1493,7 +1493,7 @@ when defined(nimSeqsV2):
     ## Appends element y to the end of the sequence.
     ##
     ## Requires copying of the sequence.
-    ##   ```
+    ##   ```nim
     ##   assert(@[1, 2, 3] & 4 == @[1, 2, 3, 4])
     ##   ```
     ##
@@ -1508,7 +1508,7 @@ when defined(nimSeqsV2):
     ## Prepends the element x to the beginning of the sequence.
     ##
     ## Requires copying of the sequence.
-    ##   ```
+    ##   ```nim
     ##   assert(1 & @[2, 3, 4] == @[1, 2, 3, 4])
     ##   ```
     newSeq(result, y.len + 1)
@@ -1522,7 +1522,7 @@ else:
     ## Concatenates two sequences.
     ##
     ## Requires copying of the sequences.
-    ##   ```
+    ##   ```nim
     ##   assert(@[1, 2, 3, 4] & @[5, 6] == @[1, 2, 3, 4, 5, 6])
     ##   ```
     ##
@@ -1538,7 +1538,7 @@ else:
     ## Appends element y to the end of the sequence.
     ##
     ## Requires copying of the sequence.
-    ##   ```
+    ##   ```nim
     ##   assert(@[1, 2, 3] & 4 == @[1, 2, 3, 4])
     ##   ```
     ##
@@ -1553,7 +1553,7 @@ else:
     ## Prepends the element x to the beginning of the sequence.
     ##
     ## Requires copying of the sequence.
-    ##   ```
+    ##   ```nim
     ##   assert(1 & @[2, 3, 4] == @[1, 2, 3, 4])
     ##   ```
     newSeq(result, y.len + 1)
@@ -1574,7 +1574,7 @@ proc instantiationInfo*(index = -1, fullPaths = false): tuple[
   ## to retrieve information about the current filename and line number.
   ## Example:
   ##
-  ##   ```
+  ##   ```nim
   ##   import std/strutils
   ##
   ##   template testException(exception, code: untyped): typed =
@@ -1674,7 +1674,7 @@ proc contains*[T](a: openArray[T], item: T): bool {.inline.}=
   ##
   ## This allows the `in` operator: `a.contains(item)` is the same as
   ## `item in a`.
-  ##   ```
+  ##   ```nim
   ##   var a = @[1, 3, 5]
   ##   assert a.contains(5)
   ##   assert 3 in a
@@ -1768,7 +1768,7 @@ when notJSnotNims:
       ##
       ## `outOfMemHook` can be used to raise an exception in case of OOM like so:
       ##
-      ##   ```
+      ##   ```nim
       ##   var gOutOfMem: ref EOutOfMemory
       ##   new(gOutOfMem) # need to be allocated *before* OOM really happened!
       ##   gOutOfMem.msg = "out of memory"
@@ -1882,7 +1882,7 @@ template likely*(val: bool): bool =
   ## You can use this template to decorate a branch condition. On certain
   ## platforms this can help the processor predict better which branch is
   ## going to be run. Example:
-  ##   ```
+  ##   ```nim
   ##   for value in inputValues:
   ##     if likely(value <= 100):
   ##       process(value)
@@ -1906,7 +1906,7 @@ template unlikely*(val: bool): bool =
   ## You can use this proc to decorate a branch condition. On certain
   ## platforms this can help the processor predict better which branch is
   ## going to be run. Example:
-  ##   ```
+  ##   ```nim
   ##   for value in inputValues:
   ##     if unlikely(value > 100):
   ##       echo "Value too big!"
@@ -2102,7 +2102,7 @@ when notJSnotNims:
     ## is pressed. Only one such hook is supported.
     ## Example:
     ##
-    ##   ```
+    ##   ```nim
     ##   proc ctrlc() {.noconv.} =
     ##     echo "Ctrl+C fired!"
     ##     # do clean up stuff
@@ -2339,7 +2339,7 @@ include "system/indices"
 
 proc `&=`*(x: var string, y: string) {.magic: "AppendStrStr", noSideEffect.}
   ## Appends in place to a string.
-  ##   ```
+  ##   ```nim
   ##   var a = "abc"
   ##   a &= "de" # a <- "abcde"
   ##   ```
@@ -2418,7 +2418,7 @@ proc repr*[T, U](x: HSlice[T, U]): string =
 when hasAlloc or defined(nimscript):
   proc insert*(x: var string, item: string, i = 0.Natural) {.noSideEffect.} =
     ## Inserts `item` into `x` at position `i`.
-    ##   ```
+    ##   ```nim
     ##   var a = "abc"
     ##   a.insert("zz", 0) # a <- "zzabc"
     ##   ```
@@ -2497,7 +2497,7 @@ proc addQuoted*[T](s: var string, x: T) =
   ## Users may overload `addQuoted` for custom (string-like) types if
   ## they want to implement a customized element representation.
   ##
-  ##   ```
+  ##   ```nim
   ##   var tmp = ""
   ##   tmp.addQuoted(1)
   ##   tmp.add(", ")
@@ -2539,7 +2539,7 @@ proc locals*(): RootObj {.magic: "Plugin", noSideEffect.} =
   ## the official signature says, the return type is *not* `RootObj` but a
   ## tuple of a structure that depends on the current scope. Example:
   ##
-  ##   ```
+  ##   ```nim
   ##   proc testLocals() =
   ##     var
   ##       a = "something"
@@ -2578,7 +2578,7 @@ when hasAlloc and notJSnotNims:
 proc procCall*(x: untyped) {.magic: "ProcCall", compileTime.} =
   ## Special magic to prohibit dynamic binding for `method`:idx: calls.
   ## This is similar to `super`:idx: in ordinary OO languages.
-  ##   ```
+  ##   ```nim
   ##   # 'someMethod' will be resolved fully statically:
   ##   procCall someMethod(a, b)
   ##   ```
@@ -2603,7 +2603,7 @@ template closureScope*(body: untyped): untyped =
   ##
   ## Example:
   ##
-  ##   ```
+  ##   ```nim
   ##   var myClosure : proc()
   ##   # without closureScope:
   ##   for i in 0 .. 5:
@@ -2623,7 +2623,7 @@ template closureScope*(body: untyped): untyped =
 
 template once*(body: untyped): untyped =
   ## Executes a block of code only once (the first time the block is reached).
-  ##   ```
+  ##   ```nim
   ##   proc draw(t: Triangle) =
   ##     once:
   ##       graphicsInit()

--- a/lib/system/compilation.nim
+++ b/lib/system/compilation.nim
@@ -1,7 +1,7 @@
 const
   NimMajor* {.intdefine.}: int = 2
     ## is the major number of Nim's version. Example:
-    ##   ```
+    ##   ```nim
     ##   when (NimMajor, NimMinor, NimPatch) >= (1, 3, 1): discard
     ##   ```
     # see also std/private/since
@@ -40,7 +40,7 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## `x` is an external symbol introduced through the compiler's
   ## `-d:x switch <nimc.html#compiler-usage-compileminustime-symbols>`_ to enable
   ## build time conditionals:
-  ##   ```
+  ##   ```nim
   ##   when not defined(release):
   ##     # Do here programmer friendly expensive sanity checks.
   ##   # Put here the normal code
@@ -57,7 +57,7 @@ proc declared*(x: untyped): bool {.magic: "Declared", noSideEffect, compileTime.
   ##
   ## This can be used to check whether a library provides a certain
   ## feature or not:
-  ##   ```
+  ##   ```nim
   ##   when not declared(strutils.toUpper):
   ##     # provide our own toUpper proc here, because strutils is
   ##     # missing it.
@@ -74,7 +74,7 @@ proc compiles*(x: untyped): bool {.magic: "Compiles", noSideEffect, compileTime.
   ## Special compile-time procedure that checks whether `x` can be compiled
   ## without any semantic error.
   ## This can be used to check whether a type supports some operation:
-  ##   ```
+  ##   ```nim
   ##   when compiles(3 + 4):
   ##     echo "'+' for integers is available"
   ##   ```
@@ -164,7 +164,7 @@ proc staticRead*(filename: string): string {.magic: "Slurp".}
   ##
   ## The maximum file size limit that `staticRead` and `slurp` can read is
   ## near or equal to the *free* memory of the device you are using to compile.
-  ##   ```
+  ##   ```nim
   ##   const myResource = staticRead"mydatafile.bin"
   ##   ```
   ##
@@ -181,7 +181,7 @@ proc staticExec*(command: string, input = "", cache = ""): string {.
   ##
   ## If `input` is not an empty string, it will be passed as a standard input
   ## to the executed program.
-  ##   ```
+  ##   ```nim
   ##   const buildInfo = "Revision " & staticExec("git rev-parse HEAD") &
   ##                     "\nCompiled on " & staticExec("uname -v")
   ##   ```
@@ -197,7 +197,7 @@ proc staticExec*(command: string, input = "", cache = ""): string {.
   ## behaviour then. `command & input & cache` (the concatenated string) is
   ## used to determine whether the entry in the cache is still valid. You can
   ## use versioning information for `cache`:
-  ##   ```
+  ##   ```nim
   ##   const stateMachine = staticExec("dfaoptimizer", "input", "0.8.0")
   ##   ```
 

--- a/lib/system/indices.nim
+++ b/lib/system/indices.nim
@@ -10,7 +10,7 @@ template `^`*(x: int): BackwardsIndex = BackwardsIndex(x)
   ## Builtin `roof`:idx: operator that can be used for convenient array access.
   ## `a[^x]` is a shortcut for `a[a.len-x]`.
   ##
-  ##   ```
+  ##   ```nim
   ##   let
   ##     a = [1, 3, 5, 7, 9]
   ##     b = "abcdefgh"
@@ -46,7 +46,7 @@ template `..^`*(a, b: untyped): untyped =
 
 template `..<`*(a, b: untyped): untyped =
   ## A shortcut for `a .. pred(b)`.
-  ##   ```
+  ##   ```nim
   ##   for i in 5 ..< 9:
   ##     echo i # => 5; 6; 7; 8
   ##   ```
@@ -76,7 +76,7 @@ template spliceImpl(s, a, L, b: typed): untyped =
 proc `[]`*[T, U: Ordinal](s: string, x: HSlice[T, U]): string {.inline, systemRaisesDefect.} =
   ## Slice operation for strings.
   ## Returns the inclusive range `[s[x.a], s[x.b]]`:
-  ##   ```
+  ##   ```nim
   ##   var s = "abcdef"
   ##   assert s[1..3] == "bcd"
   ##   ```
@@ -106,7 +106,7 @@ proc `[]=`*[T, U: Ordinal](s: var string, x: HSlice[T, U], b: string) {.systemRa
 proc `[]`*[Idx, T; U, V: Ordinal](a: array[Idx, T], x: HSlice[U, V]): seq[T] {.systemRaisesDefect.} =
   ## Slice operation for arrays.
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
-  ##   ```
+  ##   ```nim
   ##   var a = [1, 2, 3, 4]
   ##   assert a[0..2] == @[1, 2, 3]
   ##   ```
@@ -117,7 +117,7 @@ proc `[]`*[Idx, T; U, V: Ordinal](a: array[Idx, T], x: HSlice[U, V]): seq[T] {.s
 
 proc `[]=`*[Idx, T; U, V: Ordinal](a: var array[Idx, T], x: HSlice[U, V], b: openArray[T]) {.systemRaisesDefect.} =
   ## Slice assignment for arrays.
-  ##   ```
+  ##   ```nim
   ##   var a = [10, 20, 30, 40, 50]
   ##   a[1..2] = @[99, 88]
   ##   assert a == [10, 99, 88, 40, 50]
@@ -132,7 +132,7 @@ proc `[]=`*[Idx, T; U, V: Ordinal](a: var array[Idx, T], x: HSlice[U, V], b: ope
 proc `[]`*[T; U, V: Ordinal](s: openArray[T], x: HSlice[U, V]): seq[T] {.systemRaisesDefect.} =
   ## Slice operation for sequences.
   ## Returns the inclusive range `[s[x.a], s[x.b]]`:
-  ##   ```
+  ##   ```nim
   ##   var s = @[1, 2, 3, 4]
   ##   assert s[0..2] == @[1, 2, 3]
   ##   ```


### PR DESCRIPTION
nimlsp doesn't understand code blocks without language identifier.
Before:
![image](https://github.com/nim-lang/Nim/assets/33235928/5c07cb6c-86ce-4bfe-a9f8-45cc66566f0a)
After:
![image](https://github.com/nim-lang/Nim/assets/33235928/f89a53f9-947d-48b4-bee9-4cf08f531dd8)
