### PR TITLE
try windows-2022 over windows-2019 in CI

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -43,7 +43,7 @@ jobs:
           - target: linux
             os: ubuntu-20.04
           - target: windows
-            os: windows-2019
+            os: windows-2022
           - target: osx
             os: macos-12
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,16 +36,16 @@ jobs:
         CPU: amd64
         NIM_COMPILE_TO_CPP: true
       Windows_amd64_batch0_3:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-2022'
         CPU: amd64
         # see also: `NIM_TEST_PACKAGES`
         NIM_TESTAMENT_BATCH: "0_3"
       Windows_amd64_batch1_3:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-2022'
         CPU: amd64
         NIM_TESTAMENT_BATCH: "1_3"
       Windows_amd64_batch2_3:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-2022'
         CPU: amd64
         NIM_TESTAMENT_BATCH: "2_3"
 


### PR DESCRIPTION
#23108 seems to have improved macos CI times and windows CI has been lagging behind recently, maybe we will get a speed improvement here, or at least see if updating causes any issues.