### PR TITLE
run docs CI on compiler changes

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -2,8 +2,7 @@ name: Nim Docs CI
 on:
   push:
     paths:
-      - 'compiler/docgen.nim'
-      - 'compiler/renderverbatim.nim'
+      - 'compiler/**.nim'
       - 'config/nimdoc.cfg'
       - 'doc/**.rst'
       - 'doc/**.md'
@@ -18,8 +17,7 @@ on:
   pull_request:
     # Run only on changes on these files.
     paths:
-      - 'compiler/docgen.nim'
-      - 'compiler/renderverbatim.nim'
+      - 'compiler/**.nim'
       - 'config/nimdoc.cfg'
       - 'doc/**.rst'
       - 'doc/**.md'


### PR DESCRIPTION
refs #22650

Docs CI cover standard library runnable examples that aren't covered by the test suite and can be affected by compiler changes without knowing