### PR TITLE
fixes #23060; `editDistance` wrongly compare the length of rune strings

### DIFF
--- a/lib/std/editdistance.nim
+++ b/lib/std/editdistance.nim
@@ -18,7 +18,7 @@ proc editDistance*(a, b: string): int {.noSideEffect.} =
   ## This uses the `Levenshtein`:idx: distance algorithm with only a linear
   ## memory overhead.
   runnableExamples: static: doAssert editdistance("Kitten", "Bitten") == 1
-  if len(a) > len(b):
+  if runeLen(a) > runeLen(b):
     # make `b` the longer string
     return editDistance(b, a)
   # strip common prefix

--- a/tests/errmsgs/t23060.nim
+++ b/tests/errmsgs/t23060.nim
@@ -1,0 +1,5 @@
+discard """
+  errormsg: "undeclared identifier: '♔♕♖♗♘♙'"
+"""
+
+♔♕♖♗♘♙ = 1


### PR DESCRIPTION
fixes #23060