### PR TITLE
Optimize strutils.repeat

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1639,10 +1639,14 @@ when not defined(js):
     ## the same effect can be achieved with the `&` operator or with `add`.
     result = newStringOfCap(len)
     when defined(nimSeqsV2):
-      cast[ptr int](addr result)[] = len
+      let s = cast[ptr NimStringV2](addr result)
+      if len > 0:
+        s.len = len
+        s.p.data[len] = '\0'
     else:
-      var s = cast[PGenericSeq](result)
+      let s = cast[NimString](result)
       s.len = len
+      s.data[len] = '\0'
 else:
   proc newStringUninit*(len: Natural): string {.
     magic: "NewString", importc: "mnewString", noSideEffect.}


### PR DESCRIPTION
```nim
import pkg/benchy

func c_memset(p: pointer, value: cint, size: csize_t): pointer {.
  importc: "memset", header: "<string.h>", discardable.}

proc repeat1(c: char, count: Natural): string =
  result = newString(count)
  for i in 0..<count:
    result[i] = c

proc repeat2(c: char, count: Natural): string =
  result = newStringUninit(count)
  for i in 0..<count:
    result[i] = c

proc repeat3(c: char, count: Natural): string =
  result = newString(count)
  c_memset(result.cstring, c.cint, count.csize_t)

proc repeat4(c: char, count: Natural): string =
  result = newStringUninit(count)
  c_memset(result.cstring, c.cint, count.csize_t)

timeIt "repeat":
  discard repeat1('f', 1000_000)

timeIt "repeat (uninit)":
  discard repeat2('f', 1000_000)

timeIt "repeat (memset)":
  discard repeat3('f', 1000_000)

timeIt "repeat (memset, uninit)":
  discard repeat4('f', 1000_000)
```
```
name ............................... min time      avg time    std dv   runs
repeat ............................. 0.970 ms      0.992 ms    ±0.056  x1000
repeat (uninit) .................... 0.909 ms      0.915 ms    ±0.009  x1000
repeat (memset) .................... 0.121 ms      0.123 ms    ±0.006  x1000
repeat (memset, uninit) ............ 0.061 ms      0.062 ms    ±0.005  x1000
```
_Note: needs #22746._