### PR TITLE
WIP: Properly handle generic types that do not contain generic parameters in the body

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -110,6 +110,14 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
       if t.sym != nil: c.hashSym(t.sym)
       if t.sym == nil or tfFromGeneric in t.flags:
         c.hashType t.lastSon, flags, conf
+      if t.typeInst != nil:
+        # prevent against infinite recursions here, see bug #8883:
+        let inst = t.typeInst
+        t.typeInst = nil
+        assert inst.kind == tyGenericInst
+        for i in 0..<inst.len - 1:
+          c.hashType inst[i], flags, conf
+        t.typeInst = inst
     elif CoType in flags or t.sym == nil:
       c.hashType t.lastSon, flags, conf
     else:

--- a/tests/destructor/t22479.nim
+++ b/tests/destructor/t22479.nim
@@ -1,0 +1,32 @@
+discard """
+  output: '''
+int
+float
+int
+float
+'''
+"""
+
+block test_object:
+  type Obj[T] = object
+
+  proc `=destroy`[T](self: var Obj[T]) =
+    echo T
+
+  block:
+    let intObj = default(Obj[int])
+
+  block:
+    let floatObj = default(Obj[float])
+
+block test_distinct:
+  type Obj[T] = distinct string
+
+  proc `=destroy`[T](self: var Obj[T]) =
+    echo T
+
+  block:
+    let intObj = default(Obj[int])
+
+  block:
+    let floatObj = default(Obj[float])


### PR DESCRIPTION
fixes #22479

Currently [tinvalid_rebind.nim](https://github.com/nim-lang/Nim/blob/2542dc09c829a709050335066b0f414d6fc68fe2/tests/destructor/tinvalid_rebind.nim) fails.
From the beginning, the check for the existence of implicitly generated generic destructors is not working correctly. In fact, adding a `value: T` field to `Foo[T]` causes the test to fail.