### PR TITLE
ambiguous identifier resolution

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -648,6 +648,8 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
         amb = candidates.len > 1
         if amb and checkAmbiguity in flags:
           errorUseQualifier(c, n.info, candidates)
+      else:
+        result = nil
     if result == nil and checkUndeclared in flags:
       result = errorUndeclaredIdentifierHint(c, n, ident)
     elif checkAmbiguity in flags and result != nil and amb:

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -303,8 +303,16 @@ proc isAmbiguous*(c: PContext, s: PIdent, filter: TSymKinds, sym: var PSym): boo
     # imports had a candidate but wasn't ambiguous
     return false
 
-proc errorSym*(c: PContext, n: PNode): PSym =
+proc errorSym*(c: PContext, ident: PIdent, info: TLineInfo): PSym =
   ## creates an error symbol to avoid cascading errors (for IDE support)
+  result = newSym(skError, ident, c.idgen, getCurrOwner(c), info, {})
+  result.typ = errorType(c)
+  incl(result.flags, sfDiscardable)
+  # pretend it's from the top level scope to prevent cascading errors:
+  if c.config.cmd != cmdInteractive and c.compilesContextId == 0:
+    c.moduleScope.addSym(result)
+
+proc errorSym*(c: PContext, n: PNode): PSym =
   var m = n
   # ensure that 'considerQuotedIdent' can't fail:
   if m.kind == nkDotExpr: m = m[1]
@@ -312,12 +320,7 @@ proc errorSym*(c: PContext, n: PNode): PSym =
       considerQuotedIdent(c, m)
     else:
       getIdent(c.cache, "err:" & renderTree(m))
-  result = newSym(skError, ident, c.idgen, getCurrOwner(c), n.info, {})
-  result.typ = errorType(c)
-  incl(result.flags, sfDiscardable)
-  # pretend it's from the top level scope to prevent cascading errors:
-  if c.config.cmd != cmdInteractive and c.compilesContextId == 0:
-    c.moduleScope.addSym(result)
+  result = errorSym(c, ident, n.info)
 
 type
   TOverloadIterMode* = enum
@@ -499,7 +502,7 @@ proc mustFixSpelling(c: PContext): bool {.inline.} =
   result = c.config.spellSuggestMax != 0 and c.compilesContextId == 0
     # don't slowdown inside compiles()
 
-proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
+proc fixSpelling(c: PContext, ident: PIdent, result: var string) =
   ## when we cannot find the identifier, suggest nearby spellings
   var list = initHeapQueue[SpellCandidate]()
   let name0 = ident.s.nimIdentNormalize
@@ -589,11 +592,11 @@ proc errorUndeclaredIdentifier*(c: PContext; info: TLineInfo; name: string, extr
       c.recursiveDep = ""
   localError(c.config, info, errGenerated, err)
 
-proc errorUndeclaredIdentifierHint*(c: PContext; n: PNode, ident: PIdent): PSym =
+proc errorUndeclaredIdentifierHint*(c: PContext; ident: PIdent; info: TLineInfo): PSym =
   var extra = ""
-  if c.mustFixSpelling: fixSpelling(c, n, ident, extra)
-  errorUndeclaredIdentifier(c, n.info, ident.s, extra)
-  result = errorSym(c, n)
+  if c.mustFixSpelling: fixSpelling(c, ident, extra)
+  errorUndeclaredIdentifier(c, info, ident.s, extra)
+  result = errorSym(c, ident, info)
 
 proc lookUp*(c: PContext, n: PNode): PSym =
   # Looks up a symbol. Generates an error in case of nil.
@@ -601,13 +604,13 @@ proc lookUp*(c: PContext, n: PNode): PSym =
   case n.kind
   of nkIdent:
     result = searchInScopes(c, n.ident, amb)
-    if result == nil: result = errorUndeclaredIdentifierHint(c, n, n.ident)
+    if result == nil: result = errorUndeclaredIdentifierHint(c, n.ident, n.info)
   of nkSym:
     result = n.sym
   of nkAccQuoted:
     var ident = considerQuotedIdent(c, n)
     result = searchInScopes(c, ident, amb)
-    if result == nil: result = errorUndeclaredIdentifierHint(c, n, ident)
+    if result == nil: result = errorUndeclaredIdentifierHint(c, ident, n.info)
   else:
     internalError(c.config, n.info, "lookUp")
     return nil
@@ -652,7 +655,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
       else:
         result = nil
     if result == nil and checkUndeclared in flags:
-      result = errorUndeclaredIdentifierHint(c, n, ident)
+      result = errorUndeclaredIdentifierHint(c, ident, n.info)
     elif checkAmbiguity in flags and result != nil and amb:
       result = errorUseQualifier(c, n.info, result, amb)
     c.isAmbiguous = amb
@@ -677,12 +680,12 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
           else:
             result = someSym(c.graph, m, ident)
         if result == nil and checkUndeclared in flags:
-          result = errorUndeclaredIdentifierHint(c, n[1], ident)
+          result = errorUndeclaredIdentifierHint(c, ident, n[1].info)
       elif n[1].kind == nkSym:
         result = n[1].sym
         if result.owner != nil and result.owner != m and checkUndeclared in flags:
           # dotExpr in templates can end up here
-          result = errorUndeclaredIdentifierHint(c, n[1], considerQuotedIdent(c, n[1]))
+          result = errorUndeclaredIdentifierHint(c, result.name, n[1].info)
       elif checkUndeclared in flags and
            n[1].kind notin {nkOpenSymChoice, nkClosedSymChoice}:
         localError(c.config, n[1].info, "identifier expected, but got: " &

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -621,9 +621,10 @@ type
   TLookupFlag* = enum
     checkAmbiguity, checkUndeclared, checkModule, checkPureEnumFields
 
-proc lookUpCandidates*(c: PContext, ident: PIdent): seq[PSym] =
-  const allExceptModule = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage}
-  result = searchInScopesFilterBy(c, ident, allExceptModule)
+const allExceptModule = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage}
+
+proc lookUpCandidates*(c: PContext, ident: PIdent, filter: set[TSymKind]): seq[PSym] =
+  result = searchInScopesFilterBy(c, ident, filter)
   if result.len == 0:
     result.add allPureEnumFields(c, ident)
 
@@ -642,7 +643,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
           if amb and checkAmbiguity in flags:
             errorUseQualifier(c, n.info, candidates)
     else:
-      let candidates = lookUpCandidates(c, ident)
+      let candidates = lookUpCandidates(c, ident, allExceptModule)
       if candidates.len > 0:
         result = candidates[0]
         amb = candidates.len > 1

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3033,9 +3033,9 @@ proc resolveIdent(c: PContext, ident: PIdent, resultNode: var PNode,
     # choice.len == 1 can be true here but as long as it's a symchoice
     # it's still not resolved
     if isSymChoice(choice):
+      result = nil
       if efAllowSymChoice in flags:
         resultNode = choice
-        result = nil
       else:
         errorUseQualifier(c, info, candidates)
     else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3043,10 +3043,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
           s = f.sym
           break
     if s == nil:
-      let checks = if efNoEvaluateGeneric in flags:
-          {checkUndeclared, checkPureEnumFields}
-        else:
-          {checkUndeclared, checkModule, checkPureEnumFields}
       let candidates = lookUpCandidates(c, ident)
       if candidates.len == 0:
         s = errorUndeclaredIdentifierHint(c, n, ident)
@@ -3065,6 +3061,8 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
           resolveSymChoice(c, choice, flags, expectedType)
           if choice.kind == nkSym:
             s = choice.sym
+          elif efAllowSymChoice in flags:
+            result = choice
           else:
             errorUseQualifier(c, n.info, candidates)
     if s == nil:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -153,7 +153,7 @@ proc semSymChoice(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: P
     # this only makes sense for semSymChoice
     result = result[0]
   if isSymChoice(result) and efAllowSymChoice notin flags:
-    var err = "ambiguous identifier '" & result[0].sym.name.s &
+    var err = "ambiguous identifier: '" & result[0].sym.name.s &
       "' -- use one of the following:\n"
     for child in n:
       let candidate = child.sym

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2346,8 +2346,7 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
   if arg == nil or arg.kind notin nkSymChoices:
     result = paramTypesMatchAux(m, f, a, arg, argOrig)
   else:
-    let matchSet = {skProc, skFunc, skMethod, skConverter,skIterator, skMacro,
-                    skTemplate, skEnumField}
+    let matchSet = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage, skType}
     
     var best = -1
     result = arg

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2346,6 +2346,7 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
   if arg == nil or arg.kind notin nkSymChoices:
     result = paramTypesMatchAux(m, f, a, arg, argOrig)
   else:
+    # symbol kinds that don't participate in symchoice type disambiguation:
     let matchSet = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage, skType}
     
     var best = -1

--- a/tests/enum/tambiguousoverloads.nim
+++ b/tests/enum/tambiguousoverloads.nim
@@ -9,7 +9,7 @@ block: # bug #21887
     EnumC = enum C
 
   doAssert typeof(EnumC(A)) is EnumC #[tt.Error
-                        ^ ambiguous identifier 'A' -- use one of the following:
+                        ^ ambiguous identifier: 'A' -- use one of the following:
   EnumA.A: EnumA
   EnumB.A: EnumB]#
 
@@ -21,6 +21,6 @@ block: # issue #22598
       red
 
   let a = red #[tt.Error
-          ^ ambiguous identifier 'red' -- use one of the following:
+          ^ ambiguous identifier: 'red' -- use one of the following:
   A.red: A
   B.red: B]#

--- a/tests/enum/tpure_enums_conflict.nim
+++ b/tests/enum/tpure_enums_conflict.nim
@@ -1,4 +1,5 @@
 discard """
+  disabled: true
   errormsg: "ambiguous identifier: 'amb'"
   line: 19
 """

--- a/tests/enum/tpure_enums_conflict.nim
+++ b/tests/enum/tpure_enums_conflict.nim
@@ -1,5 +1,5 @@
 discard """
-  disabled: true # pure enums behave like overloadable enums now which give a different error message
+  disabled: true # pure enums behave like overloaded enums on ambiguity now which gives a different error message
   errormsg: "ambiguous identifier: 'amb'"
   line: 19
 """

--- a/tests/enum/tpure_enums_conflict.nim
+++ b/tests/enum/tpure_enums_conflict.nim
@@ -1,5 +1,5 @@
 discard """
-  disabled: true
+  disabled: true # pure enums behave like overloadable enums now which give a different error message
   errormsg: "ambiguous identifier: 'amb'"
   line: 19
 """

--- a/tests/errmsgs/t8064.nim
+++ b/tests/errmsgs/t8064.nim
@@ -5,5 +5,5 @@ values
 
 discard """
   # either this or "expression has no type":
-  errormsg: "ambiguous identifier 'values' -- use one of the following:"
+  errormsg: "ambiguous identifier: 'values' -- use one of the following:"
 """

--- a/tests/lookups/tambiguousemit.nim
+++ b/tests/lookups/tambiguousemit.nim
@@ -7,6 +7,6 @@ proc foo(x: int) = discard
 proc foo(x: float) = discard
 
 {.emit: ["// ", foo].} #[tt.Error
-                ^ ambiguous identifier 'foo' -- use one of the following:
+                ^ ambiguous identifier: 'foo' -- use one of the following:
   tambiguousemit.foo: proc (x: int){.noSideEffect, gcsafe.}
   tambiguousemit.foo: proc (x: float){.noSideEffect, gcsafe.}]#

--- a/tests/lookups/tambprocvar.nim
+++ b/tests/lookups/tambprocvar.nim
@@ -2,7 +2,7 @@ discard """
   action: reject
   cmd: "nim check $file"
   nimout: '''
-tambprocvar.nim(15, 11) Error: ambiguous identifier 'foo' -- use one of the following:
+tambprocvar.nim(15, 11) Error: ambiguous identifier: 'foo' -- use one of the following:
   tambprocvar.foo: proc (x: int){.noSideEffect, gcsafe.}
   tambprocvar.foo: proc (x: float){.noSideEffect, gcsafe.}
 '''
@@ -16,4 +16,4 @@ block:
 
 block:
   let x = `+` #[tt.Error
-           ^ ambiguous identifier '+' -- use one of the following:]#
+           ^ ambiguous identifier: '+' -- use one of the following:]#

--- a/tests/lookups/tambprocvar.nim
+++ b/tests/lookups/tambprocvar.nim
@@ -16,4 +16,4 @@ block:
 
 block:
   let x = `+` #[tt.Error
-           ^ ambiguous identifier: '+' -- use one of the following:]#
+          ^ ambiguous identifier: '+' -- use one of the following:]#

--- a/tests/lookups/tambsym3.nim
+++ b/tests/lookups/tambsym3.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "ambiguous identifier 'mDec' -- use one of the following:"
+  errormsg: "ambiguous identifier: 'mDec' -- use one of the following:"
   file: "tambsym3.nim"
   line: 11
 """

--- a/tests/macros/t23032_2.nim
+++ b/tests/macros/t23032_2.nim
@@ -1,6 +1,6 @@
 discard """
   action: "reject"
-  errormsg: "ambiguous identifier '%*'"
+  errormsg: "ambiguous identifier: '%*'"
 """
 import std/macros
 

--- a/tests/pragmas/monoff1.nim
+++ b/tests/pragmas/monoff1.nim
@@ -1,0 +1,1 @@
+proc on*() = discard

--- a/tests/pragmas/tonoff1.nim
+++ b/tests/pragmas/tonoff1.nim
@@ -1,0 +1,8 @@
+# issue #23002
+
+import monoff1
+
+proc test() =
+  {.warning[ProveInit]: on.}
+
+test()

--- a/tests/pragmas/tonoff2.nim
+++ b/tests/pragmas/tonoff2.nim
@@ -1,0 +1,14 @@
+discard """
+    action: compile
+"""
+
+# issue #22841
+
+import unittest
+
+proc on() =
+    discard
+
+suite "some suite":
+    test "some test":
+        discard


### PR DESCRIPTION
fixes #23002, fixes #22841, refs comments in #23097

When an identifier is ambiguous in scope (i.e. multiple imports contain symbols with the same name), attempt resolving it through type inference (by creating a symchoice).  To do this efficiently, `qualifiedLookUp` had to be broken up so that `semExpr` can access the ambiguous candidates directly (now obtained directly via `lookUpCandidates`). 

This fixes the linked issues, but an example like:

```nim
let on = 123

{.warning[ProveInit]: on.}
```

will still fail, since `on` is unambiguously the local `let` symbol here (this is also true for `proc on` but `proc` symbols generate symchoices anyway).

Type symbols are not considered to not confuse the type inference. This includes the change in sigmatch, up to this point symchoices with nonoverloadable symbols could be created, they just wouldn't be considered during disambiguation. Now every proper symbol except types are considered in disambiguation, so the correct symbols must be picked during the creation of the symchoice node. I remember there being a violating case of this in the compiler, but this was very likely fixed by excluding type symbols as CI seems to have found no issues.

The pure enum ambiguity test was disabled because ambiguous pure enums now behave like overloadable enums with this behavior, so we get a longer error message for `echo amb` like `type mismatch: got <MyEnum | OtherEnum> but expected T`