### PR TITLE
minor style changes in the compiler

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1481,7 +1481,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcExcept:
       # This opcode is never executed, it only holds information for the
       # exception handling routines.
-      doAssert(false)
+      raiseAssert "unreachable"
     of opcFinally:
       # Pop the last safepoint introduced by a opcTry. This opcode is only
       # executed _iff_ no exception was raised in the body of the `try`

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1392,8 +1392,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           let prcValue = c.globals[prc.position-1]
           if prcValue.kind == nkEmpty:
             globalError(c.config, c.debug[pc], "cannot run " & prc.name.s)
-          var slots2: TNodeSeq = default(TNodeSeq)
-          slots2.setLen(tos.slots.len)
+          var slots2: TNodeSeq = newSeq[PNode](tos.slots.len)
           for i in 0..<tos.slots.len:
             slots2[i] = regToNode(tos.slots[i])
           let newValue = callForeignFunction(c.config, prcValue, prc.typ, slots2,


### PR DESCRIPTION
Most of the outdated code in the compiler is modernized. The arduous part is the code in the codegen. I might fetch some time to work on them in the future.

And just for the record for myself, there is a strictdef bug that dot expressions and bracket expressions hinder strictdef analysis from working properly.

Also, we can enable `--experimental:strictdefs` for std tests so that users can enable the option to their own benefits.