### PR TITLE
Don't process a user pragma if its invalid

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -685,9 +685,12 @@ proc pragmaLine(c: PContext, n: PNode) =
 proc processPragma(c: PContext, n: PNode, i: int) =
   ## Create and add a new custom pragma `{.pragma: name.}` node to the module's context.
   let it = n[i]
-  if it.kind notin nkPragmaCallKinds and it.safeLen == 2: invalidPragma(c, n)
+  if it.kind notin nkPragmaCallKinds and it.safeLen == 2:
+    invalidPragma(c, n)
+    return
   elif it.safeLen != 2 or it[0].kind != nkIdent or it[1].kind != nkIdent:
     invalidPragma(c, n)
+    return
 
   var userPragma = newSym(skTemplate, it[1].ident, c.idgen, c.module, it.info, c.config.options)
   styleCheckDef(c, userPragma)

--- a/tests/pragmas/tinvalid_user_pragma.nim
+++ b/tests/pragmas/tinvalid_user_pragma.nim
@@ -1,0 +1,6 @@
+discard """
+cmd: "nim check $file"
+"""
+
+{.pragma test: foo.} #[tt.Error
+^ invalid pragma:  {.pragma, test: foo.} ]#

--- a/tests/pragmas/tinvalid_user_pragma.nim
+++ b/tests/pragmas/tinvalid_user_pragma.nim
@@ -4,3 +4,6 @@ cmd: "nim check $file"
 
 {.pragma test: foo.} #[tt.Error
 ^ invalid pragma:  {.pragma, test: foo.} ]#
+
+{.pragma: 1.} #[tt.Error
+^ invalid pragma:  {.pragma: 1.} ]#


### PR DESCRIPTION
When running `check`/`suggest` in a file with an invalid user pragma like
```nim
{.pragma foo: test.}
```
It will continue to try and process it which leads to the compiler running into a `FieldDefect`
```
fatal.nim(53)            sysFatal
Error: unhandled exception: field 'sons' is not accessible for type 'TNode' using 'kind = nkIdent' [FieldDefect]
```
This makes it instead bail out trying to process the user pragma if its invalid