### PR TITLE
fixes nightlies; fixes incompatible types with csource_v2

### DIFF
--- a/compiler/nir/nirvm.nim
+++ b/compiler/nir/nirvm.nim
@@ -160,13 +160,13 @@ proc traverseObject(b: var Bytecode; t, offsetKey: TypeId) =
       var offset = -1
       for y in sons(b.m.types, x):
         if b.m.types[y].kind == OffsetVal:
-          offset = b.m.lit.numbers[b.m.types[y].litId]
+          offset = int(b.m.lit.numbers[b.m.types[y].litId])
           break
       b.offsets.mgetOrPut(offsetKey, @[]).add (offset, x.firstSon)
     of SizeVal:
-      size = b.m.lit.numbers[b.m.types[x].litId]
+      size = int(b.m.lit.numbers[b.m.types[x].litId])
     of AlignVal:
-      align = b.m.lit.numbers[b.m.types[x].litId]
+      align = int(b.m.lit.numbers[b.m.types[x].litId])
     of ObjectTy:
       # inheritance
       let impl = b.typeImpls.getOrDefault(b.m.lit.strings[b.m.types[x].litId])


### PR DESCRIPTION
ref https://github.com/nim-lang/nightlies/actions/runs/6686795512/job/18166625042#logs

> /home/runner/work/nightlies/nightlies/nim/compiler/nir/nirvm.nim(163, 35) Error: type mismatch: got 'BiggestInt' for 'b.m.lit.numbers[litId(b.m.types.nodes[int(y)])]' but expected 'int'

Or unifies the type in one way or another