### PR TITLE
Fix #17509: Continue instead of return with unfinished generics

### DIFF
--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -136,8 +136,7 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
           result.typ[0]
         else:
           nil
-      b = semProcBody(c, b.copyNode, resultType)
-      #b = semProcBody(c, b, resultType)
+      b = semProcBody(c, b, resultType)
     result.ast[bodyPos] = hloBody(c, b)
     excl(result.flags, sfForward)
     trackProc(c, result, result.ast[bodyPos])

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -136,8 +136,8 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
           result.typ[0]
         else:
           nil
-      #b = semProcBody(c, b.copyNode, resultType)
-      b = semProcBody(c, b, resultType)
+      b = semProcBody(c, b.copyNode, resultType)
+      #b = semProcBody(c, b, resultType)
     result.ast[bodyPos] = hloBody(c, b)
     excl(result.flags, sfForward)
     trackProc(c, result, result.ast[bodyPos])

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -136,6 +136,7 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
           result.typ[0]
         else:
           nil
+      #b = semProcBody(c, b.copyNode, resultType)
       b = semProcBody(c, b, resultType)
     result.ast[bodyPos] = hloBody(c, b)
     excl(result.flags, sfForward)

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -47,7 +47,8 @@ proc searchInstTypes*(g: ModuleGraph; key: PType): PType =
       # XXX: This happens for prematurely cached
       # types such as Channel[empty]. Why?
       # See the notes for PActor in handleGenericInvocation
-      return
+      # if this is return the same type gets cached more than it needs to
+      continue
     if not sameFlags(inst, key):
       continue
 
@@ -386,6 +387,14 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
 
   result = newType(tyGenericInst, nextTypeId(cl.c.idgen), t[0].owner, sons = @[header[0]])
   result.flags = header.flags
+  # be careful not to propagate unnecessary flags here (don't use rawAddSon)
+  # ugh need another pass for deeply recursive generic types (e.g. PActor)
+  # we need to add the candidate here, before it's fully instantiated for
+  # recursive instantions:
+  if not cl.allowMetaTypes:
+    cacheTypeInst(cl.c, result)
+  else:
+    idTablePut(cl.localCache, t, result)
 
   let oldSkipTypedesc = cl.skipTypedesc
   cl.skipTypedesc = true
@@ -402,16 +411,6 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
     header[i] = x
     propagateToOwner(header, x)
     cl.typeMap.put(body[i-1], x)
-
-  # be careful not to propagate unnecessary flags here (don't use rawAddSon)
-  # ugh need another pass for deeply recursive generic types (e.g. PActor)
-  # we need to add the candidate here, before it's fully instantiated for
-  # recursive instantions:
-  # caching earlier leads to bad lookup
-  if not cl.allowMetaTypes:
-    cacheTypeInst(cl.c, result)
-  else:
-    idTablePut(cl.localCache, t, result)
 
   for i in 1..<t.len:
     # if one of the params is not concrete, we cannot do anything

--- a/tests/generics/t17509.nim
+++ b/tests/generics/t17509.nim
@@ -16,5 +16,10 @@ type
     edges: List[PolytopeEdge[R]]
 
 var pt: Polytope[float]
+
+static:
+  doAssert pt.vertices.next is (ptr List[PolytopeVertex[float]])
+  doAssert pt.edges.next is (ptr List[PolytopeEdge[float]])
+
 initList(addr pt.vertices)
 initList(addr pt.edges)

--- a/tests/generics/t17509.nim
+++ b/tests/generics/t17509.nim
@@ -1,0 +1,20 @@
+type List[O] = ref object
+  next: List[O]
+
+proc initList[O](l: List[O]) =
+  l.next = l
+
+type
+  PolytopeVertex[R] = object
+    list: List[PolytopeVertex[R]]
+
+  PolytopeEdge[R] = object
+    list: List[PolytopeEdge[R]]
+
+  Polytope[R] = object
+    vertices: List[PolytopeVertex[R]]
+    edges: List[PolytopeEdge[R]]
+
+var pt: Polytope[float]
+initList(pt.vertices)
+initList(pt.edges)

--- a/tests/generics/t17509.nim
+++ b/tests/generics/t17509.nim
@@ -1,8 +1,8 @@
-type List[O] = ref object
-  next: List[O]
+type List[O] = object
+  next: ptr List[O]
 
-proc initList[O](l: List[O]) =
-  l.next = l
+proc initList[O](l: ptr List[O]) =
+  l[].next = l
 
 type
   PolytopeVertex[R] = object
@@ -16,5 +16,5 @@ type
     edges: List[PolytopeEdge[R]]
 
 var pt: Polytope[float]
-initList(pt.vertices)
-initList(pt.edges)
+initList(addr pt.vertices)
+initList(addr pt.edges)


### PR DESCRIPTION
Close #17509

Current knowledge:
- delaying cache fixes the issue
- changing return of `if inst.len < key.len:` in `searchInstTypes` to `continue` fixes the issue. With return the broken types are also cached over and over

Related issues are completely unaffected as of now, so there must be something deeper.

I am also still trying to find the true cause, so feel free to ignore for now