### PR TITLE
fixes #23167; take `nkOpenSymChoice` into consideration caused by templates [backport]

### DIFF
--- a/compiler/modulepaths.nim
+++ b/compiler/modulepaths.nim
@@ -38,12 +38,16 @@ proc getModuleName*(conf: ConfigRef; n: PNode): string =
           localError(n.info, "only '/' supported with $package notation")
           result = ""
     else:
-      if n0.kind == nkIdent and n0.ident.s[0] == '/':
-        let modname = getModuleName(conf, n[2])
-        # hacky way to implement 'x / y /../ z':
-        result = getModuleName(conf, n1)
-        result.add renderTree(n0, {renderNoComments}).replace(" ")
-        result.add modname
+      if n0.kind in nkIdentKinds:
+        let ident = n0.getPIdent
+        if ident != nil and ident.s[0] == '/':
+          let modname = getModuleName(conf, n[2])
+          # hacky way to implement 'x / y /../ z':
+          result = getModuleName(conf, n1)
+          result.add renderTree(n0, {renderNoComments}).replace(" ")
+          result.add modname
+        else:
+          result = ""
       else:
         result = ""
   of nkPrefix:

--- a/tests/import/t23167.nim
+++ b/tests/import/t23167.nim
@@ -1,0 +1,5 @@
+# bug #23167
+template sharedImport() =
+  import std / os
+
+sharedImport()


### PR DESCRIPTION
fixes #23167