### PR TITLE
OOM exception handler support for arc/orc/boehm

### DIFF
--- a/lib/system/mm/malloc.nim
+++ b/lib/system/mm/malloc.nim
@@ -20,20 +20,20 @@ proc reallocImpl(p: pointer, newSize: Natural): pointer =
       raiseOutOfMem()
 
 when defined(handleOOM):
-  proc nRealloc*(p: pointer, oldsize: csize_t, newsize: csize_t): pointer {.inline.} =
-    result = c_calloc(newSize.csize_t, sizeof(cchar).csize_t)
+  proc nRealloc*(p: pointer, oldsize: csize_t, newsize: csize_t): pointer  =
+    result = c_malloc(newSize.csize_t)
     if result == nil:
       raiseOutOfMem()
     else:
-      if p != nil and newsize != 0 and newsize >= 0:
+      if p != nil and newsize != 0 and newsize > 0:
         for i in 0..(newsize - 1):
-          if i <= oldSize:
+          if i < oldSize:
             cast[ptr UncheckedArray[cchar]](result)[i] = cast[ptr UncheckedArray[cchar]](p)[i]
           else:
             cast[ptr UncheckedArray[cchar]](result)[i] = '\0'
         c_free(p)
-    else:
-      raiseOutOfMem()
+      else:
+        raiseOutOfMem()
 
 
 

--- a/lib/system/mm/malloc.nim
+++ b/lib/system/mm/malloc.nim
@@ -24,7 +24,7 @@ when defined(handleOOM):
     result = c_calloc(newSize.csize_t, sizeof(cchar).csize_t)
     if result == nil:
       raiseOutOfMem()
-    if result != nil:
+    else:
       if p != nil and newsize != 0 and newsize >= 0:
         for i in 0..(newsize - 1):
           if i <= oldSize:

--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -75,8 +75,11 @@ proc prepareSeqAdd(len: int; p: pointer; addlen, elemSize, elemAlign: int): poin
         let oldSize = headerSize + elemSize * oldCap
         let newSize = headerSize + elemSize * newCap
         var q = cast[ptr NimSeqPayloadBase](alignedRealloc0(p, oldSize, newSize, elemAlign))
-        q.cap = newCap
-        result = q
+        if q != nil:
+          q.cap = newCap
+          result = q
+        else:
+          result = nil
 
 proc shrink*[T](x: var seq[T]; newLen: Natural) {.tags: [], raises: [].} =
   when nimvm:
@@ -114,12 +117,13 @@ proc add*[T](x: var seq[T]; y: sink T) {.magic: "AppendSeqElem", noSideEffect, n
     var xu = cast[ptr NimSeqV2[T]](addr x)
     if xu.p == nil or (xu.p.cap and not strlitFlag) < oldLen+1:
       xu.p = cast[typeof(xu.p)](prepareSeqAdd(oldLen, xu.p, 1, sizeof(T), alignof(T)))
-    xu.len = oldLen+1
-    # .nodestroy means `xu.p.data[oldLen] = value` is compiled into a
-    # copyMem(). This is fine as know by construction that
-    # in `xu.p.data[oldLen]` there is nothing to destroy.
-    # We also save the `wasMoved + destroy` pair for the sink parameter.
-    xu.p.data[oldLen] = y
+    if xu.p != nil:
+      xu.len = oldLen+1
+      # .nodestroy means `xu.p.data[oldLen] = value` is compiled into a
+      # copyMem(). This is fine as know by construction that
+      # in `xu.p.data[oldLen]` there is nothing to destroy.
+      # We also save the `wasMoved + destroy` pair for the sink parameter.
+      xu.p.data[oldLen] = y
 
 proc setLen[T](s: var seq[T], newlen: Natural) =
   {.noSideEffect.}:


### PR DESCRIPTION
Test Code, should be compiled with --d:useMalloc and --d:handleOOM 

```nim
import std/os

proc trimHeap*(size: csize_t): cint {.importc: "malloc_trim", header: "<malloc.h>", nimcall.}

proc hitOOM():void =

    const str = "Hello OOM"
    var hugeStr: seq[string] = newSeq[string](5)

    while true:
        try:
            hugeStr.add str
        except:
            hugeStr = @[]
            debugEcho "EOutOfMemory Exception"
            discard trimHeap(0.csize_t)
            break
        finally:
            discard
    sleep(15000)

while true:
    hitOOM()
```

P.S.
Swap must be disabled. trimHeap reclaims freed heap back to OS (works only with glibc).