### PR TITLE
Correction of “Tnfds” type error

### DIFF
--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -606,10 +606,10 @@ when not defined(lwip):
 
   when defined(zephyr):
     type
-      Tnfds* = distinct cint
+      Tnfds* = distinct culong
   else:
     type
-      Tnfds* {.importc: "nfds_t", header: "<poll.h>".} = cint
+      Tnfds* {.importc: "nfds_t", header: "<poll.h>".} = culong
 
 var
   errno* {.importc, header: "<errno.h>".}: cint ## error variable


### PR DESCRIPTION
The types in Nim don't match the actual types in the header files, this can lead to bugs in some cases.