### PR TITLE
nimsuggest: Set default backend and default GC

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -589,6 +589,10 @@ proc mainCommand(graph: ModuleGraph) =
   registerPass graph, verbosePass
   registerPass graph, semPass
   conf.setCmd cmdIdeTools
+  if conf.backend == backendInvalid:
+    conf.backend = backendC
+  if conf.selectedGC == gcUnselected and conf.backend in {backendC, backendCpp, backendObjc}:
+    initOrcDefines(conf)
   defineSymbol(conf.symbols, $conf.backend)
   wantMainModule(conf)
 
@@ -1087,6 +1091,10 @@ else:
       retval = graph
       let conf = graph.config
       conf.setCmd cmdIdeTools
+      if conf.backend == backendInvalid:
+        conf.backend = backendC
+      if conf.selectedGC == gcUnselected and conf.backend in {backendC, backendCpp, backendObjc}:
+        initOrcDefines(conf)
       defineSymbol(conf.symbols, $conf.backend)
       clearPasses(graph)
       registerPass graph, verbosePass

--- a/nimsuggest/tests/tv3_default_settings.nim
+++ b/nimsuggest/tests/tv3_default_settings.nim
@@ -1,0 +1,10 @@
+when defined(c) and defined(gcOrc):
+  var ok = 1
+
+discard o#[!]#k
+
+discard """
+$nimsuggest --v3 --tester $file
+>def $1
+def;;skVar;;tv3_default_settings.ok;;int;;$file;;2;;6;;"";;100
+"""


### PR DESCRIPTION
Set nimsuggest's default backend to `C` and default GC to `orc` to match the behavior of `nim check`.