### PR TITLE
fixes #19782: uri.`?` doesn't concatenate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 - Changed `std/osfiles.copyFile` to allow to specify `bufferSize` instead of a hardcoded one.
 - Changed `std/osfiles.copyFile` to use `POSIX_FADV_SEQUENTIAL` hints for kernel-level aggressive sequential read-aheads.
+- Changed `` std/uri.`?` `` to append parameters to any parameters already present instead of overwriting them ([#19782](https://github.com/nim-lang/Nim/issues/19782)).
 
 [//]: # "Additions:"
 

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -489,8 +489,12 @@ func `?`*(u: Uri, query: openArray[(string, string)]): Uri =
   runnableExamples:
     let foo = parseUri("https://example.com") / "foo" ? {"bar": "qux"}
     assert $foo == "https://example.com/foo?bar=qux"
+    let bar = foo ? {"baz": "quux"}
+    assert $bar == "https://example.com/foo?bar=qux&baz=quux"
   result = u
-  result.query = encodeQuery(query)
+  if result.query != "":
+    result.query.add '&'
+  result.query.add encodeQuery(query)
 
 func `$`*(u: Uri): string =
   ## Returns the string representation of the specified URI object.

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -289,6 +289,10 @@ template main() =
       var foo = parseUri("http://example.com") / "foo" ? {"do": "do", "bar": ""}
       var foo1 = parseUri("http://example.com/foo?do=do&bar")
       doAssert foo == foo1
+    block:
+      var foo = parseUri("http://example.com") / "foo" ? {"bar": "baz"} ? {"baz": "qux"}
+      var foo1 = parseUri("http://example.com/foo?bar=baz&baz=qux")
+      doAssert foo == foo1
 
   block: # getDataUri, dataUriBase64
     doAssert getDataUri("", "text/plain") == "data:text/plain;charset=utf-8;base64,"


### PR DESCRIPTION
Fixes the following: https://github.com/nim-lang/Nim/issues/19782

This makes the the procedure's behaviour actually match its documentation.

This is a potentially breaking change for anyone relying on the old behaviour, which overwrites the parameters.