### PR TITLE
Inlay hints support

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -901,6 +901,7 @@ type
     info*: TLineInfo
     when defined(nimsuggest):
       endInfo*: TLineInfo
+      hasUserSpecifiedType*: bool  # used for determining whether to display inlay type hints
     owner*: PSym
     flags*: TSymFlags
     ast*: PNode               # syntax tree of proc, iterator, etc.:

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -57,6 +57,7 @@ type
   SymInfoPair* = object
     sym*: PSym
     info*: TLineInfo
+    isDecl*: bool
 
   PipelinePass* = enum
     NonePass

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -267,7 +267,7 @@ type
     customArgs*: string
   CfileList* = seq[Cfile]
 
-  Suggest* = ref object of RootObj
+  Suggest* = ref object
     section*: IdeCmd
     qualifiedPath*: seq[string]
     name*: ptr string         # not used beyond sorting purposes; name is also
@@ -287,8 +287,7 @@ type
     version*: int
     endLine*: uint16
     endCol*: int
-
-  SuggestDef* = ref object of Suggest
+    inlayHintInfo*: SuggestInlayHint
 
   Suggestions* = seq[Suggest]
 
@@ -296,8 +295,10 @@ type
     sihkType = "Type",
     sihkParameter = "Parameter"
 
-  SuggestInlayHint* = ref object of Suggest
+  SuggestInlayHint* = ref object
     kind*: SuggestInlayHintKind
+    line*: int                   # Starts at 1
+    column*: int                 # Starts at 0
     label*: string
     paddingLeft*: bool
     paddingRight*: bool

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -198,7 +198,7 @@ type
   IdeCmd* = enum
     ideNone, ideSug, ideCon, ideDef, ideUse, ideDus, ideChk, ideChkFile, ideMod,
     ideHighlight, ideOutline, ideKnown, ideMsg, ideProject, ideGlobalSymbols,
-    ideRecompile, ideChanged, ideType, ideDeclaration, ideExpand
+    ideRecompile, ideChanged, ideType, ideDeclaration, ideExpand, ideInlayHints
 
   Feature* = enum  ## experimental features; DO NOT RENAME THESE!
     dotOperators,
@@ -1070,6 +1070,7 @@ proc `$`*(c: IdeCmd): string =
   of ideRecompile: "recompile"
   of ideChanged: "changed"
   of ideType: "type"
+  of ideInlayHints: "inlayHints"
 
 proc floatInt64Align*(conf: ConfigRef): int16 =
   ## Returns either 4 or 8 depending on reasons.

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -303,6 +303,7 @@ type
     label*: string
     paddingLeft*: bool
     paddingRight*: bool
+    allowInsert*: bool
 
   ProfileInfo* = object
     time*: float

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -268,8 +268,6 @@ type
   CfileList* = seq[Cfile]
 
   Suggest* = ref object of RootObj
-
-  SuggestDef* = ref object of Suggest
     section*: IdeCmd
     qualifiedPath*: seq[string]
     name*: ptr string         # not used beyond sorting purposes; name is also
@@ -290,6 +288,8 @@ type
     endLine*: uint16
     endCol*: int
 
+  SuggestDef* = ref object of Suggest
+
   Suggestions* = seq[Suggest]
 
   SuggestInlayHintKind* = enum
@@ -298,8 +298,6 @@ type
 
   SuggestInlayHint* = ref object of Suggest
     kind*: SuggestInlayHintKind
-    line*: int                   # Starts at 1
-    column*: int                 # Starts at 0
     label*: string
     paddingLeft*: bool
     paddingRight*: bool

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -267,7 +267,9 @@ type
     customArgs*: string
   CfileList* = seq[Cfile]
 
-  Suggest* = ref object
+  Suggest* = ref object of RootObj
+
+  SuggestDef* = ref object of Suggest
     section*: IdeCmd
     qualifiedPath*: seq[string]
     name*: ptr string         # not used beyond sorting purposes; name is also
@@ -289,6 +291,18 @@ type
     endCol*: int
 
   Suggestions* = seq[Suggest]
+
+  SuggestInlayHintKind* = enum
+    sihkType = "Type",
+    sihkParameter = "Parameter"
+
+  SuggestInlayHint* = ref object of Suggest
+    kind*: SuggestInlayHintKind
+    line*: int                   # Starts at 1
+    column*: int                 # Starts at 0
+    label*: string
+    paddingLeft*: bool
+    paddingRight*: bool
 
   ProfileInfo* = object
     time*: float

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -304,6 +304,7 @@ type
     paddingLeft*: bool
     paddingRight*: bool
     allowInsert*: bool
+    tooltip*: string
 
   ProfileInfo* = object
     time*: float

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -672,9 +672,11 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
       addToVarSection(c, result, b)
       continue
 
+    var hasUserSpecifiedType = false
     var typ: PType = nil
     if a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
+      hasUserSpecifiedType = true
 
     var typFlags: TTypeAllowedFlags = {}
 
@@ -746,6 +748,8 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           addToVarSection(c, result, n, a)
           continue
         var v = semIdentDef(c, a[j], symkind, false)
+        when defined(nimsuggest):
+          v.hasUserSpecifiedType = hasUserSpecifiedType
         styleCheckDef(c, v)
         onDef(a[j].info, v)
         if sfGenSym notin v.flags:

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -245,6 +245,7 @@ proc suggestDefToSuggestInlayHint*(sug: SuggestDef): SuggestInlayHint =
   result.label = ": " & sug.forth
   result.paddingLeft = false
   result.paddingRight = false
+  result.allowInsert = true
 
 method `$`*(suggest: SuggestInlayHint): string =
   result = $suggest.kind
@@ -258,6 +259,8 @@ method `$`*(suggest: SuggestInlayHint): string =
   result.add($suggest.paddingLeft)
   result.add(sep)
   result.add($suggest.paddingRight)
+  result.add(sep)
+  result.add($suggest.allowInsert)
 
 proc suggestResult*(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -246,6 +246,7 @@ proc suggestDefToSuggestInlayHint*(sug: SuggestDef): SuggestInlayHint =
   result.paddingLeft = false
   result.paddingRight = false
   result.allowInsert = true
+  result.tooltip = ""
 
 method `$`*(suggest: SuggestInlayHint): string =
   result = $suggest.kind
@@ -261,6 +262,8 @@ method `$`*(suggest: SuggestInlayHint): string =
   result.add($suggest.paddingRight)
   result.add(sep)
   result.add($suggest.allowInsert)
+  result.add(sep)
+  result.add(suggest.tooltip)
 
 proc suggestResult*(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -67,7 +67,7 @@ proc extractDocComment(g: ModuleGraph; s: PSym): string =
   else:
     result = ""
 
-proc cmpSuggestions(a, b: Suggest): int =
+proc cmpSuggestDefs(a, b: SuggestDef): int =
   template cf(field) {.dirty.} =
     result = b.field.int - a.field.int
     if result != 0: return result
@@ -82,6 +82,12 @@ proc cmpSuggestions(a, b: Suggest): int =
   # if all is equal, sort alphabetically for deterministic output,
   # independent of hashing order:
   result = cmp(a.name[], b.name[])
+
+proc cmpSuggestions(a, b: Suggest): int =
+  if (a of SuggestDef) and (b of SuggestDef):
+    result = cmpSuggestDefs(SuggestDef(a), SuggestDef(b))
+  else:
+    result = 0
 
 proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int =
   let
@@ -119,12 +125,12 @@ proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int
     elif sourceIdent != ident:
       result = 0
 
-proc symToSuggest*(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info: TLineInfo;
+proc symToSuggestDef*(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info: TLineInfo;
                   quality: range[0..100]; prefix: PrefixMatch;
                   inTypeContext: bool; scope: int;
                   useSuppliedInfo = false,
                   endLine: uint16 = 0,
-                  endCol = 0): Suggest =
+                  endCol = 0): SuggestDef =
   new(result)
   result.section = section
   result.quality = quality
@@ -183,7 +189,10 @@ proc symToSuggest*(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info
   result.endLine = endLine
   result.endCol = endCol
 
-proc `$`*(suggest: Suggest): string =
+method `$`*(self: Suggest): string {.base, gcsafe.} =
+  raiseAssert "internal error: unexpected conversion"
+
+method `$`*(suggest: SuggestDef): string =
   result = $suggest.section
   result.add(sep)
   if suggest.section == ideHighlight:
@@ -227,6 +236,28 @@ proc `$`*(suggest: Suggest): string =
     result.add($suggest.endLine)
     result.add(sep)
     result.add($suggest.endCol)
+
+proc suggestDefToSuggestInlayHint*(sug: SuggestDef): SuggestInlayHint =
+  new(result)
+  result.kind = sihkType
+  result.line = sug.line
+  result.column = sug.column
+  result.label = ": " & sug.forth
+  result.paddingLeft = false
+  result.paddingRight = false
+
+method `$`*(suggest: SuggestInlayHint): string =
+  result = $suggest.kind
+  result.add(sep)
+  result.add($suggest.line)
+  result.add(sep)
+  result.add($suggest.column)
+  result.add(sep)
+  result.add(suggest.label)
+  result.add(sep)
+  result.add($suggest.paddingLeft)
+  result.add(sep)
+  result.add($suggest.paddingRight)
 
 proc suggestResult*(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):
@@ -300,16 +331,16 @@ proc getQuality(s: PSym): range[0..100] =
 proc suggestField(c: PContext, s: PSym; f: PNode; info: TLineInfo; outputs: var Suggestions) =
   var pm: PrefixMatch = default(PrefixMatch)
   if filterSym(s, f, pm) and fieldVisible(c, s):
-    outputs.add(symToSuggest(c.graph, s, isLocal=true, ideSug, info,
-                              s.getQuality, pm, c.inTypeContext > 0, 0))
+    outputs.add(symToSuggestDef(c.graph, s, isLocal=true, ideSug, info,
+                                 s.getQuality, pm, c.inTypeContext > 0, 0))
 
 template wholeSymTab(cond, section: untyped) {.dirty.} =
   for (item, scopeN, isLocal) in uniqueSyms(c):
     let it = item
     var pm: PrefixMatch = default(PrefixMatch)
     if cond:
-      outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, section, info, getQuality(it),
-                                pm, c.inTypeContext > 0, scopeN))
+      outputs.add(symToSuggestDef(c.graph, it, isLocal = isLocal, section, info, getQuality(it),
+                                   pm, c.inTypeContext > 0, scopeN))
 
 proc suggestSymList(c: PContext, list, f: PNode; info: TLineInfo, outputs: var Suggestions) =
   for i in 0..<list.len:
@@ -382,8 +413,8 @@ proc suggestEverything(c: PContext, n, f: PNode, outputs: var Suggestions) =
   for (it, scopeN, isLocal) in uniqueSyms(c):
     var pm: PrefixMatch = default(PrefixMatch)
     if filterSym(it, f, pm):
-      outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, ideSug, n.info,
-                               it.getQuality, pm, c.inTypeContext > 0, scopeN))
+      outputs.add(symToSuggestDef(c.graph, it, isLocal = isLocal, ideSug, n.info,
+                                  it.getQuality, pm, c.inTypeContext > 0, scopeN))
 
 proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) =
   # special code that deals with ``myObj.``. `n` is NOT the nkDotExpr-node, but
@@ -403,12 +434,12 @@ proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) 
         else:
           for it in allSyms(c.graph, n.sym):
             if filterSym(it, field, pm):
-              outputs.add(symToSuggest(c.graph, it, isLocal=false, ideSug,
-                                        n.info, it.getQuality, pm,
-                                        c.inTypeContext > 0, -100))
-          outputs.add(symToSuggest(c.graph, m, isLocal=false, ideMod, n.info,
-                                    100, PrefixMatch.None, c.inTypeContext > 0,
-                                    -99))
+              outputs.add(symToSuggestDef(c.graph, it, isLocal=false, ideSug,
+                                           n.info, it.getQuality, pm,
+                                           c.inTypeContext > 0, -100))
+          outputs.add(symToSuggestDef(c.graph, m, isLocal=false, ideMod, n.info,
+                                       100, PrefixMatch.None, c.inTypeContext > 0,
+                                       -99))
 
   if typ == nil:
     # a module symbol has no type for example:
@@ -417,15 +448,15 @@ proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) 
         # all symbols accessible, because we are in the current module:
         for it in items(c.topLevelScope.symbols):
           if filterSym(it, field, pm):
-            outputs.add(symToSuggest(c.graph, it, isLocal=false, ideSug,
-                                      n.info, it.getQuality, pm,
-                                      c.inTypeContext > 0, -99))
+            outputs.add(symToSuggestDef(c.graph, it, isLocal=false, ideSug,
+                                         n.info, it.getQuality, pm,
+                                         c.inTypeContext > 0, -99))
       else:
         for it in allSyms(c.graph, n.sym):
           if filterSym(it, field, pm):
-            outputs.add(symToSuggest(c.graph, it, isLocal=false, ideSug,
-                                      n.info, it.getQuality, pm,
-                                      c.inTypeContext > 0, -99))
+            outputs.add(symToSuggestDef(c.graph, it, isLocal=false, ideSug,
+                                         n.info, it.getQuality, pm,
+                                         c.inTypeContext > 0, -99))
     else:
       # fallback:
       suggestEverything(c, n, field, outputs)
@@ -453,8 +484,8 @@ proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) 
           let s = node.sym
           var pm: PrefixMatch = default(PrefixMatch)
           if filterSym(s, field, pm):
-            outputs.add(symToSuggest(c.graph, s, isLocal=true, ideSug, n.info,
-                                     s.getQuality, pm, c.inTypeContext > 0, 0))
+            outputs.add(symToSuggestDef(c.graph, s, isLocal=true, ideSug, n.info,
+                                        s.getQuality, pm, c.inTypeContext > 0, 0))
 
     suggestOperations(c, n, field, orig, outputs)
     if typ != orig:
@@ -503,10 +534,10 @@ proc findUsages(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym) =
   if g.config.suggestVersion == 1:
     if usageSym == nil and isTracked(info, g.config.m.trackPos, s.name.s.len):
       usageSym = s
-      suggestResult(g.config, symToSuggest(g, s, isLocal=false, ideUse, info, 100, PrefixMatch.None, false, 0))
+      suggestResult(g.config, symToSuggestDef(g, s, isLocal=false, ideUse, info, 100, PrefixMatch.None, false, 0))
     elif s == usageSym:
       if g.config.lastLineInfo != info:
-        suggestResult(g.config, symToSuggest(g, s, isLocal=false, ideUse, info, 100, PrefixMatch.None, false, 0))
+        suggestResult(g.config, symToSuggestDef(g, s, isLocal=false, ideUse, info, 100, PrefixMatch.None, false, 0))
       g.config.lastLineInfo = info
 
 when defined(nimsuggest):
@@ -514,12 +545,12 @@ when defined(nimsuggest):
     #echo "usages ", s.allUsages.len
     for info in s.allUsages:
       let x = if info == s.info and info.col == s.info.col: ideDef else: ideUse
-      suggestResult(g.config, symToSuggest(g, s, isLocal=false, x, info, 100, PrefixMatch.None, false, 0))
+      suggestResult(g.config, symToSuggestDef(g, s, isLocal=false, x, info, 100, PrefixMatch.None, false, 0))
 
 proc findDefinition(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym) =
   if s.isNil: return
   if isTracked(info, g.config.m.trackPos, s.name.s.len) or (s == usageSym and sfForward notin s.flags):
-    suggestResult(g.config, symToSuggest(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0, useSuppliedInfo = s == usageSym))
+    suggestResult(g.config, symToSuggestDef(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0, useSuppliedInfo = s == usageSym))
     if sfForward notin s.flags and g.config.suggestVersion != 3:
       suggestQuit()
     else:
@@ -549,10 +580,10 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
       findDefinition(g, info, s, usageSym)
     elif conf.ideCmd == ideDus and s != nil:
       if isTracked(info, conf.m.trackPos, s.name.s.len):
-        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0))
+        suggestResult(conf, symToSuggestDef(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0))
       findUsages(g, info, s, usageSym)
     elif conf.ideCmd == ideHighlight and info.fileIndex == conf.m.trackPos.fileIndex:
-      suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
+      suggestResult(conf, symToSuggestDef(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
     elif conf.ideCmd == ideOutline and isDecl:
       # if a module is included then the info we have is inside the include and
       # we need to walk up the owners until we find the outer most module,
@@ -565,7 +596,7 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
         parentModule = parentModule.owner
 
       if parentFileIndex == conf.m.trackPos.fileIndex:
-        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
+        suggestResult(conf, symToSuggestDef(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
 
 proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
   var pragmaNode: PNode
@@ -715,7 +746,7 @@ proc suggestSentinel*(c: PContext) =
   for (it, scopeN, isLocal) in uniqueSyms(c):
     var pm: PrefixMatch = default(PrefixMatch)
     if filterSymNoOpr(it, nil, pm):
-      outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, ideSug,
+      outputs.add(symToSuggestDef(c.graph, it, isLocal = isLocal, ideSug,
           newLineInfo(c.config.m.trackPos.fileIndex, 0, -1), it.getQuality,
           PrefixMatch.None, false, scopeN))
 

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -105,7 +105,7 @@ proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int
       result = 0
   elif ident[0] in linter.Letters and ident[^1] != '=':
     result = identLen(line, column)
-    if cmpIgnoreStyle(line[column..column + result - 1], ident) != 0:
+    if cmpIgnoreStyle(line[column..column + result - 1], ident[0..result-1]) != 0:
       result = 0
   else:
     var sourceIdent: string = ""
@@ -175,7 +175,7 @@ proc symToSuggest*(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info
     result.filePath = toFullPath(g.config, infox)
     result.line = toLinenumber(infox)
     result.column = toColumn(infox)
-    result.tokenLen = if section != ideHighlight:
+    result.tokenLen = if not (section in {ideHighlight, ideInlayHints}):
                         s.name.s.len
                       else:
                         getTokenLenFromSource(g.config, s.name.s, infox)
@@ -252,7 +252,7 @@ proc suggestToSuggestInlayHint*(sug: Suggest): SuggestInlayHint =
   new(result)
   result.kind = sihkType
   result.line = sug.line
-  result.column = sug.column
+  result.column = sug.column + sug.tokenLen
   result.label = ": " & sug.forth
   result.paddingLeft = false
   result.paddingRight = false

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -249,15 +249,16 @@ proc `$`*(suggest: Suggest): string =
       result.add($suggest.endCol)
 
 proc suggestToSuggestInlayHint*(sug: Suggest): SuggestInlayHint =
-  new(result)
-  result.kind = sihkType
-  result.line = sug.line
-  result.column = sug.column + sug.tokenLen
-  result.label = ": " & sug.forth
-  result.paddingLeft = false
-  result.paddingRight = false
-  result.allowInsert = true
-  result.tooltip = ""
+  SuggestInlayHint(
+    kind: sihkType,
+    line: sug.line,
+    column: sug.column + sug.tokenLen,
+    label: ": " & sug.forth,
+    paddingLeft: false,
+    paddingRight: false,
+    allowInsert: true,
+    tooltip: ""
+  )
 
 proc suggestResult*(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -175,7 +175,7 @@ proc symToSuggest*(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info
     result.filePath = toFullPath(g.config, infox)
     result.line = toLinenumber(infox)
     result.column = toColumn(infox)
-    result.tokenLen = if not (section in {ideHighlight, ideInlayHints}):
+    result.tokenLen = if section notin {ideHighlight, ideInlayHints}:
                         s.name.s.len
                       else:
                         getTokenLenFromSource(g.config, s.name.s, infox)

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -105,7 +105,7 @@ proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int
       result = 0
   elif ident[0] in linter.Letters and ident[^1] != '=':
     result = identLen(line, column)
-    if cmpIgnoreStyle(line[column..column + result - 1], ident[0..result-1]) != 0:
+    if cmpIgnoreStyle(line[column..column + result - 1], ident[0..min(result-1,len(ident)-1)]) != 0:
       result = 0
   else:
     var sourceIdent: string = ""

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -535,7 +535,7 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
   ## misnamed: should be 'symDeclared'
   let conf = g.config
   when defined(nimsuggest):
-    g.suggestSymbols.mgetOrPut(info.fileIndex, @[]).add SymInfoPair(sym: s, info: info)
+    g.suggestSymbols.mgetOrPut(info.fileIndex, @[]).add SymInfoPair(sym: s, info: info, isDecl: isDecl)
 
     if conf.suggestVersion == 0:
       if s.allUsages.len == 0:

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -837,6 +837,8 @@ proc suggestInlayHintResult(graph: ModuleGraph, sym: PSym, info: TLineInfo,
                                 endLine = endLine, endCol = endCol)
   suggestDef.inlayHintInfo = suggestToSuggestInlayHint(suggestDef)
   suggestDef.section = ideInlayHints
+  if sym.kind == skForVar:
+    suggestDef.inlayHintInfo.allowInsert = false
   suggestResult(graph.config, suggestDef)
 
 const

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1115,7 +1115,7 @@ proc executeNoHooksV3(cmd: IdeCmd, file: AbsoluteFile, dirtyfile: AbsoluteFile, 
     i += parseInt(tag, endCol, i)
     let s = graph.findSymDataInRange(file, line, col, endLine, endCol)
     for q in s:
-      if q.sym.kind in [skLet, skVar, skForVar] and q.isDecl and not q.sym.hasUserSpecifiedType:
+      if q.sym.kind in {skLet, skVar, skForVar} and q.isDecl and not q.sym.hasUserSpecifiedType:
         graph.suggestInlayHintResult(q.sym, q.info, ideInlayHints)
   else:
     myLog fmt "Discarding {cmd}"

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -775,17 +775,10 @@ proc findSymData(graph: ModuleGraph, trackPos: TLineInfo):
       result[] = s
       break
 
-proc isInRange*(current, startPos, endPos: TLineInfo, tokenLen: int): bool =
-  if current.fileIndex==startPos.fileIndex and current.line>=startPos.line and current.line<=endPos.line:
-    # TODO: more precise tracking (check col)
-    result = true
-    #let col = trackPos.col
-    #if col >= current.col and col <= current.col+tokenLen-1:
-    #  result = true
-    #else:
-    #  result = false
-  else:
-    result = false
+func isInRange*(current, startPos, endPos: TLineInfo, tokenLen: int): bool =
+  result = current.fileIndex == startPos.fileIndex and
+    (current.line > startPos.line or (current.line == startPos.line and current.col>=startPos.col)) and
+    (current.line < endPos.line or (current.line == endPos.line and current.col <= endPos.col))
 
 proc findSymDataInRange(graph: ModuleGraph, startPos, endPos: TLineInfo):
     seq[SymInfoPair] =

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1105,7 +1105,7 @@ proc executeNoHooksV3(cmd: IdeCmd, file: AbsoluteFile, dirtyfile: AbsoluteFile, 
     i += parseInt(tag, endCol, i)
     let s = graph.findSymDataInRange(file, line, col, endLine, endCol)
     for q in s:
-      if q.sym.kind in [skLet, skVar, skForVar]:
+      if q.sym.kind in [skLet, skVar, skForVar] and q.isDecl:
         # TODO: suggestInlayHint
         var li = q.info
         li.col += int16(len(q.sym.name.s))

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -833,7 +833,7 @@ proc suggestInlayHintResult(graph: ModuleGraph, sym: PSym, info: TLineInfo,
                 else:
                   ideUse
   var suggestDef = symToSuggest(graph, sym, isLocal=false, section,
-                                info, 100, PrefixMatch.None, false, 0,
+                                info, 100, PrefixMatch.None, false, 0, true,
                                 endLine = endLine, endCol = endCol)
   suggestDef.inlayHintInfo = suggestToSuggestInlayHint(suggestDef)
   suggestDef.section = ideInlayHints
@@ -1116,9 +1116,7 @@ proc executeNoHooksV3(cmd: IdeCmd, file: AbsoluteFile, dirtyfile: AbsoluteFile, 
     let s = graph.findSymDataInRange(file, line, col, endLine, endCol)
     for q in s:
       if q.sym.kind in [skLet, skVar, skForVar] and q.isDecl and not q.sym.hasUserSpecifiedType:
-        var li = q.info
-        li.col += int16(len(q.sym.name.s))
-        graph.suggestInlayHintResult(q.sym, li)
+        graph.suggestInlayHintResult(q.sym, q.info, ideInlayHints)
   else:
     myLog fmt "Discarding {cmd}"
 

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1105,7 +1105,7 @@ proc executeNoHooksV3(cmd: IdeCmd, file: AbsoluteFile, dirtyfile: AbsoluteFile, 
     i += parseInt(tag, endCol, i)
     let s = graph.findSymDataInRange(file, line, col, endLine, endCol)
     for q in s:
-      if q.sym.kind in [skLet, skVar, skForVar] and q.isDecl:
+      if q.sym.kind in [skLet, skVar, skForVar] and q.isDecl and not q.sym.hasUserSpecifiedType:
         # TODO: suggestInlayHint
         var li = q.info
         li.col += int16(len(q.sym.name.s))


### PR DESCRIPTION
This adds inlay hints support to nimsuggest. It adds a new command to nimsuggest, called 'inlayHints'.

Currently, it provides type information to 'var' and 'let' variables. In the future, inlay hints can also be added for 'const' and for function parameters. The protocol also reserves space for a tooltip field, which is not used, yet, but support for it can be added in the future, without further changing the protocol.

The change includes refactoring to allow the 'inlayHints' command to return a completely different structure, compared to the other nimsuggest commands. This will allow other future commands to have custom return types as well. All the previous commands return the same structure as before, so perfect backwards compatibility is maintained.

To use this feature, an update to the nim language server, as well as the VS code extension is needed.

Related PRs:
nimlangserver: https://github.com/nim-lang/langserver/pull/53
VS code extension: https://github.com/saem/vscode-nim/pull/134