### PR TITLE
 nimsuggest: Added optional command line option '--clientProcessId:XXX'

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -441,6 +441,7 @@ type
     expandPosition*: TLineInfo
 
     currentConfigDir*: string # used for passPP only; absolute dir
+    clientProcessId*: int
 
 
 proc parseNimVersion*(a: string): NimVer =

--- a/nimsuggest/procmonitor.nim
+++ b/nimsuggest/procmonitor.nim
@@ -1,0 +1,34 @@
+# Monitor a client process and shutdown the current process, if the client
+# process is found to be dead
+
+import os
+
+when defined(posix):
+  import posix_utils
+  import posix
+
+when defined(windows):
+  import winlean
+
+when defined(posix):
+  proc monitorClientProcessIdThreadProc(pid: int) {.thread.} =
+    while true:
+      sleep(1000)
+      try:
+        sendSignal(Pid(pid), 0)
+      except:
+        discard kill(Pid(getCurrentProcessId()), cint(SIGTERM))
+
+when defined(windows):
+  proc monitorClientProcessIdThreadProc(pid: int) {.thread.} =
+    var process = openProcess(SYNCHRONIZE, 0, DWORD(pid))
+    if process != 0:
+      discard waitForSingleObject(process, INFINITE)
+      discard closeHandle(process)
+    quit(0)
+
+var tid: Thread[int]
+
+proc hookProcMonitor*(pid: int) =
+  when defined(posix) or defined(windows):
+    createThread(tid, monitorClientProcessIdThreadProc, pid)


### PR DESCRIPTION
When it is specified, the nimsuggest instance monitors whether this process is still alive. In case it's found to be dead, nimsuggest shuts itself down. Currently only implemented on POSIX and Windows platforms. The switch is silently ignored on other platforms. Note that the Nim language server should still try to shut down its child nimsuggest processes. This switch just adds extra protection against crashing Nim language server and gets rid of the remaining nimsuggest processes, which consume memory and system resources.