### PR TITLE
Fix the problem where instances of generic objects with `sendable` pragmas are not being cached

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -641,7 +641,7 @@ const
   skError* = skUnknown
 
 var
-  eqTypeFlags* = {tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable}
+  eqTypeFlags* = {tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam}
     ## type flags that are essential for type equality.
     ## This is now a variable because for emulation of version:1.0 we
     ## might exclude {tfGcSafe, tfNoSideEffect}.


### PR DESCRIPTION
Before this PR, the following code could not be compiled.
```nim
type
  Isolated[T] {.sendable.} = object
    value: T

func isolate[T](value: sink T): Isolated[T] =
  Isolated[T](value: value)

proc `=destroy`*[T](dest: var Isolated[T]) =
  discard

proc main =
  let it = iterator(): int =
    var tmp = isolate(1)

main()
```
Since flags like `tfFinal`, `tfInheritable` and `tfPacked` are not included in `eqTypeFlags`, I think it is correct to do the same for `tfSendable`.