### PR TITLE
directly parse on/off in pragmas, ignore user override

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -287,8 +287,10 @@ proc isTurnedOn(c: PContext, n: PNode): bool =
   if n.kind in nkPragmaCallKinds and n.len == 2:
     let ident = getPIdent(n[1])
     if ident != nil and ident.id == ord(wOn):
+      n[1] = newIntTypeNode(1, getSysType(c.graph, n.info, tyBool))
       return true
     elif ident != nil and ident.id == ord(wOff):
+      n[1] = newIntTypeNode(0, getSysType(c.graph, n.info, tyBool))
       return false
     else:
       let x = c.semConstBoolExpr(c, n[1])

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -285,9 +285,15 @@ proc wordToCallConv(sw: TSpecialWord): TCallingConvention =
 proc isTurnedOn(c: PContext, n: PNode): bool =
   result = false
   if n.kind in nkPragmaCallKinds and n.len == 2:
-    let x = c.semConstBoolExpr(c, n[1])
-    n[1] = x
-    if x.kind == nkIntLit: return x.intVal != 0
+    let ident = getPIdent(n[1])
+    if ident != nil and ident.id == ord(wOn):
+      return true
+    elif ident != nil and ident.id == ord(wOff):
+      return false
+    else:
+      let x = c.semConstBoolExpr(c, n[1])
+      n[1] = x
+      if x.kind == nkIntLit: return x.intVal != 0
   localError(c.config, n.info, "'on' or 'off' expected")
 
 proc onOff(c: PContext, n: PNode, op: TOptions, resOptions: var TOptions) =
@@ -368,9 +374,7 @@ proc processNote(c: PContext, n: PNode) =
     let x = findStr(enumVals.a, enumVals.b, n[0][1].ident.s, errUnknown)
     if x !=  errUnknown:
       nk = TNoteKind(x)
-      let x = c.semConstBoolExpr(c, n[1])
-      n[1] = x
-      if x.kind == nkIntLit and x.intVal != 0: incl(notes, nk)
+      if isTurnedOn(c, n): incl(notes, nk)
       else: excl(notes, nk)
     else:
       invalidPragma(c, n)

--- a/tests/pragmas/monoff1.nim
+++ b/tests/pragmas/monoff1.nim
@@ -1,0 +1,1 @@
+proc on*() = discard

--- a/tests/pragmas/tonoff1.nim
+++ b/tests/pragmas/tonoff1.nim
@@ -1,0 +1,8 @@
+# issue #23002
+
+import monoff1
+
+proc test() =
+  {.warning[ProveInit]: on.}
+
+test()

--- a/tests/pragmas/tonoff2.nim
+++ b/tests/pragmas/tonoff2.nim
@@ -1,0 +1,10 @@
+# issue #22841
+
+import unittest
+
+proc on() =
+    discard
+
+suite "some suite":
+    test "some test":
+        discard

--- a/tests/pragmas/tonoff2.nim
+++ b/tests/pragmas/tonoff2.nim
@@ -1,3 +1,7 @@
+discard """
+    action: compile
+"""
+
 # issue #22841
 
 import unittest


### PR DESCRIPTION
fixes #22841, fixes #23002

If a pragma like `{.checks: off.}` or `{.warning[ProveInit]: on.}` has a direct identifier node on the RHS equal to either `on` or `off`, directly parse them as `true` or `false`, ignoring user overrides and overloads of the symbols `on` and `off`.

Something similar can be accomplished by turning `on` and `off` (which are `const on* = true` and `const off* = false` in system respectively) into:

```nim
type PragmaOption* = enum on, off
```

and coercing the RHS of pragmas to this type instead of `bool` (due to new enum type inference), however this would require all code that computes a custom value for the RHS like `{.checks: foo().}` to change it to something like:

```nim
{.checks: (if foo(): on else: off).}
# or
{.checks: PragmaOption(foo()).}
```

Another problem is the symbols `on` and `off` enter into the enum symbol namespace which could cause ambiguity problems in normal code (although if someone has defined enum fields `on` and `off`, the pragmas like above wouldn't work anyway).

Either change would require documentation, none is currently written in this PR because it's a POC of the initial proposal above. Will open RFC if required.