### PR TITLE
Add strformat support for Complex numbers

### DIFF
--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -36,7 +36,7 @@ runnableExamples:
 {.push checks: off, line_dir: off, stack_trace: off, debugger: off.}
 # the user does not want to trace a part of the standard library!
 
-import std/math
+import std/[math, strformat]
 
 type
   Complex*[T: SomeFloat] = object
@@ -398,5 +398,15 @@ func `$`*(z: Complex): string =
     doAssert $complex(1.0, 2.0) == "(1.0, 2.0)"
 
   result = "(" & $z.re & ", " & $z.im & ")"
+
+proc formatValue*(result: var string; value: Complex; specifier: string) =
+  ## Standard format implementation for `Complex`. It makes little
+  ## sense to call this directly, but it is required to exist
+  ## by the `&` macro.
+  result.add "("
+  formatValue(result, value.re, specifier)
+  result.add ", "
+  formatValue(result, value.im, specifier)
+  result.add ")"
 
 {.pop.}

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -399,14 +399,39 @@ func `$`*(z: Complex): string =
 
   result = "(" & $z.re & ", " & $z.im & ")"
 
-proc formatValue*(result: var string; value: Complex; specifier: string) =
-  ## Standard format implementation for `Complex`. It makes little
-  ## sense to call this directly, but it is required to exist
-  ## by the `&` macro.
+proc formatValueAsTuple(result: var string; value: Complex; specifier: string) =
+  ## Format implementation for `Complex` representing the value as a (real, imaginary) tuple.
   result.add "("
   formatValue(result, value.re, specifier)
   result.add ", "
   formatValue(result, value.im, specifier)
   result.add ")"
+
+proc formatValueAsComplexNumber(result: var string; value: Complex; specifier: string) =
+  ## Format implementation for `Complex` representing the value as a (RE+IMj) number
+  result.add "("
+  formatValue(result, value.re, specifier)
+  if value.im >= 0 and not specifier.contains({'+', '-'}):
+    result.add "+"
+  formatValue(result, value.im, specifier)
+  result.add "j)"
+
+proc formatValue*(result: var string; value: Complex; specifier: string) =
+  ## Standard format implementation for `Complex`. It makes little
+  ## sense to call this directly, but it is required to exist
+  ## by the `&` macro.
+  ## For complex numbers, we add a specific 'j' specifier, which formats
+  ## the value as (A+Bj) like in mathematics.
+  if specifier.len == 0:
+    result.add $value
+  elif 'j' in specifier:
+    let specifier = if specifier.contains({'e', 'E', 'f', 'F', 'g', 'G'}):
+        specifier.replace("j")
+      else:
+        # 'The 'j' format defaults to 'g'
+        specifier.replace('j', 'g')
+    formatValueAsComplexNumber(result, value, specifier)
+  else:
+    formatValueAsTuple(result, value, specifier)
 
 {.pop.}

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -316,7 +316,7 @@ help with readability, since there is only so much you can cram into
 single letter DSLs.
 ]##
 
-import std/[macros, parseutils, unicode]
+import std/[macros, parseutils, unicode, complex]
 import std/strutils except format
 
 when defined(nimPreviewSlimSystem):
@@ -552,6 +552,16 @@ proc formatValue*(result: var string; value: SomeFloat; specifier: string) =
     result.add toUpperAscii(res)
   else:
     result.add res
+
+proc formatValue*(result: var string; value: Complex; specifier: string) =
+  ## Standard format implementation for `Complex`. It makes little
+  ## sense to call this directly, but it is required to exist
+  ## by the `&` macro.
+  result.add "("
+  formatValue(result, value.re, specifier)
+  result.add ", "
+  formatValue(result, value.im, specifier)
+  result.add ")"
 
 proc formatValue*(result: var string; value: string; specifier: string) =
   ## Standard format implementation for `string`. It makes little

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -316,7 +316,7 @@ help with readability, since there is only so much you can cram into
 single letter DSLs.
 ]##
 
-import std/[macros, parseutils, unicode, complex]
+import std/[macros, parseutils, unicode]
 import std/strutils except format
 
 when defined(nimPreviewSlimSystem):
@@ -552,16 +552,6 @@ proc formatValue*(result: var string; value: SomeFloat; specifier: string) =
     result.add toUpperAscii(res)
   else:
     result.add res
-
-proc formatValue*(result: var string; value: Complex; specifier: string) =
-  ## Standard format implementation for `Complex`. It makes little
-  ## sense to call this directly, but it is required to exist
-  ## by the `&` macro.
-  result.add "("
-  formatValue(result, value.re, specifier)
-  result.add ", "
-  formatValue(result, value.im, specifier)
-  result.add ")"
 
 proc formatValue*(result: var string; value: string; specifier: string) =
   ## Standard format implementation for `string`. It makes little


### PR DESCRIPTION
Before this change strformat used the generic formatValue function for Complex numbers. This meant that it was not possible to control the format of the real and imaginary components of the complex numbers.

With this change this now works:
```nim
import std/[complex, strformat]
let c = complex(1.05000001, -2.000003)
echo &"{c:g}"
# You now get: (1.05, -2)
# while before you'd get a ValueError exception (invalid type in format string for string, expected 's', but got g)
```

The only small drawback of this change is that I had to import complex from strformat. I hope that is not a problem.