### PR TITLE
Fix #22604: Propagate info about terminating branches

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -518,6 +518,7 @@ type
     nfFirstWrite # this node is a first write
     nfHasComment # node has a comment
     nfSkipFieldChecking # node skips field visable checking
+    nfEndBlock # node doesn't return, helps propagate sfNoReturn and nkLastBlockStmts
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   # keep below 32 for efficiency reasons (now: 47)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -211,7 +211,7 @@ proc endsInNoReturn(n: PNode): bool =
   var it = n
   while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
     it = it.lastSon
-  result = it.kind in nkLastBlockStmts or
+  result = it.kind in nkLastBlockStmts or nfEndBlock in it.flags or
     it.kind in nkCallKinds and it[0].kind == nkSym and sfNoReturn in it[0].sym.flags
 
 proc commonType*(c: PContext; x: PType, y: PNode): PType =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2793,6 +2793,7 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = ni
     onDef(n[0].info, labl)
   n[1] = semExpr(c, n[1], flags, expectedType)
   n.typ = n[1].typ
+  result.propagateEndBlock(nfEndBlock in n[1].flags)
   if isEmptyType(n.typ): n.transitionSonsKind(nkBlockStmt)
   else: n.transitionSonsKind(nkBlockExpr)
   closeScope(c)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1113,7 +1113,6 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
           msg.addDeclaredLocMaybe(c.config, typ)
           localError(c.config, n.info, msg)
         return errorNode(c, n)
-      result = nil
     else:
       result = m.call
       instGenericConvertersSons(c, result, m)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -178,7 +178,7 @@ proc discardCheck(c: PContext, result: PNode, flags: TExprFlags) =
           s.add "; for a function call use ()"
         localError(c.config, n.info, s)
 
-proc propagateNoReturn(n: PNode; noReturn: bool) =
+proc propagateEndBlock(n: PNode; noReturn: bool) =
   if noReturn:
     incl(n.flags, nfEndBlock)
 
@@ -208,7 +208,7 @@ proc semIf(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil):
         expectedType = typ
     else: illFormedAst(it, c.config)
   
-  result.propagateNoReturn(allNoReturn)
+  result.propagateEndBlock(allNoReturn)
 
   if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped} or
       (not hasElse and efInTypeof notin flags):
@@ -321,7 +321,7 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil)
       dec last
     closeScope(c)
 
-  result.propagateNoReturn(allNoReturn)
+  result.propagateEndBlock(allNoReturn)
 
   if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped}:
     discardCheck(c, n[0], flags)
@@ -1219,7 +1219,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil
   popCaseContext(c)
   closeScope(c)
 
-  result.propagateNoReturn(allNoReturn)
+  result.propagateEndBlock(allNoReturn)
 
   if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped} or
       (not hasElse and efInTypeof notin flags):

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -208,7 +208,8 @@ proc semIf(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil):
         expectedType = typ
     else: illFormedAst(it, c.config)
   
-  result.propagateEndBlock(allNoReturn)
+  # must be exhaustive
+  result.propagateEndBlock(allNoReturn and hasElse)
 
   if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped} or
       (not hasElse and efInTypeof notin flags):

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2668,7 +2668,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, expectedType: PType =
     var m = n[i]
     while m.kind in {nkStmtListExpr, nkStmtList} and m.len > 0: # from templates
       m = m.lastSon
-    if m.kind in nkLastBlockStmts or
+    if m.kind in nkLastBlockStmts or nfEndBlock in m.flags or
         m.kind in nkCallKinds and m[0].kind == nkSym and
         sfNoReturn in m[0].sym.flags:
       for j in i + 1..<n.len:

--- a/tests/controlflow/tunreachable.nim
+++ b/tests/controlflow/tunreachable.nim
@@ -2,8 +2,9 @@ discard """
   cmd: "nim check --warningAsError:UnreachableCode $file"
   action: "reject"
   nimout: '''
-tunreachable.nim(23, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
-tunreachable.nim(30, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(24, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(31, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(41, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
 '''
 """
   
@@ -30,3 +31,13 @@ proc main2() =
   echo "after"
 
 main2()
+
+
+proc main3() =
+  if true:
+    return
+  else:
+    return
+  echo "after"
+
+main3()

--- a/tests/exprs/t22604.nim
+++ b/tests/exprs/t22604.nim
@@ -1,6 +1,6 @@
 
-# propagation to case of
 for i in 0..<1:
+  # propagation to case of
   let x =
     case false
     of true:
@@ -11,9 +11,9 @@ for i in 0..<1:
       else:
         raiseAssert "Won't get here"
 
-# propagation to block
 for i in 0..<1:
-  let x =
+  # propagation to block
+  let y =
     case false
     of true:
       42

--- a/tests/exprs/t22604.nim
+++ b/tests/exprs/t22604.nim
@@ -1,0 +1,25 @@
+
+# propagation to case of
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      if true:
+        continue
+      else:
+        raiseAssert "Won't get here"
+
+# propagation to block
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      block:
+        if true:
+          continue
+        else:
+          raiseAssert "Won't get here"


### PR DESCRIPTION
Close #22604

Propagates a new `nfEndBlock` flag for branches that terminate the block, improves type inference and unreachable code detection.
I don't know what `sempass2` is for, so if that needs to handle this situation too please provide feedback.

Thinks the echo for `"hey iterator"` in #20362 is unreachable even though it prints, so either that case needs to be made consistent or the propagation needs to somehow work around this behavior.

Alternative to this pr would be making `endsInNoReturn` check the appropriate node types.