### PR TITLE
fixes #22863; allows constructing empty tuple types in parentheses

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -441,8 +441,6 @@ proc semOrdinal(c: PContext, n: PNode, prev: PType): PType =
     result = newOrPrevType(tyError, prev, c)
 
 proc semAnonTuple(c: PContext, n: PNode, prev: PType): PType =
-  if n.len == 0:
-    localError(c.config, n.info, errTypeExpected)
   result = newOrPrevType(tyTuple, prev, c)
   for it in n:
     let t = semTypeNode(c, it, nil)

--- a/tests/tuples/ttuples_various.nim
+++ b/tests/tuples/ttuples_various.nim
@@ -209,3 +209,26 @@ block: # tuple unpacking assignment with underscore
   doAssert (a, b) == (6, 2)
   (b, _) = (7, 8)
   doAssert (a, b) == (6, 7)
+
+block: # bug #22863
+  # annon tuple types
+  macro works(): typedesc =
+    nnkTupleConstr.newTree(ident"ValueError")
+
+  macro fails(): typedesc =
+    nnkTupleConstr.newTree()
+
+  type
+    A[T] = object
+    B = A[works()]
+    C = A[type(())]
+    D = A[fails()]
+
+  var x: tuple[] = ()
+  var s: () = ()
+
+  proc foo(x: ()) =
+    doAssert x == s
+
+  foo(x)
+  foo(s)


### PR DESCRIPTION
fixes #22863

```nim
var x: tuple[]
```
is supported, but `var x: ()` is not. The PR tries to unify these two cases to make it more consistent to construct tuple types.