### PR TITLE
fixes #22753; Nimsuggest segfault with invalid assignment to table

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1886,7 +1886,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
       result.add(n[1])
       if mode == noOverloadedSubscript:
         bracketNotFoundError(c, result)
-        return n
+        return errorNode(c, n)
       else:
         result = semExprNoType(c, result)
         return result

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -66,7 +66,7 @@ proc semArrGet(c: PContext; n: PNode; flags: TExprFlags): PNode =
     x[0] = newIdentNode(getIdent(c.cache, "[]"), n.info)
     bracketNotFoundError(c, x)
     #localError(c.config, n.info, "could not resolve: " & $n)
-    result = n
+    result = errorNode(c, n)
 
 proc semArrPut(c: PContext; n: PNode; flags: TExprFlags): PNode =
   # rewrite `[]=`(a, i, x)  back to ``a[i] = x``.

--- a/tests/errmsgs/t10735.nim
+++ b/tests/errmsgs/t10735.nim
@@ -1,10 +1,12 @@
 discard """
   cmd: "nim check $file"
-  errormsg: "selector must be of an ordinal type, float or string"
+  errormsg: "illformed AST: case buf[pos]"
   nimout: '''
-t10735.nim(38, 5) Error: 'let' symbol requires an initialization
-t10735.nim(39, 10) Error: undeclared identifier: 'pos'
-t10735.nim(39, 9) Error: type mismatch: got <cstring, >
+t10735.nim(43, 5) Error: 'let' symbol requires an initialization
+t10735.nim(44, 10) Error: undeclared identifier: 'pos'
+t10735.nim(44, 10) Error: expression 'pos' has no type (or is ambiguous)
+t10735.nim(44, 10) Error: expression 'pos' has no type (or is ambiguous)
+t10735.nim(44, 9) Error: type mismatch: got <cstring, >
 but expected one of:
 proc `[]`(s: string; i: BackwardsIndex): char
   first type mismatch at position: 0
@@ -26,11 +28,14 @@ proc `[]`[T](s: openArray[T]; i: BackwardsIndex): T
   first type mismatch at position: 0
 proc `[]`[T](s: var openArray[T]; i: BackwardsIndex): var T
   first type mismatch at position: 0
+template `[]`(a: WideCStringObj; idx: int): Utf16Char
+  first type mismatch at position: 0
 template `[]`(s: string; i: int): char
   first type mismatch at position: 0
 
 expression: `[]`(buf, pos)
-t10735.nim(39, 9) Error: selector must be of an ordinal type, float or string
+t10735.nim(44, 9) Error: expression '' has no type (or is ambiguous)
+t10735.nim(46, 3) Error: illformed AST: case buf[pos]
 '''
   joinable: false
 """

--- a/tests/errmsgs/t22753.nim
+++ b/tests/errmsgs/t22753.nim
@@ -1,0 +1,35 @@
+discard """
+cmd: "nim check --hints:off $file"
+errormsg: "type mismatch"
+nimoutFull: true
+nimout: '''
+t22753.nim(34, 13) Error: array expects two type parameters
+t22753.nim(35, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(35, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(35, 2) Error: type mismatch: got <>
+but expected one of:
+proc `[]=`(s: var string; i: BackwardsIndex; x: char)
+  first type mismatch at position: 0
+proc `[]=`[I: Ordinal; T, S](a: T; i: I; x: sink S)
+  first type mismatch at position: 0
+proc `[]=`[Idx, T; U, V: Ordinal](a: var array[Idx, T]; x: HSlice[U, V];
+                                  b: openArray[T])
+  first type mismatch at position: 0
+proc `[]=`[Idx, T](a: var array[Idx, T]; i: BackwardsIndex; x: T)
+  first type mismatch at position: 0
+proc `[]=`[T, U: Ordinal](s: var string; x: HSlice[T, U]; b: string)
+  first type mismatch at position: 0
+proc `[]=`[T; U, V: Ordinal](s: var seq[T]; x: HSlice[U, V]; b: openArray[T])
+  first type mismatch at position: 0
+proc `[]=`[T](s: var openArray[T]; i: BackwardsIndex; x: T)
+  first type mismatch at position: 0
+template `[]=`(a: WideCStringObj; idx: int; val: Utf16Char)
+  first type mismatch at position: 0
+template `[]=`(s: string; i: int; val: char)
+  first type mismatch at position: 0
+
+expression: `[]=`(x, 0, 9)
+'''
+"""
+var x: array[3] # bug #22753
+x[0] = 9

--- a/tests/generics/tuninstantiated_failure.nim
+++ b/tests/generics/tuninstantiated_failure.nim
@@ -11,6 +11,6 @@ func `[]`[T, K](x: var Test[T, K], idx: int): var Test[T, K] =
   x
 
 var b: Something
-# Should give a type-mismatch since Something isn't a valid Test
+# Should give an error since Something isn't a valid Test
 b[0].name = "Test" #[tt.Error
-            ^  type mismatch]#
+ ^  expression '' has no type (or is ambiguous]#

--- a/tests/generics/tuninstantiated_failure.nim
+++ b/tests/generics/tuninstantiated_failure.nim
@@ -13,4 +13,4 @@ func `[]`[T, K](x: var Test[T, K], idx: int): var Test[T, K] =
 var b: Something
 # Should give an error since Something isn't a valid Test
 b[0].name = "Test" #[tt.Error
- ^  expression '' has no type (or is ambiguous]#
+ ^  expression '' has no type (or is ambiguous)]#


### PR DESCRIPTION
fixes #22753

## Future work
We should turn all the error nodes into nodes of a nkError kind, which could be a industrious task. But perhaps we can add a special treatment for error nodes to make the transition smooth.