### PR TITLE
give typedesc param nodes type T not typedesc[T] [backport:2.0]

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2124,7 +2124,7 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       genRdVar(c, n, dest, flags)
     of skParam:
       if s.typ.kind == tyTypeDesc:
-        genTypeLit(c, s.typ, dest)
+        genTypeLit(c, s.typ.skipTypes({tyTypeDesc}), dest)
       else:
         genRdVar(c, n, dest, flags)
     of skProc, skFunc, skConverter, skMacro, skTemplate, skMethod, skIterator:

--- a/tests/vm/ttypedesc.nim
+++ b/tests/vm/ttypedesc.nim
@@ -16,3 +16,16 @@ block: # issue #15760
 
   doAssert x[SpecialBanana]() == "SpecialBanana"
   doAssert y(SpecialBanana) == "SpecialBanana"
+
+import macros
+
+block: # issue #23112
+  type Container = object
+    foo: string
+
+  proc canBeImplicit(t: typedesc) {.compileTime.} =
+    let tDesc = getType(t)
+    doAssert tDesc.kind == nnkObjectTy
+
+  static:
+    canBeImplicit(Container)

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -4,8 +4,7 @@ import os
 # bug #4462
 block:
   proc foo(t: typedesc) {.compileTime.} =
-    assert sameType(getType(t), getType(typedesc[int]))
-    assert sameType(getType(t), getType(type int))
+    assert sameType(getType(t), getType(int))
 
   static:
     foo(int)


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/23112, fixes a mistake in https://github.com/nim-lang/Nim/pull/22581

This makes `getType(t)` where `t` is a typedesc param with value `T` equal to `getType(T)`.