### PR TITLE
Add missing std prefix

### DIFF
--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -19,7 +19,7 @@ when defined(nimPreviewSlimSystem):
 const hasRstdin = (defined(nimUseLinenoise) or defined(useLinenoise) or defined(useGnuReadline)) and
   not defined(windows)
 
-when hasRstdin: import rdstdin
+when hasRstdin: import std/rdstdin
 
 type
   TLLRepl* = proc (s: PLLStream, buf: pointer, bufLen: int): int


### PR DESCRIPTION
without it, devels fails to build with `-d:useLinenoise`