### PR TITLE
fixes #22613; Default value does not work with object's discriminator

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -351,7 +351,7 @@ proc semConstructFields(c: PContext, n: PNode, constrCtx: var ObjConstrContext,
         if discriminator.sym.ast != nil:
           # branch is selected by the default field value of discriminator
           let discriminatorDefaultVal = discriminator.sym.ast
-          result.status = initPartial
+          result.status = initUnknown
           result.defaults.add newTree(nkExprColonExpr, n[0], discriminatorDefaultVal)
           if discriminatorDefaultVal.kind == nkIntLit:
             let matchedBranch = n.pickCaseBranch discriminatorDefaultVal

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -377,7 +377,7 @@ template main {.dirty.} =
         Red, Blue, Yellow
   
     type
-      ObjectVarint3 = object # fixme it doesn't work with static
+      ObjectVarint3 = object
         case kind: Color = Blue
         of Red:
           data1: int = 10

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -703,5 +703,20 @@ template main {.dirty.} =
     var foo = new Container
     doAssert int(foo.thing[0].x) == 1
 
+  block: # bug #22613
+    type
+      K = enum
+        A = "a"
+        B = "b"
+      T = object
+        case kind: K = B
+        of A:
+          a: int
+        of B:
+          b: float
+
+    doAssert T().kind == B
+
+
 static: main()
 main()


### PR DESCRIPTION
fixes #22613

will make a following PR on objects with a default descriminator and explicit fields initialization later.