### PR TITLE
explicitly import using `std/` in `tempfiles.nim`

### DIFF
--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -17,7 +17,7 @@ See also:
 * `mkstemp` (posix), refs https://man7.org/linux/man-pages/man3/mkstemp.3.html
 ]#
 
-import os, random
+import std / [os, random]
 
 when defined(nimPreviewSlimSystem):
   import std/syncio


### PR DESCRIPTION
At least on modern Nim `tempfiles` is not usable if the user has https://github.com/oprypin/nim-random installed, because the compiler picks the nimble path over the stdlib path (apparently). 