### PR TITLE
Removed `localStorage.hasKey` binding

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1682,7 +1682,6 @@ proc `$`*(s: Selection): string = $(s.toString())
 # Storage "methods"
 proc getItem*(s: Storage, key: cstring): cstring
 proc setItem*(s: Storage, key, value: cstring)
-proc hasItem*(s: Storage, key: cstring): bool
 proc clear*(s: Storage)
 proc removeItem*(s: Storage, key: cstring)
 


### PR DESCRIPTION
Doesn't exists anymore.

Use `window.localStorage.getItem("key").isNil` instead

![Screenshot from 2023-09-28 07-22-41](https://github.com/nim-lang/Nim/assets/74574275/65d58921-58c7-4a81-9f3b-5faa3a79c4f2)
