### PR TITLE
Fix using `--stdout` with `jsondoc`

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1806,7 +1806,7 @@ proc writeOutputJson*(d: PDoc, useWarning = false) =
     "moduleDescription": modDesc,
     "entries": d.jEntriesFinal}
   if optStdout in d.conf.globalOptions:
-    write(stdout, $content)
+    writeLine(stdout, $content)
   else:
     let dir = d.destFile.splitFile.dir
     createDir(dir)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -725,6 +725,8 @@ proc genSuccessX*(conf: ConfigRef) =
   elif conf.outFile.isEmpty and conf.cmd notin {cmdJsonscript} + cmdDocLike + cmdBackends:
     # for some cmd we expect a valid absOutFile
     output = "unknownOutput"
+  elif  optStdout in conf.globalOptions:
+    output = "stdout"
   else:
     output = $conf.absOutFile
   if conf.filenameOption != foAbs: output = output.AbsoluteFile.extractFilename

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -725,7 +725,7 @@ proc genSuccessX*(conf: ConfigRef) =
   elif conf.outFile.isEmpty and conf.cmd notin {cmdJsonscript} + cmdDocLike + cmdBackends:
     # for some cmd we expect a valid absOutFile
     output = "unknownOutput"
-  elif  optStdout in conf.globalOptions:
+  elif optStdout in conf.globalOptions:
     output = "stdout"
   else:
     output = $conf.absOutFile


### PR DESCRIPTION
Fixes the assertion defect that happens when using `jsondoc --stdout` (There is no outfile since its just stdout)

```
Error: unhandled exception: options.nim(732, 3) `not conf.outFile.isEmpty`  [AssertionDefect]
```

Also makes the output easier to parse by ending each module output with a new line.