### PR TITLE
remove nkPar for tuples; nkPar shouldn't exist after semantic checking

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -85,7 +85,7 @@ type
                           # either typeDesc or expr may be nil; used in
                           # formal parameters, var statements, etc.
     nkVarTuple,           # a ``var (a, b) = expr`` construct
-    nkPar,                # syntactic (); may be a tuple constructor
+    nkPar,                # syntactic ()
     nkObjConstr,          # object constructor: T(a: 1, b: 2)
     nkCurly,              # syntactic {}
     nkCurlyExpr,          # an expression like a{i}

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1115,7 +1115,7 @@ proc genBracketExpr(p: BProc; n: PNode; d: var TLoc) =
 proc isSimpleExpr(n: PNode): bool =
   # calls all the way down --> can stay expression based
   case n.kind
-  of nkCallKinds, nkDotExpr, nkPar, nkTupleConstr,
+  of nkCallKinds, nkDotExpr, nkTupleConstr,
       nkObjConstr, nkBracket, nkCurly, nkHiddenDeref, nkDerefExpr, nkHiddenAddr,
       nkHiddenStdConv, nkHiddenSubConv, nkConv, nkAddr:
     for c in n:
@@ -2681,7 +2681,7 @@ proc isConstClosure(n: PNode): bool {.inline.} =
       n[1].kind == nkNilLit
 
 proc genClosure(p: BProc, n: PNode, d: var TLoc) =
-  assert n.kind in {nkPar, nkTupleConstr, nkClosure}
+  assert n.kind in {nkTupleConstr, nkClosure}
 
   if isConstClosure(n):
     inc(p.module.labels)
@@ -3029,7 +3029,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       genSeqConstr(p, n, d)
     else:
       genArrayConstr(p, n, d)
-  of nkPar, nkTupleConstr:
+  of nkTupleConstr:
     if n.typ != nil and n.typ.kind == tyProc and n.len == 2:
       genClosure(p, n, d)
     elif isDeepConstExpr(n) and n.len != 0:
@@ -3413,7 +3413,7 @@ proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType; resul
         # this hack fixes issue that nkNilLit is expanded to {NIM_NIL,NIM_NIL}
         # this behaviour is needed since closure_var = nil must be
         # expanded to {NIM_NIL,NIM_NIL}
-        # in VM closures are initialized with nkPar(nkNilLit, nkNilLit)
+        # in VM closures are initialized with nkTupleConstr(nkNilLit, nkNilLit)
         # leading to duplicate code like this:
         # "{NIM_NIL,NIM_NIL}, {NIM_NIL,NIM_NIL}"
         if n[0].kind == nkNilLit:

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -466,7 +466,7 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
 
     needsSplit = true
 
-  of nkPar, nkObjConstr, nkTupleConstr, nkBracket:
+  of nkObjConstr, nkTupleConstr, nkBracket:
     var ns = false
     for i in 0..<n.len:
       n[i] = ctx.lowerStmtListExprs(n[i], ns)

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -462,7 +462,7 @@ proc gen(c: var Con; n: PNode) =
   of nkBreakStmt: genBreak(c, n)
   of nkTryStmt, nkHiddenTryStmt: genTry(c, n)
   of nkStmtList, nkStmtListExpr, nkChckRangeF, nkChckRange64, nkChckRange,
-     nkBracket, nkCurly, nkPar, nkTupleConstr, nkClosure, nkObjConstr, nkYieldStmt:
+     nkBracket, nkCurly, nkTupleConstr, nkClosure, nkObjConstr, nkYieldStmt:
     for x in n: gen(c, x)
   of nkPragmaBlock: gen(c, n.lastSon)
   of nkDiscardStmt, nkObjDownConv, nkObjUpConv, nkStringToCString, nkCStringToString:

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -163,7 +163,7 @@ proc getField(conf: ConfigRef, n: PNode; position: int): PSym =
   else: result = nil
 
 proc packObject(conf: ConfigRef, x: PNode, typ: PType, res: pointer) =
-  internalAssert conf, x.kind in {nkObjConstr, nkPar, nkTupleConstr}
+  internalAssert conf, x.kind in {nkObjConstr, nkTupleConstr}
   # compute the field's offsets:
   discard getSize(conf, typ)
   for i in ord(x.kind == nkObjConstr)..<x.len:
@@ -270,7 +270,7 @@ proc unpackObject(conf: ConfigRef, x: pointer, typ: PType, n: PNode): PNode =
   discard getSize(conf, typ)
 
   # iterate over any actual field of 'n' ... if n is nil we need to create
-  # the nkPar node:
+  # the nkTupleConstr node:
   if n.isNil:
     result = newNode(nkTupleConstr)
     result.typ = typ
@@ -279,7 +279,7 @@ proc unpackObject(conf: ConfigRef, x: pointer, typ: PType, n: PNode): PNode =
     unpackObjectAdd(conf, x, typ.n, result)
   else:
     result = n
-    if result.kind notin {nkObjConstr, nkPar, nkTupleConstr}:
+    if result.kind notin {nkObjConstr, nkTupleConstr}:
       globalError(conf, n.info, "cannot map value from FFI")
     if typ.n.isNil:
       globalError(conf, n.info, "cannot unpack unnamed tuple")

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -497,7 +497,7 @@ proc containsConstSeq(n: PNode): bool =
   of nkObjConstr, nkClosure:
     for i in 1..<n.len:
       if containsConstSeq(n[i]): return true
-  of nkCurly, nkBracket, nkPar, nkTupleConstr:
+  of nkCurly, nkBracket, nkTupleConstr:
     for son in n:
       if containsConstSeq(son): return true
   else: discard

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -336,7 +336,7 @@ proc useMagic(p: PProc, name: string) =
 proc isSimpleExpr(p: PProc; n: PNode): bool =
   # calls all the way down --> can stay expression based
   case n.kind
-  of nkCallKinds, nkBracketExpr, nkDotExpr, nkPar, nkTupleConstr,
+  of nkCallKinds, nkBracketExpr, nkDotExpr, nkTupleConstr,
     nkObjConstr, nkBracket, nkCurly,
     nkDerefExpr, nkHiddenDeref, nkAddr, nkHiddenAddr,
     nkConv, nkHiddenStdConv, nkHiddenSubConv:
@@ -1221,7 +1221,7 @@ proc countJsParams(typ: PType): int =
 
 const
   nodeKindsNeedNoCopy = {nkCharLit..nkInt64Lit, nkStrLit..nkTripleStrLit,
-    nkFloatLit..nkFloat64Lit, nkPar, nkStringToCString,
+    nkFloatLit..nkFloat64Lit, nkStringToCString,
     nkObjConstr, nkTupleConstr, nkBracket,
     nkCStringToString, nkCall, nkPrefix, nkPostfix, nkInfix,
     nkCommand, nkHiddenCallConv, nkCallStrLit}
@@ -2920,7 +2920,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkClosure: gen(p, n[0], r)
   of nkCurly: genSetConstr(p, n, r)
   of nkBracket: genArrayConstr(p, n, r)
-  of nkPar, nkTupleConstr: genTupleConstr(p, n, r)
+  of nkTupleConstr: genTupleConstr(p, n, r)
   of nkObjConstr: genObjConstr(p, n, r)
   of nkHiddenStdConv, nkHiddenSubConv, nkConv: genConv(p, n, r)
   of nkAddr, nkHiddenAddr:

--- a/compiler/nilcheck.nim
+++ b/compiler/nilcheck.nim
@@ -1218,7 +1218,7 @@ proc check(n: PNode, ctx: NilCheckerContext, map: NilMap): Check =
      nkCast:
     result = check(n.sons[1], ctx, map)
   of nkStmtList, nkStmtListExpr, nkChckRangeF, nkChckRange64, nkChckRange,
-     nkBracket, nkCurly, nkPar, nkTupleConstr, nkClosure, nkObjConstr, nkElse:
+     nkBracket, nkCurly, nkTupleConstr, nkClosure, nkObjConstr, nkElse:
     result.map = map
     if n.kind in {nkObjConstr, nkTupleConstr}:
       # TODO deeper nested elements?

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1143,7 +1143,7 @@ proc track(tracked: PEffects, n: PNode) =
           varDecl(tracked, child[i])
           if last.kind != nkEmpty:
             initVar(tracked, child[i], volatileCheck=false)
-          if last.kind in {nkPar, nkTupleConstr}:
+          if last.kind == nkTupleConstr:
             addAsgnFact(tracked.guards, child[i], last[i])
             notNilCheck(tracked, last[i], child[i].typ)
       # since 'var (a, b): T = ()' is not even allowed, there is always type

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -634,7 +634,7 @@ proc putArgInto(arg: PNode, formal: PType): TPutArgInto =
       if putArgInto(arg[i], formal) != paDirectMapping:
         return paFastAsgn
     result = paDirectMapping
-  of nkPar, nkTupleConstr, nkObjConstr:
+  of nkTupleConstr, nkObjConstr:
     for i in 0..<arg.len:
       let a = if arg[i].kind == nkExprColonExpr: arg[i][1]
               else: arg[0]

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -108,7 +108,7 @@ proc isDeepConstExpr*(n: PNode; preventInheritance = false): bool =
     result = true
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv:
     result = isDeepConstExpr(n[1], preventInheritance)
-  of nkCurly, nkBracket, nkPar, nkTupleConstr, nkObjConstr, nkClosure, nkRange:
+  of nkCurly, nkBracket, nkTupleConstr, nkObjConstr, nkClosure, nkRange:
     for i in ord(n.kind == nkObjConstr)..<n.len:
       if not isDeepConstExpr(n[i], preventInheritance): return false
     if n.typ.isNil: result = true
@@ -231,7 +231,7 @@ proc dontInlineConstant*(orig, cnst: PNode): bool {.inline.} =
   # symbols that expand to a complex constant (array, etc.) should not be
   # inlined, unless it's the empty array:
   result = orig.kind != cnst.kind and
-           cnst.kind in {nkCurly, nkPar, nkTupleConstr, nkBracket, nkObjConstr} and
+           cnst.kind in {nkCurly, nkTupleConstr, nkBracket, nkObjConstr} and
            cnst.len > ord(cnst.kind == nkObjConstr)
 
 proc isRunnableExamples*(n: PNode): bool =

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2239,7 +2239,7 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   of nkBracket: genArrayConstr(c, n, dest)
   of nkCurly: genSetConstr(c, n, dest)
   of nkObjConstr: genObjConstr(c, n, dest)
-  of nkPar, nkClosure, nkTupleConstr: genTupleConstr(c, n, dest)
+  of nkClosure, nkTupleConstr: genTupleConstr(c, n, dest)
   of nkCast:
     if allowCast in c.features:
       genConv(c, n, n[1], dest, opcCast)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1128,7 +1128,7 @@ proc newPar*(exprs: NimNode): NimNode =
 proc newPar*(exprs: varargs[NimNode]): NimNode {.deprecated:
         "don't use newPar/nnkPar to construct tuple expressions; use nnkTupleConstr instead".} =
   ## Create a new parentheses-enclosed expression.
-  newNimNode(nnkPar).add(exprs)
+  newNimNode(nnkTupleConstr).add(exprs)
 
 proc newBlockStmt*(label, body: NimNode): NimNode =
   ## Create a new block statement with label.
@@ -1695,7 +1695,7 @@ macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
         result = p[1]
       else:
         let def = p[0].getImpl[3]
-        result = newTree(nnkPar)
+        result = newTree(nnkTupleConstr)
         for i in 1 ..< def.len:
           let key = def[i][0]
           let val = p[i]


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/13793

I have changed newPar to create a nkTupleConStr node instead besides it has been deprecated for few months. The remaining breaking change is that users use nnkPar to create a tuple directly.

Well, in the worse case, I suppose we can transform it in the transf, so the backend will not suffer from it. Soon the MIR should handle it in one way or another.

