### PR TITLE
Added new command line option `--info:X` to nimsuggest for obtaining …

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -35,6 +35,7 @@ when defined(windows):
 else:
   import posix
 
+const HighestSuggestProtocolVersion = 3
 const DummyEof = "!EOF!"
 const Usage = """
 Nimsuggest - Tool to give every editor IDE like capabilities for Nim
@@ -53,6 +54,9 @@ Options:
   --v1                    use version 1 of the protocol; for backwards compatibility
   --v2                    use version 2(default) of the protocol
   --v3                    use version 3 of the protocol
+  --info:X                information
+    --info:nimVer           return the Nim compiler version that nimsuggest uses internally
+    --info:protocolVer      return the newest protocol version that is supported
   --refresh               perform automatic refreshes to keep the analysis precise
   --maxresults:N          limit the number of suggestions to N
   --tester                implies --stdin and outputs a line
@@ -637,6 +641,16 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
       of "v1": conf.suggestVersion = 1
       of "v2": conf.suggestVersion = 0
       of "v3": conf.suggestVersion = 3
+      of "info":
+        case p.val.normalize
+        of "protocolver":
+          stdout.writeLine(HighestSuggestProtocolVersion)
+          quit 0
+        of "nimver":
+          stdout.writeLine(system.NimVersion)
+          quit 0
+        else:
+          processSwitch(pass, p, conf)
       of "tester":
         gMode = mstdin
         gEmitEof = true


### PR DESCRIPTION
…information. (#22940)

`--info:protocolVer` returns the highest nimsuggest protocol version that is supported (currently, it's version 3).
`--info:nimVer` returns the Nim compiler version that nimsuggest uses internally.

Note that you can obtain the Nim compiler version via `nimsuggest -v`, but that requires parsing the output, which looks like this:

```
Nim Compiler Version 2.1.1 [Linux: amd64]
Compiled at 2023-11-14
Copyright (c) 2006-2023 by Andreas Rumpf

git hash: 47ddfeca5247dce992becd734d1ae44e621207b8
active boot switches: -d:release -d:danger --gc:markAndSweep
```

`--info:nimVer` will return just:

```
2.1.1
```

(cherry picked from commit d0cc02dfc439d14bfadd4e5ac3a7855fe8d8e417)