### PR TITLE
fixes #22687; js backend - std/bitops/bitsliced throws compile error …

### DIFF
--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -65,7 +65,7 @@ type BitsRange*[T] = range[0..sizeof(T)*8-1]
 
 template typeMasked[T: SomeInteger](x: T): T =
   when defined(js):
-    x and ((0xffffffff_ffffffff'u shr (64 - sizeof(T) * 8)))
+    T(x and ((0xffffffff_ffffffff'u shr (64 - sizeof(T) * 8))))
   else:
     x
 

--- a/tests/stdlib/t21564.nim
+++ b/tests/stdlib/t21564.nim
@@ -22,6 +22,10 @@ proc main() =
     # test `bitops.toMask` patch via bitops.masked
     doAssert(0x12FFFF34.masked(8..23) == 0x00FFFF00)
 
+  block: # bug #22687
+    var a: uint8 = 0b1111_1111
+    doAssert a.bitsliced(4..7).int == 15
+
 main()
 
 static:


### PR DESCRIPTION
…in typeMasked

fixes #22687