### PR TITLE
Allow hashing procs in JS backend

### DIFF
--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -185,7 +185,6 @@ proc `and`*(x, y: JsObject): JsObject {.importjs: "(# && #)".}
 proc `or`*(x, y: JsObject): JsObject {.importjs: "(# || #)".}
 proc `not`*(x:    JsObject): JsObject {.importjs: "(!#)".}
 proc `in`*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
-proc `notin`*(x, y: JsObject): JsObject {.importjs: "!(# in #)".}
 
 proc `[]`*(obj: JsObject, field: cstring): JsObject {.importjs: getImpl.}
   ## Returns the value of a property of name `field` from a JsObject `obj`.

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -184,7 +184,7 @@ proc `**`*(x, y: JsObject): JsObject {.importjs: "((#) ** #)".}
 proc `and`*(x, y: JsObject): JsObject {.importjs: "(# && #)".}
 proc `or`*(x, y: JsObject): JsObject {.importjs: "(# || #)".}
 proc `not`*(x:    JsObject): JsObject {.importjs: "(!#)".}
-proc `in`*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
+proc contains*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
 
 proc `[]`*(obj: JsObject, field: cstring): JsObject {.importjs: getImpl.}
   ## Returns the value of a property of name `field` from a JsObject `obj`.

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -185,6 +185,7 @@ proc `and`*(x, y: JsObject): JsObject {.importjs: "(# && #)".}
 proc `or`*(x, y: JsObject): JsObject {.importjs: "(# || #)".}
 proc `not`*(x:    JsObject): JsObject {.importjs: "(!#)".}
 proc `in`*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
+proc `notin`*(x, y: JsObject): JsObject {.importjs: "!(# in #)".}
 
 proc `[]`*(obj: JsObject, field: cstring): JsObject {.importjs: getImpl.}
   ## Returns the value of a property of name `field` from a JsObject `obj`.

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -184,7 +184,8 @@ proc `**`*(x, y: JsObject): JsObject {.importjs: "((#) ** #)".}
 proc `and`*(x, y: JsObject): JsObject {.importjs: "(# && #)".}
 proc `or`*(x, y: JsObject): JsObject {.importjs: "(# || #)".}
 proc `not`*(x:    JsObject): JsObject {.importjs: "(!#)".}
-proc contains*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
+proc `in`*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
+template `notin`*(x, y: JsObject): JsObject = not (x in y)
 
 proc `[]`*(obj: JsObject, field: cstring): JsObject {.importjs: getImpl.}
   ## Returns the value of a property of name `field` from a JsObject `obj`.

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -218,7 +218,7 @@ when defined(js):
   var objectID = 0
   proc getObjectId(x: pointer): int =
     asm """
-      if (typeof `x` == "object") {
+      if (typeof `x` == "object" || typeof `x` == "function") {
         if ("_NimID" in `x`)
           `result` = `x`["_NimID"];
         else {
@@ -540,7 +540,10 @@ proc hash*[T: tuple | object | proc | iterator {.closure.}](x: T): Hash =
     outer()
 
   when T is "closure":
-    result = hash((rawProc(x), rawEnv(x)))
+    when defined(js):
+      result = hash(rawProc(x))
+    else:
+      result = hash((rawProc(x), rawEnv(x)))
   elif T is (proc):
     result = hash(cast[pointer](x))
   else:

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -216,7 +216,7 @@ else:
 
 when defined(js):
   var objectID = 0
-  proc getObjectId(x: pointer): int =
+  proc getObjectId*(x: pointer | proc): int =
     asm """
       if (typeof `x` == "object" || typeof `x` == "function") {
         if ("_NimID" in `x`)
@@ -539,11 +539,10 @@ proc hash*[T: tuple | object | proc | iterator {.closure.}](x: T): Hash =
       assert hash(fn2) != hash(fn1)
     outer()
 
-  when T is "closure":
-    when defined(js):
-      result = hash(rawProc(x))
-    else:
-      result = hash((rawProc(x), rawEnv(x)))
+  when defined(js) and (T is "closure" or T is proc):
+    result = hash(getObjectId(x))
+  elif T is "closure":
+    result = hash((rawProc(x), rawEnv(x)))
   elif T is (proc):
     result = hash(cast[pointer](x))
   else:

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -597,8 +597,7 @@ when defined(js):
 
   proc getObjectId(x: pointer | proc): int =
     var obj = x.toJS()
-    if jsTypeof(obj) in ["object".cstring, "function".cstring]:
-      if (idKey.toJS notin obj).to(bool):
-        objectID += 1
-        obj[idKey] = objectID
-      return obj[idKey].to(int)
+    if (idKey.toJS() notin obj).to(bool):
+      objectID += 1
+      obj[idKey] = objectID
+    return obj[idKey].to(int)

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -216,7 +216,7 @@ else:
 
 when defined(js):
   var objectID = 0
-  proc getObjectId*(x: pointer | proc): int =
+  proc getObjectId(x: pointer | proc): int =
     asm """
       if (typeof `x` == "object" || typeof `x` == "function") {
         if ("_NimID" in `x`)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2352,8 +2352,6 @@ when notJSnotNims:
     {.emit: """
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
-elif defined(js):
-  func rawProc*(prc: proc {.closure.}): pointer {.importjs: "[@, 0]".}
 
 from std/private/digitsutils import addInt
 export addInt

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2352,6 +2352,8 @@ when notJSnotNims:
     {.emit: """
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
+elif defined(js):
+  func rawProc*(prc: proc {.closure.}): pointer {.importjs: "[@, 0]".}
 
 from std/private/digitsutils import addInt
 export addInt

--- a/tests/js/tprochash.nim
+++ b/tests/js/tprochash.nim
@@ -1,0 +1,22 @@
+import std/sets
+
+proc foo(x: int): proc (): int =
+  result = proc (): int = x
+
+proc bar(): int = 9
+
+let
+  x = foo(9)
+  y = foo(1)
+  z = bar
+  procs = [x, y, z]
+
+var all = initHashSet[proc (): int]()
+for p in procs:
+  all.incl p
+  assert p in all
+
+
+
+
+

--- a/tests/js/tprochash.nim
+++ b/tests/js/tprochash.nim
@@ -1,4 +1,4 @@
-import std/sets
+import std/[sets, hashes]
 
 proc foo(x: int): proc (): int =
   result = proc (): int = x
@@ -13,10 +13,6 @@ let
 
 var all = initHashSet[proc (): int]()
 for p in procs:
+  assert p notin all
   all.incl p
   assert p in all
-
-
-
-
-


### PR DESCRIPTION
Procs can now be hashed in the JS backend (Which had issues before due to `rawProc` not being defined). Uses `getObjectId` instead of defining `rawProc` since using `rawProc` would cause problems with the hash being different even with the same function.

Also refactors `std/jsffi` to use `std/macrocache` to remove a cyclic dependency occuring