### PR TITLE
fixes #22860; suppress `AnyEnumConv` warning when iterating over set

### DIFF
--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -61,7 +61,10 @@ iterator items*[T](a: set[T]): T {.inline.} =
   ## able to hold).
   var i = low(T).int
   while i <= high(T).int:
-    if T(i) in a: yield T(i)
+    when T is enum and not defined(js):
+      if cast[T](i) in a: yield cast[T](i)
+    else:
+      if T(i) in a: yield T(i)
     unCheckedInc(i)
 
 iterator items*(a: cstring): char {.inline.} =


### PR DESCRIPTION
fixes #22860