### PR TITLE
trigger range check with new type inference on nkIntLit [backport:1.6]

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3147,17 +3147,15 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
         # or: result = fitNode(c, expectedType, result, n.info)
   of nkIntLit:
     if result.typ == nil:
+      setIntLitType(c, result)
       if expectedType != nil and (
           let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
           expected.kind in {tyInt..tyInt64,
             tyUInt..tyUInt64,
             tyFloat..tyFloat128}):
-        result.typ = expected
         if expected.kind in {tyFloat..tyFloat128}:
           n.transitionIntToFloatKind(nkFloatLit)
         changeType(c, result, expectedType, check=true)
-      else:
-        setIntLitType(c, result)
   of nkInt8Lit: directLiteral(tyInt8)
   of nkInt16Lit: directLiteral(tyInt16)
   of nkInt32Lit: directLiteral(tyInt32)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -630,7 +630,7 @@ proc changeType(c: PContext; n: PNode, newType: PType, check: bool) =
           a.add m
           changeType(m, tup[i], check)
   of nkCharLit..nkUInt64Lit:
-    if check and n.kind != nkUInt64Lit and not sameType(n.typ, newType):
+    if check and n.kind != nkUInt64Lit and not sameTypeOrNil(n.typ, newType):
       let value = n.intVal
       if value < firstOrd(c.config, newType) or value > lastOrd(c.config, newType):
         localError(c.config, n.info, "cannot convert " & $value &
@@ -3147,7 +3147,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
         # or: result = fitNode(c, expectedType, result, n.info)
   of nkIntLit:
     if result.typ == nil:
-      setIntLitType(c, result)
       if expectedType != nil and (
           let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
           expected.kind in {tyInt..tyInt64,
@@ -3156,6 +3155,8 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
         if expected.kind in {tyFloat..tyFloat128}:
           n.transitionIntToFloatKind(nkFloatLit)
         changeType(c, result, expectedType, check=true)
+      else:
+        setIntLitType(c, result)
   of nkInt8Lit: directLiteral(tyInt8)
   of nkInt16Lit: directLiteral(tyInt16)
   of nkInt32Lit: directLiteral(tyInt32)

--- a/tests/overflow/twronginference.nim
+++ b/tests/overflow/twronginference.nim
@@ -1,0 +1,10 @@
+discard """
+  errormsg: "cannot convert 256 to int8"
+  line: 9
+"""
+
+# issue #23177
+
+var x: int8
+x = 256
+echo x # 0


### PR DESCRIPTION
fixes #23177

`changeType` doesn't perform range checks to see if the expression fits the new type [if the old type is the same as the new type](https://github.com/nim-lang/Nim/blob/62d8ca43063197272968b4acf8c7a1ef27874c54/compiler/semexprs.nim#L633). For `nkIntLit`, we previously set the type to the concrete base of the expected type first, then call `changeType`, which works for things like range types but not bare types of smaller bit size like `int8`. Now we don't set the type (so the type is nil), and `changeType` performs the range check when the type is unset (nil).