### PR TITLE
fix: std/marshal unmarshaling of `ref` objects

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -339,7 +339,7 @@ proc getPointer*(x: Any): pointer =
   ## `akString`, `akCString`, `akProc`, `akRef`, `akPtr`,
   ## `akPointer` or `akSequence`.
   assert x.rawType.kind in pointerLike
-  result = cast[ppointer](x.value)[]
+  result = cast[pointer](x.value)
 
 proc setPointer*(x: Any, y: pointer) =
   ## Sets the pointer value of `x`. `x` needs to be of kind


### PR DESCRIPTION
`setPointer()` stores a pointer directly, but `getPointer()` was previously always dereferencing that pointer, before returning it, which is clearly not correct.

The big impact is that `std/marshal` was unable to unmarshal `ref` types-- instead of the new `Any` object's value field getting the correct pointer to the object, it was getting the value obtained by dereferencing the pointer. Perhaps there were other downstream effects too; I'm not sure if anything else in stdlib uses `typeinfo`.