### PR TITLE
fixes #19250; fixes #22259; ORC AssertionDefect not containsManagedMemory(n.typ)

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2161,6 +2161,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = semProcTypeWithScope(c, n, prev, symKind)
       if n.kind == nkIteratorTy and result.kind == tyProc:
         result.flags.incl(tfIterator)
+      if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
+        result.flags.incl tfHasAsgn
   of nkEnumTy: result = semEnum(c, n, prev)
   of nkType: result = n.typ
   of nkStmtListType: result = semStmtListType(c, n, prev)


### PR DESCRIPTION
fixes #19250
fixes #22259

The strings, seqs, refs types all have this flag, why should closures be treated differently? 

follow up https://github.com/nim-lang/Nim/pull/14336