### PR TITLE
build documentation for `htmlparser`

### DIFF
--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -154,6 +154,7 @@ lib/posix/posix_openbsd_amd64.nim
 lib/posix/posix_haiku.nim
 lib/pure/md5.nim
 lib/std/sha1.nim
+lib/pure/htmlparser.nim
 """.splitWhitespace()
 
   officialPackagesList = """
@@ -170,6 +171,7 @@ pkgs/checksums/src/checksums/sha1.nim
 pkgs/checksums/src/checksums/sha2.nim
 pkgs/checksums/src/checksums/sha3.nim
 pkgs/checksums/src/checksums/bcrypt.nim
+pkgs/htmlparser/src/htmlparser.nim
 """.splitWhitespace()
 
   officialPackagesListWithoutIndex = """
@@ -344,7 +346,7 @@ proc buildJS(): string =
 proc buildDocsDir*(args: string, dir: string) =
   let args = nimArgs & " " & args
   let docHackJsSource = buildJS()
-  gitClonePackages(@["asyncftpclient", "punycode", "smtp", "db_connector", "checksums", "atlas"])
+  gitClonePackages(@["asyncftpclient", "punycode", "smtp", "db_connector", "checksums", "atlas", "htmlparser"])
   createDir(dir)
   buildDocSamples(args, dir)
 

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -190,6 +190,7 @@ when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
     result = path.len > 0 and not ret.startsWith ".."
 
 proc getDocList(): seq[string] =
+  ##
   var docIgnore: HashSet[string]
   for a in withoutIndex: docIgnore.incl a
   for a in ignoredModules: docIgnore.incl a


### PR DESCRIPTION
I have added a note for installment https://github.com/nim-lang/htmlparser/pull/5

> In order to use this module, run `nimble install htmlparser`.