### PR TITLE
Don't crash for invalid toplevel parseStmt/Expr calls

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1925,6 +1925,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                             proc (conf: ConfigRef; info: TLineInfo; msg: TMsgKind; arg: string) =
                               if error.len == 0 and msg <= errMax:
                                 error = formatMsg(conf, info, msg, arg))
+
+      regs[ra].node = newNode(nkEmpty)
       if error.len > 0:
         c.errorFlag = error
       elif ast.len != 1:
@@ -1942,6 +1944,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                                 error = formatMsg(conf, info, msg, arg))
       if error.len > 0:
         c.errorFlag = error
+        regs[ra].node = newNode(nkEmpty)
       else:
         regs[ra].node = ast
     of opcQueryErrorFlag:

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -201,8 +201,8 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
   result.column = 0
 
   result.err = reNimcCrash
-  let exitCode = p.peekExitCode
-  case exitCode
+  result.exitCode = p.peekExitCode
+  case result.exitCode
   of 0:
     if foundErrorMsg:
       result.debugInfo.add " compiler exit code was 0 but some Error's were found."
@@ -214,7 +214,7 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
     if foundSuccessMsg:
       result.debugInfo.add " compiler exit code was 1 but no `isSuccess` was true."
   else:
-    result.debugInfo.add " expected compiler exit code 0 or 1, got $1." % $exitCode
+    result.debugInfo.add " expected compiler exit code 0 or 1, got $1." % $result.exitCode
 
   if err =~ pegLineError:
     result.file = extractFilename(matches[0])
@@ -521,7 +521,13 @@ proc testSpecHelper(r: var TResults, test: var TTest, expected: TSpec,
             r.addResult(test, target, extraOptions, expected.output, bufB, reOutputsDiffer)
           compilerOutputTests(test, target, extraOptions, given, expected, r)
   of actionReject:
-    cmpMsgs(r, expected, given, test, target, extraOptions)
+    # Make sure its the compiler rejecting and not the system (e.g. segfault)
+    if given.exitCode != QuitFailure:
+      r.addResult(test, target, extraOptions, "exitcode: " & $QuitFailure,
+                        "exitcode: " & $given.exitCode & "\n\nOutput:\n" &
+                        given.nimout, reExitcodesDiffer)
+    else:
+      cmpMsgs(r, expected, given, test, target, extraOptions)
 
 proc targetHelper(r: var TResults, test: TTest, expected: TSpec, extraOptions: string) =
   for target in expected.targets:

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -193,7 +193,6 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
         foundSuccessMsg = true
     elif not running(p):
       break
-  close(p)
   result.msg = ""
   result.file = ""
   result.output = ""
@@ -202,6 +201,7 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
 
   result.err = reNimcCrash
   result.exitCode = p.peekExitCode
+  close p
   case result.exitCode
   of 0:
     if foundErrorMsg:

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -522,12 +522,11 @@ proc testSpecHelper(r: var TResults, test: var TTest, expected: TSpec,
           compilerOutputTests(test, target, extraOptions, given, expected, r)
   of actionReject:
     # Make sure its the compiler rejecting and not the system (e.g. segfault)
+    cmpMsgs(r, expected, given, test, target, extraOptions)
     if given.exitCode != QuitFailure:
       r.addResult(test, target, extraOptions, "exitcode: " & $QuitFailure,
                         "exitcode: " & $given.exitCode & "\n\nOutput:\n" &
                         given.nimout, reExitcodesDiffer)
-    else:
-      cmpMsgs(r, expected, given, test, target, extraOptions)
 
 proc targetHelper(r: var TResults, test: TTest, expected: TSpec, extraOptions: string) =
   for target in expected.targets:

--- a/tests/macros/tfail_parse.nim
+++ b/tests/macros/tfail_parse.nim
@@ -1,0 +1,15 @@
+discard """
+action: "reject"
+cmd: "nim check $file"
+errormsg: "unhandled exception: (1, 2) Error: invalid character literal [ValueError]"
+file: "macros.nim"
+"""
+
+import macros
+static:
+  discard parseStmt("'")
+  discard parseExpr("'")
+  discard parseExpr("""
+proc foo()
+proc foo() = discard
+""")

--- a/tests/macros/tfail_parse.nim
+++ b/tests/macros/tfail_parse.nim
@@ -1,7 +1,7 @@
 discard """
 action: "reject"
 cmd: "nim check $file"
-errormsg: "..${/}..${/}lib${/}core${/}macros.nim(577, 29) Error: expected expression, but got multiple statements [ValueError]"
+errormsg: "expected expression, but got multiple statements [ValueError]"
 file: "macros.nim"
 """
 

--- a/tests/macros/tfail_parse.nim
+++ b/tests/macros/tfail_parse.nim
@@ -1,7 +1,7 @@
 discard """
 action: "reject"
 cmd: "nim check $file"
-errormsg: "unhandled exception: (1, 2) Error: invalid character literal [ValueError]"
+errormsg: "..${/}..${/}lib${/}core${/}macros.nim(577, 29) Error: expected expression, but got multiple statements [ValueError]"
 file: "macros.nim"
 """
 

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -29,7 +29,7 @@ Failure: reOutputsDiffer
 FAIL: tests/shouldfail/toutputsub.nim
 Failure: reOutputsDiffer
 FAIL: tests/shouldfail/treject.nim
-Failure: reExitcodesDiffer
+Failure: reFilesDiffer
 FAIL: tests/shouldfail/tsortoutput.nim
 Failure: reOutputsDiffer
 FAIL: tests/shouldfail/ttimeout.nim

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -29,7 +29,7 @@ Failure: reOutputsDiffer
 FAIL: tests/shouldfail/toutputsub.nim
 Failure: reOutputsDiffer
 FAIL: tests/shouldfail/treject.nim
-Failure: reFilesDiffer
+Failure: reExitcodesDiffer
 FAIL: tests/shouldfail/tsortoutput.nim
 Failure: reOutputsDiffer
 FAIL: tests/shouldfail/ttimeout.nim


### PR DESCRIPTION
This code will crash `check`/`nimsuggest` since the `ra` register is uninitialised 

```nim
import macros

static:
  discard parseExpr("'")
```
Now it assigns an empty node so that it has something

Testament changes were so I could properly write a test. It would pass even with a segfault since it could find the error