### PR TITLE
rework the vtable implementation embedding the vtable array directly with new strictions on methods

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 - `-d:nimStrictDelete` becomes the default. An index error is produced when the index passed to `system.delete` was out of bounds. Use `-d:nimAuditDelete` to mimic the old behavior for backwards compatibility.
 - The default user-agent in `std/httpclient` has been changed to `Nim-httpclient/<version>` instead of `Nim httpclient/<version>` which was incorrect according to the HTTP spec.
+- Methods now support implementations based on vtable by using `-d:nimPreviewVtables`.
 
 ## Standard library additions and changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 
 - `-d:nimStrictDelete` becomes the default. An index error is produced when the index passed to `system.delete` was out of bounds. Use `-d:nimAuditDelete` to mimic the old behavior for backwards compatibility.
 - The default user-agent in `std/httpclient` has been changed to `Nim-httpclient/<version>` instead of `Nim httpclient/<version>` which was incorrect according to the HTTP spec.
-- Methods now support implementations based on vtable by using `-d:nimPreviewVtables`.
+- Methods now support implementations based on vtable by using `-d:nimPreviewVtables`. methods are confined in the same module where the type has been defined.
 - With `-d:nimPreviewNonVarDestructor`, non-var destructors become the default.
 
 ## Standard library additions and changes

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1762,7 +1762,6 @@ proc genTypeInfoV2Impl(m: BModule; t, origType: PType, name: Rope; info: TLineIn
   add(typeEntry, ", .traceImpl = (void*)")
   genHook(m, t, info, attachedTrace, typeEntry)
 
-  let vTablePointerName = getTempName(m)
   let dispatchMethods = toSeq(getMethodsPerType(m.g.graph, t))
   if dispatchMethods.len > 0:
     addf(typeEntry, ", .flags = $1", [rope(flags)])

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1768,7 +1768,7 @@ proc genTypeInfoV2Impl(m: BModule; t, origType: PType, name: Rope; info: TLineIn
     addf(typeEntry, ", .flags = $1", [rope(flags)])
     for i in dispatchMethods:
       genProcPrototype(m, i)
-    addf(typeEntry, ", .vTable = $1};$n", [genVTable(m, dispatchMethods)])
+    addf(typeEntry, ", .vTable = $1};$n", [genVTable(dispatchMethods)])
     m.s[cfsVars].add typeEntry
   else:
     addf(typeEntry, ", .flags = $1};$n", [rope(flags)])

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -366,6 +366,8 @@ proc dataField(p: BProc): Rope =
   else:
     result = rope"->data"
 
+proc genProcPrototype(m: BModule, sym: PSym)
+
 include ccgliterals
 include ccgtypes
 
@@ -734,7 +736,7 @@ proc genVarPrototype(m: BModule, n: PNode)
 proc requestConstImpl(p: BProc, sym: PSym)
 proc genStmts(p: BProc, t: PNode)
 proc expr(p: BProc, n: PNode, d: var TLoc)
-proc genProcPrototype(m: BModule, sym: PSym)
+
 proc putLocIntoDest(p: BProc, d: var TLoc, s: TLoc)
 proc intLiteral(i: BiggestInt; result: var Rope)
 proc genLiteral(p: BProc, n: PNode; result: var Rope)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2194,7 +2194,7 @@ proc initializeVTable*(m: BModule, typ: PType, dispatchMethods: seq[PSym]) =
   let objVTable = getTempName(m)
   let vTablePointerName = getTempName(m)
   let patches = newNode(nkStmtList)
-  for i in getDispatchers(m.g.graph):
+  for i in dispatchMethods:
     let node = newNode(nkDiscardStmt)
     node.add newSymNode(i)
     patches.add node

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2252,7 +2252,9 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
 
       if m.g.forwardedProcs.len == 0:
         incl m.flags, objHasKidsValid
-      if {optMultiMethods, optNoMain} * m.g.config.globalOptions != {} or m.g.config.selectedGC notin {gcArc, gcOrc, gcAtomicArc}:
+      if {optMultiMethods, optNoMain} * m.g.config.globalOptions != {} or
+          m.g.config.selectedGC notin {gcArc, gcOrc, gcAtomicArc} or
+          not m.g.config.isDefined("nimPreviewVtables"):
         generateIfMethodDispatchers(graph, m.idgen)
       else:
         for value in graph.getMethodsPerType:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2183,9 +2183,9 @@ proc updateCachedModule(m: BModule) =
 
 proc genVTable(m: BModule, seqs: seq[PSym]): Rope =
   result = Rope"{"
-  for i in 0..<seqs.len-1:
-    result.add "(void *) " & seqs[i].loc.r & ", "
-  result.add "(void *) " & seqs[^1].loc.r
+  for i in 0..<seqs.len:
+    if i > 0: result.add ", "
+    result.add "(void *) " & seqs[i].loc.r
   result.add "}"
 
 proc initializeVTable*(m: BModule, typ: PType, dispatchMethods: seq[PSym]) =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2232,9 +2232,10 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
 
       if m.g.forwardedProcs.len == 0:
         incl m.flags, objHasKidsValid
-      if {optMultiMethods, optNoMain} * m.g.config.globalOptions != {} or
+      if optMultiMethods in m.g.config.globalOptions or
           m.g.config.selectedGC notin {gcArc, gcOrc, gcAtomicArc} or
-          not m.g.config.isDefined("nimPreviewVtables"):
+          not m.g.config.isDefined("nimPreviewVtables") or
+          m.g.config.backend == backendCpp or sfCompileToCpp in m.module.flags:
         generateIfMethodDispatchers(graph, m.idgen)
 
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2257,8 +2257,8 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
       if {optMultiMethods, optNoMain} * m.g.config.globalOptions != {} or m.g.config.selectedGC notin {gcArc, gcOrc, gcAtomicArc}:
         generateIfMethodDispatchers(graph, m.idgen)
       else:
-        for value in graph.methodsPerType.mitems:
-          initializeVTable(m, value.typ, value.methods)
+        for value in graph.methodsPerType.mvalues:
+          initializeVTable(m, resolveType(graph, value.typ), value.methods)
 
 
   let mm = m

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2254,8 +2254,12 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
 
       if m.g.forwardedProcs.len == 0:
         incl m.flags, objHasKidsValid
-      if false: # TODO: soon
-        generateMethodDispatchers(graph, m.idgen)
+      if {optMultiMethods, optNoMain} * m.g.config.globalOptions != {} or m.g.config.selectedGC notin {gcArc, gcOrc, gcAtomicArc}:
+        generateIfMethodDispatchers(graph, m.idgen)
+      else:
+        for value in graph.methodsPerType.mitems:
+          initializeVTable(m, value.typ, value.methods)
+
 
   let mm = m
   m.g.modulesClosed.add mm

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -292,4 +292,4 @@ proc generateIfMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator) =
         # if multi-methods are not enabled, we are interested only in the first field
         break
     sortBucket(g.methods[bucket].methods, relevantCols)
-    g.dispatchers.add LazySym(sym: genIfDispatcher(g, g.methods[bucket].methods, relevantCols, idgen))
+    g.addDispatchers genIfDispatcher(g, g.methods[bucket].methods, relevantCols, idgen)

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -224,7 +224,7 @@ proc sortBucket*(a: var seq[PSym], relevantCols: IntSet) =
       a[j] = v
     if h == 1: break
 
-proc genDispatcher*(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; idgen: IdGenerator): PSym =
+proc genIfDispatcher*(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; idgen: IdGenerator): PSym =
   var base = methods[0].ast[dispatcherPos].sym
   result = base
   var paramLen = base.typ.len
@@ -283,7 +283,7 @@ proc genDispatcher*(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; id
   nilchecks.flags.incl nfTransf # should not be further transformed
   result.ast[bodyPos] = nilchecks
 
-proc generateMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator) =
+proc generateIfMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator) =
   for bucket in 0..<g.methods.len:
     var relevantCols = initIntSet()
     for col in 1..<g.methods[bucket].methods[0].typ.len:
@@ -292,4 +292,4 @@ proc generateMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator) =
         # if multi-methods are not enabled, we are interested only in the first field
         break
     sortBucket(g.methods[bucket].methods, relevantCols)
-    g.dispatchers.add LazySym(sym: genDispatcher(g, g.methods[bucket].methods, relevantCols, idgen))
+    g.dispatchers.add LazySym(sym: genIfDispatcher(g, g.methods[bucket].methods, relevantCols, idgen))

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -16,6 +16,7 @@ import
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
+import std/[tables]
 
 proc genConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
   var dest = skipTypes(d, abstractPtrs)
@@ -171,6 +172,11 @@ proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
     of Invalid:
       if witness.isNil: witness = g.methods[i].methods[0]
   # create a new dispatcher:
+  # stores the id and the position
+  if s.typ[1].skipTypes(skipPtrs).itemId notin g.bucketTable:
+    g.bucketTable[s.typ[1].skipTypes(skipPtrs).itemId] = 1
+  else:
+    g.bucketTable.inc(s.typ[1].skipTypes(skipPtrs).itemId)
   g.methods.add((methods: @[s], dispatcher: createDispatcher(s, g, idgen)))
   #echo "adding ", s.info
   if witness != nil:
@@ -179,7 +185,7 @@ proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
   elif sfBase notin s.flags:
     message(g.config, s.info, warnUseBase)
 
-proc relevantCol(methods: seq[PSym], col: int): bool =
+proc relevantCol*(methods: seq[PSym], col: int): bool =
   # returns true iff the position is relevant
   result = false
   var t = methods[0].typ[col].skipTypes(skipPtrs)
@@ -199,7 +205,7 @@ proc cmpSignatures(a, b: PSym, relevantCols: IntSet): int =
       if (d != high(int)) and d != 0:
         return d
 
-proc sortBucket(a: var seq[PSym], relevantCols: IntSet) =
+proc sortBucket*(a: var seq[PSym], relevantCols: IntSet) =
   # we use shellsort here; fast and simple
   var n = a.len
   var h = 1
@@ -218,7 +224,7 @@ proc sortBucket(a: var seq[PSym], relevantCols: IntSet) =
       a[j] = v
     if h == 1: break
 
-proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; idgen: IdGenerator): PSym =
+proc genDispatcher*(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; idgen: IdGenerator): PSym =
   var base = methods[0].ast[dispatcherPos].sym
   result = base
   var paramLen = base.typ.len
@@ -277,8 +283,7 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet; idg
   nilchecks.flags.incl nfTransf # should not be further transformed
   result.ast[bodyPos] = nilchecks
 
-proc generateMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator): PNode =
-  result = newNode(nkStmtList)
+proc generateMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator) =
   for bucket in 0..<g.methods.len:
     var relevantCols = initIntSet()
     for col in 1..<g.methods[bucket].methods[0].typ.len:
@@ -287,4 +292,4 @@ proc generateMethodDispatchers*(g: ModuleGraph, idgen: IdGenerator): PNode =
         # if multi-methods are not enabled, we are interested only in the first field
         break
     sortBucket(g.methods[bucket].methods, relevantCols)
-    result.add newSymNode(genDispatcher(g, g.methods[bucket].methods, relevantCols, idgen))
+    g.dispatchers.add LazySym(sym: genDispatcher(g, g.methods[bucket].methods, relevantCols, idgen))

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -157,7 +157,7 @@ proc fixupDispatcher(meth, disp: PSym; conf: ConfigRef) =
 
 proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
   var witness: PSym = nil
-  if s.typ[1].owner.getModule != s.getModule:
+  if s.typ[1].owner.getModule != s.getModule and g.config.isDefined("nimPreviewVtables"):
     localError(g.config, s.info, errGenerated, "method `" & s.name.s &
           "` can be defined only in the same module with its type (" & s.typ[1].typeToString() & ")")
   for i in 0..<g.methods.len:

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -11,8 +11,7 @@
 
 import
   options, ast, msgs, idents, renderer, types, magicsys,
-  sempass2, modulegraphs, lineinfos
-
+  sempass2, modulegraphs, lineinfos, astalgo
 
 import std/intsets
 
@@ -158,6 +157,9 @@ proc fixupDispatcher(meth, disp: PSym; conf: ConfigRef) =
 
 proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
   var witness: PSym = nil
+  if s.typ[1].owner.getModule != s.getModule:
+    localError(g.config, s.info, errGenerated, "method `" & s.name.s &
+          "` can be defined only in the same module with its type (" & s.typ[1].typeToString() & ")")
   for i in 0..<g.methods.len:
     let disp = g.methods[i].dispatcher
     case sameMethodBucket(disp, s, multimethods = optMultiMethods in g.config.globalOptions)

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -50,10 +50,9 @@ proc generateCodeForModule(g: ModuleGraph; m: var LoadedModule; alive: var Alive
     let n = unpackTree(g, m.module.position, m.fromDisk.topLevel, p)
     cgen.genTopLevelStmt(bmod, n)
 
-  let disps = finalCodegenActions(g, bmod, newNodeI(nkStmtList, m.module.info))
-  if disps != nil:
-    for disp in disps:
-      genProcAux(bmod, disp.sym)
+  finalCodegenActions(g, bmod, newNodeI(nkStmtList, m.module.info))
+  for disp in resolveLazySymSeq(g, g.dispatchers):
+    genProcAux(bmod, disp)
   m.fromDisk.backendFlags = cgen.whichInitProcs(bmod)
 
 proc replayTypeInfo(g: ModuleGraph; m: var LoadedModule; origin: FileIndex) =

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -51,7 +51,7 @@ proc generateCodeForModule(g: ModuleGraph; m: var LoadedModule; alive: var Alive
     cgen.genTopLevelStmt(bmod, n)
 
   finalCodegenActions(g, bmod, newNodeI(nkStmtList, m.module.info))
-  for disp in resolveLazySymSeq(g, g.dispatchers):
+  for disp in getDispatchers(g):
     genProcAux(bmod, disp)
   m.fromDisk.backendFlags = cgen.whichInitProcs(bmod)
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -49,7 +49,7 @@ type
     typeInstCache*: seq[(PackedItemId, PackedItemId)]
     procInstCache*: seq[PackedInstantiation]
     attachedOps*: seq[(PackedItemId, TTypeAttachedOp, PackedItemId)]
-    methodsPerType*: seq[(PackedItemId, int, PackedItemId)]
+    methodsPerGenericType*: seq[(PackedItemId, int, PackedItemId)]
     enumToStringProcs*: seq[(PackedItemId, PackedItemId)]
 
     emittedTypeInfo*: seq[string]
@@ -618,7 +618,7 @@ proc loadRodFile*(filename: AbsoluteFile; m: var PackedModule; config: ConfigRef
   loadSeqSection typeInstCacheSection, m.typeInstCache
   loadSeqSection procInstCacheSection, m.procInstCache
   loadSeqSection attachedOpsSection, m.attachedOps
-  loadSeqSection methodsPerTypeSection, m.methodsPerType
+  loadSeqSection methodsPerTypeSection, m.methodsPerGenericType
   loadSeqSection enumToStringProcsSection, m.enumToStringProcs
   loadSeqSection typeInfoSection, m.emittedTypeInfo
 
@@ -683,7 +683,7 @@ proc saveRodFile*(filename: AbsoluteFile; encoder: var PackedEncoder; m: var Pac
   storeSeqSection typeInstCacheSection, m.typeInstCache
   storeSeqSection procInstCacheSection, m.procInstCache
   storeSeqSection attachedOpsSection, m.attachedOps
-  storeSeqSection methodsPerTypeSection, m.methodsPerType
+  storeSeqSection methodsPerTypeSection, m.methodsPerGenericType
   storeSeqSection enumToStringProcsSection, m.enumToStringProcs
   storeSeqSection typeInfoSection, m.emittedTypeInfo
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -51,6 +51,8 @@ type
     attachedOps*: seq[(PackedItemId, TTypeAttachedOp, PackedItemId)]
     methodsPerGenericType*: seq[(PackedItemId, int, PackedItemId)]
     enumToStringProcs*: seq[(PackedItemId, PackedItemId)]
+    methodsPerType*: seq[(PackedItemId, PackedItemId)]
+    dispatchers*: seq[PackedItemId]
 
     emittedTypeInfo*: seq[string]
     backendFlags*: set[ModuleBackendFlag]
@@ -618,8 +620,10 @@ proc loadRodFile*(filename: AbsoluteFile; m: var PackedModule; config: ConfigRef
   loadSeqSection typeInstCacheSection, m.typeInstCache
   loadSeqSection procInstCacheSection, m.procInstCache
   loadSeqSection attachedOpsSection, m.attachedOps
-  loadSeqSection methodsPerTypeSection, m.methodsPerGenericType
+  loadSeqSection methodsPerGenericTypeSection, m.methodsPerGenericType
   loadSeqSection enumToStringProcsSection, m.enumToStringProcs
+  loadSeqSection methodsPerTypeSection, m.methodsPerType
+  loadSeqSection dispatchersSection, m.dispatchers
   loadSeqSection typeInfoSection, m.emittedTypeInfo
 
   f.loadSection backendFlagsSection
@@ -683,8 +687,10 @@ proc saveRodFile*(filename: AbsoluteFile; encoder: var PackedEncoder; m: var Pac
   storeSeqSection typeInstCacheSection, m.typeInstCache
   storeSeqSection procInstCacheSection, m.procInstCache
   storeSeqSection attachedOpsSection, m.attachedOps
-  storeSeqSection methodsPerTypeSection, m.methodsPerGenericType
+  storeSeqSection methodsPerGenericTypeSection, m.methodsPerGenericType
   storeSeqSection enumToStringProcsSection, m.enumToStringProcs
+  storeSeqSection methodsPerTypeSection, m.methodsPerType
+  storeSeqSection dispatchersSection, m.dispatchers
   storeSeqSection typeInfoSection, m.emittedTypeInfo
 
   f.storeSection backendFlagsSection

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -134,7 +134,7 @@ proc checkModule(c: var CheckedContext; m: PackedModule) =
     typeInstCache*: seq[(PackedItemId, PackedItemId)]
     procInstCache*: seq[PackedInstantiation]
     attachedOps*: seq[(TTypeAttachedOp, PackedItemId, PackedItemId)]
-    methodsPerType*: seq[(PackedItemId, int, PackedItemId)]
+    methodsPerGenericType*: seq[(PackedItemId, int, PackedItemId)]
     enumToStringProcs*: seq[(PackedItemId, PackedItemId)]
   ]#
 

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -136,6 +136,8 @@ proc checkModule(c: var CheckedContext; m: PackedModule) =
     attachedOps*: seq[(TTypeAttachedOp, PackedItemId, PackedItemId)]
     methodsPerGenericType*: seq[(PackedItemId, int, PackedItemId)]
     enumToStringProcs*: seq[(PackedItemId, PackedItemId)]
+    methodsPerType*: seq[(PackedItemId, PackedItemId)]
+    dispatchers*: seq[PackedItemId]
   ]#
 
 proc checkIntegrity*(g: ModuleGraph) =

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -107,8 +107,7 @@ proc replayBackendProcs*(g: ModuleGraph; module: int) =
     let key = translateId(it[0], g.packed, module, g.config)
     let tmp = translateId(it[1], g.packed, module, g.config)
     let symId = FullId(module: tmp.module, packed: it[1])
-    g.methodsPerType.mgetOrPut(key, (LazyType(id: FullId(module: module, packed: it[1]), typ: nil), @[])
-          ).methods.add LazySym(id: symId, sym: nil)
+    g.methodsPerType.mgetOrPut(key, @[]).add LazySym(id: symId, sym: nil)
 
   for it in mitems(g.packed[module].fromDisk.dispatchers):
     let tmp = translateId(it, g.packed, module, g.config)

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -127,12 +127,12 @@ proc replayGenericCacheInformation*(g: ModuleGraph; module: int) =
       module: module, sym: FullId(module: sym.module, packed: it.sym),
       concreteTypes: concreteTypes, inst: nil)
 
-  for it in mitems(g.packed[module].fromDisk.methodsPerType):
+  for it in mitems(g.packed[module].fromDisk.methodsPerGenericType):
     let key = translateId(it[0], g.packed, module, g.config)
     let col = it[1]
     let tmp = translateId(it[2], g.packed, module, g.config)
     let symId = FullId(module: tmp.module, packed: it[2])
-    g.methodsPerType.mgetOrPut(key, @[]).add (col, LazySym(id: symId, sym: nil))
+    g.methodsPerGenericType.mgetOrPut(key, @[]).add (col, LazySym(id: symId, sym: nil))
 
   replayBackendProcs(g, module)
 

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -103,6 +103,18 @@ proc replayBackendProcs*(g: ModuleGraph; module: int) =
     let symId = FullId(module: tmp.module, packed: it[1])
     g.enumToStringProcs[key] = LazySym(id: symId, sym: nil)
 
+  for it in mitems(g.packed[module].fromDisk.methodsPerType):
+    let key = translateId(it[0], g.packed, module, g.config)
+    let tmp = translateId(it[1], g.packed, module, g.config)
+    let symId = FullId(module: tmp.module, packed: it[1])
+    g.methodsPerType.mgetOrPut(key, (LazyType(id: FullId(module: module, packed: it[1]), typ: nil), @[])
+          ).methods.add LazySym(id: symId, sym: nil)
+
+  for it in mitems(g.packed[module].fromDisk.dispatchers):
+    let tmp = translateId(it, g.packed, module, g.config)
+    let symId = FullId(module: tmp.module, packed: it)
+    g.dispatchers.add LazySym(id: symId, sym: nil)
+
 proc replayGenericCacheInformation*(g: ModuleGraph; module: int) =
   ## We remember the generic instantiations a module performed
   ## in order to to avoid the code bloat that generic code tends

--- a/compiler/ic/rodfiles.nim
+++ b/compiler/ic/rodfiles.nim
@@ -92,8 +92,10 @@ type
     typeInstCacheSection
     procInstCacheSection
     attachedOpsSection
-    methodsPerTypeSection
+    methodsPerGenericTypeSection
     enumToStringProcsSection
+    methodsPerTypeSection
+    dispatchersSection
     typeInfoSection  # required by the backend
     backendFlagsSection
     aliveSymsSection # beware, this is stored in a `.alivesyms` file.

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -3097,9 +3097,8 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
       var p = newInitProc(globals, m)
       attachProc(p, prc)
 
-  var disp = generateMethodDispatchers(graph, m.idgen)
-  for i in 0..<disp.len:
-    let prc = disp[i].sym
+  generateMethodDispatchers(graph, m.idgen)
+  for prc in resolveLazySymSeq(graph, graph.dispatchers):
     if not globals.generatedSyms.containsOrIncl(prc.id):
       var p = newInitProc(globals, m)
       attachProc(p, prc)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -3097,7 +3097,7 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
       var p = newInitProc(globals, m)
       attachProc(p, prc)
 
-  generateMethodDispatchers(graph, m.idgen)
+  generateIfMethodDispatchers(graph, m.idgen)
   for prc in resolveLazySymSeq(graph, graph.dispatchers):
     if not globals.generatedSyms.containsOrIncl(prc.id):
       var p = newInitProc(globals, m)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -3098,7 +3098,7 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
       attachProc(p, prc)
 
   generateIfMethodDispatchers(graph, m.idgen)
-  for prc in resolveLazySymSeq(graph, graph.dispatchers):
+  for prc in getDispatchers(graph):
     if not globals.generatedSyms.containsOrIncl(prc.id):
       var p = newInitProc(globals, m)
       attachProc(p, prc)

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -110,7 +110,7 @@ type
     methods*: seq[tuple[methods: seq[PSym], dispatcher: PSym]] # needs serialization!
     bucketTable*: CountTable[ItemId]
     objectTree*: Table[ItemId, seq[tuple[depth: int, value: PType]]]
-    methodsPerType*: seq[tuple[typ: PType, methods: seq[LazySym]]] # TODO: should ba LazySym
+    methodsPerType*: Table[ItemId, tuple[typ: LazyType, methods: seq[LazySym]]]
     dispatchers*: seq[LazySym]
 
     systemModule*: PSym
@@ -284,7 +284,7 @@ iterator systemModuleSyms*(g: ModuleGraph; name: PIdent): PSym =
     yield r
     r = nextModuleIter(mi, g)
 
-proc resolveType(g: ModuleGraph; t: var LazyType): PType =
+proc resolveType*(g: ModuleGraph; t: var LazyType): PType =
   result = t.typ
   if result == nil and isCachedModule(g, t.id.module):
     result = loadTypeFromId(g.config, g.cache, g.packed, t.id.module, t.id.packed)
@@ -327,6 +327,12 @@ iterator procInstCacheItems*(g: ModuleGraph; s: PSym): PInstantiation =
     let x = addr(g.procInstCache[s.itemId])
     for t in mitems(x[]):
       yield resolveInst(g, t)
+
+
+# proc setMethodsPerType(g: ModuleGraph; typ: PType, methods: seq[LazySym]) =
+#   g.methodsPerType[typ.itemId] = (LazyType(typ: typ), methods)
+
+# iterator getMethodsPerType(g: ModuleGraph): (PType, seq[PSym])
 
 proc getAttachedOp*(g: ModuleGraph; t: PType; op: TTypeAttachedOp): PSym =
   ## returns the requested attached operation for type `t`. Can return nil

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -160,6 +160,8 @@ proc resetForBackend*(g: ModuleGraph) =
     a.clear()
   g.methodsPerGenericType.clear()
   g.enumToStringProcs.clear()
+  g.dispatchers.setLen(0)
+  g.methodsPerType.clear()
 
 const
   cb64 = [

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -9,6 +9,7 @@ define:nimPreviewSlimSystem
 define:nimPreviewCstringConversion
 define:nimPreviewProcConversion
 define:nimPreviewRangeDefault
+define:nimPreviewVtables
 threads:off
 
 #import:"$projectpath/testability"

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -194,7 +194,7 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
       finalCodegenActions(graph, m, finalNode)
       if graph.dispatchers.len > 0:
         let ctx = preparePContext(graph, module, idgen)
-        for disp in resolveLazySymSeq(graph, graph.dispatchers):
+        for disp in getDispatchers(graph):
           let retTyp = disp.typ[0]
           if retTyp != nil:
             # TODO: properly semcheck the code of dispatcher?

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -190,15 +190,18 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
   case graph.pipelinePass
   of CgenPass:
     if bModule != nil:
-      let disps = finalCodegenActions(graph, BModule(bModule), finalNode)
-      if disps != nil:
+      let m = BModule(bModule)
+      finalCodegenActions(graph, m, finalNode)
+      if graph.dispatchers.len > 0:
         let ctx = preparePContext(graph, module, idgen)
-        for disp in disps:
-          let retTyp = disp.sym.typ[0]
+        for value in graph.methodsPerType.mitems:
+          initializeVTable(m, value.typ, value.methods)
+        for disp in resolveLazySymSeq(graph, graph.dispatchers):
+          let retTyp = disp.typ[0]
           if retTyp != nil:
-            # todo properly semcheck the code of dispatcher?
-            createTypeBoundOps(graph, ctx, retTyp, disp.info, idgen)
-          genProcAux(BModule(bModule), disp.sym)
+            # TODO: properly semcheck the code of dispatcher?
+            createTypeBoundOps(graph, ctx, retTyp, disp.ast.info, idgen)
+          genProcAux(m, disp)
         discard closePContext(graph, ctx, nil)
   of JSgenPass:
     when not defined(leanCompiler):

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -194,8 +194,6 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
       finalCodegenActions(graph, m, finalNode)
       if graph.dispatchers.len > 0:
         let ctx = preparePContext(graph, module, idgen)
-        for value in graph.methodsPerType.mitems:
-          initializeVTable(m, value.typ, value.methods)
         for disp in resolveLazySymSeq(graph, graph.dispatchers):
           let retTyp = disp.typ[0]
           if retTyp != nil:

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -841,7 +841,9 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   if c.config.cmd == cmdIdeTools:
     appendToModule(c.module, result)
   trackStmt(c, c.module, result, isTopLevel = true)
-  if sfMainModule in c.module.flags:
+  if sfMainModule in c.module.flags and
+      {optMultiMethods, optNoMain} * c.config.globalOptions == {} and
+      c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
     collectVTableDispatchers(c.graph)
 
 proc recoverContext(c: PContext) =

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -22,6 +22,7 @@ import
   isolation_check, typeallowed, modulegraphs, enumtostr, concepts, astmsgs,
   extccomp
 
+import vtables
 
 when not defined(leanCompiler):
   import spawn
@@ -840,6 +841,8 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   if c.config.cmd == cmdIdeTools:
     appendToModule(c.module, result)
   trackStmt(c, c.module, result, isTopLevel = true)
+  if sfMainModule in c.module.flags:
+    collectVTableDispatchers(c.graph)
 
 proc recoverContext(c: PContext) =
   # clean up in case of a semantic error: We clean up the stacks, etc. This is

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -842,7 +842,8 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   trackStmt(c, c.module, result, isTopLevel = true)
   if sfMainModule in c.module.flags and
       {optMultiMethods, optNoMain} * c.config.globalOptions == {} and
-      c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
+      c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
+      c.config.isDefined("nimPreviewVtables"):
     collectVTableDispatchers(c.graph)
 
 proc recoverContext(c: PContext) =

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -842,14 +842,13 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   trackStmt(c, c.module, result, isTopLevel = true)
   if optMultiMethods notin c.config.globalOptions and
       c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
-      c.config.isDefined("nimPreviewVtables"):
+      c.config.isDefined("nimPreviewVtables") and 
+      c.config.backend != backendCpp and
+      sfCompileToCpp notin c.module.flags:
     sortVTableDispatchers(c.graph)
 
-  if sfMainModule in c.module.flags and
-      {optMultiMethods, optNoMain} * c.config.globalOptions == {} and
-      c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
-      c.config.isDefined("nimPreviewVtables"):
-    collectVTableDispatchers(c.graph)
+    if sfMainModule in c.module.flags:
+      collectVTableDispatchers(c.graph)
 
 proc recoverContext(c: PContext) =
   # clean up in case of a semantic error: We clean up the stacks, etc. This is

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -840,6 +840,11 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   if c.config.cmd == cmdIdeTools:
     appendToModule(c.module, result)
   trackStmt(c, c.module, result, isTopLevel = true)
+  if optMultiMethods notin c.config.globalOptions and
+      c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
+      c.config.isDefined("nimPreviewVtables"):
+    sortVTableDispatchers(c.graph)
+
   if sfMainModule in c.module.flags and
       {optMultiMethods, optNoMain} * c.config.globalOptions == {} and
       c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -22,6 +22,9 @@ when defined(useDfa):
 import liftdestructors
 include sinkparameter_inference
 
+
+import std/options as opt
+
 #[ Second semantic checking pass over the AST. Necessary because the old
    way had some inherent problems. Performs:
 
@@ -88,6 +91,37 @@ type
 const
   errXCannotBeAssignedTo = "'$1' cannot be assigned to"
   errLetNeedsInit = "'let' symbol requires an initialization"
+
+proc getObjDepth(t: PType): Option[tuple[depth: int, root: ItemId]] =
+  var x = t
+  var res: tuple[depth: int, root: ItemId]
+  res.depth = -1
+  var stack = newSeq[ItemId]()
+  while x != nil:
+    x = skipTypes(x, skipPtrs)
+    if x.kind != tyObject:
+      return none(tuple[depth: int, root: ItemId])
+    stack.add x.itemId
+    x = x[0]
+    inc(res.depth)
+  res.root = stack[^2]
+  result = some(res)
+
+proc collectObjectTree(graph: ModuleGraph, n: PNode) =
+  for section in n:
+    if section.kind == nkTypeDef and section[^1].kind in {nkObjectTy, nkRefTy, nkPtrTy}:
+      let typ = section[^1].typ.skipTypes(skipPtrs)
+      if typ.len > 0 and typ[0] != nil:
+        let depthItem = getObjDepth(typ)
+        if isSome(depthItem):
+          let (depthLevel, root) = depthItem.unsafeGet
+          if depthLevel == 1:
+            graph.objectTree[root] = @[]
+          else:
+            if root notin graph.objectTree:
+              graph.objectTree[root] = @[(depthLevel, typ)]
+            else:
+              graph.objectTree[root].add (depthLevel, typ)
 
 proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
   if typ == nil or sfGeneratedOp in tracked.owner.flags:
@@ -1321,8 +1355,11 @@ proc track(tracked: PEffects, n: PNode) =
   of nkProcDef, nkConverterDef, nkMethodDef, nkIteratorDef, nkLambda, nkFuncDef, nkDo:
     if n[0].kind == nkSym and n[0].sym.ast != nil:
       trackInnerProc(tracked, getBody(tracked.graph, n[0].sym))
-  of nkTypeSection, nkMacroDef, nkTemplateDef:
+  of nkMacroDef, nkTemplateDef:
     discard
+  of nkTypeSection:
+    if tracked.isTopLevel:
+      collectObjectTree(tracked.graph, n)
   of nkCast:
     if n.len == 2:
       track(tracked, n[1])
@@ -1635,13 +1672,18 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     checkNil(s, body, g.config, c.idgen)
 
 proc trackStmt*(c: PContext; module: PSym; n: PNode, isTopLevel: bool) =
-  if n.kind in {nkPragma, nkMacroDef, nkTemplateDef, nkProcDef, nkFuncDef,
-                nkTypeSection, nkConverterDef, nkMethodDef, nkIteratorDef}:
-    return
-  let g = c.graph
-  var effects = newNodeI(nkEffectList, n.info)
-  var t: TEffects = initEffects(g, effects, module, c)
-  t.isTopLevel = isTopLevel
-  track(t, n)
-  when defined(drnim):
-    if c.graph.strongSemCheck != nil: c.graph.strongSemCheck(c.graph, module, n)
+  case n.kind
+  of {nkPragma, nkMacroDef, nkTemplateDef, nkProcDef, nkFuncDef,
+                nkConverterDef, nkMethodDef, nkIteratorDef}:
+    discard
+  of nkTypeSection:
+    if isTopLevel:
+      collectObjectTree(c.graph, n)
+  else:
+    let g = c.graph
+    var effects = newNodeI(nkEffectList, n.info)
+    var t: TEffects = initEffects(g, effects, module, c)
+    t.isTopLevel = isTopLevel
+    track(t, n)
+    when defined(drnim):
+      if c.graph.strongSemCheck != nil: c.graph.strongSemCheck(c.graph, module, n)

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -99,29 +99,32 @@ proc getObjDepth(t: PType): Option[tuple[depth: int, root: ItemId]] =
   var stack = newSeq[ItemId]()
   while x != nil:
     x = skipTypes(x, skipPtrs)
+    if x.kind == tyGenericBody:
+      x = x.lastSon
+    x = skipTypes(x, skipPtrs)
     if x.kind != tyObject:
       return none(tuple[depth: int, root: ItemId])
     stack.add x.itemId
     x = x[0]
     inc(res.depth)
-  res.root = stack[^2]
-  result = some(res)
+  if stack.len > 1:
+    res.root = stack[^2]
+    result = some(res)
+  else:
+    result = none(tuple[depth: int, root: ItemId])
 
-proc collectObjectTree(graph: ModuleGraph, n: PNode) =
-  for section in n:
-    if section.kind == nkTypeDef and section[^1].kind in {nkObjectTy, nkRefTy, nkPtrTy}:
-      let typ = section[^1].typ.skipTypes(skipPtrs)
-      if typ.len > 0 and typ[0] != nil:
-        let depthItem = getObjDepth(typ)
-        if isSome(depthItem):
-          let (depthLevel, root) = depthItem.unsafeGet
-          if depthLevel == 1:
-            graph.objectTree[root] = @[]
-          else:
-            if root notin graph.objectTree:
-              graph.objectTree[root] = @[(depthLevel, typ)]
-            else:
-              graph.objectTree[root].add (depthLevel, typ)
+proc collectObjectTypeTree(graph: ModuleGraph, typ: PType) =
+  if typ.len > 0 and typ[0] != nil:
+    let depthItem = getObjDepth(typ)
+    if isSome(depthItem):
+      let (depthLevel, root) = depthItem.unsafeGet
+      if root notin graph.objectTree:
+        if depthLevel == 1:
+          graph.objectTree[root] = @[]
+        else:
+          graph.objectTree[root] = @[(depthLevel, typ)]
+      else:
+        graph.objectTree[root].add (depthLevel, typ)
 
 proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
   if typ == nil or sfGeneratedOp in tracked.owner.flags:
@@ -135,6 +138,8 @@ proc createTypeBoundOps(tracked: PEffects, typ: PType; info: TLineInfo) =
       createTypeBoundOps(tracked.graph, tracked.c, realType.lastSon, info)
 
   createTypeBoundOps(tracked.graph, tracked.c, typ, info, tracked.c.idgen)
+  # TODO: cache types by means of canonTypes
+  collectObjectTypeTree(tracked.graph, typ)
   if (tfHasAsgn in typ.flags) or
       optSeqDestructors in tracked.config.globalOptions:
     tracked.owner.flags.incl sfInjectDestructors
@@ -1355,11 +1360,8 @@ proc track(tracked: PEffects, n: PNode) =
   of nkProcDef, nkConverterDef, nkMethodDef, nkIteratorDef, nkLambda, nkFuncDef, nkDo:
     if n[0].kind == nkSym and n[0].sym.ast != nil:
       trackInnerProc(tracked, getBody(tracked.graph, n[0].sym))
-  of nkMacroDef, nkTemplateDef:
+  of nkMacroDef, nkTemplateDef, nkTypeSection:
     discard
-  of nkTypeSection:
-    if tracked.isTopLevel:
-      collectObjectTree(tracked.graph, n)
   of nkCast:
     if n.len == 2:
       track(tracked, n[1])
@@ -1674,11 +1676,8 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
 proc trackStmt*(c: PContext; module: PSym; n: PNode, isTopLevel: bool) =
   case n.kind
   of {nkPragma, nkMacroDef, nkTemplateDef, nkProcDef, nkFuncDef,
-                nkConverterDef, nkMethodDef, nkIteratorDef}:
+                nkConverterDef, nkMethodDef, nkIteratorDef, nkTypeSection}:
     discard
-  of nkTypeSection:
-    if isTopLevel:
-      collectObjectTree(c.graph, n)
   else:
     let g = c.graph
     var effects = newNodeI(nkEffectList, n.info)

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -1,0 +1,125 @@
+import ast, modulegraphs, magicsys, lineinfos, options, cgmeth, types
+import std/[algorithm, tables, intsets, assertions]
+
+
+proc genVTableDispatcher(g: ModuleGraph; methods: seq[PSym]; index: int): PSym =
+#[
+proc dispatch(x: Base, params: ...) =
+  cast[proc bar(x: Base, params: ...)](x.vTable[index])(x, params)
+]#
+  var base = methods[0].ast[dispatcherPos].sym
+  result = base
+  var paramLen = base.typ.len
+  var body = newNodeI(nkStmtList, base.info)
+
+  var disp = newNodeI(nkIfStmt, base.info)
+
+  var vTableAccess = newNodeIT(nkBracketExpr, base.info, base.typ)
+  let nimGetVTableSym = getCompilerProc(g, "nimGetVTable")
+  let ptrPNimType = nimGetVTableSym.typ.n[1].sym.typ
+
+  var nTyp = base.typ.n[1].sym.typ
+  var dispatchObject = newSymNode(base.typ.n[1].sym)
+  if nTyp.kind == tyObject:
+    dispatchObject = newTree(nkAddr, dispatchObject)
+  else:
+    if g.config.backend != backendCpp: # TODO: maybe handle ptr?
+      if nTyp.kind == tyVar and nTyp.skipTypes({tyVar}).kind != tyObject:
+        dispatchObject = newTree(nkDerefExpr, dispatchObject)
+
+  var getVTableCall = newTree(nkCall,
+    newSymNode(nimGetVTableSym),
+    dispatchObject,
+    newIntNode(nkIntLit, index)
+  )
+  getVTableCall.typ = base.typ
+  var vTableCall = newNodeIT(nkCall, base.info, base.typ[0])
+  var castNode = newTree(nkCast,
+        newNodeIT(nkType, base.info, base.typ),
+        getVTableCall)
+
+  castNode.typ = base.typ
+  vTableCall.add castNode
+  for col in 1..<paramLen:
+    let param = base.typ.n[col].sym
+    vTableCall.add newSymNode(param)
+
+  var ret: PNode
+  if base.typ[0] != nil:
+    var a = newNodeI(nkFastAsgn, base.info)
+    a.add newSymNode(base.ast[resultPos].sym)
+    a.add vTableCall
+    ret = newNodeI(nkReturnStmt, base.info)
+    ret.add a
+  else:
+    ret = vTableCall
+
+  if base.typ.n[1].sym.typ.skipTypes(abstractInst).kind in {tyRef, tyPtr}:
+    let ifBranch = newNodeI(nkElifBranch, base.info)
+    let boolType = getSysType(g, unknownLineInfo, tyBool)
+    var isNil = getSysMagic(g, unknownLineInfo, "isNil", mIsNil)
+    let checkSelf = newNodeIT(nkCall, base.info, boolType)
+    checkSelf.add newSymNode(isNil)
+    checkSelf.add newSymNode(base.typ.n[1].sym)
+    ifBranch.add checkSelf
+    ifBranch.add newTree(nkCall,
+        newSymNode(getCompilerProc(g, "chckNilDisp")), newSymNode(base.typ.n[1].sym))
+    let elseBranch = newTree(nkElifBranch, ret)
+    disp.add ifBranch
+    disp.add elseBranch
+  else:
+    disp = ret
+
+  body.add disp
+  body.flags.incl nfTransf # should not be further transformed
+  result.ast[bodyPos] = body
+
+proc collectVTableDispatchers*(g: ModuleGraph) =
+  var itemTable = initTable[ItemId, seq[LazySym]]()
+  var rootTypeSeq = newSeq[PType]()
+  var rootItemIdCount = initCountTable[ItemId]()
+  for bucket in 0..<g.methods.len:
+    var relevantCols = initIntSet()
+    if relevantCol(g.methods[bucket].methods, 1): incl(relevantCols, 1)
+    sortBucket(g.methods[bucket].methods, relevantCols)
+    let base = g.methods[bucket].methods[^1]
+    let baseType = base.typ[1].skipTypes(skipPtrs-{tyTypeDesc})
+    if baseType.itemId in g.objectTree:
+      let methodIndexLen = g.bucketTable[baseType.itemId]
+      if baseType.itemId notin itemTable: # once is enough
+        rootTypeSeq.add baseType
+        itemTable[baseType.itemId] = newSeq[LazySym](methodIndexLen)
+
+        sort(g.objectTree[baseType.itemId], cmp = proc (x, y: tuple[depth: int, value: PType]): int =
+          if x.depth >= y.depth: 1
+          else: -1
+          )
+
+        for item in g.objectTree[baseType.itemId]:
+          if item.value.itemId notin itemTable:
+            itemTable[item.value.itemId] = newSeq[LazySym](methodIndexLen)
+
+      var mIndex = 0 # here is the correpsonding index
+      if baseType.itemId notin rootItemIdCount:
+        rootItemIdCount[baseType.itemId] = 1
+      else:
+        mIndex = rootItemIdCount[baseType.itemId]
+        rootItemIdCount.inc(baseType.itemId)
+      for idx in 0..<g.methods[bucket].methods.len:
+        let obj = g.methods[bucket].methods[idx].typ[1].skipTypes(skipPtrs)
+        itemTable[obj.itemId][mIndex] = LazySym(sym: g.methods[bucket].methods[idx])
+      g.dispatchers.add LazySym(sym: genVTableDispatcher(g, g.methods[bucket].methods, mIndex))
+    else: # if the base object doesn't have this method
+      g.dispatchers.add LazySym(sym: cgmeth.genDispatcher(g, g.methods[bucket].methods, relevantCols, g.idgen))
+
+  for baseType in rootTypeSeq:
+    let root = baseType.itemId
+    g.methodsPerType.add (baseType, itemTable[baseType.itemId])
+    for item in g.objectTree[root]:
+      let typ = item.value.skipTypes(skipPtrs)
+      let idx = typ.itemId
+      for mIndex in 0..<itemTable[idx].len:
+        if itemTable[idx][mIndex].sym == nil:
+          let parentIndex = typ[0].skipTypes(skipPtrs).itemId
+          itemTable[idx][mIndex] = itemTable[parentIndex][mIndex]
+      g.methodsPerType.add (typ, itemTable[idx])

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -84,7 +84,7 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
     sortBucket(g.methods[bucket].methods, relevantCols)
     let base = g.methods[bucket].methods[^1]
     let baseType = base.typ[1].skipTypes(skipPtrs-{tyTypeDesc})
-    if baseType.itemId in g.objectTree:
+    if baseType.itemId in g.objectTree and g.methods[bucket].methods.len > 1:
       let methodIndexLen = g.bucketTable[baseType.itemId]
       if baseType.itemId notin itemTable: # once is enough
         rootTypeSeq.add baseType

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -96,19 +96,8 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
           )
 
         for item in g.objectTree[baseType.itemId]:
-          let depth = item.depth
-          var i = 0
-          var x = item.value
-          while x != nil:
-            x = skipTypes(x, skipPtrs)
-            if x.kind == tyGenericBody:
-              x = x.lastSon
-            x = skipTypes(x, skipPtrs)
-            if x.itemId notin itemTable:
-              itemTable[x.itemId] = newSeq[LazySym](methodIndexLen)
-            else:
-              break
-            x = x[0]
+          if item.value.itemId notin itemTable:
+            itemTable[item.value.itemId] = newSeq[LazySym](methodIndexLen)
 
       var mIndex = 0 # here is the correpsonding index
       if baseType.itemId notin rootItemIdCount:

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -2,12 +2,6 @@ import ast, modulegraphs, magicsys, lineinfos, options, cgmeth, types
 import std/[algorithm, tables, intsets, assertions]
 
 
-proc genVTable*(seqs: seq[PSym]): string =
-  result = "{"
-  for i in 0..<seqs.len:
-    if i > 0: result.add ", "
-    result.add "(void *) " & seqs[i].loc.r
-  result.add "}"
 
 proc genVTableDispatcher(g: ModuleGraph; methods: seq[PSym]; index: int): PSym =
 #[

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -110,7 +110,7 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
         itemTable[obj.itemId][mIndex] = LazySym(sym: g.methods[bucket].methods[idx])
       g.dispatchers.add LazySym(sym: genVTableDispatcher(g, g.methods[bucket].methods, mIndex))
     else: # if the base object doesn't have this method
-      g.dispatchers.add LazySym(sym: cgmeth.genDispatcher(g, g.methods[bucket].methods, relevantCols, g.idgen))
+      g.dispatchers.add LazySym(sym: genIfDispatcher(g, g.methods[bucket].methods, relevantCols, g.idgen))
 
   for baseType in rootTypeSeq:
     let root = baseType.itemId

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -108,13 +108,13 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
       for idx in 0..<g.methods[bucket].methods.len:
         let obj = g.methods[bucket].methods[idx].typ[1].skipTypes(skipPtrs)
         itemTable[obj.itemId][mIndex] = LazySym(sym: g.methods[bucket].methods[idx])
-      g.dispatchers.add LazySym(sym: genVTableDispatcher(g, g.methods[bucket].methods, mIndex))
+      g.addDispatchers genVTableDispatcher(g, g.methods[bucket].methods, mIndex)
     else: # if the base object doesn't have this method
-      g.dispatchers.add LazySym(sym: genIfDispatcher(g, g.methods[bucket].methods, relevantCols, g.idgen))
+      g.addDispatchers genIfDispatcher(g, g.methods[bucket].methods, relevantCols, g.idgen)
 
   for baseType in rootTypeSeq:
     let root = baseType.itemId
-    g.methodsPerType[root] = (LazyType(typ: baseType), itemTable[baseType.itemId])
+    g.setMethodsPerType(baseType, itemTable[baseType.itemId])
     for item in g.objectTree[root]:
       let typ = item.value.skipTypes(skipPtrs)
       let idx = typ.itemId
@@ -122,4 +122,4 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
         if itemTable[idx][mIndex].sym == nil:
           let parentIndex = typ[0].skipTypes(skipPtrs).itemId
           itemTable[idx][mIndex] = itemTable[parentIndex][mIndex]
-      g.methodsPerType[idx] = (LazyType(typ: typ), itemTable[idx])
+      g.setMethodsPerType(typ, itemTable[idx])

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -96,8 +96,19 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
           )
 
         for item in g.objectTree[baseType.itemId]:
-          if item.value.itemId notin itemTable:
-            itemTable[item.value.itemId] = newSeq[LazySym](methodIndexLen)
+          let depth = item.depth
+          var i = 0
+          var x = item.value
+          while x != nil:
+            x = skipTypes(x, skipPtrs)
+            if x.kind == tyGenericBody:
+              x = x.lastSon
+            x = skipTypes(x, skipPtrs)
+            if x.itemId notin itemTable:
+              itemTable[x.itemId] = newSeq[LazySym](methodIndexLen)
+            else:
+              break
+            x = x[0]
 
       var mIndex = 0 # here is the correpsonding index
       if baseType.itemId notin rootItemIdCount:

--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -114,7 +114,7 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
 
   for baseType in rootTypeSeq:
     let root = baseType.itemId
-    g.methodsPerType.add (baseType, itemTable[baseType.itemId])
+    g.methodsPerType[root] = (LazyType(typ: baseType), itemTable[baseType.itemId])
     for item in g.objectTree[root]:
       let typ = item.value.skipTypes(skipPtrs)
       let idx = typ.itemId
@@ -122,4 +122,4 @@ proc collectVTableDispatchers*(g: ModuleGraph) =
         if itemTable[idx][mIndex].sym == nil:
           let parentIndex = typ[0].skipTypes(skipPtrs).itemId
           itemTable[idx][mIndex] = itemTable[parentIndex][mIndex]
-      g.methodsPerType.add (typ, itemTable[idx])
+      g.methodsPerType[idx] = (LazyType(typ: typ), itemTable[idx])

--- a/config/config.nims
+++ b/config/config.nims
@@ -21,4 +21,4 @@ when defined(nimStrictMode):
     # future work: XDeclaredButNotUsed
 
 switch("define", "nimVersion:" & NimVersion)
-
+switch("define", "nimPreviewVtables")

--- a/config/config.nims
+++ b/config/config.nims
@@ -21,4 +21,3 @@ when defined(nimStrictMode):
     # future work: XDeclaredButNotUsed
 
 switch("define", "nimVersion:" & NimVersion)
-switch("define", "nimPreviewVtables")

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -152,7 +152,7 @@ proc none*(T: typedesc): Option[T] {.inline.} =
     assert none(int).isNone
 
   # the default is the none type
-  discard
+  result = Option[T]()
 
 proc none*[T]: Option[T] {.inline.} =
   ## Alias for `none(T) <#none,typedesc>`_.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1606,7 +1606,7 @@ when not defined(js) and defined(nimV2):
       traceImpl: pointer
       typeInfoV1: pointer # for backwards compat, usually nil
       flags: int
-      when defined(nimPreviewVtables):
+      when defined(nimPreviewVtables) and not defined(cpp):
         vTable: UncheckedArray[pointer] # vtable for types
     PNimTypeV2 = ptr TNimTypeV2
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1596,6 +1596,7 @@ when not defined(js) and defined(nimV2):
       align: int16
       depth: int16
       display: ptr UncheckedArray[uint32] # classToken
+      vTable: ptr UncheckedArray[pointer] # vtable for types
       when defined(nimTypeNames) or defined(nimArcIds):
         name: cstring
       traceImpl: pointer

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1596,7 +1596,8 @@ when not defined(js) and defined(nimV2):
       align: int16
       depth: int16
       display: ptr UncheckedArray[uint32] # classToken
-      vTable: ptr UncheckedArray[pointer] # vtable for types
+      when defined(nimPreviewVtables):
+        vTable: ptr UncheckedArray[pointer] # vtable for types
       when defined(nimTypeNames) or defined(nimArcIds):
         name: cstring
       traceImpl: pointer

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1596,13 +1596,13 @@ when not defined(js) and defined(nimV2):
       align: int16
       depth: int16
       display: ptr UncheckedArray[uint32] # classToken
-      when defined(nimPreviewVtables):
-        vTable: ptr UncheckedArray[pointer] # vtable for types
       when defined(nimTypeNames) or defined(nimArcIds):
         name: cstring
       traceImpl: pointer
       typeInfoV1: pointer # for backwards compat, usually nil
       flags: int
+      when defined(nimPreviewVtables):
+        vTable: UncheckedArray[pointer] # vtable for types
     PNimTypeV2 = ptr TNimTypeV2
 
 proc supportsCopyMem(t: typedesc): bool {.magic: "TypeTrait".}

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -244,6 +244,7 @@ template tearDownForeignThreadGc* =
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token
 
-proc nimGetVTable(p: pointer, index: int): pointer
-       {.compilerRtl, inline, raises: [].} =
-  result = cast[ptr PNimTypeV2](p).vTable[index]
+when defined(nimPreviewVtables):
+  proc nimGetVTable(p: pointer, index: int): pointer
+        {.compilerRtl, inline, raises: [].} =
+    result = cast[ptr PNimTypeV2](p).vTable[index]

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -244,7 +244,7 @@ template tearDownForeignThreadGc* =
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token
 
-when defined(nimPreviewVtables):
+when defined(nimPreviewVtables) and not defined(cpp):
   proc nimGetVTable(p: pointer, index: int): pointer
         {.compilerRtl, inline, raises: [].} =
     result = cast[ptr PNimTypeV2](p).vTable[index]

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -243,3 +243,7 @@ template tearDownForeignThreadGc* =
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token
+
+proc nimGetVTable(p: pointer, index: int): pointer
+       {.compilerRtl, inline, raises: [].} =
+  result = cast[ptr PNimTypeV2](p).vTable[index]

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -43,4 +43,5 @@ switch("define", "nimPreviewRangeDefault")
 
 switch("warningAserror", "UnnamedBreak")
 switch("legacy", "verboseTypeMismatch")
+switch("define", "nimPreviewVtables")
 

--- a/tests/generics/tobjecttyperel.nim
+++ b/tests/generics/tobjecttyperel.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "-u:nimPreviewNonVarDestructor"
+  matrix: "-u:nimPreviewVtables"
   output: '''(peel: 0, color: 15)
 (color: 15)
 17

--- a/tests/generics/tobjecttyperel.nim
+++ b/tests/generics/tobjecttyperel.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "-u:nimPreviewNonVarDestructor"
   output: '''(peel: 0, color: 15)
 (color: 15)
 17

--- a/tests/method/nim.cfg
+++ b/tests/method/nim.cfg
@@ -1,1 +1,0 @@
-multimethods:on

--- a/tests/method/tcompilegenerics.nim
+++ b/tests/method/tcompilegenerics.nim
@@ -1,0 +1,24 @@
+discard """
+  matrix: "--mm:arc; --mm:refc"
+  output: '''
+newDNode base
+'''
+"""
+
+type
+  SNodeAny = ref object of RootObj
+  SNode[T] = ref object of SNodeAny
+    m: T
+  DNode[T] = ref object
+
+method getStr(s: SNode[float]): string {.base.} = "blahblah"
+
+method newDNode(s: SNodeAny) {.base.} =
+  echo "newDNode base"
+
+method newDNode[T](s: SNode[T]) =
+  echo "newDNode generic"
+
+let m = SNode[float]()
+let s = SNodeAny(m)
+newDnode(s)

--- a/tests/method/tgeneric_methods.nim
+++ b/tests/method/tgeneric_methods.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:arc; --mm:refc"
+  matrix: "--mm:arc --multimethods:on; --mm:refc --multimethods:on"
   output: '''wow2
 X 1
 X 3'''

--- a/tests/method/tgeneric_methods.nim
+++ b/tests/method/tgeneric_methods.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:arc --multimethods:on; --mm:refc --multimethods:on"
+  matrix: "--mm:arc --multimethods:on -u:nimPreviewVtables; --mm:refc --multimethods:on -u:nimPreviewVtables"
   output: '''wow2
 X 1
 X 3'''

--- a/tests/method/tmethod_various.nim
+++ b/tests/method/tmethod_various.nim
@@ -1,15 +1,12 @@
 discard """
   matrix: "--mm:arc; --mm:refc"
   output: '''
-do nothing
 HELLO WORLD!
 '''
 """
 
 
-# tmethods1
-method somethin(obj: RootObj) {.base.} =
-  echo "do nothing"
+
 
 type
   TNode* {.inheritable.} = object
@@ -23,8 +20,6 @@ type
 method foo(a: PNode, b: PSomethingElse) {.base.} = discard
 method foo(a: PNodeFoo, b: PSomethingElse) = discard
 
-var o: RootObj
-o.somethin()
 
 
 

--- a/tests/method/tmethods_old.nim
+++ b/tests/method/tmethods_old.nim
@@ -1,0 +1,12 @@
+discard """
+  matrix: "--mm:arc -u:nimPreviewVtables"
+  output: '''
+do nothing
+'''
+"""
+
+# tmethods1
+method somethin(obj: RootObj) {.base.} =
+  echo "do nothing"
+var o: RootObj
+o.somethin()

--- a/tests/method/tmultim.nim
+++ b/tests/method/tmultim.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--multimethods:on"
   output: '''
 collide: unit, thing
 collide: unit, thing

--- a/tests/method/tvtable.nim
+++ b/tests/method/tvtable.nim
@@ -1,0 +1,19 @@
+type FooBase = ref object of RootObj
+  dummy: int
+type Foo = ref object of FooBase
+  value : float32
+type Foo2 = ref object of Foo
+  change : float32
+method bar(x: FooBase, a: float32) {.base.} =
+  discard
+method bar(x: Foo, a: float32)  =
+  x.value += a
+method bar(x: Foo2, a: float32)  =
+  x.value += a
+
+
+proc test() =
+  var x = new Foo2
+  x.bar(2.3)
+
+test()


### PR DESCRIPTION
**TODO**
- [x] fixes changelog
With the new option `nimPreviewVtables`, `methods` are confined in the same module where the type of the first parameter is defined

- [x] make it opt in after CI checks its feasibility

## In the following-up PRs

- [ ] in the following PRs, refactor code into a more efficient one

- [ ] cpp needs special treatments since it cannot embed array in light of the preceding limits: ref https://github.com/nim-lang/Nim/pull/20977#discussion_r1035528927; we can support cpp backends with vtable implementations later on the comprise that uses indirect vtable access