### PR TITLE
proof of concept: prefer unambiguous captured symbols in symchoices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,14 @@
   ```
   will no longer compile.
 
+- In template and generic bodies, for symbols with only 1 overload in scope,
+  previously the compiler would not allow other overloads in the instantiation
+  context to be used, which was not the case for 0 or more than 1 overloads.
+  Now other overloads are allowed with a preference for the original overload
+  in cases of ambiguity. Some code might need to be changed to use `bind` to
+  prevent outside overloads from replacing a weaker captured overload. See
+  [issue #11184](https://github.com/nim-lang/Nim/issues/11184) for more details.
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -521,6 +521,7 @@ type
     nfHasComment # node has a comment
     nfSkipFieldChecking # node skips field visable checking
     nfOpenSym # node is a captured sym but can be overriden by local symbols
+    nfPreferredSym # node is a preferred sym in a symchoice
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   # keep below 32 for efficiency reasons (now: 47)
@@ -1097,7 +1098,7 @@ const
                                       nfFromTemplate, nfDefaultRefsParam,
                                       nfExecuteOnReload, nfLastRead,
                                       nfFirstWrite, nfSkipFieldChecking,
-                                      nfOpenSym}
+                                      nfOpenSym, nfPreferredSym}
   namePos* = 0
   patternPos* = 1    # empty except for term rewriting macros
   genericParamsPos* = 2

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -333,7 +333,6 @@ type
     mode*: TOverloadIterMode
     symChoiceIndex*: int
     symChoiceLastPreferred: bool
-    fallback: PSym
     currentScope: PScope
     importIdx: int
     marked: IntSet
@@ -736,6 +735,8 @@ proc initOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
   of nkSym:
     result = n.sym
     if nfPreferredSym in n.flags:
+      # standalone sym node with nfPreferredSym acts like an open symchoice,
+      # see semtempl.symChoice for reasoning
       o.mode = oimSymChoiceLocalLookup
       o.symChoiceLastPreferred = true
       o.currentScope = c.currentScope
@@ -847,9 +848,6 @@ proc nextOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
         result = nextOverloadIterImports(o, c, n)
     else:
       result = nil
-    if result == nil and o.fallback != nil and o.fallback.id notin o.marked:
-      result = o.fallback
-      o.fallback = nil
   of oimSelfModule:
     result = nextIdentIter(o.it, c.topLevelScope.symbols)
   of oimOtherModule:

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -268,41 +268,6 @@ proc cmpScopes*(ctx: PContext, s: PSym): int =
   else:
     result = 1
 
-proc isAmbiguous*(c: PContext, s: PIdent, filter: TSymKinds, sym: var PSym): bool =
-  result = false
-  block outer:
-    for scope in allScopes(c.currentScope):
-      var ti: TIdentIter
-      var candidate = initIdentIter(ti, scope.symbols, s)
-      var scopeHasCandidate = false
-      while candidate != nil:
-        if candidate.kind in filter:
-          if scopeHasCandidate:
-            # 2 candidates in same scope, ambiguous
-            return true
-          else:
-            scopeHasCandidate = true
-            sym = candidate
-        candidate = nextIdentIter(ti, scope.symbols)
-      if scopeHasCandidate:
-        # scope had a candidate but wasn't ambiguous
-        return false
-
-  var importsHaveCandidate = false
-  var marked = initIntSet()
-  for im in c.imports.mitems:
-    for s in symbols(im, marked, s, c.graph):
-      if s.kind in filter:
-        if importsHaveCandidate:
-          # 2 candidates among imports, ambiguous
-          return true
-        else:
-          importsHaveCandidate = true
-          sym = s
-  if importsHaveCandidate:
-    # imports had a candidate but wasn't ambiguous
-    return false
-
 proc errorSym*(c: PContext, ident: PIdent, info: TLineInfo): PSym =
   ## creates an error symbol to avoid cascading errors (for IDE support)
   result = newSym(skError, ident, c.idgen, getCurrOwner(c), info, {})

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -332,6 +332,8 @@ type
     m*: PSym
     mode*: TOverloadIterMode
     symChoiceIndex*: int
+    symChoiceLastPreferred: bool
+    fallback: PSym
     currentScope: PScope
     importIdx: int
     marked: IntSet
@@ -611,6 +613,11 @@ proc lookUp*(c: PContext, n: PNode): PSym =
     var ident = considerQuotedIdent(c, n)
     result = searchInScopes(c, ident, amb)
     if result == nil: result = errorUndeclaredIdentifierHint(c, ident, n.info)
+  of nkOpenSymChoice, nkClosedSymChoice:
+    if nfPreferredSym in n[0].flags:
+      result = n[0].sym
+    else:
+      result = nil
   else:
     internalError(c.config, n.info, "lookUp")
     return nil
@@ -691,6 +698,11 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
         localError(c.config, n[1].info, "identifier expected, but got: " &
                    renderTree(n[1]))
         result = errorSym(c, n[1])
+  of nkOpenSymChoice, nkClosedSymChoice:
+    if nfPreferredSym in n[0].flags:
+      result = n[0].sym
+    else:
+      result = nil
   else:
     result = nil
   when false:
@@ -723,7 +735,16 @@ proc initOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
 
   of nkSym:
     result = n.sym
-    o.mode = oimDone
+    if nfPreferredSym in n.flags:
+      o.mode = oimSymChoiceLocalLookup
+      o.symChoiceLastPreferred = true
+      o.currentScope = c.currentScope
+      o.it.h = result.name.h
+      o.it.name = result.name
+      o.marked = initIntSet()
+      incl(o.marked, result.id)
+    else:
+      o.mode = oimDone
   of nkDotExpr:
     result = nil
     o.mode = oimOtherModule
@@ -749,6 +770,7 @@ proc initOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
     o.mode = oimSymChoice
     if n[0].kind == nkSym:
       result = n[0].sym
+      o.symChoiceLastPreferred = nfPreferredSym in n[0].flags
     else:
       o.mode = oimDone
       return nil
@@ -767,6 +789,11 @@ proc lastOverloadScope*(o: TOverloadIter): int =
              else: o.currentScope.depthLevel
   of oimSelfModule:  result = 1
   of oimOtherModule: result = 0
+  of oimSymChoice, oimSymChoiceLocalLookup:
+    if o.symChoiceLastPreferred:
+      result = 999
+    else:
+      result = -1
   else: result = -1
 
 proc nextOverloadIterImports(o: var TOverloadIter, c: PContext, n: PNode): PSym =
@@ -820,11 +847,15 @@ proc nextOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
         result = nextOverloadIterImports(o, c, n)
     else:
       result = nil
+    if result == nil and o.fallback != nil and o.fallback.id notin o.marked:
+      result = o.fallback
+      o.fallback = nil
   of oimSelfModule:
     result = nextIdentIter(o.it, c.topLevelScope.symbols)
   of oimOtherModule:
     result = nextModuleIter(o.mit, c.graph)
   of oimSymChoice:
+    o.symChoiceLastPreferred = false
     if o.symChoiceIndex < n.len:
       result = n[o.symChoiceIndex].sym
       incl(o.marked, result.id)
@@ -849,13 +880,15 @@ proc nextOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
     else:
       result = nil
   of oimSymChoiceLocalLookup:
+    o.symChoiceLastPreferred = false
     if o.currentScope != nil:
       result = nextIdentExcluding(o.it, o.currentScope.symbols, o.marked)
       while result == nil:
         o.currentScope = o.currentScope.parent
         if o.currentScope != nil:
+          let name = if n.kind == nkSym: n.sym.name else: n[0].sym.name
           result = firstIdentExcluding(o.it, o.currentScope.symbols,
-                                      n[0].sym.name, o.marked)
+                                       name, o.marked)
         else:
           o.importIdx = 0
           result = symChoiceExtension(o, c, n)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -141,9 +141,9 @@ proc resolveSymChoice(c: PContext, n: var PNode, flags: TExprFlags = {}, expecte
   if isSymChoice(n) and efAllowSymChoice notin flags:
     # some contexts might want sym choices preserved for later disambiguation
     # in general though they are ambiguous
-    let first = n[0].sym
+    let first = n[0]
     if nfPreferredSym in first.flags:
-      n = n[0]
+      n = first
 
 proc semSymChoice(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode =
   result = n

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3109,8 +3109,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
       result = semSymChoice(c, result, flags, expectedType)
   of nkClosedSymChoice, nkOpenSymChoice:
     result = semSymChoice(c, result, flags, expectedType)
-    if isSymChoice(result):
-      return # don't put nfSem
   of nkSym:
     let s = n.sym
     if nfOpenSym in n.flags:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3109,6 +3109,8 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
       result = semSymChoice(c, result, flags, expectedType)
   of nkClosedSymChoice, nkOpenSymChoice:
     result = semSymChoice(c, result, flags, expectedType)
+    if isSymChoice(result):
+      return # don't put nfSem
   of nkSym:
     let s = n.sym
     if nfOpenSym in n.flags:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1145,7 +1145,7 @@ proc track(tracked: PEffects, n: PNode) =
     if n.sym.typ != nil and tfHasAsgn in n.sym.typ.flags:
       tracked.owner.flags.incl sfInjectDestructors
       # bug #15038: ensure consistency
-      if not hasDestructor(n.typ) and sameType(n.typ, n.sym.typ): n.typ = n.sym.typ
+      if n.typ != nil and not hasDestructor(n.typ) and sameType(n.typ, n.sym.typ): n.typ = n.sym.typ
   of nkHiddenAddr, nkAddr:
     if n[0].kind == nkSym and isLocalSym(tracked, n[0].sym):
       useVarNoInitCheck(tracked, n[0], n[0].sym)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -81,7 +81,7 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
         # instead we allow standalone sym nodes to have nfPreferredSym
         # which acts like an open symchoice in initOverloadIter
         result.flags.incl nfPreferredSym
-        result = newTreeIT(nkOpenSymChoice, info, result.typ, result)
+        #result = newTreeIT(nkOpenSymChoice, info, result.typ, result)
         incl(s.flags, sfUsed)
         markOwnerModuleAsUsed(c, s)
     else:

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -81,7 +81,7 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
         # instead we allow standalone sym nodes to have nfPreferredSym
         # which acts like an open symchoice in initOverloadIter
         result.flags.incl nfPreferredSym
-        #result = newTreeIT(nkOpenSymChoice, info, result.typ, result)
+        result = newTreeIT(nkOpenSymChoice, info, result.typ, result)
         incl(s.flags, sfUsed)
         markOwnerModuleAsUsed(c, s)
     else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2469,13 +2469,6 @@ proc prepareOperand(c: PContext; a: PNode): PNode =
     result = a
     considerGenSyms(c, result)
 
-proc finishOperand(c: PContext; a: PNode): PNode =
-  if a.typ.isNil:
-    result = c.semExprWithType(c, a, {efOperand, efAllowSymChoice})
-  else:
-    result = a
-    considerGenSyms(c, result)
-
 proc prepareNamedParam(a: PNode; c: PContext) =
   if a[0].kind != nkIdent:
     var info = a[0].info
@@ -2717,7 +2710,7 @@ proc semFinishOperands*(c: PContext, n: PNode) =
   # this needs to be called to ensure that after overloading resolution every
   # argument has been sem'checked:
   for i in 1..<n.len:
-    n[i] = finishOperand(c, n[i])
+    n[i] = prepareOperand(c, n[i])
 
 proc partialMatch*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
   # for 'suggest' support:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -246,7 +246,8 @@ proc sumGeneric(t: PType): int =
           result += sumGeneric(a)
       break
     of tyProc:
-      result += sumGeneric(t.returnType)
+      if t.returnType != nil:
+        result += sumGeneric(t.returnType)
       for _, a in t.paramTypes:
         result += sumGeneric(a)
       break

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -38,10 +38,10 @@ proc slotsNeeded(count: Natural): int {.inline.} =
   # Make sure to synchronize with `mustRehash` above
   result = nextPowerOfTwo(count * 3 div 2 + 4)
 
-template rawGetKnownHCImpl() {.dirty.} =
+template rawGetKnownHCImpl() =
   if t.dataLen == 0:
     return -1
-  var h: Hash = hc and maxHash(t) # start with real hash value
+  var h {.inject.}: Hash = hc and maxHash(t) # start with real hash value
   while isFilled(t.data[h].hcode):
     # Compare hc THEN key with boolean short circuit. This makes the common case
     # zero ==key's for missing (e.g.inserts) and exactly one ==key for present.

--- a/tests/enum/tcrossmodule.nim
+++ b/tests/enum/tcrossmodule.nim
@@ -14,3 +14,5 @@ block: # account for scope
   doAssert x is set[MyEnum]
   proc foo[T](a: T): string = $a
   doAssert foo(Success) == "Success"
+  proc bar[T](): string = $Success
+  doAssert bar[int]() == "Success"

--- a/tests/enum/tcrossmodule.nim
+++ b/tests/enum/tcrossmodule.nim
@@ -9,7 +9,8 @@ template t =
 
 t()
 
-block: # legacy support for behavior before overloadableEnums
-  # warning: ambiguous enum field 'Success' assumed to be of type MyEnum
+block: # account for scope
   let x = {Success}
   doAssert x is set[MyEnum]
+  proc foo[T](a: T): string = $a
+  doAssert foo(Success) == "Success"

--- a/tests/lookups/mpreferredsym.nim
+++ b/tests/lookups/mpreferredsym.nim
@@ -1,0 +1,28 @@
+# foo0 has 0 overloads
+
+template myTemplate0*(): string =
+  foo0(bar)
+
+# foo1 has 1 overload
+
+proc foo1(arg: int): string =
+  "foo1 bad"
+
+template myTemplate1*(): string =
+  foo1(bar)
+
+# foo2 has 2 overloads
+
+proc foo2(arg: int): string =
+  "foo2 bad 1"
+
+proc foo2(arg: string): string =
+  "foo2 bad 2"
+
+template myTemplate2*(): string =
+  foo2(bar)
+
+proc overloadToPrefer(x: int): int = x + 1
+
+template singleOverload*: untyped =
+  (overloadToPrefer(123), overloadToPrefer("abc"))

--- a/tests/lookups/tpreferredsym.nim
+++ b/tests/lookups/tpreferredsym.nim
@@ -1,0 +1,21 @@
+import mpreferredsym
+
+block: # issue #11184
+  type MyType = object
+
+  proc foo0(arg: MyType): string = "foo0"
+  proc foo1(arg: MyType): string = "foo1"
+  proc foo2(arg: MyType): string = "foo2"
+
+  proc test() =
+    var bar: MyType
+
+    doAssert myTemplate0() == "foo0"
+    doAssert myTemplate1() == "foo1"
+    doAssert myTemplate2() == "foo2"
+
+  test()
+
+block: 
+  proc overloadToPrefer(x: string): string = x & "def"
+  doAssert singleOverload() == (124, "abcdef")

--- a/tests/template/tbaddeprecated.nim
+++ b/tests/template/tbaddeprecated.nim
@@ -1,0 +1,13 @@
+# issue #15650
+
+{.warningAsError[Deprecated]: on.}
+
+proc bar() {.deprecated.} = discard
+
+template foo() =
+  when false:
+    bar()
+  else:
+    discard
+
+foo()


### PR DESCRIPTION
fixes #11184, fixes #15650, fixes (untested) #18785, cleans up after #20457, remainder of #22744 after split off from #23091

When a sym choice is being created, if the first symbol is not ambiguous in the current scope, mark it as `nfPreferredSym`. Then when a sym choice has to be resolved and type disambiguation etc. is not enough, if the first symbol is marked `nfPreferredSym` then use it.

This fixes the shortcoming of overloadable enums that required #20457 and allows us to implement #11184, now symbols that only have 1 overload in scope in generics/templates can still receive additional overloads in instantiation scope. However just generating an open sym choice with 1 element has issues:

* The symbol `false` for example would have type `None` in generic contexts, which includes default parameter values in proc declarations (which call `semGenericStmt`), which means `proc foo(param = false)` would not be able to infer the type of `param`. 
* Adding a type to the symchoice requires skipping `nfSem` in `semExpr` and also makes the compiler not call `semSym`.
* We generate way more symchoice nodes than before which may hinder performance.

The solution in this PR is to allow standalone sym nodes to also be annotated `nfPreferredSym`, which makes them act the same as a unary `nkOpenSymChoice` during symbol lookup.