### PR TITLE
fixes #22856; enables `-d:nimStrictDelete`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 
 ## Changes affecting backward compatibility
 
+- `-d:nimStrictDelete` becomes the default. An index error is produced when the index passed to `system.delete` was out of bounds. Use `-d:nimAuditDelete` to mimic the old behavior for backwards compatibility.
 
 ## Standard library additions and changes
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1986,10 +1986,6 @@ proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect, auditDelete.} =
   ##
   ## This is an `O(n)` operation.
   ##
-  ## .. note:: With `-d:nimStrictDelete`, an index error is produced when the index passed
-  ##    to it was out of bounds. `-d:nimStrictDelete` will become the default
-  ##    in upcoming versions.
-  ##
   ## See also:
   ## * `del <#del,seq[T],Natural>`_ for O(1) operation
   ##
@@ -1998,7 +1994,7 @@ proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect, auditDelete.} =
     s.delete(2)
     doAssert s == @[1, 2, 4, 5]
 
-  when defined(nimStrictDelete):
+  when not defined(nimAuditDelete):
     if i > high(x):
       # xxx this should call `raiseIndexError2(i, high(x))` after some refactoring
       raise (ref IndexDefect)(msg: "index out of bounds: '" & $i & "' < '" & $x.len & "' failed")


### PR DESCRIPTION
fixes #22856

`-d:nimStrictDelete` is introduced in 1.6.0, which promised to be enabled in the coming versions. To keep backwards incompatibilities, it also extends the feature of `-d:nimAuditDelete`, which now mimics the old behaviors.