### PR TITLE
test fixing (?) ancient macro subscript behavior

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1694,11 +1694,9 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags): PNode =
         else:
           # We are processing macroOrTmpl[] not in call. Transform it to the
           # macro or template call with generic arguments here.
-          n.transitionSonsKind(nkCall)
-          case s.kind
-          of skMacro: result = semMacroExpr(c, n, n, s, flags)
-          of skTemplate: result = semTemplateExpr(c, n, s, flags)
-          else: discard
+          setGenericParams(c, n, nil)
+          let call = newTreeI(nkCall, n.info, n)
+          result = semDirectOp(c, call, flags)
       of skType:
         result = symNodeFromType(c, semTypeNode(c, n, nil), n.info)
       else:

--- a/tests/macros/tsubscript.nim
+++ b/tests/macros/tsubscript.nim
@@ -1,0 +1,7 @@
+macro foo[T](x: T) = discard
+doAssert not compiles(foo[abc])
+
+template bar[T](): untyped = T(0)
+let x = bar[int]
+doAssert x == 0
+doAssert not compiles(bar[abc])


### PR DESCRIPTION
As described in #20218, currently all standalone expressions like `foo[a, b, c]` where `foo` is a macro is transformed into `foo(a, b, c)` and evaluated as such. The comment above the code which performs this says:

> Transform it to the macro or template call *with generic arguments*

which implies that this was an accident and what the code is supposed to do is transform it to `foo[a, b, c]()`. This PR performs this transform instead.

Since this was the behavior for [at least 7 years](https://github.com/nim-lang/Nim/commit/e52044660d63832d9f2aaf81323f86e13e48cc01), this might break some code. Also doing what the comment says introduces yet another feature, not to mention one analogous to the alias syntax thing which is notorious for being questionable design. Then again maybe erroring is too extreme.

Edit: Single package depends on it: https://github.com/alehander92/comprehension