### PR TITLE
Show the name of the unexpected exception that was thrown in `std/unittest`

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -773,7 +773,8 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
     except errorTypes:
       discard
     except:
-      checkpoint(lineInfoLit & ": Expect Failed, unexpected exception was thrown.")
+      let err = getCurrentException()
+      checkpoint(lineInfoLit & ": Expect Failed, " & $err.name & " was thrown.")
       fail()
     {.pop.}
 


### PR DESCRIPTION
Show name of error that wasn't expected in an `expect` block