### PR TITLE
Fix nimsuggest `def` being different on proc definition/use

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2169,8 +2169,8 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     s.owner = c.getCurrOwner
   else:
     # Highlighting needs to be done early so the position for
-    # names isn't changed. But can't check if this is the definition
-    # yet since the doc comments aren't passed
+    # name isn't changed (see taccent_highlight). We don't want to check if this is the
+    # defintion yet since we are missing some info (comments, side effects)
     s = semIdentDef(c, n[namePos], kind, reportToNimsuggest=isHighlight)
     n[namePos] = newSymNode(s)
     when false:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2166,7 +2166,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     s = n[namePos].sym
     s.owner = c.getCurrOwner
   else:
-    s = semIdentDef(c, n[namePos], kind)
+    s = semIdentDef(c, n[namePos], kind, reportToNimsuggest=false)
     n[namePos] = newSymNode(s)
     when false:
       # disable for now
@@ -2412,6 +2412,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
       result.typ = makeVarType(c, result.typ, tyOwned)
   elif isTopLevel(c) and s.kind != skIterator and s.typ.callConv == ccClosure:
     localError(c.config, s.info, "'.closure' calling convention for top level routines is invalid")
+  suggestSym(c.graph, s.info, s, c.graph.usageSym)
 
 proc determineType(c: PContext, s: PSym) =
   if s.typ != nil: return

--- a/nimsuggest/tests/tdef1.nim
+++ b/nimsuggest/tests/tdef1.nim
@@ -1,12 +1,14 @@
 discard """
 $nimsuggest --tester $file
 >def $1
-def;;skProc;;tdef1.hello;;proc (): string{.noSideEffect, gcsafe.};;$file;;9;;5;;"Return hello";;100
->def $1
-def;;skProc;;tdef1.hello;;proc (): string{.noSideEffect, gcsafe.};;$file;;9;;5;;"Return hello";;100
+def;;skProc;;tdef1.hello;;proc (): string{.noSideEffect, gcsafe.};;$file;;11;;5;;"Return hello";;100
+>def $2
+def;;skProc;;tdef1.hello;;proc (): string{.noSideEffect, gcsafe.};;$file;;11;;5;;"Return hello";;100
+>def $2
+def;;skProc;;tdef1.hello;;proc (): string{.noSideEffect, gcsafe.};;$file;;11;;5;;"Return hello";;100
 """
 
-proc hello(): string =
+proc hel#[!]#lo(): string =
   ## Return hello
   "Hello"
 

--- a/nimsuggest/tests/tsug_recursive.nim
+++ b/nimsuggest/tests/tsug_recursive.nim
@@ -1,0 +1,8 @@
+discard """
+$nimsuggest --tester $file
+>sug $1
+sug;;skProc;;tsug_recursive.fooBar;;proc ();;$file;;7;;5;;"";;100;;Prefix
+"""
+
+proc fooBar() =
+  fooBa#[!]#


### PR DESCRIPTION
Currently the documentation isn't shown when running `def` on the definition of a proc (Which works for things like variables). `gcsafe`/`noSideEffects` status also isn't showing up when running `def` on the definition 

Images of current behavior. After PR both look like "Usage"
**Definition**
![image](https://github.com/nim-lang/Nim/assets/19339842/bf75ff0b-9a96-49e5-bf8a-d2c503efa784)
**Usage**
![image](https://github.com/nim-lang/Nim/assets/19339842/15ea3ebf-64e1-48f5-9233-22605183825f)


Issue was the symbol getting passed too early to nimsuggest so it didn't have all that info, now gets passed once proc is fully semmed