### PR TITLE
fixes #22555; implements `newStringUninit`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 [//]: # "Additions:"
 
-- Adds `newStringUninitialized` to system, which creates a new string of length `len` like `newString` but with uninitialized content.
+- Adds `newStringUninit` to system, which creates a new string of length `len` like `newString` but with uninitialized content.
 
 [//]: # "Deprecations:"
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
 
 [//]: # "Additions:"
 
+- Adds `newStringUninitialized` to system, which creates a new string of length `len` like `newString` but with uninitialized content.
+
 [//]: # "Deprecations:"
 
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1630,7 +1630,7 @@ when not defined(js):
       var s = cast[PGenericSeq](result)
       s.len = len
 
-  func newStringUninitialized*(len: Natural): string =
+  proc newStringUninitialized*(len: Natural): string =
     ## Returns a new string of length `len` but with uninitialized
     ## content. One needs to fill the string character after character
     ## with the index operator `s[i]`.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -646,26 +646,6 @@ proc newSeqOfCap*[T](cap: Natural): seq[T] {.
   ##   ```
   discard
 
-when not defined(js):
-  proc newSeqUninitialized*[T: SomeNumber](len: Natural): seq[T] =
-    ## Creates a new sequence of type `seq[T]` with length `len`.
-    ##
-    ## Only available for numbers types. Note that the sequence will be
-    ## uninitialized. After the creation of the sequence you should assign
-    ## entries to the sequence instead of adding them.
-    ## Example:
-    ##   ```nim
-    ##   var x = newSeqUninitialized[int](3)
-    ##   assert len(x) == 3
-    ##   x[0] = 10
-    ##   ```
-    result = newSeqOfCap[T](len)
-    when defined(nimSeqsV2):
-      cast[ptr int](addr result)[] = len
-    else:
-      var s = cast[PGenericSeq](result)
-      s.len = len
-
 func len*[TOpenArray: openArray|varargs](x: TOpenArray): int {.magic: "LengthOpenArray".} =
   ## Returns the length of an openArray.
   runnableExamples:
@@ -973,8 +953,8 @@ proc setLen*(s: var string, newlen: Natural) {.
 
 proc newString*(len: Natural): string {.
   magic: "NewString", importc: "mnewString", noSideEffect.}
-  ## Returns a new string of length `len` but with uninitialized
-  ## content. One needs to fill the string character after character
+  ## Returns a new string of length `len`.
+  ## One needs to fill the string character after character
   ## with the index operator `s[i]`.
   ##
   ## This procedure exists only for optimization purposes;
@@ -1629,6 +1609,40 @@ when not defined(js) and defined(nimV2):
 when notJSnotNims and defined(nimSeqsV2):
   include "system/strs_v2"
   include "system/seqs_v2"
+
+when not defined(js):
+  proc newSeqUninitialized*[T: SomeNumber](len: Natural): seq[T] =
+    ## Creates a new sequence of type `seq[T]` with length `len`.
+    ##
+    ## Only available for numbers types. Note that the sequence will be
+    ## uninitialized. After the creation of the sequence you should assign
+    ## entries to the sequence instead of adding them.
+    ## Example:
+    ##   ```nim
+    ##   var x = newSeqUninitialized[int](3)
+    ##   assert len(x) == 3
+    ##   x[0] = 10
+    ##   ```
+    result = newSeqOfCap[T](len)
+    when defined(nimSeqsV2):
+      cast[ptr int](addr result)[] = len
+    else:
+      var s = cast[PGenericSeq](result)
+      s.len = len
+
+  func newStringUninitialized*(len: Natural): string =
+    ## Returns a new string of length `len` but with uninitialized
+    ## content. One needs to fill the string character after character
+    ## with the index operator `s[i]`.
+    ##
+    ## This procedure exists only for optimization purposes;
+    ## the same effect can be achieved with the `&` operator or with `add`.
+    result = newStringOfCap(len)
+    when defined(nimSeqsV2):
+      cast[ptr int](addr result)[] = len
+    else:
+      var s = cast[PGenericSeq](result)
+      s.len = len
 
 {.pop.}
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1630,7 +1630,7 @@ when not defined(js):
       var s = cast[PGenericSeq](result)
       s.len = len
 
-  proc newStringUninitialized*(len: Natural): string =
+  proc newStringUninit*(len: Natural): string =
     ## Returns a new string of length `len` but with uninitialized
     ## content. One needs to fill the string character after character
     ## with the index operator `s[i]`.

--- a/tests/system/tnewstring_uninitialized.nim
+++ b/tests/system/tnewstring_uninitialized.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 # bug #22555
-var x = newStringUninitialized(10)
+var x = newStringUninit(10)
 doAssert x.len == 10
 for i in 0..<x.len:
   x[i] = chr(ord('a') + i)

--- a/tests/system/tnewstring_uninitialized.nim
+++ b/tests/system/tnewstring_uninitialized.nim
@@ -1,0 +1,11 @@
+discard """
+  matrix: "--mm:refc;"
+"""
+
+# bug #22555
+var x = newStringUninitialized(10)
+doAssert x.len == 10
+for i in 0..<x.len:
+  x[i] = chr(ord('a') + i)
+
+doAssert x == "abcdefghij"


### PR DESCRIPTION
fixes #22555; alternative to https://github.com/nim-lang/Nim/pull/22562

close https://github.com/nim-lang/Nim/pull/22562