### PR TITLE
Exclude block from endsInNoReturn, fix regression

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -220,7 +220,7 @@ proc endsInNoReturn(n: PNode): bool =
 
   var it = n
   # skip these beforehand, no special handling needed
-  while it.kind in {nkStmtList, nkStmtListExpr, nkBlockStmt} and it.len > 0:
+  while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
     it = it.lastSon
 
   case it.kind

--- a/tests/exprs/t22604.nim
+++ b/tests/exprs/t22604.nim
@@ -10,19 +10,6 @@ for i in 0..<1:
       else:
         raiseAssert "Won't get here"
 
-# block
-for i in 0..<1:
-  let x =
-    case false
-    of true:
-      42
-    of false:
-      block:
-        if true:
-          continue
-        else:
-          raiseAssert "Won't get here"
-
 # nested case
 for i in 0..<1:
   let x =


### PR DESCRIPTION
Close #22626

This seems to be the limit of this method as accurately handling blocks would require access to symbol lookup in the current scope to handle named blocks.
From here the best bet is probably that type-based approach so it actually works together with the sem stages, but for now just fixing the regression. Even then though it would probably have to carry a depth value or similar with it somehow, so that is beyond me.