### PR TITLE
fixes #22554; makes `newSeqWith` use `newSeqUninit`

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1117,7 +1117,7 @@ template newSeqWith*(len: int, init: untyped): untyped =
     assert seqRand[0] != seqRand[1]
   type T = typeof(init)
   let newLen = len
-  when supportsCopyMem(T):
+  when supportsCopyMem(T) and declared(newSeqUninit):
     var result = newSeqUninit[T](newLen)
   else: # TODO: use `newSeqUnsafe` when that's available
     var result = newSeq[T](newLen)

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -83,6 +83,7 @@ runnableExamples:
 import std/private/since
 
 import macros
+from typetraits import supportsCopyMem
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -1114,8 +1115,12 @@ template newSeqWith*(len: int, init: untyped): untyped =
     import std/random
     var seqRand = newSeqWith(20, rand(1.0))
     assert seqRand[0] != seqRand[1]
+  type T = typeof(init)
   let newLen = len
-  var result = newSeq[typeof(init)](newLen)
+  when supportsCopyMem(T):
+    var result = newSeqUninit[T](newLen)
+  else: # TODO: use `newSeqUnsafe` when that's available
+    var result = newSeq[T](newLen)
   for i in 0 ..< newLen:
     result[i] = init
   move(result) # refs bug #7295

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1615,11 +1615,12 @@ when notJSnotNims and defined(nimSeqsV2):
 when not defined(js):
   template newSeqImpl(T, len) =
     result = newSeqOfCap[T](len)
-    when defined(nimSeqsV2):
-      cast[ptr int](addr result)[] = len
-    else:
-      var s = cast[PGenericSeq](result)
-      s.len = len
+    {.cast(noSideEffect).}:
+      when defined(nimSeqsV2):
+        cast[ptr int](addr result)[] = len
+      else:
+        var s = cast[PGenericSeq](result)
+        s.len = len
 
   proc newSeqUninitialized*[T: SomeNumber](len: Natural): seq[T] {.deprecated: "Use `newSeqUninit` instead".} =
     ## Creates a new sequence of type `seq[T]` with length `len`.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1640,7 +1640,7 @@ when not defined(js):
       var s = cast[PGenericSeq](result)
       s.len = len
 
-  proc newSeqUninit*[T](len: Natural): seq[T] =
+  func newSeqUninit*[T](len: Natural): seq[T] =
     ## Creates a new sequence of type `seq[T]` with length `len`.
     ##
     ## Only available for types, which don't contain


### PR DESCRIPTION
fixes #22554