### PR TITLE
Asm syntax pragma

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1539,7 +1539,7 @@ proc genAsmStmt(p: BProc, t: PNode) =
   var s = newRopeAppender()
 
   var inlineAsmSyntax = ""
-  if (let p = t[0]; p).kind == nkPragma:
+  if (let p = t[0]; p.kind == nkPragma):
     for i in p:
       if whichPragma(i) == wInlineAsmSyntax:
         inlineAsmSyntax = i[1].strVal

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1538,16 +1538,16 @@ proc genAsmStmt(p: BProc, t: PNode) =
   genLineDir(p, t)
   var s = newRopeAppender()
 
-  var inlineAsmSyntax = ""
+  var asmSyntax = ""
   if (let p = t[0]; p.kind == nkPragma):
     for i in p:
-      if whichPragma(i) == wInlineAsmSyntax:
-        inlineAsmSyntax = i[1].strVal
+      if whichPragma(i) == wAsmSyntax:
+        asmSyntax = i[1].strVal
 
-  if inlineAsmSyntax != "" and 
+  if asmSyntax != "" and 
      not (
-      inlineAsmSyntax == "gcc" and hasGnuAsm in CC[p.config.cCompiler].props or
-      inlineAsmSyntax == "vcc" and hasGnuAsm notin CC[p.config.cCompiler].props):
+      asmSyntax == "gcc" and hasGnuAsm in CC[p.config.cCompiler].props or
+      asmSyntax == "vcc" and hasGnuAsm notin CC[p.config.cCompiler].props):
     localError(
       p.config, t.info, 
       "Your compiler does not support the specified inline assembler")

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1537,6 +1537,21 @@ proc genAsmStmt(p: BProc, t: PNode) =
   assert(t.kind == nkAsmStmt)
   genLineDir(p, t)
   var s = newRopeAppender()
+
+  var inlineAsmSyntax = ""
+  if (let p = t[0]; p).kind == nkPragma:
+    for i in p:
+      if whichPragma(i) == wInlineAsmSyntax:
+        inlineAsmSyntax = i[1].strVal
+
+  if inlineAsmSyntax != "" and 
+     not (
+      inlineAsmSyntax == "gcc" and hasGnuAsm in CC[p.config.cCompiler].props or
+      inlineAsmSyntax == "vcc" and hasGnuAsm notin CC[p.config.cCompiler].props):
+    localError(
+      p.config, t.info, 
+      "Your compiler does not support the specified inline assembler")
+  
   genAsmOrEmitStmt(p, t, isAsmStmt=true, s)
   # see bug #2362, "top level asm statements" seem to be a mis-feature
   # but even if we don't do this, the example in #2362 cannot possibly

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -304,7 +304,7 @@ proc pragmaAsm*(c: PContext, n: PNode): char =
         of wSubsChar:
           if it[1].kind == nkCharLit: result = chr(int(it[1].intVal))
           else: invalidPragma(c, it)
-        of wInlineAsmSyntax:
+        of wAsmSyntax:
           let s = expectStrLit(c, it)
           if s notin ["gcc", "vcc"]: invalidPragma(c, it)
         else: invalidPragma(c, it)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -153,20 +153,6 @@ proc pragmaEnsures(c: PContext, n: PNode) =
     n[1] = c.semExpr(c, n[1])
     closeScope(c)
 
-proc pragmaAsm*(c: PContext, n: PNode): char =
-  result = '\0'
-  if n != nil:
-    for i in 0..<n.len:
-      let it = n[i]
-      if it.kind in nkPragmaCallKinds and it.len == 2 and it[0].kind == nkIdent:
-        case whichKeyword(it[0].ident)
-        of wSubsChar:
-          if it[1].kind == nkCharLit: result = chr(int(it[1].intVal))
-          else: invalidPragma(c, it)
-        else: invalidPragma(c, it)
-      else:
-        invalidPragma(c, it)
-
 proc setExternName(c: PContext; s: PSym, extname: string, info: TLineInfo) =
   # special cases to improve performance:
   if extname == "$1":
@@ -306,6 +292,24 @@ proc pragmaNoForward*(c: PContext, n: PNode; flag=sfNoForward) =
   message(c.config, n.info, warnDeprecated,
           "use {.experimental: \"codeReordering\".} instead; " &
           (if flag == sfNoForward: "{.noForward.}" else: "{.reorder.}") & " is deprecated")
+
+proc pragmaAsm*(c: PContext, n: PNode): char =
+  ## Checks asm pragmas and get's the asm subschar (default: '`').
+  result = '\0'
+  if n != nil:
+    for i in 0..<n.len:
+      let it = n[i]
+      if it.kind in nkPragmaCallKinds and it.len == 2 and it[0].kind == nkIdent:
+        case whichKeyword(it[0].ident)
+        of wSubsChar:
+          if it[1].kind == nkCharLit: result = chr(int(it[1].intVal))
+          else: invalidPragma(c, it)
+        of wInlineAsmSyntax:
+          let s = expectStrLit(c, it)
+          if s notin ["gcc", "vcc"]: invalidPragma(c, it)
+        else: invalidPragma(c, it)
+      else:
+        invalidPragma(c, it)
 
 proc processCallConv(c: PContext, n: PNode) =
   if n.kind in nkPragmaCallKinds and n.len == 2 and n[1].kind == nkIdent:

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -84,7 +84,7 @@ type
     wComputedGoto = "computedGoto", wExperimental = "experimental", wDoctype = "doctype",
     wWrite = "write", wGensym = "gensym", wInject = "inject", wDirty = "dirty",
     wInheritable = "inheritable", wThreadVar = "threadvar", wEmit = "emit",
-    wAsmNoStackFrame = "asmNoStackFrame", wInlineAsmSyntax = "inlineAsmSyntax", wImplicitStatic = "implicitStatic",
+    wAsmNoStackFrame = "asmNoStackFrame", wAsmSyntax = "asmSyntax", wImplicitStatic = "implicitStatic",
     wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
     wGuard = "guard", wLocks = "locks", wPartial = "partial", wExplain = "explain",
     wLiftLocals = "liftlocals", wEnforceNoRaises = "enforceNoRaises", wSystemRaisesDefect = "systemRaisesDefect",

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -84,7 +84,7 @@ type
     wComputedGoto = "computedGoto", wExperimental = "experimental", wDoctype = "doctype",
     wWrite = "write", wGensym = "gensym", wInject = "inject", wDirty = "dirty",
     wInheritable = "inheritable", wThreadVar = "threadvar", wEmit = "emit",
-    wAsmNoStackFrame = "asmNoStackFrame", wImplicitStatic = "implicitStatic",
+    wAsmNoStackFrame = "asmNoStackFrame", wInlineAsmSyntax = "inlineAsmSyntax", wImplicitStatic = "implicitStatic",
     wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
     wGuard = "guard", wLocks = "locks", wPartial = "partial", wExplain = "explain",
     wLiftLocals = "liftlocals", wEnforceNoRaises = "enforceNoRaises", wSystemRaisesDefect = "systemRaisesDefect",

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2595,3 +2595,20 @@ method foo(x: Base) {.base.} = discard
 ```
 
 It gives an error: method `foo` can be defined only in the same module with its type (Base).
+
+
+inlineAsmSyntax pragma
+=============
+
+`inlineAsmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
+
+It prevents compiling code with different of the target CC inline asm syntax, i.e. it will not allow gcc inline asm code to be compiled with vcc.
+
+```nim
+proc nothing() =
+  asm {.inlineAsmSyntax: "gcc".}"""
+    nop
+  """
+```
+
+The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.inlineAsmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like asm and vcc-like.

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2597,18 +2597,18 @@ method foo(x: Base) {.base.} = discard
 It gives an error: method `foo` can be defined only in the same module with its type (Base).
 
 
-inlineAsmSyntax pragma
+asmSyntax pragma
 ======================
 
-`inlineAsmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
+`asmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
 
 It prevents compiling code with different of the target CC inline asm syntax, i.e. it will not allow gcc inline asm code to be compiled with vcc.
 
 ```nim
 proc nothing() =
-  asm {.inlineAsmSyntax: "gcc".}"""
+  asm {.asmSyntax: "gcc".}"""
     nop
   """
 ```
 
-The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.inlineAsmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like asm and vcc-like.
+The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.asmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like asm and vcc-like.

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2598,7 +2598,7 @@ It gives an error: method `foo` can be defined only in the same module with its 
 
 
 inlineAsmSyntax pragma
-=============
+======================
 
 `inlineAsmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
 

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2598,7 +2598,7 @@ It gives an error: method `foo` can be defined only in the same module with its 
 
 
 asmSyntax pragma
-======================
+================
 
 `asmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
 

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2600,7 +2600,7 @@ It gives an error: method `foo` can be defined only in the same module with its 
 asmSyntax pragma
 ================
 
-`asmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.
+The `asmSyntax` pragma is used to specify target inline assembler syntax in an `asm` statement.
 
 It prevents compiling code with different of the target CC inline asm syntax, i.e. it will not allow gcc inline asm code to be compiled with vcc.
 
@@ -2611,4 +2611,4 @@ proc nothing() =
   """
 ```
 
-The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.asmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like asm and vcc-like.
+The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.asmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like and vcc-like asm.


### PR DESCRIPTION
(Inspired by this pragma in nir asm PR)

`inlineAsmSyntax` pragma allowing specify target inline assembler syntax in `asm` stmt.

It prevents compiling code with different of the target CC inline asm syntax, i.e. it will not allow gcc inline asm code to be compiled with vcc.

```nim
proc nothing() =
  asm {.inlineAsmSyntax: "gcc".} """
    nop
  """
```

The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.inlineAsmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like asm and vcc-like. For implement support for gcc and for vcc at the same time in ICC compiler, we need to refactor extccomp
