### PR TITLE
2.0 branch fixes: no LineTooLong, update macos CI

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -47,7 +47,7 @@ jobs:
           - target: windows
             os: windows-2019
           - target: osx
-            os: macos-11
+            os: macos-12
 
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-12]
         cpu: [amd64]
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,10 +29,10 @@ jobs:
 #         vmImage: 'ubuntu-18.04'
 #         CPU: i386
       OSX_amd64:
-        vmImage: 'macOS-11'
+        vmImage: 'macOS-12'
         CPU: amd64
       OSX_amd64_cpp:
-        vmImage: 'macOS-11'
+        vmImage: 'macOS-12'
         CPU: amd64
         NIM_COMPILE_TO_CPP: true
       Windows_amd64_batch0_3:

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -158,3 +158,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimAllowNonVarDestructor")
   defineSymbol("nimHasQuirky")
   defineSymbol("nimHasEnsureMove")
+  defineSymbol("nimHasNoLineTooLong")


### PR DESCRIPTION
Adapts #23108 to the version-2-0 branch and makes the 2.0 compiler define `nimHasNoLineTooLong` as the devel compiler depends on it to not turn off `hint[LineTooLong]`, which means the 2.0 compiler errors on the devel compiler config (as mentioned in https://github.com/nim-lang/Nim/issues/23178#issuecomment-1880511322).

Would have these as separate PRs but the macos CI PR would have to be merged first, then the second PR would have to be rebased.