### PR TITLE
strutils.multiReplace: Making order of replacement explicit

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2290,8 +2290,9 @@ func multiReplace*(s: string, replacements: varargs[(string, string)]): string =
   ## If the resulting string is not longer than the original input string,
   ## only a single memory allocation is required.
   ##
-  ## The order of the replacements does matter. Earlier replacements are
-  ## preferred over later replacements in the argument list.
+  ## Replacements are done left to right in the string. If at a given position
+  ## multiple replacements match, earlier replacements are preferred over
+  ## later replacements in the argument list.
   result = newStringOfCap(s.len)
   var i = 0
   var fastChk: set[char] = {}


### PR DESCRIPTION
In the docs for strutils.multiReplace:

Making it more explicit that left to right comes before the order in the replacements arg (but that the latter matters too).

E.g.

```
echo "ab".multiReplace(@[("a", "1"), ("ax", "2")])
echo "ab".multiReplace(@[("ab", "2"), ("a", "1")])
```

gives

```
1b
2
```

resolves #23016 
