### PR TITLE
backport to v 1.6: nimsuggest: Added optional command line option '--clientProcessId:XXX' (#22969)

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -417,6 +417,8 @@ type
     expandNodeResult*: string
     expandPosition*: TLineInfo
 
+    clientProcessId*: int
+
 proc parseNimVersion*(a: string): NimVer =
   # could be moved somewhere reusable
   if a.len > 0:

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -13,6 +13,7 @@ import algorithm
 import tables
 import std/sha1
 import times
+import procmonitor
 
 ## Nimsuggest is a tool that helps to give editors IDE like capabilities.
 
@@ -48,6 +49,7 @@ Options:
   --address:HOST          binds to that address, by default ""
   --stdin                 read commands from stdin and write results to
                           stdout instead of using sockets
+  --clientProcessId:PID   shutdown nimsuggest in case this process dies
   --epc                   use emacs epc mode
   --debug                 enable debug output
   --log                   enable verbose logging to nimsuggest.log file
@@ -596,6 +598,9 @@ proc mainCommand(graph: ModuleGraph) =
   open(requests)
   open(results)
 
+  if graph.config.clientProcessId != 0:
+    hookProcMonitor(graph.config.clientProcessId)
+
   case gMode
   of mstdin: createThread(inputThread, replStdin, (gPort, gAddress))
   of mtcp: createThread(inputThread, replTcp, (gPort, gAddress))
@@ -671,6 +676,8 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         conf.suggestMaxResults = parseInt(p.val)
       of "find":
         findProject = true
+      of "clientprocessid":
+        conf.clientProcessId = parseInt(p.val)
       else: processSwitch(pass, p, conf)
     of cmdArgument:
       let a = unixToNativePath(p.key)

--- a/nimsuggest/procmonitor.nim
+++ b/nimsuggest/procmonitor.nim
@@ -1,0 +1,34 @@
+# Monitor a client process and shutdown the current process, if the client
+# process is found to be dead
+
+import os
+
+when defined(posix):
+  import posix_utils
+  import posix
+
+when defined(windows):
+  import winlean
+
+when defined(posix):
+  proc monitorClientProcessIdThreadProc(pid: int) {.thread.} =
+    while true:
+      sleep(1000)
+      try:
+        sendSignal(Pid(pid), 0)
+      except:
+        discard kill(Pid(getCurrentProcessId()), cint(SIGTERM))
+
+when defined(windows):
+  proc monitorClientProcessIdThreadProc(pid: int) {.thread.} =
+    var process = openProcess(SYNCHRONIZE, 0, DWORD(pid))
+    if process != 0:
+      discard waitForSingleObject(process, INFINITE)
+      discard closeHandle(process)
+    quit(0)
+
+var tid: Thread[int]
+
+proc hookProcMonitor*(pid: int) =
+  when defined(posix) or defined(windows):
+    createThread(tid, monitorClientProcessIdThreadProc, pid)


### PR DESCRIPTION
When it is specified, the nimsuggest instance monitors whether this process is still alive. In case it's found to be dead, nimsuggest shuts itself down. Currently only implemented on POSIX and Windows platforms. The switch is silently ignored on other platforms. Note that the Nim language server should still try to shut down its child nimsuggest processes. This switch just adds extra protection against crashing Nim language server and gets rid of the remaining nimsuggest processes, which consume memory and system resources.

(cherry picked from commit 502a4486aeb8d0a5dcdf86540522d3dc16960536)