### PR TITLE
Don't provide suggestions for enum fields

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -733,7 +733,7 @@ proc suggestDecl*(c: PContext, n: PNode; s: PSym) =
   defer:
     if attached: dec(c.inTypeContext)
   # If user is typing out an enum field, then don't provide suggestions
-  if s.kind == skEnumField and exactEquals(c.config.m.trackPos, n.info):
+  if s.kind == skEnumField and c.config.cmd == cmdIdeTools and exactEquals(c.config.m.trackPos, n.info):
     suggestQuit()
   suggestExpr(c, n)
 

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -732,6 +732,9 @@ proc suggestDecl*(c: PContext, n: PNode; s: PSym) =
   if attached: inc(c.inTypeContext)
   defer:
     if attached: dec(c.inTypeContext)
+  # If user is typing out an enum field, then don't provide suggestions
+  if exactEquals(c.config.m.trackPos, n.info) and s.kind == skEnumField:
+    suggestQuit()
   suggestExpr(c, n)
 
 proc suggestStmt*(c: PContext, n: PNode) =

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -733,7 +733,7 @@ proc suggestDecl*(c: PContext, n: PNode; s: PSym) =
   defer:
     if attached: dec(c.inTypeContext)
   # If user is typing out an enum field, then don't provide suggestions
-  if exactEquals(c.config.m.trackPos, n.info) and s.kind == skEnumField:
+  if s.kind == skEnumField and exactEquals(c.config.m.trackPos, n.info):
     suggestQuit()
   suggestExpr(c, n)
 

--- a/nimsuggest/tests/tenum_field.nim
+++ b/nimsuggest/tests/tenum_field.nim
@@ -1,0 +1,17 @@
+discard """
+$nimsuggest --tester $file
+>sug $1
+>sug $2
+sug;;skConst;;tenum_field.BarFoo;;int literal(1);;$file;;10;;6;;"";;100;;Prefix
+"""
+
+proc something() = discard
+
+const BarFoo = 1
+
+type
+  Foo = enum
+    # Test that typing the name doesn't give suggestions
+    somethi#[!]#
+    # Test that the right hand side still gets suggestions
+    another = BarFo#[!]#


### PR DESCRIPTION
Currently the suggestions create a lot of noise when creating enum fields. I don't see any way of a macro creating fields (when called inside an enum) so it should be safe to not show suggestions