### PR TITLE
docs: add another switch example for nimscript

### DIFF
--- a/doc/nims.md
+++ b/doc/nims.md
@@ -124,6 +124,8 @@ Here are few examples of using the `switch` proc:
   switch("define", "release")
   # command-line: --forceBuild
   switch("forceBuild")
+  # command-line: --hint[Conf]:off or --hint:Conf:off
+  switch("hint", "[Conf]:off")
   ```
 
 NimScripts also support `--`:option: templates for convenience, which look

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -161,6 +161,7 @@ template `--`*(key, val: untyped) =
   ##   ```nim
   ##   --path:somePath # same as switch("path", "somePath")
   ##   --path:"someOtherPath" # same as switch("path", "someOtherPath")
+  ##   --hint:"[Conf]:off" # same as switch("hint", "[Conf]:off")
   ##   ```
   switch(strip(astToStr(key)), strip(astToStr(val)))
 


### PR DESCRIPTION
I couldn't find any documentation on the syntax for --hint:X:on|off with `nimscript` except in [this old forum post](https://forum.nim-lang.org/t/8526#55236).