### PR TITLE
fixes #22939; fixes #16890; push should but doesn't apply to importc …

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -528,6 +528,15 @@ proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
     else: discard
   else:
     result = semIdentVis(c, kind, n, allowed)
+    case kind
+    of skType:
+      # process pragmas later, because result.typ has not been set yet
+      discard
+    of skField: implicitPragmas(c, result, n.info, fieldPragmas)
+    of skVar:   implicitPragmas(c, result, n.info, varPragmas)
+    of skLet:   implicitPragmas(c, result, n.info, letPragmas)
+    of skConst: implicitPragmas(c, result, n.info, constPragmas)
+    else: discard
 
 proc checkForOverlap(c: PContext, t: PNode, currentEx, branchIndex: int) =
   let ex = t[branchIndex][currentEx].skipConv

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -529,9 +529,6 @@ proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
   else:
     result = semIdentVis(c, kind, n, allowed)
     case kind
-    of skType:
-      # process pragmas later, because result.typ has not been set yet
-      discard
     of skField: implicitPragmas(c, result, n.info, fieldPragmas)
     of skVar:   implicitPragmas(c, result, n.info, varPragmas)
     of skLet:   implicitPragmas(c, result, n.info, letPragmas)

--- a/tests/nimdoc/m13129.nim
+++ b/tests/nimdoc/m13129.nim
@@ -4,6 +4,7 @@ when defined(cpp):
   {.push header: "<vector>".}
   type
     Vector[T] {.importcpp: "std::vector".} = object
+  {.pop.}
 elif defined(js):
   proc endsWith*(s, suffix: cstring): bool {.noSideEffect,importjs: "#.endsWith(#)".}
 elif defined(c):


### PR DESCRIPTION
…var/let symbols


fixes #22939
fixes #16890

Besides, it was applied to let/const/var with pragmas, now it is universally applied.

```nim
{.push exportc.}
proc foo =
  let bar = 12
  echo bar
{.pop.}
```

For example, the `bar` variable will be affected by `exportc`.