### PR TITLE
fixes #22354; Wrong C++ codegen for default parameter values in ORC

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2939,7 +2939,7 @@ proc hoistParamsUsedInDefault(c: PContext, call, letSection, defExpr: var PNode)
 
       call[paramPos] = newSymNode(hoistedVarSym) # Refer the original arg to its hoisted sym
 
-    # arg we refer to is a sym, wether introduced by hoisting or not doesn't matter, we simply reuse it
+    # arg we refer to is a sym, whether introduced by hoisting or not doesn't matter, we simply reuse it
     defExpr = call[paramPos]
   else:
     for i in 0..<defExpr.safeLen:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2927,7 +2927,7 @@ proc hoistParamsUsedInDefault(c: PContext, call, letSection, defExpr: var PNode)
   if defExpr.kind == nkSym and defExpr.sym.kind == skParam and defExpr.sym.owner == call[0].sym:
     let paramPos = defExpr.sym.position + 1
 
-    if call[paramPos].kind != nkSym:
+    if call[paramPos].skipAddr.kind != nkSym:
       let hoistedVarSym = newSym(skLet, getIdent(c.graph.cache, genPrefix), c.idgen,
                                  c.p.owner, letSection.info, c.p.owner.options)
       hoistedVarSym.typ = call[paramPos].typ

--- a/tests/ccgbugs2/tcodegen.nim
+++ b/tests/ccgbugs2/tcodegen.nim
@@ -26,3 +26,22 @@ block: # NRVO2
   let innerAddress = x.innerAddress
   let outerAddress = cast[uint](x.addr)
   doAssert(innerAddress == outerAddress) # [OK]
+
+block: # bug #22354
+  type Object = object
+    foo: int
+
+  proc takeFoo(self: var Object): int =
+    result = self.foo
+    self.foo = 999
+
+  proc doSomething(self: var Object; foo: int = self.takeFoo()) =
+    discard
+
+  proc main() =
+    var obj = Object(foo: 2)
+    obj.doSomething()
+    doAssert obj.foo == 999
+
+
+  main()


### PR DESCRIPTION
fixes #22354

It skips `nkHiddenAddr`. No need to hoist `var parameters` without side effects. Besides, it saves lots of temporary variables in ORC.