### PR TITLE
Show proper error message if trying to run a Nim file in a directory that doesn't exist

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -788,7 +788,10 @@ proc setFromProjectName*(conf: ConfigRef; projectName: string) =
     conf.projectFull = AbsoluteFile projectName
   let p = splitFile(conf.projectFull)
   let dir = if p.dir.isEmpty: AbsoluteDir getCurrentDir() else: p.dir
-  conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile dir)
+  try:
+    conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile dir)
+  except OSError:
+    conf.projectPath = dir
   conf.projectName = p.name
 
 proc removeTrailingDirSep*(path: string): string =


### PR DESCRIPTION
For example with the command `nim r foo/bar.nim`, if `foo/` doesn't exist then it shows this message
```
oserrors.nim(92)         raiseOSError
Error: unhandled exception: No such file or directory
Additional info: foo [OSError]
```

After PR it shows
```
Error: cannot open 'foo/bar.nim'
```
Which makes it line up with the error message if `foo/` did exist but `bar.nim` didn't. Does this by using the same logic for [handling if the file doesn't exist](https://github.com/ire4ever1190/Nim/blob/0dc12ec24b7902ef0023a9e694faa11bcf99e257/compiler/options.nim#L785-L788)