### PR TITLE
fix 22556, Set SEQ_DECL_SIZE to 1 and delete the `dummy` field

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -800,11 +800,6 @@ proc getRecordDesc(m: BModule; typ: PType, name: Rope,
     if not hasField and typ.itemId notin m.g.graph.memberProcsPerType:
       if desc == "":
         result.add("\tchar dummy;\n")
-      elif typ.len == 1 and typ.n[0].kind == nkSym:
-        let field = typ.n[0].sym
-        let fieldType = field.typ.skipTypes(abstractInst)
-        if fieldType.kind == tyUncheckedArray:
-          result.add("\tchar dummy;\n")
       result.add(desc)
     else:
       result.add(desc)

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -467,7 +467,7 @@ typedef char* NCSTRING;
 #if defined(__cplusplus) && defined(__clang__)
 #  define SEQ_DECL_SIZE 1
 #elif defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
-#  define SEQ_DECL_SIZE /* empty is correct! */
+#  define SEQ_DECL_SIZE 1 /* see https://github.com/nim-lang/Nim/issues/22556 */
 #else
 #  define SEQ_DECL_SIZE 1000000
 #endif

--- a/tests/misc/t22556.nim
+++ b/tests/misc/t22556.nim
@@ -1,0 +1,19 @@
+discard """
+valgrind: "leaks"
+matrix: "-d:useMalloc"
+targets: "c cpp"
+"""
+
+type
+  ChunkObj = object
+    data: UncheckedArray[byte]
+
+proc alloc(size: int): ref ChunkObj =
+  unsafeNew(result, size)
+
+proc main() =
+  let buf = alloc(10)
+  buf.data[9] = 100    # index out of bounds, because one byte is occupied by the 'dummy' field, 
+                       # the actual usable size of data is 9 bytes
+
+main()


### PR DESCRIPTION
The `dummy` field is no longer generated for the `UncheckedArray` object. see https://github.com/nim-lang/Nim/issues/22556