### PR TITLE
fixes #22541; peg matchLen can raise an unlisted exception: Exception

### DIFF
--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -562,7 +562,7 @@ template matchOrParse(mopProc: untyped) =
   # procs. For the former, *enter* and *leave* event handler code generators
   # are provided which just return *discard*.
 
-  proc mopProc(s: string, p: Peg, start: int, c: var Captures): int {.gcsafe.} =
+  proc mopProc(s: string, p: Peg, start: int, c: var Captures): int {.gcsafe, raises: [].} =
     proc matchBackRef(s: string, p: Peg, start: int, c: var Captures): int =
       # Parse handler code must run in an *of* clause of its own for each
       # *PegKind*, so we encapsulate the identical clause body for


### PR DESCRIPTION
fixes #22541

The `mopProc` is a recursive function.