### PR TITLE
fixes a strictdef ten years long vintage bug, which counts the same thing twice

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -24,6 +24,7 @@ proc canRaiseDisp(p: BProc; n: PNode): bool =
 
 proc preventNrvo(p: BProc; dest, le, ri: PNode): bool =
   proc locationEscapes(p: BProc; le: PNode; inTryStmt: bool): bool =
+    result = false
     var n = le
     while true:
       # do NOT follow nkHiddenDeref here!

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2150,6 +2150,7 @@ proc expectString(c: PContext, n: PNode): string =
   if n.kind in nkStrKinds:
     return n.strVal
   else:
+    result = ""
     localError(c.config, n.info, errStringLiteralExpected)
 
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -356,12 +356,15 @@ proc useVar(a: PEffects, n: PNode) =
 type
   TIntersection = seq[tuple[id, count: int]] # a simple count table
 
-proc addToIntersection(inter: var TIntersection, s: int) =
+proc addToIntersection(inter: var TIntersection, s: int, zeroInit: bool) =
   for j in 0..<inter.len:
     if s == inter[j].id:
       inc inter[j].count
       return
-  inter.add((id: s, count: 1))
+  if zeroInit:
+    inter.add((id: s, count: 0))
+  else:
+    inter.add((id: s, count: 1))
 
 proc throws(tracked, n, orig: PNode) =
   if n.typ == nil or n.typ.kind != tyError:
@@ -465,7 +468,7 @@ proc trackTryStmt(tracked: PEffects, n: PNode) =
   track(tracked, n[0])
   dec tracked.inTryStmt
   for i in oldState..<tracked.init.len:
-    addToIntersection(inter, tracked.init[i])
+    addToIntersection(inter, tracked.init[i], false)
 
   var branches = 1
   var hasFinally = false
@@ -500,7 +503,7 @@ proc trackTryStmt(tracked: PEffects, n: PNode) =
           tracked.init.add b[j][2].sym.id
       track(tracked, b[^1])
       for i in oldState..<tracked.init.len:
-        addToIntersection(inter, tracked.init[i])
+        addToIntersection(inter, tracked.init[i], false)
     else:
       setLen(tracked.init, oldState)
       track(tracked, b[^1])
@@ -698,9 +701,11 @@ proc trackCase(tracked: PEffects, n: PNode) =
       addCaseBranchFacts(tracked.guards, n, i)
     for i in 0..<branch.len:
       track(tracked, branch[i])
-    if not breaksBlock(branch.lastSon): inc toCover
+    let hasBreaksBlock = breaksBlock(branch.lastSon)
+    if not hasBreaksBlock:
+      inc toCover
     for i in oldState..<tracked.init.len:
-      addToIntersection(inter, tracked.init[i])
+      addToIntersection(inter, tracked.init[i], hasBreaksBlock)
 
   setLen(tracked.init, oldState)
   if not stringCase or lastSon(n).kind == nkElse:
@@ -720,9 +725,11 @@ proc trackIf(tracked: PEffects, n: PNode) =
   var inter: TIntersection = @[]
   var toCover = 0
   track(tracked, n[0][1])
-  if not breaksBlock(n[0][1]): inc toCover
+  let hasBreaksBlock = breaksBlock(n[0][1])
+  if not hasBreaksBlock:
+    inc toCover
   for i in oldState..<tracked.init.len:
-    addToIntersection(inter, tracked.init[i])
+    addToIntersection(inter, tracked.init[i], hasBreaksBlock)
 
   for i in 1..<n.len:
     let branch = n[i]
@@ -734,9 +741,12 @@ proc trackIf(tracked: PEffects, n: PNode) =
     setLen(tracked.init, oldState)
     for i in 0..<branch.len:
       track(tracked, branch[i])
-    if not breaksBlock(branch.lastSon): inc toCover
+    let hasBreaksBlock = breaksBlock(branch.lastSon)
+    if not hasBreaksBlock:
+      inc toCover
     for i in oldState..<tracked.init.len:
-      addToIntersection(inter, tracked.init[i])
+      addToIntersection(inter, tracked.init[i], hasBreaksBlock)
+
   setLen(tracked.init, oldState)
   if lastSon(n).len == 1:
     for id, count in items(inter):
@@ -1327,6 +1337,7 @@ proc track(tracked: PEffects, n: PNode) =
 
 proc subtypeRelation(g: ModuleGraph; spec, real: PNode): bool =
   if spec.typ.kind == tyOr:
+    result = false
     for t in spec.typ:
       if safeInheritanceDiff(g.excType(real), t) <= 0:
         return true


### PR DESCRIPTION
`trackIf` compares the variable `count`, which is the number of initializations of a specific variable in all branches, with the variable `toCover`,  which represents the branches it needs to cover excluding the branch concludes with `return`, `break` etc. 

Not only did the old code detract the value of the variable `toCover` for a branch, which ends up with `return`, `break` etc. , but also it counts every variable initialization in a branch in that branch. Obviously, it counts the same thing twice.


A basic example:

```nim
{.experimental: "strictdefs".}


proc hasImportStmt(): bool =
  if false:
    return true
  else:
    discard

echo hasImportStmt()
```
Should give a warning, but it doesn't.