### PR TITLE
Nim manual: better byref pragma explanation

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8576,7 +8576,7 @@ When applied to a type it instructs the compiler to pass the type by reference
 if the the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
 parameters are marked as `byref` in an `importc` proc, these params translate to pointers.
 When an `importcpp` type has a `byref` pragma, these params translate to
-cpp references `&`.
+C++ references `&`.
 
   ```Nim
   {.emit: """/*TYPESECTION*/

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8575,7 +8575,7 @@ When applied to a type it instructs the compiler to pass the type by reference
 (hidden pointer) to procs. When applied to a param it will take precedence, even
 if the the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
 parameters are marked as `byref` in an `importc` proc, these params translate to pointers.
-When a `importcpp` type has `byref` pragma, these params will translate to
+When an `importcpp` type has a `byref` pragma, these params translate to
 cpp references `&`.
 
   ```Nim

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8574,7 +8574,7 @@ The `byref` pragma can be applied to an object or tuple type or a proc param.
 When applied to a type it instructs the compiler to pass the type by reference
 (hidden pointer) to procs. When applied to a param it will take precedence, even
 if the the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
-params are marked as `byref` in `importc` proc, these params will translate to pointers.
+parameters are marked as `byref` in an `importc` proc, these params translate to pointers.
 When a `importcpp` type has `byref` pragma, these params will translate to
 cpp references `&`.
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8574,8 +8574,9 @@ The `byref` pragma can be applied to an object or tuple type or a proc param.
 When applied to a type it instructs the compiler to pass the type by reference
 (hidden pointer) to procs. When applied to a param it will take precedence, even
 if the the type was marked as `bycopy`. When a `importc` type has `byref` pragma or
-params marked as `byref` in `importc` proc, these params will translate to pointers.
-When a `importcpp` type has `byref` pragma, these params will translate to cpp references `&`.
+params are marked as `byref` in `importc` proc, these params will translate to pointers.
+When a `importcpp` type has `byref` pragma, these params will translate to
+cpp references `&`.
 
   ```Nim
   {.emit: """/*TYPESECTION*/

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8573,7 +8573,7 @@ Byref pragma
 The `byref` pragma can be applied to an object or tuple type or a proc param.
 When applied to a type it instructs the compiler to pass the type by reference
 (hidden pointer) to procs. When applied to a param it will take precedence, even
-if the the type was marked as `bycopy`. When a `importc` type has `byref` pragma or
+if the the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
 params are marked as `byref` in `importc` proc, these params will translate to pointers.
 When a `importcpp` type has `byref` pragma, these params will translate to
 cpp references `&`.


### PR DESCRIPTION
Nim manual says:
> When using the Cpp backend, params marked as byref will translate to cpp references `&`

But how `byref` pragma translate to depends on whether it is used with `importc` or `importcpp`.
When `byref` pragma used with `importc` types and compiled with the Cpp backend, it is not traslated to cpp reference `&`.
