### PR TITLE
correct logic for qualified symbol in templates

### DIFF
--- a/tests/template/template_issues.nim
+++ b/tests/template/template_issues.nim
@@ -302,3 +302,7 @@ block: # bug #21920
     discard
 
   t[void]() # Error: expression has no type: discard
+
+block: # issue #19865
+  template f() = discard default(system.int)
+  f()


### PR DESCRIPTION
fixes #19865

The new code is mirrored from the [nkIdent case](https://github.com/nim-lang/Nim/blob/94454addb2a045731f2b4f44d697a319e3a20071/compiler/semtempl.nim#L383-L385). It properly calls `semTemplSymbol` which handles different symbol kinds accordingly.

The old code always called `symChoice` regardless of the symbol kind, which causes weird things like qualified type symbols to have themselves as their type, hence the bug.