### PR TITLE
renderIr should print the actual return assign node

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -586,7 +586,7 @@ proc lsub(g: TSrcGen; n: PNode): int =
     if n.len > 1: result = MaxLineLen + 1
     else: result = lsons(g, n) + len("using_")
   of nkReturnStmt:
-    if n.len > 0 and n[0].kind == nkAsgn:
+    if n.len > 0 and n[0].kind == nkAsgn and renderIr notin g.flags:
       result = len("return_") + lsub(g, n[0][1])
     else:
       result = len("return_") + lsub(g, n[0])
@@ -1635,7 +1635,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
       gsub(g, n[0])
   of nkReturnStmt:
     putWithSpace(g, tkReturn, "return")
-    if n.len > 0 and n[0].kind == nkAsgn:
+    if n.len > 0 and n[0].kind == nkAsgn and renderIr notin g.flags:
       gsub(g, n[0], 1)
     else:
       gsub(g, n, 0)


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/10806

Eventually we need a new option to print high level IR. It's confusing when I'm debugging the compiler without showing  `return result = 1` using the expandArc option.

For 
```nim
proc foo: int =
  return 2
```
It now outputs when expanding ARC IR
```nim
proc foo: int =
  return result = 2
```