### PR TITLE
Only suggest symbols that could be pragmas when typing a pragma

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -14,6 +14,8 @@ import
   wordrecg, ropes, options, extccomp, magicsys, trees,
   types, lookups, lineinfos, pathutils, linter, modulepaths
 
+from sigmatch import trySuggestPragmas
+
 import std/[os, math, strutils]
 
 when defined(nimPreviewSlimSystem):
@@ -119,6 +121,7 @@ const
 
 proc invalidPragma*(c: PContext; n: PNode) =
   localError(c.config, n.info, "invalid pragma: " & renderTree(n, {renderNoComments}))
+
 proc illegalCustomPragma*(c: PContext, n: PNode, s: PSym) =
   var msg = "cannot attach a custom pragma to '" & s.name.s & "'"
   if s != nil:
@@ -786,6 +789,8 @@ proc semCustomPragma(c: PContext, n: PNode, sym: PSym): PNode =
   else:
     invalidPragma(c, n)
     return n
+
+  trySuggestPragmas(c, callNode[0])
 
   let r = c.semOverloadedCall(c, callNode, n, {skTemplate}, {efNoUndeclared})
   if r.isNil or sfCustomPragma notin r[0].sym.flags:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -525,6 +525,8 @@ proc semVarMacroPragma(c: PContext, a: PNode, n: PNode): PNode =
       let it = pragmas[i]
       let key = if it.kind in nkPragmaCallKinds and it.len >= 1: it[0] else: it
 
+      trySuggestPragmas(c, key)
+
       if isPossibleMacroPragma(c, it, key):
         # we transform ``var p {.m, rest.}`` into ``m(do: var p {.rest.})`` and
         # let the semantic checker deal with it:
@@ -1740,9 +1742,8 @@ proc semProcAnnotation(c: PContext, prc: PNode;
   for i in 0..<n.len:
     let it = n[i]
     let key = if it.kind in nkPragmaCallKinds and it.len >= 1: it[0] else: it
-    when defined(nimsuggest):
-      if c.config.ideCmd == ideSug and exactEquals(c.config.m.trackPos, key.info):
-        suggestPragmas(c, key, validPragmas)
+
+    trySuggestPragmas(c, key)
 
     if isPossibleMacroPragma(c, it, key):
       # we transform ``proc p {.m, rest.}`` into ``m(do: proc p {.rest.})`` and

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1740,6 +1740,9 @@ proc semProcAnnotation(c: PContext, prc: PNode;
   for i in 0..<n.len:
     let it = n[i]
     let key = if it.kind in nkPragmaCallKinds and it.len >= 1: it[0] else: it
+    when defined(nimsuggest):
+      if c.config.ideCmd == ideSug and exactEquals(c.config.m.trackPos, key.info):
+        suggestPragmas(c, key, validPragmas)
 
     if isPossibleMacroPragma(c, it, key):
       # we transform ``proc p {.m, rest.}`` into ``m(do: proc p {.rest.})`` and

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1741,10 +1741,10 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
   result = nil
   for p in pragmas:
     let key = if p.kind in nkPragmaCallKinds and p.len >= 1: p[0] else: p
-
     if p.kind == nkEmpty or whichPragma(p) != wInvalid:
       discard "builtin pragma"
     else:
+      trySuggestPragmas(c, key)
       let ident = considerQuotedIdent(c, key)
       if strTableGet(c.userPragmas, ident) != nil:
         discard "User-defined pragma"

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -761,7 +761,7 @@ proc suggestPragmas*(c: PContext, n: PNode) =
 
   # Now show suggestions for user pragmas
   for pragma in c.userPragmas:
-      var pm: PrefixMatch = default(PrefixMatch)
+      var pm = default(PrefixMatch)
       if filterSym(pragma, n, pm):
         outputs &= symToSuggest(c.graph, pragma, isLocal=true, ideSug, info,
                                  pragma.getQuality, pm, c.inTypeContext > 0, 0,

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -762,6 +762,30 @@ proc suggestPragmas*(c: PContext, n: PNode, validPragmas: TSpecialWords) =
     (sfCustomPragma in it.flags or it.kind == skMacro),
     ideSug)
 
+  # We need addresses later for comparing so
+  # store them all globally so we can safely store
+  # a pointer
+  let pragmaNames {.global.} = block:
+    var res: array[TSpecialWord, string]
+    for pragma in TSpecialWord:
+      res[pragma] = $pragma
+    res
+
+  # Now add suggestions for valid pragmas.
+  # TODO: Link to the definition in wordrecg.
+  # Tried to use symToSuggest but don't think its
+  # possible to find the original symbol since its likely not in scope
+  for pragma in validPragmas:
+    var sug = Suggestion()
+    sug.section = ideSug
+    sug.prefix = n
+    sug.name = addr pragmaNames[pragma]
+    sug.contextFits = true # Already considered valid by caller
+    sug.kind = byte skUnknown
+    sug.forth = $pragma
+    if optIdeTerse notin g.config.globalOptions:
+      sug.qualifiedPath &= $pragma
+
   produceOutput(outputs, c.config)
   if outputs.len > 0:
     suggestQuit()

--- a/nimsuggest/tests/tsug_pragmas.nim
+++ b/nimsuggest/tests/tsug_pragmas.nim
@@ -1,0 +1,18 @@
+template fooBar1() {.pragma.}
+proc fooBar2() = discard
+macro fooBar3(x: untyped) = discard
+
+# Procs shouldn't be suggested.
+# Not perfect, but cuts down on invalid suggestions
+proc test1() {.fooBar#[!]#.} = discard
+
+# We also want to suggest built in pragmas which
+# wouldn't normally come up in suggestions
+proc test2() {.stackTrac#[!]#.} = discard
+
+discard """
+$nimsuggest --tester $file
+>sug $1
+sug;;skMacro;;fooBar1;;LogLevel;;$file;;1;;9;;"";;100;;Prefix
+"""
+

--- a/nimsuggest/tests/tsug_pragmas.nim
+++ b/nimsuggest/tests/tsug_pragmas.nim
@@ -1,18 +1,40 @@
 template fooBar1() {.pragma.}
 proc fooBar2() = discard
 macro fooBar3(x: untyped) = discard
+{.pragma: fooBar4 fooBar3.}
 
-# Procs shouldn't be suggested.
-# Not perfect, but cuts down on invalid suggestions
+# Check only macros/templates/pragmas are suggested
 proc test1() {.fooBar#[!]#.} = discard
 
-# We also want to suggest built in pragmas which
-# wouldn't normally come up in suggestions
-proc test2() {.stackTrac#[!]#.} = discard
+var test2 {.fooBar#[!]#.} = 9
+
+type
+  Person {.fooBar#[!]#.} = object
+    hello {.fooBar#[!]#.}: string
+  Callback = proc test() {.fooBar#[!]#.}
 
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skMacro;;fooBar1;;LogLevel;;$file;;1;;9;;"";;100;;Prefix
+sug;;skTemplate;;fooBar4;;;;$file;;4;;8;;"";;100;;Prefix
+sug;;skTemplate;;tsug_pragmas.fooBar1;;template ();;$file;;1;;9;;"";;100;;Prefix
+sug;;skMacro;;tsug_pragmas.fooBar3;;macro (x: untyped){.noSideEffect, gcsafe.};;$file;;3;;6;;"";;50;;Prefix
+>sug $2
+sug;;skTemplate;;fooBar4;;;;$file;;4;;8;;"";;100;;Prefix
+sug;;skTemplate;;tsug_pragmas.fooBar1;;template ();;$file;;1;;9;;"";;100;;Prefix
+sug;;skMacro;;tsug_pragmas.fooBar3;;macro (x: untyped){.noSideEffect, gcsafe.};;$file;;3;;6;;"";;50;;Prefix
+>sug $3
+sug;;skTemplate;;fooBar4;;;;$file;;4;;8;;"";;100;;Prefix
+sug;;skTemplate;;tsug_pragmas.fooBar1;;template ();;$file;;1;;9;;"";;100;;Prefix
+sug;;skMacro;;tsug_pragmas.fooBar3;;macro (x: untyped){.noSideEffect, gcsafe.};;$file;;3;;6;;"";;50;;Prefix
+>sug $4
+sug;;skTemplate;;fooBar4;;;;$file;;4;;8;;"";;100;;Prefix
+sug;;skTemplate;;tsug_pragmas.fooBar1;;template ();;$file;;1;;9;;"";;100;;Prefix
+sug;;skMacro;;tsug_pragmas.fooBar3;;macro (x: untyped){.noSideEffect, gcsafe.};;$file;;3;;6;;"";;50;;Prefix
+>sug $5
+sug;;skTemplate;;fooBar4;;;;$file;;4;;8;;"";;100;;Prefix
+sug;;skTemplate;;tsug_pragmas.fooBar1;;template ();;$file;;1;;9;;"";;100;;Prefix
+sug;;skMacro;;tsug_pragmas.fooBar3;;macro (x: untyped){.noSideEffect, gcsafe.};;$file;;3;;6;;"";;50;;Prefix
 """
+
 

--- a/nimsuggest/tests/tsug_pragmas.nim
+++ b/nimsuggest/tests/tsug_pragmas.nim
@@ -3,7 +3,6 @@ proc fooBar2() = discard
 macro fooBar3(x: untyped) = discard
 {.pragma: fooBar4 fooBar3.}
 
-# Check only macros/templates/pragmas are suggested
 proc test1() {.fooBar#[!]#.} = discard
 
 var test2 {.fooBar#[!]#.} = 9
@@ -11,8 +10,9 @@ var test2 {.fooBar#[!]#.} = 9
 type
   Person {.fooBar#[!]#.} = object
     hello {.fooBar#[!]#.}: string
-  Callback = proc test() {.fooBar#[!]#.}
+  Callback = proc () {.fooBar#[!]#.}
 
+# Check only macros/templates/pragmas are suggested
 discard """
 $nimsuggest --tester $file
 >sug $1


### PR DESCRIPTION
Currently pragmas just fall through to `suggestSentinel` and show everything which isn't very useful. Now it filters for symbols that could be pragmas (templates with `{.pragma.}`, macros, user pragmas) and only shows them