### PR TITLE
Fix #22366 by making nimlf_/nimln_ part of the same line (backport)

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -311,10 +311,10 @@ proc genLineDir(p: BProc, t: PNode) =
       (p.prc == nil or sfPure notin p.prc.flags) and t.info.fileIndex != InvalidFileIdx:
       if freshLine:
         if lastFileIndex == t.info.fileIndex:
-          linefmt(p, cpsStmts, "nimln_($1);\n",
+          linefmt(p, cpsStmts, "nimln_($1);",
               [line])
         else:
-          linefmt(p, cpsStmts, "nimlf_($1, $2);\n",
+          linefmt(p, cpsStmts, "nimlf_($1, $2);",
               [line, quotedFilename(p.config, t.info)])
 
 proc accessThreadLocalVar(p: BProc, s: PSym)


### PR DESCRIPTION
This is a backport of #22503 to fix #22366. See PR for details.

I've tested it with nim-gdb, and with CodeLLDB in VS Code.