### PR TITLE
Add magic toOpenArrayChar

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2715,6 +2715,9 @@ proc toOpenArrayByte*(x: openArray[char]; first, last: int): openArray[byte] {.
 proc toOpenArrayByte*(x: seq[char]; first, last: int): openArray[byte] {.
   magic: "Slice".}
 
+proc toOpenArrayChar*(x: openArray[byte]; first, last: int): openArray[char] {.
+  magic: "Slice".}
+
 when defined(genode):
   var componentConstructHook*: proc (env: GenodeEnv) {.nimcall.}
     ## Hook into the Genode component bootstrap process.


### PR DESCRIPTION
Should help with stuff like the checksums package which only takes `openArray[char]`