### PR TITLE
require untyped macros/templates to match before early expansion in generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -297,8 +297,10 @@ proc semGenericStmt(c: PContext, n: PNode,
       of skMacro, skTemplate:
         # unambiguous macros/templates are expanded if all params are untyped
         if sfAllUntyped in s.flags and sc.safeLen <= 1:
+          # even if template is all untyped, we still need to check if it
+          # matches the call, i.e. if the parameter count matches
           onUse(fn.info, s)
-          var errors: CandidateErrors
+          var errors: CandidateErrors = @[]
           var r = resolveOverloads(c, n, n, {skTemplate, skMacro}, {efNoDiagnostics},
                                    errors, false)
           if r.state == csMatch:

--- a/tests/generics/tuntypedmacro.nim
+++ b/tests/generics/tuntypedmacro.nim
@@ -1,0 +1,21 @@
+block: # issue #22740
+  macro foo(n: untyped): untyped = discard
+  # Remove this macro to fix the problem
+  macro foo(n, n2: untyped): untyped = discard
+
+  # This one is fine
+  proc test1(v: string) =
+    foo >"test1"
+
+  # This one fails to compile
+  proc test2[T](v: T) = 
+    foo >"test2"
+
+  test1("hello")
+  test2("hello")
+
+block: # above simplified (yes this errored)
+  proc foo[T]() =
+    when false:
+      >1
+  foo[int]()


### PR DESCRIPTION
fixes #22740

In generic procs we expand fully untyped templates/macros as long as only 1 overload is in scope, however up to this point we didn't check if this overload actually matches the call (for example if the argument numbers are different). In this PR, after picking out the single fully untyped template/macro overload, we call `resolveOverloads` on it to see if it matches, and don't expand it if it doesn't.