### PR TITLE
fix #22834

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -445,11 +445,12 @@ when not useNimNetLite:
       var i = 0
       while not isNil(s.h_addr_list[i]):
         var ipStr = newString(strAddrLen)
-        if inet_ntop(result.addrtype.cint, s.h_addr_list[i], cstring(ipStr),
-                     len(ipStr).int32) == nil:
+        echo result.addrtype.cint
+        if inet_ntop(nativeAfInet6, cast[pointer](s.h_addr_list[i]),
+                     cstring(ipStr), len(ipStr).int32) == nil:
           raiseOSError(osLastError())
         when not useWinVersion:
-          if posix.IN6_IS_ADDR_V4MAPPED(s.h_addr_list[i]) != 0:
+          if posix.IN6_IS_ADDR_V4MAPPED(cast[ptr In6Addr](s.h_addr_list[i])) != 0:
             ipStr.setSlice("::ffff:".len..<strAddrLen)
         setLen(ipStr, len(cstring(ipStr)))
         result.addrList.add(ipStr)

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -393,11 +393,11 @@ when not useNimNetLite:
       addrLen = 0
       family = 0
 
-    if addrInfo.ai_addr.sa_family == nativeAfInet:
+    if addrInfo.ai_addr.sa_family.cint == nativeAfInet:
       family = nativeAfInet
       myAddr = addr cast[ptr Sockaddr_in](addrInfo.ai_addr).sin_addr
       addrLen = 4
-    elif addrInfo.ai_addr.sa_family == nativeAfInet6:
+    elif addrInfo.ai_addr.sa_family.cint == nativeAfInet6:
       family = nativeAfInet6
       myAddr = addr cast[ptr Sockaddr_in6](addrInfo.ai_addr).sin6_addr
       addrLen = 16

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -445,7 +445,6 @@ when not useNimNetLite:
       var i = 0
       while not isNil(s.h_addr_list[i]):
         var ipStr = newString(strAddrLen)
-        echo result.addrtype.cint
         if inet_ntop(nativeAfInet6, cast[pointer](s.h_addr_list[i]),
                      cstring(ipStr), len(ipStr).int32) == nil:
           raiseOSError(osLastError())

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -387,21 +387,37 @@ when not useNimNetLite:
 
   proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
     ## This function will lookup the hostname of an IP Address.
-    var myaddr: InAddr
-    myaddr.s_addr = inet_addr(ip)
+    var
+      addrInfo = getAddrInfo(ip, Port(0), AF_UNSPEC)
+      myAddr: pointer
+      addrLen = 0
+      family = 0
+
+    if addrInfo.ai_addr.sa_family == nativeAfInet:
+      family = nativeAfInet
+      myAddr = addr cast[ptr Sockaddr_in](addrInfo.ai_addr).sin_addr
+      addrLen = 4
+    elif addrInfo.ai_addr.sa_family == nativeAfInet6:
+      family = nativeAfInet6
+      myAddr = addr cast[ptr Sockaddr_in6](addrInfo.ai_addr).sin6_addr
+      addrLen = 16
+    else:
+      raise newException(IOError, "Unknown socket family in `getHostByAddr()`")
+
+    freeAddrInfo(addrInfo)
 
     when useWinVersion:
-      var s = winlean.gethostbyaddr(addr(myaddr), sizeof(myaddr).cuint,
-                                    cint(AF_INET))
+      var s = winlean.gethostbyaddr(cast[ptr InAddr](myAddr), addrLen.cuint,
+                                    cint(family))
       if s == nil: raiseOSError(osLastError())
     else:
       var s =
         when defined(android4):
-          posix.gethostbyaddr(cast[cstring](addr(myaddr)), sizeof(myaddr).cint,
-                              cint(posix.AF_INET))
+          posix.gethostbyaddr(cast[cstring](myAddr), addrLen.cint,
+                              cint(family))
         else:
-          posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).SockLen,
-                              cint(posix.AF_INET))
+          posix.gethostbyaddr(myAddr, addrLen.SockLen,
+                              cint(family))
       if s == nil:
         raiseOSError(osLastError(), $hstrerror(h_errno))
 


### PR DESCRIPTION
fix #22834

Edit: also fixes `result.addrList` when IPv6, which previously only performed a `result.addrList = cstringArrayToSeq(s.h_addr_list)` which does not provide the textual representation of an IPv6