### PR TITLE
fixes `result` requires explicit initialization on noReturn code

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1556,7 +1556,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
        strictDefs in c.features) and
      s.kind in {skProc, skFunc, skConverter, skMethod} and s.magic == mNone:
     var res = s.ast[resultPos].sym # get result symbol
-    if res.id notin t.init:
+    if res.id notin t.init and breaksBlock(body) != bsNoReturn:
       if tfRequiresInit in s.typ[0].flags:
         localError(g.config, body.info, "'$1' requires explicit initialization" % "result")
       else:

--- a/tests/init/tcompiles.nim
+++ b/tests/init/tcompiles.nim
@@ -62,3 +62,30 @@ block:
       raise newException(ValueError, "unreachable")
 
   discard test(true)
+
+# bug #21615
+# bug #16735
+
+block:
+  type Test {.requiresInit.} = object
+    id: int
+
+  proc bar(): int =
+    raise newException(CatchableError, "error")
+
+  proc test(): Test =
+    raise newException(CatchableError, "")
+
+  template catchError(body) =
+    var done = false
+    try:
+      body
+    except CatchableError:
+      done = true
+    doAssert done
+
+  catchError:
+    echo test()
+
+  catchError:
+    echo bar()


### PR DESCRIPTION
fixes #21615; fixes #16735

It also partially fixes | #22673, though It still gives 'baseless' warnings.