### PR TITLE
fix: std/marshal unmarshaling of ref objects

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -339,7 +339,10 @@ proc getPointer*(x: Any): pointer =
   ## `akString`, `akCString`, `akProc`, `akRef`, `akPtr`,
   ## `akPointer` or `akSequence`.
   assert x.rawType.kind in pointerLike
-  result = cast[pointer](x.value)
+  result = cast[ppointer](x.value)[]
+
+  if result != nil and x.rawType.kind != tyPointer:
+      result = cast[pointer](x.value)
 
 proc setPointer*(x: Any, y: pointer) =
   ## Sets the pointer value of `x`. `x` needs to be of kind

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -339,7 +339,7 @@ proc getPointer*(x: Any): pointer =
   ## `akString`, `akCString`, `akProc`, `akRef`, `akPtr`,
   ## `akPointer` or `akSequence`.
   assert x.rawType.kind in pointerLike
-  result = cast[ppointer](x.value)[]
+  result = cast[pointer](x.value)
 
 proc setPointer*(x: Any, y: pointer) =
   ## Sets the pointer value of `x`. `x` needs to be of kind

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -342,7 +342,7 @@ proc getPointer*(x: Any): pointer =
   result = cast[ppointer](x.value)[]
 
   if result != nil and x.rawType.kind != tyPointer:
-      result = cast[pointer](x.value)
+    result = cast[pointer](x.value)
 
 proc setPointer*(x: Any, y: pointer) =
   ## Sets the pointer value of `x`. `x` needs to be of kind

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -341,9 +341,6 @@ proc getPointer*(x: Any): pointer =
   assert x.rawType.kind in pointerLike
   result = cast[ppointer](x.value)[]
 
-  if result != nil and x.rawType.kind != tyPointer:
-    result = cast[pointer](x.value)
-
 proc setPointer*(x: Any, y: pointer) =
   ## Sets the pointer value of `x`. `x` needs to be of kind
   ## `akString`, `akCString`, `akProc`, `akRef`, `akPtr`,

--- a/lib/pure/marshal.nim
+++ b/lib/pure/marshal.nim
@@ -210,7 +210,8 @@ proc loadAny(p: var JsonParser, a: Any, t: var Table[BiggestInt, pointer]) =
       setPointer(a, nil)
       next(p)
     of jsonInt:
-      setPointer(a, t.getOrDefault(p.getInt))
+      var raw = t.getOrDefault(p.getInt)
+      setPointer(a, addr raw)
       next(p)
     of jsonArrayStart:
       next(p)

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -166,6 +166,24 @@ block:
   let a: ref A = new(B)
   doAssert $$a[] == "{}" # not "{f: 0}"
 
+# bug #16496
+block:
+  type
+    A = ref object
+      data: seq[int]
+
+    B = ref object
+      x: A
+  let o = A(data: @[1, 2, 3, 4])
+  let s1 = @[B(x: o), B(x: o)]
+  let m  = $$ s1
+  let s2 = to[seq[B]](m)
+  doAssert s2[0].x.data == s2[1].x.data
+  doAssert s1[0].x.data == s2[1].x.data
+
+
+
+
 template checkMarshal(data: typed) =
   let orig = data
   let m = $$orig

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 import std/marshal
-import std/[assertions, objectdollar]
+import std/[assertions, objectdollar, streams]
 
 # TODO: add static tests
 
@@ -182,6 +182,28 @@ block:
   doAssert s1[0].x.data == s2[1].x.data
 
 
+block:
+  type
+    Obj = ref object
+      i: int
+      b: bool
+
+  let
+    strm = newStringStream()
+
+  var
+    o = Obj(i: 1, b: false)
+    t1 = @[o, o]
+    t2: seq[Obj]
+
+  doAssert t1[0] == t1[1]
+
+  strm.store(t1)
+  strm.setPosition(0)
+  strm.load(t2)
+  strm.close()
+
+  doAssert t2[0] == t2[1]
 
 
 template checkMarshal(data: typed) =


### PR DESCRIPTION
Fixes #16496 

![Marshal doesn't properly unmarshal *most* ref objects; the exceptions being nil ones](https://github-production-user-asset-6210df.s3.amazonaws.com/4764481/285471431-a39ee2c5-5670-4b12-aa10-7a10ba6b5b96.gif)
Test case added.

Note that this test (t9754) does pass locally, but there are tons of failures by default on OS X arm64, mostly around the bohem GC, so it's pretty spammy, and could easily have missed something. If there are better instructions please do let me know.