### PR TITLE
Allow `parseAll` to parse statements separated by semicolons

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2514,22 +2514,6 @@ proc parseStmt(p: var Parser): PNode =
           if err and p.tok.tokType == tkEof: break
   setEndInfo()
 
-proc parseAll*(p: var Parser): PNode =
-  ## Parses the rest of the input stream held by the parser into a PNode.
-  result = newNodeP(nkStmtList, p)
-  while p.tok.tokType != tkEof:
-    p.hasProgress = false
-    var a = complexOrSimpleStmt(p)
-    if a.kind != nkEmpty and p.hasProgress:
-      result.add(a)
-    else:
-      parMessage(p, errExprExpected, p.tok)
-      # bugfix: consume a token here to prevent an endless loop:
-      getTok(p)
-    if p.tok.indent != 0:
-      parMessage(p, errInvalidIndentation)
-  setEndInfo()
-
 proc checkFirstLineIndentation*(p: var Parser) =
   if p.tok.indent != 0 and tsLeading in p.tok.spacing:
     parMessage(p, errInvalidIndentation)
@@ -2562,6 +2546,16 @@ proc parseTopLevelStmt*(p: var Parser): PNode =
       result = complexOrSimpleStmt(p)
       if result.kind == nkEmpty: parMessage(p, errExprExpected, p.tok)
       break
+  setEndInfo()
+
+proc parseAll*(p: var Parser): PNode =
+  ## Parses the rest of the input stream held by the parser into a PNode.
+  result = newNodeP(nkStmtList, p)
+  while true:
+    let nextStmt = p.parseTopLevelStmt()
+    if nextStmt.kind == nkEmpty:
+      break
+    result &= nextStmt
   setEndInfo()
 
 proc parseString*(s: string; cache: IdentCache; config: ConfigRef;

--- a/tests/macros/ttryparseexpr.nim
+++ b/tests/macros/ttryparseexpr.nim
@@ -10,7 +10,6 @@ macro test(text: string): untyped =
     result = parseExpr(text.strVal)
   except ValueError:
     result = newLit getCurrentExceptionMsg()
-
 const
   valid = 45
   a = test("foo&&")
@@ -18,3 +17,7 @@ const
   c = test("\"") # bug #2504
 
 echo a, " ", b
+
+static:
+  # Issue #9918
+  discard parseStmt("echo(1+1);")

--- a/tests/macros/ttryparseexpr.nim
+++ b/tests/macros/ttryparseexpr.nim
@@ -10,6 +10,7 @@ macro test(text: string): untyped =
     result = parseExpr(text.strVal)
   except ValueError:
     result = newLit getCurrentExceptionMsg()
+
 const
   valid = 45
   a = test("foo&&")


### PR DESCRIPTION
Fixes the second issue listed in #9918.

Fixed by replacing the logic used in `parseAll` with just a continious loop to `complexOrSimpleStmt` like what the [normal parser does](https://github.com/nim-lang/Nim/blob/devel/compiler/passes.nim#L143-L146). `complexOrSimpleStmt` [guarantees progress](https://github.com/nim-lang/Nim/blob/devel/compiler/parser.nim#L2541) so we don't need to check progress ourselves.

Also allows `nimpretty` to parse more valid Nim code such as 
```nim
proc foo(); # Would complain about indention here
# ...
proc foo() = 
  # ...
```