### PR TITLE
Register declaration of enum field has a use

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -148,6 +148,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     result.n.add symNode
     styleCheckDef(c, e)
     onDef(e.info, e)
+    suggestSym(c.graph, e.info, e, c.graph.usageSym)
     if sfGenSym notin e.flags:
       if not isPure:
         addInterfaceOverloadableSymAt(c, c.currentScope, e)

--- a/nimsuggest/tests/tuse_enum.nim
+++ b/nimsuggest/tests/tuse_enum.nim
@@ -1,8 +1,8 @@
 discard """
 $nimsuggest --tester $file
 >use $1
-def;;skEnum;;tuse_enum.Red;;Colour;;$file;;10;;4;;"";;100
-use;;skEnum;;tuse_enum.Red;;Colour;;$file;;14;;8;;"";;100
+def;;skEnumField;;tuse_enum.Colour.Red;;Colour;;$file;;10;;4;;"";;100
+use;;skEnumField;;tuse_enum.Colour.Red;;Colour;;$file;;14;;8;;"";;100
 """
 
 type

--- a/nimsuggest/tests/tuse_enum.nim
+++ b/nimsuggest/tests/tuse_enum.nim
@@ -1,0 +1,15 @@
+discard """
+$nimsuggest --tester $file
+>use $1
+def;;skEnum;;tuse_enum.Red;;Colour;;$file;;10;;4;;"";;100
+use;;skEnum;;tuse_enum.Red;;Colour;;$file;;14;;8;;"";;100
+"""
+
+type
+  Colour = enum
+    Red
+    Green
+    Blue
+
+discard #[!]#Red
+


### PR DESCRIPTION
Currently when using `use` with nimsuggest on an enum field, it doesn't return the definition of the field.

Breaks renaming in IDEs since it will replace all the usages, but not the declaration