### PR TITLE
fully revert generic inst sym change, test #22646

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -434,17 +434,6 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   # handleGenericInvocation will handle the alias-to-alias-to-alias case
   if newbody.isGenericAlias: newbody = newbody.skipGenericAlias
 
-  let origSym = newbody.sym
-  if origSym != nil and sfFromGeneric notin origSym.flags:
-    # same as `replaceTypeVarsS` but directly set the type without recursion:
-    newbody.sym = copySym(origSym, cl.c.idgen)
-    incl(newbody.sym.flags, sfFromGeneric)
-    newbody.sym.owner = origSym.owner
-    newbody.sym.typ = newbody
-    # unfortunately calling `replaceTypeVarsN` causes recursion, so this AST
-    # is the original generic body AST
-    newbody.sym.ast = copyTree(origSym.ast)
-
   rawAddSon(result, newbody)
   checkPartialConstructedType(cl.c.config, cl.info, newbody)
   if not cl.allowMetaTypes:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -505,13 +505,6 @@ proc skipToObject(t: PType; skipped: var SkippedPtr): PType =
   if r.kind == tyObject and ptrs <= 1: result = r
   else: result = nil
 
-proc getObjectSym(t: PType): PSym =
-  if tfFromGeneric in t.flags and t.typeInst.kind == tyGenericInst:
-    var dummy: SkippedPtr
-    result = t.typeInst[0].skipToObject(dummy).sym
-  else:
-    result = t.sym
-
 proc isGenericSubtype(c: var TCandidate; a, f: PType, d: var int, fGenericOrigin: PType): bool =
   assert f.kind in {tyGenericInst, tyGenericInvocation, tyGenericBody}
   var askip = skippedNone
@@ -519,12 +512,11 @@ proc isGenericSubtype(c: var TCandidate; a, f: PType, d: var int, fGenericOrigin
   var t = a.skipToObject(askip)
   let r = f.skipToObject(fskip)
   if r == nil: return false
-  let rSym = getObjectSym(r)
   var depth = 0
   var last = a
   # XXX sameObjectType can return false here. Need to investigate
   # why that is but sameObjectType does way too much work here anyway.
-  while t != nil and rSym != getObjectSym(t) and askip == fskip:
+  while t != nil and r.sym != t.sym and askip == fskip:
     t = t[0]
     if t == nil: break
     last = t
@@ -1610,7 +1602,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         # crossing path with metatypes/aliases, so we need to separate them
         # by checking sym.id
         let genericSubtype = isGenericSubtype(c, x, f, depth, f)
-        if not (genericSubtype and getObjectSym(aobj).id != getObjectSym(fobj).id) and aOrig.kind != tyGenericBody:
+        if not (genericSubtype and aobj.sym.id != fobj.sym.id) and aOrig.kind != tyGenericBody:
           depth = -1
 
       if depth >= 0:

--- a/tests/generics/timpl_ast.nim
+++ b/tests/generics/timpl_ast.nim
@@ -43,38 +43,3 @@ block: # issues #9899, ##14708
     macro parse(s: static string) =
       result = parseStmt(s)
     parse("type " & implRepr(Option))
-
-block: # issue #22639
-  type
-    Spectrum[N: static int] = object
-      data: array[N, float]
-    AngleInterpolator = object
-      data: seq[Spectrum[60]]
-  proc initInterpolator(num: int): AngleInterpolator =
-    result = AngleInterpolator()
-    for i in 0 ..< num:
-      result.data.add Spectrum[60]()
-  macro genCompatibleTuple(t: typed): untyped =
-    let typ = t.getType[1].getTypeImpl[2]
-    result = nnkTupleTy.newTree()
-    for i, ch in typ: # is `nnkObjectTy`
-      result.add nnkIdentDefs.newTree(ident(ch[0].strVal), # ch is `nnkIdentDefs`
-                                      ch[1],
-                                      newEmptyNode())
-  proc fullSize[T: object | tuple](x: T): int =
-    var tmp: genCompatibleTuple(T)
-    result = 0
-    for field, val in fieldPairs(x):
-      result += sizeof(val)
-    doAssert result == sizeof(tmp)
-
-  let reflectivity = initInterpolator(1)
-  for el in reflectivity.data:
-    doAssert fullSize(el) == sizeof(el)
-  doAssert fullSize(reflectivity.data[0]) == sizeof(reflectivity.data[0])
-  doAssert genCompatibleTuple(Spectrum[60]) is tuple[data: array[60, float]]
-  doAssert genCompatibleTuple(Spectrum[120]) is tuple[data: array[120, float]]
-  type Foo[T] = object
-    data: T
-  doAssert genCompatibleTuple(Foo[int]) is tuple[data: int]
-  doAssert genCompatibleTuple(Foo[float]) is tuple[data: float]


### PR DESCRIPTION
reverts #22642, reopens #22639, closes #22646, refs #22650, refs https://github.com/alaviss/union/issues/51, refs #22652

The fallout is too much from #22642, we can come back to it if we can account for all the affected code.