### PR TITLE
fixes branches interacting with break, raise etc. in strictdefs

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -561,7 +561,7 @@ proc lookUp*(c: PContext, n: PNode): PSym =
     if result == nil: result = errorUndeclaredIdentifierHint(c, n, ident)
   else:
     internalError(c.config, n.info, "lookUp")
-    return
+    return nil
   if amb:
     #contains(c.ambiguousSymbols, result.id):
     result = errorUseQualifier(c, n.info, result, amb)

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -74,7 +74,7 @@ type
     owner: PSym
     ownerModule: PSym
     init: seq[int] # list of initialized variables
-    resultId: Option[int] # the id of rersult if it exists
+    resultId: Option[int] # the id of result if it exists
     scopes: Table[int, int] # maps var-id to its scope (see also `currentBlock`).
     guards: TModel # nested guards
     locked: seq[PNode] # locked locations

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -16,7 +16,7 @@ import
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
-import std/options
+import std/options as opt
 
 when defined(useDfa):
   import dfa

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -152,7 +152,7 @@ proc none*(T: typedesc): Option[T] {.inline.} =
     assert none(int).isNone
 
   # the default is the none type
-  discard
+  result = Option[T]()
 
 proc none*[T]: Option[T] {.inline.} =
   ## Alias for `none(T) <#none,typedesc>`_.


### PR DESCRIPTION
```nim
{.experimental: "strictdefs".}

type Test = object
  id: int

proc test(): Test =
  if true:
    return Test()
  else:
    return
echo test()
```

I will tackle https://github.com/nim-lang/Nim/issues/16735 and #21615 in the following PR.