### PR TITLE
Revert "Add `cursor` to lists iterator variables (#22531)" and revert #22240

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -654,7 +654,7 @@ proc findWrongOwners(c: PTransf, n: PNode) =
   else:
     for i in 0..<n.safeLen: findWrongOwners(c, n[i])
 
-proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool =
+proc isSimpleIteratorVar(c: PTransf; iter: PSym): bool =
   proc rec(n: PNode; owner: PSym; dangerousYields: var int) =
     case n.kind
     of nkEmpty..nkNilLit: discard
@@ -666,22 +666,9 @@ proc isSimpleIteratorVar(c: PTransf; iter: PSym; call: PNode; owner: PSym): bool
     else:
       for c in n: rec(c, owner, dangerousYields)
 
-  proc recSym(n: PNode; owner: PSym; sameOwner: var bool) =
-    case n.kind
-    of {nkEmpty..nkNilLit} - {nkSym}: discard
-    of nkSym:
-      if n.sym.owner != owner:
-        sameOwner = false
-    else:
-      for c in n: recSym(c, owner, sameOwner)
-
   var dangerousYields = 0
   rec(getBody(c.graph, iter), iter, dangerousYields)
   result = dangerousYields == 0
-  # the parameters should be owned by the owner
-  # bug #22237
-  for i in 1..<call.len:
-    recSym(call[i], owner, result)
 
 template destructor(t: PType): PSym = getAttachedOp(c.graph, t, attachedDestructor)
 
@@ -725,7 +712,7 @@ proc transformFor(c: PTransf, n: PNode): PNode =
       for j in 0..<n[i].len-1:
         addVar(v, copyTree(n[i][j])) # declare new vars
     else:
-      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter, call, n[i].sym.owner):
+      if n[i].kind == nkSym and isSimpleIteratorVar(c, iter):
         incl n[i].sym.flags, sfCursor
       addVar(v, copyTree(n[i])) # declare new vars
   stmtList.add(v)

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -264,7 +264,7 @@ iterator nodes*[T](L: SomeLinkedList[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it {.cursor.} = L.head
+  var it = L.head
   while it != nil:
     let nxt = it.next
     yield it
@@ -289,7 +289,7 @@ iterator nodes*[T](L: SomeLinkedRing[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it {.cursor.} = L.head
+  var it = L.head
   if it != nil:
     while true:
       let nxt = it.next
@@ -711,7 +711,7 @@ proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.disc
     if L.tail.next == n:
       L.tail.next = L.head # restore cycle
   else:
-    var prev {.cursor.} = L.head
+    var prev = L.head
     while prev.next != n and prev.next != nil:
       prev = prev.next
     if prev.next == nil:


### PR DESCRIPTION
This reverts commit fc6a388780c9a0e2eb6c5eff4e291e7bcfcd5f7a.
revert #22240

it needs https://github.com/nim-lang/Nim/pull/22638