### PR TITLE
use old typeinfo generation for hot code reloading

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1772,7 +1772,7 @@ proc genTypeInfoV2(m: BModule; t: PType; info: TLineInfo): Rope =
     return prefixTI.rope & result & ")".rope
 
   m.g.typeInfoMarkerV2[sig] = (str: result, owner: owner)
-  if m.compileToCpp:
+  if m.compileToCpp or m.hcrOn:
     genTypeInfoV2OldImpl(m, t, origType, result, info)
   else:
     genTypeInfoV2Impl(m, t, origType, result, info)

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -81,10 +81,13 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string, isOrc =
   testSpec r, makeTest("tests/dll/nimhcr_unit.nim", options & " --threads:off" & rpath, cat)
   testSpec r, makeTest("tests/dll/visibility.nim", options & " --threads:off" & rpath, cat)
 
-  if "boehm" notin options and not isOrc:
+  if "boehm" notin options:
     # hcr tests
     
-    testSpec r, makeTest("tests/dll/nimhcr_basic.nim", options & " --threads:off --forceBuild --hotCodeReloading:on " & rpath, cat)
+    var basicHcrTest = makeTest("tests/dll/nimhcr_basic.nim", options & " --threads:off --forceBuild --hotCodeReloading:on " & rpath, cat)
+    # test segfaults for now but compiles:
+    if isOrc: basicHcrTest.spec.action = actionCompile
+    testSpec r, basicHcrTest
 
     # force build required - see the comments in the .nim file for more details
     var hcri = makeTest("tests/dll/nimhcr_integration.nim",

--- a/tests/dll/nimhcr_basic.nim
+++ b/tests/dll/nimhcr_basic.nim
@@ -3,5 +3,6 @@ discard """
 Hello world
 '''
 """
+# for now orc only tests successful compilation
 
 echo "Hello world"


### PR DESCRIPTION
This stops the immediate compile error when trying to compile hello world with hot code reloading on arc/orc:

```
@m..@s..@slib@ssystem@sexceptions.nim.c:179:75: error: initializer element is not constant
 N_LIB_PRIVATE TNimTypeV2 NTIv2__csKIu4niikiR0hmsc9asX0Q_ = {.destructor = (void*)rttiDestroy__systemZexceptions_u56___grOaF4HD6uomto1opDGctg, .size = sizeof(tyObject_OverflowDefect__csKIu4niikiR0hmsc9asX0Q), .align = (NI16) NIM_ALIGNOF(tyObject_OverflowDefect__csKIu4niikiR0hmsc9asX0Q), .depth = 4, .display = TM__TzI3paKQY09cLjc9cmCvur3A_2, .traceImpl = (void*)eqtrace___system_u4832___Ec9cY8mQrpjwZoTV9aw9aOu1g, .flags = 0};
                                                                           ^
```

Then hello world compiles, but segfaults. Hello world compiling but not running is now tested with orc.