### PR TITLE
Don't try and get enum value if its invalid

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -113,10 +113,11 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
         strVal = v
         x = counter
       else:
-        if not isOrdinalType(v.typ, allowEnumWithHoles=true):
+        if isOrdinalType(v.typ, allowEnumWithHoles=true):
+          x = toInt64(getOrdValue(v))
+          n[i][1] = newIntTypeNode(x, getSysType(c.graph, unknownLineInfo, tyInt))
+        else:
           localError(c.config, v.info, errOrdinalTypeExpected % typeToString(v.typ, preferDesc))
-        x = toInt64(getOrdValue(v))
-        n[i][1] = newIntTypeNode(x, getSysType(c.graph, unknownLineInfo, tyInt))
       if i != 1:
         if x != counter: incl(result.flags, tfEnumHasHoles)
         if x < counter:

--- a/tests/enum/tenum_invalid.nim
+++ b/tests/enum/tenum_invalid.nim
@@ -4,4 +4,5 @@ cmd: "nim check $file"
 
 type
   Test = enum
-    A = 9.0
+    A = 9.0 #[tt.Error
+        ^ ordinal type expected; given: float]#

--- a/tests/enum/tenum_invalid.nim
+++ b/tests/enum/tenum_invalid.nim
@@ -1,0 +1,7 @@
+discard """
+cmd: "nim check $file"
+"""
+
+type
+  Test = enum
+    A = 9.0


### PR DESCRIPTION
Currently running `nimsuggest`/`check` on this code causes the compiler to raise an exception

```nim
type
  Test = enum
    A = 9.0 
```

```
assertions.nim(34)       raiseAssert
Error: unhandled exception: int128.nim(69, 11) `arg.sdata(3) == 0` out of range [AssertionDefect]
```

Issue was the compiler still trying to get the ordinal value even if it wasn't an ordinal