### PR TITLE
C++ Adds support for default arg using object construction syntax. Fixes a compiler crash 

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -296,7 +296,12 @@ proc genCppParamsForCtor(p: BProc; call: PNode): string =
   assert(typ.kind == tyProc)
   for i in 1..<call.len:
     assert(typ.len == typ.n.len)
-    genOtherArg(p, call, i, typ, result, argsCounter)
+    #if it's a type we can just generate here another initializer as we are in an initializer context
+    if call[i].kind == nkCall and call[i][0].kind == nkSym and call[i][0].sym.kind == skType:
+      if argsCounter > 0: result.add ","
+      result.add genCppInitializer(p.module, p, call[i][0].sym.typ)
+    else:
+      genOtherArg(p, call, i, typ, result, argsCounter)
 
 proc genCppVarForCtor(p: BProc; call: PNode; decl: var Rope) =
   let params = genCppParamsForCtor(p, call)

--- a/tests/cpp/tinitializers.nim
+++ b/tests/cpp/tinitializers.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "cpp"
+  cmd: "nim cpp $file"
 """
 
 {.emit:"""/*TYPESECTION*/
@@ -31,3 +31,30 @@ proc main =
   discard initChildStruct() #generates ChildStruct temp ({}) bypassed with makeChildStruct
   (proc (s:CppStruct) = discard)(CppStruct()) #CppStruct temp ({10})
 main()
+
+
+#Should handle ObjectCalls
+{.emit:"""/*TYPESECTION*/
+struct Foo {
+};
+struct Boo {
+  Boo(int x, char* y, Foo f): x(x), y(y), foo(f){}
+  int x;
+  char* y;
+  Foo foo;
+};
+""".}
+type
+  Foo {.importcpp, inheritable, bycopy.} = object
+  Boo {.importcpp, inheritable.} = object
+    x: int32
+    y: cstring
+    foo: Foo
+
+proc makeBoo(a:cint = 10, b:cstring = "hello", foo: Foo = Foo()): Boo {.importcpp, constructor.}
+
+proc main2() = 
+  let cppStruct = makeBoo()
+  (proc (s:Boo) = discard)(Boo()) 
+
+main2()


### PR DESCRIPTION
`Foo()` below makes the compiler crash. 
```nim

proc makeBoo(a:cint = 10, b:cstring = "hello", foo: Foo = Foo()): Boo {.importcpp, constructor.}

```