### PR TITLE
backport to version 1.6: Also show the `raises` pragma when converting proc types to string (#23026)

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
-  lineinfos, int128, modulegraphs, astmsgs
+  lineinfos, int128, modulegraphs, astmsgs, wordrecg
 
 type
   TPreferedDesc* = enum
@@ -753,6 +753,14 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
       result.add(')')
       if t.len > 0 and t[0] != nil: result.add(": " & typeToString(t[0]))
       var prag = if t.callConv == ccNimCall and tfExplicitCallConv notin t.flags: "" else: $t.callConv
+      if not isNil(t.owner) and not isNil(t.owner.ast) and (t.owner.ast.len - 1) >= pragmasPos:
+        let pragmasNode = t.owner.ast[pragmasPos]
+        let raisesSpec = effectSpec(pragmasNode, wRaises)
+        if not isNil(raisesSpec):
+          addSep(prag)
+          prag.add("raises: ")
+          prag.add($raisesSpec)
+
       if tfNoSideEffect in t.flags:
         addSep(prag)
         prag.add("noSideEffect")

--- a/tests/effects/teffects1.nim
+++ b/tests/effects/teffects1.nim
@@ -42,7 +42,7 @@ proc foo(x: int): string {.raises: [ValueError].} =
 
 var p: MyProcType = foo #[tt.Error
                     ^
-type mismatch: got <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> but expected 'MyProcType = proc (x: int): string{.closure.}'
+type mismatch: got <proc (x: int): string{.raises: [ValueError], noSideEffect, gcsafe, locks: 0.}> but expected 'MyProcType = proc (x: int): string{.closure.}'
 
 ]#
 {.pop.}


### PR DESCRIPTION
This affects also nimsuggest hints (e.g. on mouse hover), as well as compiler messages.

(cherry picked from commit 618ccb6b6a60f9a315997f95cbbd81be9e9d7f53)