### PR TITLE
minor refactoring, move some sym/type construction to semdata

### DIFF
--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -13,8 +13,6 @@
 
 import ast, astalgo, semdata, lookups, lineinfos, idents, msgs, renderer, types, intsets
 
-from magicsys import addSonSkipIntLit
-
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
@@ -32,18 +30,6 @@ proc declareSelf(c: PContext; info: TLineInfo) =
   s.typ.flags.incl {tfUnresolved, tfPacked}
   s.typ.add newType(tyEmpty, nextTypeId(c.idgen), ow)
   addDecl(c, s, info)
-
-proc isSelf*(t: PType): bool {.inline.} =
-  ## Is this the magical 'Self' type?
-  t.kind == tyTypeDesc and tfPacked in t.flags
-
-proc makeTypeDesc*(c: PContext, typ: PType): PType =
-  if typ.kind == tyTypeDesc and not isSelf(typ):
-    result = typ
-  else:
-    result = newTypeS(tyTypeDesc, c)
-    incl result.flags, tfCheckedForDestructor
-    result.addSonSkipIntLit(typ, c.idgen)
 
 proc semConceptDecl(c: PContext; n: PNode): PNode =
   ## Recursive helper for semantic checking for the concept declaration.

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -329,16 +329,6 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
 proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
                   flags: TExprFlags = {}; expectedType: PType = nil): PNode
 
-proc symFromType(c: PContext; t: PType, info: TLineInfo): PSym =
-  if t.sym != nil: return t.sym
-  result = newSym(skType, getIdent(c.cache, "AnonType"), c.idgen, t.owner, info)
-  result.flags.incl sfAnon
-  result.typ = t
-
-proc symNodeFromType(c: PContext, t: PType, info: TLineInfo): PNode =
-  result = newSymNode(symFromType(c, t, info), info)
-  result.typ = makeTypeDesc(c, t)
-
 when false:
   proc createEvalContext(c: PContext, mode: TEvalMode): PEvalContext =
     result = newEvalContext(c.module, mode)

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -12,8 +12,6 @@
 import ast, astalgo, msgs, types, magicsys, semdata, renderer, options,
   lineinfos, modulegraphs
 
-from concepts import makeTypeDesc
-
 when defined(nimPreviewSlimSystem):
   import std/assertions
 


### PR DESCRIPTION
Move `symFromType` and `symNodeFromType` from `sem`, and `isSelf` and `makeTypeDesc` from `concepts` into `semdata`.

`makeTypeDesc` was moved out from semdata [when the `concepts` module was added](https://github.com/nim-lang/Nim/commit/6278b5d89af38e90aa30cfc4c217a2f4b1323339), so its old position might have been intended. If not, `isSelf` can also go in `ast`.