### PR TITLE
fix getNullValue for cstring in VM, make other VM code aware of nil cstring

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1017,7 +1017,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcLenCstring:
       decodeBImm(rkInt)
       assert regs[rb].kind == rkNode
-      regs[ra].intVal = regs[rb].node.strVal.cstring.len - imm
+      if regs[rb].node.kind == nkNilLit:
+        regs[ra].intVal = 0
+      else:
+        regs[ra].intVal = regs[rb].node.strVal.cstring.len - imm
     of opcIncl:
       decodeB(rkNode)
       let b = regs[rb].regToNode

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1215,6 +1215,12 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcEqStr:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].node.strVal == regs[rc].node.strVal)
+    of opcEqCString:
+      decodeBC(rkInt)
+      let bNil = regs[rb].node.kind == nkNilLit
+      let cNil = regs[rc].node.kind == nkNilLit
+      regs[ra].intVal = ord((bNil and cNil) or
+        (not bNil and not cNil and regs[rb].node.strVal == regs[rc].node.strVal))
     of opcLeStr:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].node.strVal <= regs[rc].node.strVal)
@@ -1498,7 +1504,13 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           regs[ra].node
       c.currentExceptionA = raised
       # Set the `name` field of the exception
-      c.currentExceptionA[2].skipColon.strVal = c.currentExceptionA.typ.sym.name.s
+      var exceptionNameNode = newStrNode(nkStrLit, c.currentExceptionA.typ.sym.name.s)
+      if c.currentExceptionA[2].kind == nkExprColonExpr:
+        exceptionNameNode.typ = c.currentExceptionA[2][1].typ
+        c.currentExceptionA[2][1] = exceptionNameNode
+      else:
+        exceptionNameNode.typ = c.currentExceptionA[2].typ
+        c.currentExceptionA[2] = exceptionNameNode
       c.exceptionInstr = pc
 
       var frame = tos

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1018,7 +1018,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBImm(rkInt)
       assert regs[rb].kind == rkNode
       if regs[rb].node.kind == nkNilLit:
-        regs[ra].intVal = 0
+        regs[ra].intVal = -imm
       else:
         regs[ra].intVal = regs[rb].node.strVal.cstring.len - imm
     of opcIncl:

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -99,7 +99,7 @@ type
     opcLeFloat, opcLtFloat, opcLeu, opcLtu,
     opcEqRef, opcEqNimNode, opcSameNodeType,
     opcXor, opcNot, opcUnaryMinusInt, opcUnaryMinusFloat, opcBitnotInt,
-    opcEqStr, opcLeStr, opcLtStr, opcEqSet, opcLeSet, opcLtSet,
+    opcEqStr, opcEqCString, opcLeStr, opcLtStr, opcEqSet, opcLeSet, opcLtSet,
     opcMulSet, opcPlusSet, opcMinusSet, opcConcatStr,
     opcContainsSet, opcRepr, opcSetLenStr, opcSetLenSeq,
     opcIsNil, opcOf, opcIs,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1877,10 +1877,10 @@ proc getNullValue(typ: PType, info: TLineInfo; conf: ConfigRef): PNode =
     result = newNodeIT(nkUIntLit, info, t)
   of tyFloat..tyFloat128:
     result = newNodeIT(nkFloatLit, info, t)
-  of tyCstring, tyString:
+  of tyString:
     result = newNodeIT(nkStrLit, info, t)
     result.strVal = ""
-  of tyVar, tyLent, tyPointer, tyPtr, tyUntyped,
+  of tyCstring, tyVar, tyLent, tyPointer, tyPtr, tyUntyped,
      tyTyped, tyTypeDesc, tyRef, tyNil:
     result = newNodeIT(nkNilLit, info, t)
   of tyProc:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1159,7 +1159,8 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
       c.gABC(n, opcNarrowU, dest, TRegister(size*8))
   of mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr, mCStrToStr, mStrToStr, mEnumToStr:
     genConv(c, n, n[1], dest)
-  of mEqStr, mEqCString: genBinaryABC(c, n, dest, opcEqStr)
+  of mEqStr: genBinaryABC(c, n, dest, opcEqStr)
+  of mEqCString: genBinaryABC(c, n, dest, opcEqCString)
   of mLeStr: genBinaryABC(c, n, dest, opcLeStr)
   of mLtStr: genBinaryABC(c, n, dest, opcLtStr)
   of mEqSet: genBinarySet(c, n, dest, opcEqSet)

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -735,3 +735,15 @@ block: # bug #22190
     tab = mkOpTable(Berlin)
 
   doAssert not tab
+
+block: # issue #22524
+  const cnst = cstring(nil)
+  let b = cnst
+  doAssert b.isNil
+
+  let a = static: cstring(nil)
+  doAssert a.isNil
+
+  static:
+    var x: cstring
+    doAssert x.isNil

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -747,3 +747,11 @@ block: # issue #22524
   static:
     var x: cstring
     doAssert x.isNil
+
+block: # issue #15730
+  const s: cstring = ""
+  doAssert s != nil
+
+  static:
+    const s: cstring = ""
+    doAssert s != nil

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -738,8 +738,11 @@ block: # bug #22190
 
 block: # issue #22524
   const cnst = cstring(nil)
+  doAssert cnst.isNil
+  doAssert cnst == nil
   let b = cnst
   doAssert b.isNil
+  doAssert b == nil
 
   let a = static: cstring(nil)
   doAssert a.isNil
@@ -747,11 +750,19 @@ block: # issue #22524
   static:
     var x: cstring
     doAssert x.isNil
+    doAssert x == nil
+    doAssert x != ""
 
 block: # issue #15730
   const s: cstring = ""
   doAssert s != nil
 
   static:
-    const s: cstring = ""
+    let s: cstring = ""
+    doAssert not s.isNil
     doAssert s != nil
+    doAssert s == ""
+
+static: # more nil cstring issues
+  let x = cstring(nil)
+  doAssert x.len == 0


### PR DESCRIPTION
fixes #22524, fixes #15730

Default value of `cstring` in VM is now `nil` like runtime. VM code had to be updated in a couple ways to accomodate:

* `opcEqCString` opcode added distinct from `opcEqStr` (previously both `mEqStr` and `mEqCString` would emit `opcEqStr`) which also checks for nil equality. We could merge them into the same opcode but string equality doesn't need to check for nil.
* The code for raising exceptions in the VM tried to set the exception object name by editing the `strVal` field of the `name` field of the instantiated exception object which used to be an empty string but is now an `nkNilLit`, so we need to set it to a new node altogether.

Also `opcLenCstring` didn't check for nil cstring, which it does now. 