### PR TITLE
Fix #22604: Make endsInNoReturn traverse the tree

### DIFF
--- a/compiler/hlo.nim
+++ b/compiler/hlo.nim
@@ -10,9 +10,6 @@
 # This include implements the high level optimization pass.
 # included from sem.nim
 
-when defined(nimPreviewSlimSystem):
-  import std/assertions
-
 proc hlo(c: PContext, n: PNode): PNode
 
 proc evalPattern(c: PContext, n, orig: PNode): PNode =

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -10,7 +10,6 @@
 # This module implements the semantic checking pass.
 
 import tables
-import std/assertions
 
 import
   ast, strutils, options, astalgo, trees,
@@ -27,7 +26,10 @@ when not defined(leanCompiler):
   import spawn
 
 when defined(nimPreviewSlimSystem):
-  import std/formatfloat
+  import std/[
+    formatfloat,
+    assertions,
+  ]
 
 # implementation
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -218,7 +218,7 @@ proc endsInNoReturn(n: PNode): bool =
 
   var it = n
   # skip these beforehand, no special handling needed
-  while it.kind in {nkStmtList, nkStmtListExpr, nkBlockStmt}:
+  while it.kind in {nkStmtList, nkStmtListExpr, nkBlockStmt} and it.len > 0:
     it = it.lastSon
 
   case it.kind

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -226,7 +226,7 @@ proc endsInNoReturn(n: PNode): bool =
     var hasElse = false
     for branch in it:
       checkBranch:
-        if branch.len() == 2:
+        if branch.len == 2:
           branch[1]
         elif branch.len == 1:
           hasElse = true

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1113,7 +1113,6 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
           msg.addDeclaredLocMaybe(c.config, typ)
           localError(c.config, n.info, msg)
         return errorNode(c, n)
-      result = nil
     else:
       result = m.call
       instGenericConvertersSons(c, result, m)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2648,6 +2648,8 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, expectedType: PType =
     if m.kind in nkLastBlockStmts or
         m.kind in nkCallKinds and m[0].kind == nkSym and
         sfNoReturn in m[0].sym.flags:
+      discard
+    if endsInNoReturn(n):
       for j in i + 1..<n.len:
         case n[j].kind
         of nkPragma, nkCommentStmt, nkNilLit, nkEmpty, nkState: discard

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2645,11 +2645,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, expectedType: PType =
     var m = n[i]
     while m.kind in {nkStmtListExpr, nkStmtList} and m.len > 0: # from templates
       m = m.lastSon
-    if m.kind in nkLastBlockStmts or
-        m.kind in nkCallKinds and m[0].kind == nkSym and
-        sfNoReturn in m[0].sym.flags:
-      discard
-    if endsInNoReturn(n):
+    if endsInNoReturn(m):
       for j in i + 1..<n.len:
         case n[j].kind
         of nkPragma, nkCommentStmt, nkNilLit, nkEmpty, nkState: discard

--- a/tests/controlflow/tunreachable.nim
+++ b/tests/controlflow/tunreachable.nim
@@ -2,8 +2,9 @@ discard """
   cmd: "nim check --warningAsError:UnreachableCode $file"
   action: "reject"
   nimout: '''
-tunreachable.nim(23, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
-tunreachable.nim(30, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(24, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(31, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
+tunreachable.nim(40, 3) Error: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
 '''
 """
   
@@ -30,3 +31,12 @@ proc main2() =
   echo "after"
 
 main2()
+
+proc main3() =
+  if true:
+    return
+  else:
+    return
+  echo "after"
+
+main3()

--- a/tests/exprs/t22604.nim
+++ b/tests/exprs/t22604.nim
@@ -1,0 +1,49 @@
+# if
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      if true:
+        continue
+      else:
+        raiseAssert "Won't get here"
+
+# block
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      block:
+        if true:
+          continue
+        else:
+          raiseAssert "Won't get here"
+
+# nested case
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      case true
+      of true:
+        continue
+      of false:
+        raiseAssert "Won't get here"
+
+# try except
+for i in 0..<1:
+  let x =
+    case false
+    of true:
+      42
+    of false:
+      try:
+        continue
+      except:
+        raiseAssert "Won't get here"


### PR DESCRIPTION
Close #22604 

`endsInNoReturn` now traverses relevant nodes to determine if the block really doesn't return.
Same story as in previous pr, improves type inference and unreachable code detection somewhat, iterator example also now not seen as a noreturn, so thanks for stopping the flag nonsense I was doing.

Alternative to #22608 