### PR TITLE
test unlocking paramTypesMatch for templates and macros

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1575,7 +1575,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
 
   track(t, body)
 
-  if s.kind != skMacro:
+  if s.kind notin {skMacro, skTemplate}:
     let params = s.typ.n
     for i in 1..<params.len:
       let param = params[i].sym

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -694,7 +694,7 @@ proc procTypeRel(c: var TCandidate, f, a: PType): TTypeRelation =
     elif a[0] != nil:
       return isNone
 
-    result = getProcConvMismatch(c.c.config, f, a, result)[1]
+    result = getProcConvMismatch(c.c.config, f, a, result, c.calleeSym != nil and c.calleeSym.kind in {skTemplate, skMacro})[1]
 
     when useEffectSystem:
       if compatibleEffects(f, a) != efCompat: return isNone
@@ -2172,7 +2172,8 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     m.calleeSym.kind in {skMacro, skTemplate}:
     # XXX: duplicating this is ugly, but we cannot (!) move this
     # directly into typeRel using return-like templates
-    if f.kind in {tyTyped, tyUntyped, tyTypeDesc}:
+    if f.kind in {tyTyped, tyUntyped, tyTypeDesc,
+        tyVar, tyLent, tySink, tyOpenArray}:
       incMatches(m, r)
       return arg
     elif f.kind == tyStatic and arg.typ.n != nil:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2172,10 +2172,11 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     m.calleeSym.kind in {skMacro, skTemplate}:
     # XXX: duplicating this is ugly, but we cannot (!) move this
     # directly into typeRel using return-like templates
-    incMatches(m, r)
     if f.kind in {tyTyped, tyUntyped, tyTypeDesc}:
+      incMatches(m, r)
       return arg
     elif f.kind == tyStatic and arg.typ.n != nil:
+      incMatches(m, r)
       return arg.typ.n
 
   # If r == isBothMetaConvertible then we rerun typeRel.

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2173,14 +2173,10 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     # XXX: duplicating this is ugly, but we cannot (!) move this
     # directly into typeRel using return-like templates
     incMatches(m, r)
-    if f.kind == tyTyped:
-      return arg
-    elif f.kind == tyTypeDesc:
+    if f.kind in {tyTyped, tyUntyped, tyTypeDesc}:
       return arg
     elif f.kind == tyStatic and arg.typ.n != nil:
       return arg.typ.n
-    else:
-      return argSemantized # argOrig
 
   # If r == isBothMetaConvertible then we rerun typeRel.
   # bothMetaCounter is for safety to avoid any infinite loop,

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -211,7 +211,7 @@ when defined(nimHasStyleChecks):
 when defined(posix) and not defined(lwip):
   from std/posix import TPollfd, POLLIN, POLLPRI, POLLOUT, POLLWRBAND, Tnfds
 
-  template monitorPollEvent(x: var SocketHandle, y: cint, timeout: int): int =
+  template monitorPollEvent(x: var SocketHandle, y: cshort, timeout: int): int =
     var tpollfd: TPollfd
     tpollfd.fd = cast[cint](x)
     tpollfd.events = y

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -81,7 +81,7 @@ proc runeLenAt*(s: openArray[char], i: Natural): int =
 
 const replRune = Rune(0xFFFD)
 
-template fastRuneAt*[I: Ordinal](s: openArray[char] or string, i: var I, result: untyped, doInc = true) =
+template fastRuneAt*(s: openArray[char] or string, i: typed, result: untyped, doInc = true) =
   ## Returns the rune ``s[i]`` in ``result``.
   ##
   ## If ``doInc == true`` (default), ``i`` is incremented by the number

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -81,7 +81,7 @@ proc runeLenAt*(s: openArray[char], i: Natural): int =
 
 const replRune = Rune(0xFFFD)
 
-template fastRuneAt*(s: openArray[char] or string, i: int, result: untyped, doInc = true) =
+template fastRuneAt*(s: openArray[char] or string, i: var int, result: untyped, doInc = true) =
   ## Returns the rune ``s[i]`` in ``result``.
   ##
   ## If ``doInc == true`` (default), ``i`` is incremented by the number

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -81,7 +81,7 @@ proc runeLenAt*(s: openArray[char], i: Natural): int =
 
 const replRune = Rune(0xFFFD)
 
-template fastRuneAt*(s: openArray[char] or string, i: var int, result: untyped, doInc = true) =
+template fastRuneAt*[I: Ordinal](s: openArray[char] or string, i: var I, result: untyped, doInc = true) =
   ## Returns the rune ``s[i]`` in ``result``.
   ##
   ## If ``doInc == true`` (default), ``i`` is incremented by the number

--- a/tests/template/ttypedarg.nim
+++ b/tests/template/ttypedarg.nim
@@ -1,0 +1,9 @@
+block: # issue #18667
+  template fn(b: seq[string]) =
+    let d = $(b, )
+  fn(@[])
+
+block: # issue #18667
+  template fn(b: seq[string]) =
+    let d = $b
+  fn(@[])


### PR DESCRIPTION
fixes #18667

Chronos failure is likely caused by `sink T` [here](https://github.com/status-im/nim-chronos/blob/e15dc3b41fea95348b58f32244962c1c6df310a7/chronos/internal/asyncfutures.nim#L212)

Normalize: [this](https://github.com/nitely/nim-normalize/blob/06f715f0dbea5e238c91f3a298d26d89a2f7c31b/src/normalize.nim#L643) needs to use `var int32` - done

Note: #5030, #12780, #21813, #22881 should have been fixed but maybe weren't if I didn't mention them, related #2459 probably not fixed here because `tyOpenArray` is disabled