### PR TITLE
revert generic inst sym change while keeping fix

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -434,17 +434,6 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   # handleGenericInvocation will handle the alias-to-alias-to-alias case
   if newbody.isGenericAlias: newbody = newbody.skipGenericAlias
 
-  let origSym = newbody.sym
-  if origSym != nil and sfFromGeneric notin origSym.flags:
-    # same as `replaceTypeVarsS` but directly set the type without recursion:
-    newbody.sym = copySym(origSym, cl.c.idgen)
-    incl(newbody.sym.flags, sfFromGeneric)
-    newbody.sym.owner = origSym.owner
-    newbody.sym.typ = newbody
-    # unfortunately calling `replaceTypeVarsN` causes recursion, so this AST
-    # is the original generic body AST
-    newbody.sym.ast = copyTree(origSym.ast)
-
   rawAddSon(result, newbody)
   checkPartialConstructedType(cl.c.config, cl.info, newbody)
   if not cl.allowMetaTypes:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -505,13 +505,6 @@ proc skipToObject(t: PType; skipped: var SkippedPtr): PType =
   if r.kind == tyObject and ptrs <= 1: result = r
   else: result = nil
 
-proc getObjectSym(t: PType): PSym =
-  if tfFromGeneric in t.flags and t.typeInst.kind == tyGenericInst:
-    var dummy: SkippedPtr
-    result = t.typeInst[0].skipToObject(dummy).sym
-  else:
-    result = t.sym
-
 proc isGenericSubtype(c: var TCandidate; a, f: PType, d: var int, fGenericOrigin: PType): bool =
   assert f.kind in {tyGenericInst, tyGenericInvocation, tyGenericBody}
   var askip = skippedNone
@@ -519,12 +512,11 @@ proc isGenericSubtype(c: var TCandidate; a, f: PType, d: var int, fGenericOrigin
   var t = a.skipToObject(askip)
   let r = f.skipToObject(fskip)
   if r == nil: return false
-  let rSym = getObjectSym(r)
   var depth = 0
   var last = a
   # XXX sameObjectType can return false here. Need to investigate
   # why that is but sameObjectType does way too much work here anyway.
-  while t != nil and rSym != getObjectSym(t) and askip == fskip:
+  while t != nil and r.sym != t.sym and askip == fskip:
     t = t[0]
     if t == nil: break
     last = t
@@ -1610,7 +1602,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         # crossing path with metatypes/aliases, so we need to separate them
         # by checking sym.id
         let genericSubtype = isGenericSubtype(c, x, f, depth, f)
-        if not (genericSubtype and getObjectSym(aobj).id != getObjectSym(fobj).id) and aOrig.kind != tyGenericBody:
+        if not (genericSubtype and aobj.sym.id != fobj.sym.id) and aOrig.kind != tyGenericBody:
           depth = -1
 
       if depth >= 0:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -89,7 +89,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     id
   template newIdentDefs(s): untyped = newIdentDefs(s, s.typ)
 
-  if inst and not allowRecursion and t.sym != nil:
+  if inst and not allowRecursion and t.sym != nil and
+      tfFromGeneric notin t.flags:
     # getTypeInst behavior: return symbol
     return atomicType(t.sym)
 
@@ -155,7 +156,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result = newNodeX(nkDistinctTy)
       result.add mapTypeToAst(t[0], info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
@@ -179,7 +180,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       else:
         result.add newNodeI(nkEmpty, info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = newNodeIT(nkObjectTy, if t.n.isNil: info else: t.n.info, t)
         result.add newNodeI(nkEmpty, info)
         if t[0] == nil:


### PR DESCRIPTION
reverts #22642 but keeps #22639 fixed, closes #22646, refs #22650, refs https://github.com/alaviss/union/issues/51

Just make getType account for the old behavior instead of changing the behavior so getType works. This might still break some uses of getType.