### PR TITLE
fixes #23162; streams module fails to compile when using -d:useNimRTL and -mm:arc

### DIFF
--- a/lib/system/strs_v2.nim
+++ b/lib/system/strs_v2.nim
@@ -190,7 +190,7 @@ proc nimPrepareStrMutationImpl(s: var NimStringV2) =
   s.p.cap = s.len
   copyMem(unsafeAddr s.p.data[0], unsafeAddr oldP.data[0], s.len+1)
 
-proc nimPrepareStrMutationV2(s: var NimStringV2) {.compilerRtl, inl.} =
+proc nimPrepareStrMutationV2(s: var NimStringV2) {.compilerRtl, inl, raises: [], tags: [].} =
   if s.p != nil and (s.p.cap and strlitFlag) == strlitFlag:
     nimPrepareStrMutationImpl(s)
 

--- a/tests/arc/t16458.nim
+++ b/tests/arc/t16458.nim
@@ -2,5 +2,7 @@ discard """
   matrix: "--gc:orc --d:useNimRtl"
   action: "compile"
 """
-
+# bug #23162
+# bug #16458
+import streams
 echo 134


### PR DESCRIPTION
fixes #23162

`{.pragma: compilerRtl, compilerproc, importc: "nimrtl_$1", dynlib: nimrtl.}` contains `importc`, which will create empty Exception and Tag lists in the sempass2 for function types. So I enforce `raises: [], tags: []` on this specific function.
