### PR TITLE
'j' format specifier docs

### DIFF
--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -409,6 +409,11 @@ proc formatValueAsTuple(result: var string; value: Complex; specifier: string) =
 
 proc formatValueAsComplexNumber(result: var string; value: Complex; specifier: string) =
   ## Format implementation for `Complex` representing the value as a (RE+IMj) number
+  ## By default, the real and imaginary parts are formatted using the general ('g') format
+  let specifier = if specifier.contains({'e', 'E', 'f', 'F', 'g', 'G'}):
+      specifier.replace("j")
+    else:
+      specifier.replace('j', 'g')
   result.add "("
   formatValue(result, value.re, specifier)
   if value.im >= 0 and not specifier.contains({'+', '-'}):
@@ -425,11 +430,6 @@ proc formatValue*(result: var string; value: Complex; specifier: string) =
   if specifier.len == 0:
     result.add $value
   elif 'j' in specifier:
-    let specifier = if specifier.contains({'e', 'E', 'f', 'F', 'g', 'G'}):
-        specifier.replace("j")
-      else:
-        # 'The 'j' format defaults to 'g'
-        specifier.replace('j', 'g')
     formatValueAsComplexNumber(result, value, specifier)
   else:
     formatValueAsTuple(result, value, specifier)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -264,6 +264,12 @@ The available floating point presentation types are:
                          exponent notation.
 `G`                      General format. Same as `g` except it switches to `E`
                          if the number gets to large.
+`i`                      Complex General format. This is only supported for
+                         complex numbers, which it prints using the mathematical
+                         (RE+IMj) format. The real and imaginary parts are printed
+                         using the general format `g` by default, but it is
+                         possible to combine this format with one of the other
+                         formats (e.g `jf`).
 (None)                   Similar to `g`, except that it prints at least one
                          digit after the decimal point.
 =================        ====================================================


### PR DESCRIPTION
This is a small improvement on top of PR #22924, which documents the new 'j' format specifier for Complex numbers. In addition to that it moves the handling of the j specifier into the function that actually implements it (formatValueAsComplexNumber), which seems a little cleaner.