### PR TITLE
fixes #23051; don't generate documentation for exported symbols again

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1400,7 +1400,8 @@ proc generateDoc*(d: PDoc, n, orig: PNode, config: ConfigRef, docFlags: DocFlags
     for it in n: traceDeps(d, it)
   of nkExportStmt:
     for it in n:
-      if it.kind == nkSym:
+      # bug #23051; don't generate documentation for exported symbols again
+      if it.kind == nkSym and sfExported notin it.sym.flags:
         if d.module != nil and d.module == it.sym.owner:
           generateDoc(d, it.sym.ast, orig, config, kForceExport)
         elif it.sym.ast != nil:


### PR DESCRIPTION
fixes #23051

Before

![image](https://github.com/nim-lang/Nim/assets/43030857/d402a837-281e-4035-8302-500f64dccdb5)

After

![image](https://github.com/nim-lang/Nim/assets/43030857/de9a23f1-9e50-4551-b3fd-3311e1de378e)
