### PR TITLE
enable reorder by default see what breaks

### DIFF
--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -144,8 +144,7 @@ proc processModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
         var n = parseTopLevelStmt(p)
         if n.kind == nkEmpty: break
         sl.add n
-      if sfReorder in module.flags or codeReordering in graph.config.features:
-        sl = reorder(graph, sl, module)
+      sl = reorder(graph, sl, module)
       discard processTopLevelStmt(graph, sl, a)
 
     closeParser(p)


### PR DESCRIPTION
nimsuggest tests fail