### PR TITLE
update mac CI to macos 12

### DIFF
--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-12]
         cpu: [amd64]
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,10 +29,10 @@ jobs:
 #         vmImage: 'ubuntu-18.04'
 #         CPU: i386
       OSX_amd64:
-        vmImage: 'macOS-11'
+        vmImage: 'macOS-12'
         CPU: amd64
       OSX_amd64_cpp:
-        vmImage: 'macOS-11'
+        vmImage: 'macOS-12'
         CPU: amd64
         NIM_COMPILE_TO_CPP: true
       Windows_amd64_batch0_3:


### PR DESCRIPTION
closes #23107

Could also change to `macos-latest` but nothing else in CI uses `latest` OS versions.