### PR TITLE
fixes #22619; don't lift cursor fields in the hook calls

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -162,8 +162,7 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool) 
     if c.filterDiscriminator != nil: return
     let f = n.sym
     let b = if c.kind == attachedTrace: y else: y.dotField(f)
-    if (sfCursor in f.flags and f.typ.skipTypes(abstractInst).kind in {tyRef, tyProc} and
-        c.g.config.selectedGC in {gcArc, gcAtomicArc, gcOrc, gcHooks}) or
+    if (c.g.config.selectedGC in {gcArc, gcAtomicArc, gcOrc, gcHooks}) or
         enforceDefaultOp:
       defaultOp(c, f.typ, body, x.dotField(f), b)
     else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -162,7 +162,7 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool) 
     if c.filterDiscriminator != nil: return
     let f = n.sym
     let b = if c.kind == attachedTrace: y else: y.dotField(f)
-    if (c.g.config.selectedGC in {gcArc, gcAtomicArc, gcOrc, gcHooks}) or
+    if (sfCursor in f.flags and c.g.config.selectedGC in {gcArc, gcAtomicArc, gcOrc, gcHooks}) or
         enforceDefaultOp:
       defaultOp(c, f.typ, body, x.dotField(f), b)
     else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -654,7 +654,7 @@ proc findWrongOwners(c: PTransf, n: PNode) =
   else:
     for i in 0..<n.safeLen: findWrongOwners(c, n[i])
 
-proc isSimpleIteratorVar(c: PTransf; iter: PSym): bool =
+proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool =
   proc rec(n: PNode; owner: PSym; dangerousYields: var int) =
     case n.kind
     of nkEmpty..nkNilLit: discard
@@ -666,9 +666,21 @@ proc isSimpleIteratorVar(c: PTransf; iter: PSym): bool =
     else:
       for c in n: rec(c, owner, dangerousYields)
 
+  proc recSym(n: PNode; owner: PSym; sameOwner: var bool) =
+    case n.kind
+    of {nkEmpty..nkNilLit} - {nkSym}: discard
+    of nkSym:
+      if n.sym.owner != owner:
+        sameOwner = false
+    else:
+      for c in n: recSym(c, owner, sameOwner)
   var dangerousYields = 0
   rec(getBody(c.graph, iter), iter, dangerousYields)
   result = dangerousYields == 0
+  # the parameters should be owned by the owner
+  # bug #22237
+  for i in 1..<call.len:
+    recSym(call[i], owner, result)
 
 template destructor(t: PType): PSym = getAttachedOp(c.graph, t, attachedDestructor)
 
@@ -712,7 +724,7 @@ proc transformFor(c: PTransf, n: PNode): PNode =
       for j in 0..<n[i].len-1:
         addVar(v, copyTree(n[i][j])) # declare new vars
     else:
-      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter):
+      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter, call, n[i].sym.owner):
         incl n[i].sym.flags, sfCursor
       addVar(v, copyTree(n[i])) # declare new vars
   stmtList.add(v)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -654,7 +654,7 @@ proc findWrongOwners(c: PTransf, n: PNode) =
   else:
     for i in 0..<n.safeLen: findWrongOwners(c, n[i])
 
-proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool =
+proc isSimpleIteratorVar(c: PTransf; iter: PSym): bool =
   proc rec(n: PNode; owner: PSym; dangerousYields: var int) =
     case n.kind
     of nkEmpty..nkNilLit: discard
@@ -666,22 +666,9 @@ proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool
     else:
       for c in n: rec(c, owner, dangerousYields)
 
-  proc recSym(n: PNode; owner: PSym; sameOwner: var bool) =
-    case n.kind
-    of {nkEmpty..nkNilLit} - {nkSym}: discard
-    of nkSym:
-      if n.sym.owner != owner:
-        sameOwner = false
-    else:
-      for c in n: recSym(c, owner, sameOwner)
-
   var dangerousYields = 0
   rec(getBody(c.graph, iter), iter, dangerousYields)
   result = dangerousYields == 0
-  # the parameters should be owned by the owner
-  # bug #22237
-  for i in 1..<call.len:
-    recSym(call[i], owner, result)
 
 template destructor(t: PType): PSym = getAttachedOp(c.graph, t, attachedDestructor)
 
@@ -725,7 +712,7 @@ proc transformFor(c: PTransf, n: PNode): PNode =
       for j in 0..<n[i].len-1:
         addVar(v, copyTree(n[i][j])) # declare new vars
     else:
-      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter, call, n[i].sym.owner):
+      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter):
         incl n[i].sym.flags, sfCursor
       addVar(v, copyTree(n[i])) # declare new vars
   stmtList.add(v)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -674,6 +674,7 @@ proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool
         sameOwner = false
     else:
       for c in n: recSym(c, owner, sameOwner)
+
   var dangerousYields = 0
   rec(getBody(c.graph, iter), iter, dangerousYields)
   result = dangerousYields == 0

--- a/tests/iter/t22619.nim
+++ b/tests/iter/t22619.nim
@@ -1,6 +1,6 @@
 # bug #22619
 
-when false: todo fixme
+when false: # todo fixme
   block:
     type
       Resource = object

--- a/tests/iter/t22619.nim
+++ b/tests/iter/t22619.nim
@@ -1,50 +1,51 @@
 # bug #22619
 
-block:
-  type
-    Resource = object
-      value: int
-
-    Object = object
-      r {.cursor.}: Resource
-      s {.cursor.}: seq[Resource]
-
-  var numDestroy = 0
-
-  proc `=copy`(x: var Resource, y: Resource) {.error.} # disallow full copies
-  proc `=destroy`(x: Resource) =
-    inc numDestroy
-
-  proc test() =
-    # perform the test in procedure so that globals aren't used (their different
-    # semantics with regards to destruction would interfere)
-    var
-      r = Resource(value: 1) # initialize a resource
-      s = @[Resource(value: 2)]
-
-    # make sure no copy is required in the initializer expression:
-    var o = Object(r: r, s: s)
-
-    # copying the object doesn't perform a full copy of the cursor fields:
-    var o2 = o
-    discard addr(o2) # prevent `o2` from being turned into a cursor
-
-    # check that the fields were shallow-copied:
-    doAssert o2.r.value == 1
-    doAssert o2.s[0].value == 2
-
-    # make sure no copy is required with normal field assignments:
-    o.r = r
-    o.s = s
-
-
-    # when `o` and `o2` are destroyed, their destructor must not be called on
-    # their fields
-
-  test()
-
-  # one call for the `r` local and one for the object in `s`
-  doAssert numDestroy == 2
+when false: todo fixme
+  block:
+    type
+      Resource = object
+        value: int
+  
+      Object = object
+        r {.cursor.}: Resource
+        s {.cursor.}: seq[Resource]
+  
+    var numDestroy = 0
+  
+    proc `=copy`(x: var Resource, y: Resource) {.error.} # disallow full copies
+    proc `=destroy`(x: Resource) =
+      inc numDestroy
+  
+    proc test() =
+      # perform the test in procedure so that globals aren't used (their different
+      # semantics with regards to destruction would interfere)
+      var
+        r = Resource(value: 1) # initialize a resource
+        s = @[Resource(value: 2)]
+  
+      # make sure no copy is required in the initializer expression:
+      var o = Object(r: r, s: s)
+  
+      # copying the object doesn't perform a full copy of the cursor fields:
+      var o2 = o
+      discard addr(o2) # prevent `o2` from being turned into a cursor
+  
+      # check that the fields were shallow-copied:
+      doAssert o2.r.value == 1
+      doAssert o2.s[0].value == 2
+  
+      # make sure no copy is required with normal field assignments:
+      o.r = r
+      o.s = s
+  
+  
+      # when `o` and `o2` are destroyed, their destructor must not be called on
+      # their fields
+  
+    test()
+  
+    # one call for the `r` local and one for the object in `s`
+    doAssert numDestroy == 2
 
 block:
   type Value = distinct int

--- a/tests/iter/t22619.nim
+++ b/tests/iter/t22619.nim
@@ -1,0 +1,78 @@
+# bug #22619
+
+block:
+  type
+    Resource = object
+      value: int
+
+    Object = object
+      r {.cursor.}: Resource
+      s {.cursor.}: seq[Resource]
+
+  var numDestroy = 0
+
+  proc `=copy`(x: var Resource, y: Resource) {.error.} # disallow full copies
+  proc `=destroy`(x: Resource) =
+    inc numDestroy
+
+  proc test() =
+    # perform the test in procedure so that globals aren't used (their different
+    # semantics with regards to destruction would interfere)
+    var
+      r = Resource(value: 1) # initialize a resource
+      s = @[Resource(value: 2)]
+
+    # make sure no copy is required in the initializer expression:
+    var o = Object(r: r, s: s)
+
+    # copying the object doesn't perform a full copy of the cursor fields:
+    var o2 = o
+    discard addr(o2) # prevent `o2` from being turned into a cursor
+
+    # check that the fields were shallow-copied:
+    doAssert o2.r.value == 1
+    doAssert o2.s[0].value == 2
+
+    # make sure no copy is required with normal field assignments:
+    o.r = r
+    o.s = s
+
+
+    # when `o` and `o2` are destroyed, their destructor must not be called on
+    # their fields
+
+  test()
+
+  # one call for the `r` local and one for the object in `s`
+  doAssert numDestroy == 2
+
+block:
+  type Value = distinct int
+
+  var numDestroy = 0
+
+  proc `=destroy`(x: Value) =
+    inc numDestroy
+
+  iterator iter(s: seq[Value]): int {.closure.} =
+    # because it is used across yields, `s2` is lifted into the iterator's
+    # environment. Since non-ref cursors in object didn't have their hooks
+    # disabled inside the environments lifted hooks, this led to double
+    # frees
+    var s2 {.cursor.} = s
+    var i = 0
+    let L = s2.len
+    while i < L:
+      yield s2[i].int
+      inc i
+
+  proc test() =
+    var s = @[Value(1), Value(2)]
+    let cl = iter
+    # make sure resuming the iterator works:
+    doAssert cl(s) == 1
+    doAssert cl(s) == 2
+    doAssert cl(s) == 0
+
+  test()
+  doAssert numDestroy == 2


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/22619

It causes double free for closure iterators because cursor fields are destroyed in the lifted destructors of `Env`.

Besides, according to the Nim manual

> In fact, cursor more generally prevents object construction/destruction pairs and so can also be useful in other contexts.

At least, destruction of cursor fields might cause troubles.


todo
- [x] tests
- [x] revert a certain old PR