### PR TITLE
fixes an issue where sometimes wasMoved produced bad codegen for cpp

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2324,7 +2324,10 @@ proc genMove(p: BProc; n: PNode; d: var TLoc) =
             s = "$1, $1Len_0" % [rdLoc(a)]
           linefmt(p, cpsStmts, "$1($2);$n", [rdLoc(b), s])
         else:
-          linefmt(p, cpsStmts, "$1($2);$n", [rdLoc(b), byRefLoc(p, a)])
+          if p.module.compileToCpp:
+            linefmt(p, cpsStmts, "$1($2);$n", [rdLoc(b), rdLoc(a)])
+          else:
+            linefmt(p, cpsStmts, "$1($2);$n", [rdLoc(b), byRefLoc(p, a)])
     else:
       let flags = if not canMove(p, n[1], d): {needToCopy} else: {}
       genAssignment(p, d, a, flags)


### PR DESCRIPTION
I failed to create a minimal repro to add to the test. The issue is that the cpp backend takes into account refs via `lfIndirect`. So it doenst really need the call to `byRefLoc` as wasMoved will always be `&`.  `rdLoc` does the right thing which is to deref it when `lfIndirect`