### PR TITLE
retain postfix node for typed variable/routine AST; save field syms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,15 @@ rounding guarantees (via the
 - The `default` parameter of `tables.getOrDefault` has been renamed to `def` to
   avoid conflicts with `system.default`, so named argument usage for this
   parameter like `getOrDefault(..., default = ...)` will have to be changed.
+- `bindMethod` in `std/jsffi` is deprecated, don't use it with closures.
+
+- JS backend now supports lambda lifting for closures. Use `--legacy:jsNoLambdaLifting` to emulate old behavior.
+
+- `owner` in `std/macros` is deprecated.
+- Typed AST of type, variable and routine declarations including symbol
+  implementations now retain the postfix export marker node on the name.
+  Macros that examine the name node of these declarations may now need to skip
+  `nnkPostfix` nodes. 
 
 ## Standard library additions and changes
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1075,13 +1075,17 @@ proc extractPragma*(s: PSym): PNode =
     result = nil
   assert result == nil or result.kind == nkPragma
 
-proc skipPragmaExpr*(n: PNode): PNode =
-  ## if pragma expr, give the node the pragmas are applied to,
-  ## otherwise give node itself
-  if n.kind == nkPragmaExpr:
-    result = n[0]
-  else:
-    result = n
+proc skipPostfix*(n: PNode): PNode {.inline.} =
+  ## if postfix, give the operand, otherwise give node itself
+  result = n
+  if result.kind == nkPostfix: result = result[1]
+
+proc skipPragmaExpr*(n: PNode): PNode {.inline.} =
+  ## if pragma expr, take the node the pragmas are applied to,
+  ## otherwise take node itself; then skip postfix
+  result = n
+  if result.kind == nkPragmaExpr: result = result[0]
+  result = skipPostfix(result)
 
 proc setInfoRecursive*(n: PNode, info: TLineInfo) =
   ## set line info recursively

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -737,7 +737,8 @@ proc assignParam(p: BProc, s: PSym, retType: PType) =
   scopeMangledParam(p, s)
 
 proc fillProcLoc(m: BModule; n: PNode) =
-  let sym = skipPostfix(n).sym
+  let n = skipPostfix(n)
+  let sym = n.sym
   if sym.loc.k == locNone:
     fillBackendName(m, sym)
     fillLoc(sym.loc, locProc, n, OnStack)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -737,7 +737,7 @@ proc assignParam(p: BProc, s: PSym, retType: PType) =
   scopeMangledParam(p, s)
 
 proc fillProcLoc(m: BModule; n: PNode) =
-  let sym = n.sym
+  let sym = skipPostfix(n).sym
   if sym.loc.k == locNone:
     fillBackendName(m, sym)
     fillLoc(sym.loc, locProc, n, OnStack)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -805,9 +805,7 @@ proc getAllRunnableExamples(d: PDoc, n: PNode, dest: var ItemPre) =
 proc isVisible(d: PDoc; n: PNode): bool =
   result = false
   if n.kind == nkPostfix:
-    if n.len == 2 and n[0].kind == nkIdent:
-      var v = n[0].ident
-      result = v.id == ord(wStar) or v.id == ord(wMinus)
+    result = isVisible(d, n[1])
   elif n.kind == nkSym:
     # we cannot generate code for forwarded symbols here as we have no
     # exception tracking information here. Instead we copy over the comment

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1297,7 +1297,7 @@ proc exportSym(d: PDoc; s: PSym) =
                    symbolOrId])
 
 proc documentNewEffect(cache: IdentCache; n: PNode): PNode =
-  let s = n[namePos].sym
+  let s = skipPostfix(n[namePos]).sym
   if tfReturnsNew in s.typ.flags:
     result = newIdentNode(getIdent(cache, "new"), n.info)
   else:
@@ -1306,7 +1306,7 @@ proc documentNewEffect(cache: IdentCache; n: PNode): PNode =
 proc documentEffect(cache: IdentCache; n, x: PNode, effectType: TSpecialWord, idx: int): PNode =
   let spec = effectSpec(x, effectType)
   if isNil(spec):
-    let s = n[namePos].sym
+    let s = skipPostfix(n[namePos]).sym
 
     let actual = s.typ.n[0]
     if actual.len != effectListLen: return
@@ -1328,7 +1328,7 @@ proc documentEffect(cache: IdentCache; n, x: PNode, effectType: TSpecialWord, id
     result = nil
 
 proc documentWriteEffect(cache: IdentCache; n: PNode; flag: TSymFlag; pragmaName: string): PNode =
-  let s = n[namePos].sym
+  let s = skipPostfix(n[namePos]).sym
   let params = s.typ.n
 
   var effects = newNodeI(nkBracket, n.info)
@@ -1343,7 +1343,7 @@ proc documentWriteEffect(cache: IdentCache; n: PNode; flag: TSymFlag; pragmaName
     result = nil
 
 proc documentRaises*(cache: IdentCache; n: PNode) =
-  if n[namePos].kind != nkSym: return
+  if skipPostfix(n[namePos]).kind != nkSym: return
   let pragmas = n[pragmasPos]
   let p1 = documentEffect(cache, n, pragmas, wRaises, exceptionEffects)
   let p2 = documentEffect(cache, n, pragmas, wTags, tagEffects)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1126,7 +1126,7 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags, nonEx
 
   var attype = ""
   if k in routineKinds and symNameNode.kind == nkSym:
-    let att = attachToType(d, nameNode.sym)
+    let att = attachToType(d, symNameNode.sym)
     if att != nil:
       attype = esc(d.target, att.name.s)
   elif k == skType and symNameNode.kind == nkSym and

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -130,8 +130,10 @@ proc aliveCode(c: var AliveContext; g: PackedModuleGraph; tree: PackedTree; n: N
   of nkChckRangeF, nkChckRange64, nkChckRange:
     rangeCheckAnalysis(c, g, tree, n)
   of nkProcDef, nkConverterDef, nkMethodDef, nkFuncDef, nkIteratorDef:
-    if n.firstSon.kind == nkSym and isNotGeneric(n):
-      let item = tree[n.firstSon].soperand
+    var name = n.firstSon
+    if name.kind == nkPostfix: name = tree.ithSon(name, 1)
+    if name.kind == nkSym and isNotGeneric(n):
+      let item = tree[name].soperand
       if isExportedToC(c, g, item):
         # This symbol is alive and everything its body references.
         followLater(c, g, c.thisModule, item)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -170,7 +170,7 @@ proc newProc(globals: PGlobals, module: BModule, procDef: PNode,
     procDef: procDef,
     g: globals,
     extraIndent: int(procDef != nil))
-  if procDef != nil: result.prc = procDef[namePos].sym
+  if procDef != nil: result.prc = skipPostfix(procDef[namePos]).sym
 
 proc initProcOptions(module: BModule): TOptions =
   result = module.config.options

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -86,7 +86,7 @@ proc isExported(n: PNode): bool =
   ## This is meant to be used with idents in nkIdentDefs.
   case n.kind
   of nkPostfix:
-    n[0].ident.s == "*" and n[1].kind == nkIdent
+    true
   of nkPragmaExpr:
     n[0].isExported()
   else: false
@@ -1436,7 +1436,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
       let s = n[1].sym
       var ret = renderDefinitionName(s)
       ret.genSymSuffix(s)
-      put(g, tkSymbol, ret)
+      put(g, tkSymbol, ret, if renderSyms in g.flags: s else: nil)
     else:
       gsub(g, n, 1)
     if renderNoPostfix notin g.flags:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1432,7 +1432,13 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
       while i < n.len and n[i].kind notin postExprBlocks: i.inc
       postStatements(g, n, i, fromStmtList)
   of nkPostfix:
-    gsub(g, n, 1)
+    if n[1].kind == nkSym:
+      let s = n[1].sym
+      var ret = renderDefinitionName(s)
+      ret.genSymSuffix(s)
+      put(g, tkSymbol, ret)
+    else:
+      gsub(g, n, 1)
     if renderNoPostfix notin g.flags:
       gsub(g, n, 0)
   of nkRange:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -241,7 +241,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
 
     if err.sym.kind in routineKinds and err.sym.ast != nil:
       candidates.add(renderTree(err.sym.ast,
-            {renderNoBody, renderNoComments, renderNoPragmas}))
+        {renderNoBody, renderNoComments, renderNoPragmas, renderNoPostfix}))
     else:
       candidates.add(getProcHeader(c.config, err.sym, prefer))
     candidates.addDeclaredLocMaybe(c.config, err.sym)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2539,8 +2539,9 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     n[genericParamsPos] = proto.ast[genericParamsPos]
     n[paramsPos] = proto.ast[paramsPos]
     n[pragmasPos] = proto.ast[pragmasPos]
-    if n[namePos].kind != nkSym: internalError(c.config, n.info, "semProcAux")
-    n[namePos].sym = proto
+    let name = skipPostfix(n[namePos])
+    if name.kind != nkSym: internalError(c.config, n.info, "semProcAux")
+    name.sym = proto
     if importantComments(c.config) and proto.ast.comment.len > 0:
       n.comment = proto.ast.comment
     proto.ast = n             # needed for code generation
@@ -2659,7 +2660,7 @@ proc semIterator(c: PContext, n: PNode): PNode =
   # nkIteratorDef aynmore, return. The iterator then might have been
   # sem'checked already. (Or not, if the macro skips it.)
   if result.kind != n.kind: return
-  var s = result[namePos].sym
+  let s = skipPostfix(result[namePos]).sym
   var t = s.typ
   if t.returnType == nil and s.typ.callConv != ccClosure:
     localError(c.config, n.info, "iterator needs a return type")
@@ -2693,7 +2694,7 @@ proc semMethod(c: PContext, n: PNode): PNode =
   # nkIteratorDef aynmore, return. The iterator then might have been
   # sem'checked already. (Or not, if the macro skips it.)
   if result.kind != nkMethodDef: return
-  var s = result[namePos].sym
+  let s = skipPostfix(result[namePos]).sym
   # we need to fix the 'auto' return type for the dispatcher here (see tautonotgeneric
   # test case):
   let disp = getDispatcher(s)
@@ -2714,7 +2715,7 @@ proc semConverterDef(c: PContext, n: PNode): PNode =
   # nkIteratorDef aynmore, return. The iterator then might have been
   # sem'checked already. (Or not, if the macro skips it.)
   if result.kind != nkConverterDef: return
-  var s = result[namePos].sym
+  let s = skipPostfix(result[namePos]).sym
   var t = s.typ
   if t.returnType == nil: localError(c.config, n.info, errXNeedsReturnType % "converter")
   if t.len != 2: localError(c.config, n.info, "a converter takes exactly one argument")
@@ -2728,7 +2729,7 @@ proc semMacroDef(c: PContext, n: PNode): PNode =
   # nkIteratorDef aynmore, return. The iterator then might have been
   # sem'checked already. (Or not, if the macro skips it.)
   if result.kind != nkMacroDef: return
-  var s = result[namePos].sym
+  let s = skipPostfix(result[namePos]).sym
   var t = s.typ
   var allUntyped = true
   var nullary = true

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -699,7 +699,10 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   incl(s.flags, sfNoalias)
   pushOwner(c, s)
   openScope(c)
-  n[namePos] = newSymNode(s)
+  if n[namePos].kind == nkPostfix:
+    n[namePos][1] = newSymNode(s)
+  else:
+    n[namePos] = newSymNode(s)
   s.ast = n # for implicitPragmas to use
   pragmaCallable(c, s, n, templatePragmas)
   implicitPragmas(c, s, n.info, templatePragmas)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1594,8 +1594,10 @@ proc trySemObjectTypeForInheritedGenericInst(c: PContext, n: PNode, t: PType): b
 proc containsGenericInvocationWithForward(n: PNode): bool =
   if n.kind == nkSym and n.sym.ast != nil and n.sym.ast.len > 1 and n.sym.ast[2].kind == nkObjectTy:
     for p in n.sym.ast[2][^1]:
-      if p.kind == nkIdentDefs and p[1].typ != nil and p[1].typ.kind == tyGenericInvocation and
-        p[1][0].kind == nkSym and p[1][0].typ.kind == tyForward:
+      if p.kind == nkIdentDefs:
+        let pTyp = p[^2]
+        if pTyp.typ != nil and pTyp.typ.kind == tyGenericInvocation and
+            pTyp.kind == nkBracketExpr and pTyp[0].kind == nkSym and pTyp[0].typ.kind == tyForward:
           return true
   return false
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1597,7 +1597,7 @@ proc containsGenericInvocationWithForward(n: PNode): bool =
       if p.kind == nkIdentDefs:
         let pTyp = p[^2]
         if pTyp.typ != nil and pTyp.typ.kind == tyGenericInvocation and
-            pTyp.kind == nkBracketExpr and pTyp[0].kind == nkSym and pTyp[0].typ.kind == tyForward:
+            pTyp.typ[0].kind == tyForward:
           return true
   return false
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1595,9 +1595,9 @@ proc containsGenericInvocationWithForward(n: PNode): bool =
   if n.kind == nkSym and n.sym.ast != nil and n.sym.ast.len > 1 and n.sym.ast[2].kind == nkObjectTy:
     for p in n.sym.ast[2][^1]:
       if p.kind == nkIdentDefs:
-        let pTyp = p[^2]
-        if pTyp.typ != nil and pTyp.typ.kind == tyGenericInvocation and
-            pTyp.typ[0].kind == tyForward:
+        let pTyp = p[^2].typ
+        if pTyp != nil and pTyp.kind == tyGenericInvocation and
+            pTyp.base.kind == tyForward:
           return true
   return false
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -895,6 +895,16 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
         fSym.sym.ast.flags.incl nfSkipFieldChecking
       if a.kind == nkEmpty: father.add fSym
       else: a.add fSym
+      if n[i].kind == nkPragmaExpr:
+        if n[i][0].kind == nkPostfix:
+          n[i][0][1] = fSym
+        else:
+          n[i][0] = fSym
+      else:
+        if n[i].kind == nkPostfix:
+          n[i][1] = fSym
+        else:
+          n[i] = fSym
       styleCheckDef(c, f)
       onDef(f.info, f)
     if a.kind != nkEmpty: father.add a

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -194,6 +194,7 @@ proc transformVarSection(c: PTransf, v: PNode): PNode =
     elif it.kind == nkIdentDefs:
       var vn = it[0]
       if vn.kind == nkPragmaExpr: vn = vn[0]
+      if vn.kind == nkPostfix: vn = vn[1]
       if vn.kind == nkSym:
         internalAssert(c.graph.config, it.len == 3)
         let x = freshVar(c, vn.sym)
@@ -330,8 +331,10 @@ proc introduceNewLocalVars(c: PTransf, n: PNode): PNode =
     return n
   of nkProcDef: # todo optimize nosideeffects?
     result = newTransNode(n)
-    let x = newSymNode(copySym(n[namePos].sym, c.idgen))
-    c.transCon.mapping[n[namePos].sym.itemId] = x
+    var name = n[namePos]
+    if name.kind == nkPostfix: name = name[1]
+    let x = newSymNode(copySym(name.sym, c.idgen))
+    c.transCon.mapping[name.sym.itemId] = x
     result[namePos] = x # we have to copy proc definitions for iters
     for i in 1..<n.len:
       result[i] = introduceNewLocalVars(c, n[i])

--- a/tests/macros/tastrepr.nim
+++ b/tests/macros/tastrepr.nim
@@ -13,6 +13,19 @@ var
   b = 2
 type
   A* = object
+var
+  c* = 1
+  d* {.used.} = 1
+  e* = 2
+let f* = 1
+const
+  g* = 1
+proc h*() =
+  discard
+
+template i*() =
+  discard
+
 
 var data = @[(1, "one"), (2, "two")]
 for (i, d) in pairs(data):
@@ -24,6 +37,18 @@ for i, (x, y) in pairs(data):
 var (a, b) = (1, 2)
 type
   A* = object
+var
+  c* = 1
+  (d* {.used.}, e*) = (1, 2)
+let f* = 1
+const
+  g* = 1
+proc h*() =
+  discard
+
+template i*() =
+  discard
+
 
 var t04 = 1.0'f128
 t04 = 2.0'f128
@@ -52,6 +77,13 @@ echoTypedAndUntypedRepr:
     discard
   var (a,b) = (1,2)
   type A* = object # issue #22933
+  var
+    c* = 1
+    (d* {.used.}, e*) = (1, 2)
+  let f* = 1
+  const g* = 1
+  proc h*() = discard
+  template i*() = discard
 
 echoUntypedRepr:
   var t04 = 1'f128

--- a/tests/template/mexport.nim
+++ b/tests/template/mexport.nim
@@ -1,0 +1,19 @@
+import macros
+
+type
+  Storage[N: static[int]] = array[N, float32]
+  Quat* = object
+    data*: Storage[4]
+  
+proc `[]`(q: Quat, index: int): float32 = q.data[index]
+proc `[]=`(q: var Quat, index: int, value: float32) = q.data[index] = value
+
+template genAccessor(t, a, i): untyped =
+  template a*(q: t): float32 {.inject.} = q[i]
+  template `a=`*(q: var t, value: float32) {.inject.} = q[i] = value
+
+genAccessor Quat, w, 0
+genAccessor Quat, x, 1
+genAccessor Quat, y, 2
+expandMacros:
+  genAccessor Quat, z, 3

--- a/tests/template/texport.nim
+++ b/tests/template/texport.nim
@@ -1,0 +1,9 @@
+# issue #13828
+
+import mexport
+
+var a = Quat()
+a.data = [1f,2,3,4]
+a.x = 42.0
+doAssert a.x == 42
+doAssert a.z == 4


### PR DESCRIPTION
fixes #13828, refs #23101

Postfix nodes in `var`/`let`/`const`/routine nodes are now retained in typed AST, previously they would just become either an `nkSym` node or an `nkPragmaExpr` node containing the `nkSym` node. This was done for type sections in #23101 which also handled doc generation of postfix nodes. The newly generated postfix nodes get transformed back into just the symbol nodes in `transf`.

On top of this, object fields now store their symbol node in the AST. The old output of:

```nim
import macros

type Foo = object
  a: int

static:
  echo treeRepr getImpl bindSym"Foo"
```

was:

```
TypeDef
  Sym "Foo"
  Empty
  ObjectTy
    Empty
    Empty
    RecList
      IdentDefs
        Ident "a"
        Sym "int"
        Empty
```

Now the `Ident "a"` becomes `Sym "a"`, storing the symbol of the field.