### PR TITLE
fixes #22787; marks `var section` in the loop as reassign preventing cursor

### DIFF
--- a/compiler/varpartitions.nim
+++ b/compiler/varpartitions.nim
@@ -823,11 +823,10 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
           registerVariable(c, child[i])
           #deps(c, child[i], last)
 
-        if child[0].kind == nkSym: # bug #22787
+        if c.inLoop > 0 and child[0].kind == nkSym: # bug #22787
           let vid = variableId(c, child[0].sym)
           if child[^1].kind != nkEmpty:
-            if c.inLoop > 0:
-              markAsReassigned(c, vid)
+            markAsReassigned(c, vid)
   of nkAsgn, nkFastAsgn, nkSinkAsgn:
     computeLiveRanges(c, n[0])
     computeLiveRanges(c, n[1])

--- a/compiler/varpartitions.nim
+++ b/compiler/varpartitions.nim
@@ -823,6 +823,11 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
           registerVariable(c, child[i])
           #deps(c, child[i], last)
 
+        if child[0].kind == nkSym:
+          let vid = variableId(c, child[0].sym)
+          if child[^1].kind != nkEmpty:
+            if c.inLoop > 0:
+              markAsReassigned(c, vid)
   of nkAsgn, nkFastAsgn, nkSinkAsgn:
     computeLiveRanges(c, n[0])
     computeLiveRanges(c, n[1])

--- a/compiler/varpartitions.nim
+++ b/compiler/varpartitions.nim
@@ -823,7 +823,7 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
           registerVariable(c, child[i])
           #deps(c, child[i], last)
 
-        if child[0].kind == nkSym:
+        if child[0].kind == nkSym: # bug #22787
           let vid = variableId(c, child[0].sym)
           if child[^1].kind != nkEmpty:
             if c.inLoop > 0:

--- a/tests/arc/t22787.nim
+++ b/tests/arc/t22787.nim
@@ -1,0 +1,37 @@
+discard """
+  joinable: false
+"""
+
+import std/assertions
+
+proc foo =
+  var s:seq[string]
+  var res = ""
+
+  for i in 0..3:
+    s.add ("test" & $i)
+    s.add ("test" & $i)
+
+  var lastname:string
+
+  for i in s:
+    var name = i[0..4]
+
+    if name != lastname:
+      res.add "NEW:" & name & "\n"
+    else:
+      res.add name & ">" & lastname & "\n"
+
+    lastname = name
+
+  doAssert res == """
+NEW:test0
+test0>test0
+NEW:test1
+test1>test1
+NEW:test2
+test2>test2
+NEW:test3
+test3>test3
+"""
+foo()


### PR DESCRIPTION
fixes #22787