### PR TITLE
treat generic proc param/return type like generic type body

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1485,17 +1485,25 @@ proc tryReadingGenericParam(c: PContext, n: PNode, i: PIdent, t: PType): PNode =
   of tyGenericInst:
     result = readTypeParameter(c, t, i, n.info)
     if result == c.graph.emptyNode:
-      result = semGenericStmt(c, n)
-      result.typ = makeTypeFromExpr(c, result.copyTree)
+      if c.inGenericContext > 0:
+        result = semGenericStmt(c, n)
+        result.typ = makeTypeFromExpr(c, result.copyTree)
+      else:
+        result = nil
   of tyUserTypeClasses:
     if t.isResolvedUserTypeClass:
       result = readTypeParameter(c, t, i, n.info)
-    else:
+    elif c.inGenericContext > 0:
       result = semGenericStmt(c, n)
       result.typ = makeTypeFromExpr(c, copyTree(result))
+    else:
+      result = nil
   elif t.containsGenericType:
-    result = semGenericStmt(c, n)
-    result.typ = makeTypeFromExpr(c, copyTree(result))
+    if c.inGenericContext > 0:
+      result = semGenericStmt(c, n)
+      result.typ = makeTypeFromExpr(c, copyTree(result))
+    else:
+      result = nil
   else:
     result = nil
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1482,7 +1482,7 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
 
 proc tryReadingGenericParam(c: PContext, n: PNode, i: PIdent, t: PType): PNode =
   case t.kind
-  of tyTypeParamsHolders:
+  of tyGenericInst:
     result = readTypeParameter(c, t, i, n.info)
     if result == c.graph.emptyNode:
       result = semGenericStmt(c, n)
@@ -1493,7 +1493,7 @@ proc tryReadingGenericParam(c: PContext, n: PNode, i: PIdent, t: PType): PNode =
     else:
       result = semGenericStmt(c, n)
       result.typ = makeTypeFromExpr(c, copyTree(result))
-  of tyFromExpr, tyGenericParam, tyAnything:
+  elif t.containsGenericType:
     result = semGenericStmt(c, n)
     result.typ = makeTypeFromExpr(c, copyTree(result))
   else:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -738,7 +738,8 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
         result.setIndexType result.indexType.skipTypes({tyStatic, tyDistinct})
 
       of tyStatic:
-        if not cl.allowMetaTypes and result.n != nil:
+        if not cl.allowMetaTypes and result.n != nil and
+            result.base.kind != tyNone:
           if result.n.kind notin nkLiterals:
             result.n = cl.c.semConstExpr(cl.c, result.n)
 

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -690,6 +690,9 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
     propagateToOwner(result, result.last)
 
   else:
+    if cl.c.matchedConcept != nil and t.kind == tyStatic:
+      # allow concepts to not instantiate statics for now
+      return
     if containsGenericType(t):
       #if not cl.allowMetaTypes:
       bailout()
@@ -736,7 +739,8 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
 
       of tyStatic:
         if not cl.allowMetaTypes and result.n != nil:
-          result.n = cl.c.semConstExpr(cl.c, result.n)
+          if result.n.kind notin nkLiterals:
+            result.n = cl.c.semConstExpr(cl.c, result.n)
 
       else: discard
     else:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -678,7 +678,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
     elif t.elementType.kind != tyNone:
       result = makeTypeDesc(cl.c, replaceTypeVarsT(cl, t.elementType))
 
-  of tyUserTypeClass, tyStatic:
+  of tyUserTypeClass:#, tyStatic:
     result = t
 
   of tyGenericInst, tyUserTypeClassInst:
@@ -733,6 +733,10 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
 
       of tyRange:
         result.setIndexType result.indexType.skipTypes({tyStatic, tyDistinct})
+
+      of tyStatic:
+        if not cl.allowMetaTypes and result.n != nil:
+          result.n = cl.c.semConstExpr(cl.c, result.n)
 
       else: discard
     else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -967,7 +967,7 @@ proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =
     else: discard
 
   elif lhs.kind == nkSym and lhs.typ.kind == tyStatic and
-      idTableGet(c.bindings, lhs.typ) == nil:
+      (lhs.typ.n == nil or idTableGet(c.bindings, lhs.typ) == nil):
     var inferred = newTypeS(tyStatic, c.c, lhs.typ.elementType)
     inferred.n = newIntNode(nkIntLit, rhs)
     put(c, lhs.typ, inferred)
@@ -1880,7 +1880,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           if result != isNone and f.n != nil:
             var r = tryResolvingStaticExpr(c, f.n)
             if r == nil: r = f.n
-            if not exprStructuralEquivalent(f.n, aOrig.n) and
+            if not exprStructuralEquivalent(r, aOrig.n) and
                 not (aOrig.n.kind == nkIntLit and
                   inferStaticParam(c, r, aOrig.n.intVal)):
               result = isNone

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2188,7 +2188,11 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
         a = typ
       else:
         if m.callee.kind == tyGenericBody:
-          if f.kind == tyStatic and typeRel(m, f.base, a) != isNone:
+          # we can't use `makeStaticExpr` if `arg` has a generic type
+          # because it generates `tyStatic`, which semtypinst doesn't touch
+          # not sure if checking for `tyFromExpr` is enough
+          if f.kind == tyStatic and typeRel(m, f.base, a) != isNone and
+              a.kind != tyFromExpr:
             result = makeStaticExpr(m.c, arg)
             result.typ.flags.incl tfUnresolved
             result.typ.n = arg

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1874,9 +1874,12 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           # faulty instantiations in calls in generic bodies
           # but not for generic invocations as they only check constraints
           result = isNone
-        elif f.base.kind == tyNone:
-          result = isGeneric
-        elif f.base.containsGenericType:
+        elif f.base.kind notin {tyNone, tyGenericParam}:
+          result = typeRel(c, f.base, a, flags)
+          if result != isNone and f.n != nil:
+            if not exprStructuralEquivalent(f.n, aOrig.n):
+              result = isNone
+        elif f.base.kind == tyGenericParam:
           # Handling things like `type A[T; Y: static T] = object`
           if f.base.len > 0: # There is a constraint, handle it
             result = typeRel(c, f.base.last, a, flags)
@@ -1888,10 +1891,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
               # for things like `proc fun[T](a: static[T])`
               result = typeRel(c, f.base, a, flags)
         else:
-          result = typeRel(c, f.base, a, flags)
-          if result != isNone and f.n != nil:
-            if not exprStructuralEquivalent(f.n, aOrig.n):
-              result = isNone
+          result = isGeneric
         if result != isNone: put(c, f, aOrig)
       elif aOrig.n != nil and aOrig.n.typ != nil:
         result = if f.base.kind != tyNone:

--- a/tests/generics/t23854.nim
+++ b/tests/generics/t23854.nim
@@ -63,7 +63,8 @@ template getBits[bits: static int](x: ptr UncheckedArray[BigInt[bits]]): int = b
 
 proc main() =
   let ctx = ECFFT_Descriptor[EC_ShortW_Aff[Fp[BLS12_381]]].new()
-  when false: echo getBits(ctx.rootsOfUnity2) # doesn't work yet?
+  doAssert getBits(ctx.rootsOfUnity1) == 255
+  doAssert getBits(ctx.rootsOfUnity2) == 255
   doAssert ctx.rootsOfUnity1[0].limbs.len == wordsRequired(255)
   doAssert ctx.rootsOfUnity2[0].limbs.len == wordsRequired(255)
 

--- a/tests/generics/t23855.nim
+++ b/tests/generics/t23855.nim
@@ -55,7 +55,7 @@ template getBits[bits: static int](x: ptr UncheckedArray[BigInt[bits]]): int = b
 
 proc main() =
   let ctx = ECFFT_Descriptor[EC_ShortW_Aff[Fp[BLS12_381]]].new()
-  when false: echo getBits(ctx.rootsOfUnity) # doesn't work yet?
+  doAssert getBits(ctx.rootsOfUnity) == 255
   doAssert ctx.rootsOfUnity[0].limbs.len == wordsRequired(255)
 
 main()

--- a/tests/misc/t8545.nim
+++ b/tests/misc/t8545.nim
@@ -14,7 +14,7 @@ proc main() =
   proc foo2(a: static[bool]): bar(a) = 1
   doAssert foo2(true) == 1
 
-  proc foo3(a: static[bool]): bar(cast[static[bool]](a)) = 1
+  proc foo3(a: static[bool]): bar(cast[bool](a)) = 1
   doAssert foo3(true) == 1
 
   proc foo4(a: static[bool]): bar(static(a)) = 1

--- a/tests/misc/t8545.nim
+++ b/tests/misc/t8545.nim
@@ -1,8 +1,3 @@
-discard """
-  # just tests that this doesn't crash the compiler
-  errormsg: "cannot instantiate: 'a:type'"
-"""
-
 # bug #8545
 
 template bar(a: static[bool]): untyped = int

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -147,3 +147,22 @@ block: # issue #7008
   implicitGenericProc1(n, 5) # works
   explicitGenericProc1(n, 5) # works
   explicitGenericProc2(n, 5) # doesn't
+
+block: # issue #20027
+  block:
+    type Test[T] = object
+    proc run(self: Test): self.T = discard
+    discard run(Test[int]())
+  block:
+    type Test[T] = object
+    proc run[T](self: Test[T]): self.T = discard
+    discard run(Test[int]())
+  block:
+    type Test[T] = object
+    proc run(self: Test[auto]): self.T = discard
+    discard run(Test[int]())
+
+block: # issue #11112
+  proc foo[A, B]: type(A.default + B.default) =
+    discard
+  doAssert foo[int, int]() is int

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -1,0 +1,71 @@
+when false: # issue #22607, needs proper nkWhenStmt handling
+  proc test[x: static bool](
+    t: (
+      when x:
+        int
+      else:
+        float
+      )
+  ) = discard
+  test[true](1.int)
+  test[false](1.0)
+  doAssert not compiles(test[])
+
+block: # expanded version of t8545
+  template bar(a: static[bool]): untyped =
+    when a:
+      int
+    else:
+      float
+
+  proc main() =
+    proc foo1(a: static[bool]): auto = 1
+    doAssert foo1(true) == 1
+
+    proc foo2(a: static[bool]): bar(a) = 1
+    doAssert foo2(true) == 1
+    doAssert foo2(true) is int
+    doAssert foo2(false) == 1.0
+    doAssert foo2(false) is float
+
+    proc foo3(a: static[bool]): bar(cast[bool](a)) = 1
+    doAssert foo3(true) == 1
+    doAssert foo3(true) is int
+    doAssert foo3(false) == 1.0
+    doAssert foo3(false) is float
+
+    proc foo4(a: static[bool]): bar(static(a)) = 1
+    doAssert foo4(true) == 1
+    doAssert foo4(true) is int
+    doAssert foo4(false) == 1.0
+    doAssert foo4(false) is float
+
+  static: main()
+  main()
+
+block: # issue #8406
+  macro f(x: static[int]): untyped = discard
+  proc g[X: static[int]](v: f(X)) = discard
+
+import macros
+
+block: # issue #8551
+  macro distinctBase2(T: typedesc): untyped =
+    let typeNode = getTypeImpl(T)
+    expectKind(typeNode, nnkBracketExpr)
+    if typeNode[0].typeKind != ntyTypeDesc:
+      error "expected typeDesc, got " & $typeNode[0]
+    var typeSym = typeNode[1]
+
+    typeSym = getTypeImpl(typeSym)
+
+    if typeSym.typeKind != ntyDistinct:
+      error "type is not distinct: " & $typeSym.typeKind
+
+    typeSym = typeSym[0]
+    typeSym
+
+  func distinctBase[T](a: T): distinctBase2(T) = distinctBase2(T)(a)
+
+  type T = distinct int
+  doAssert distinctBase(T(0)) is int

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -1,4 +1,4 @@
-when false: # issue #22607, needs proper nkWhenStmt handling
+when false: # issue #22607, needs nkWhenStmt to be handled like nkRecWhen
   proc test[x: static bool](
     t: (
       when x:


### PR DESCRIPTION
fixes #4228, fixes #7006, fixes #7008, fixes #8406, fixes #8551, fixes #11112, fixes #20027, fixes #22647 (maybe not entirely by the end, `N * 2` needs the `tyStatic` change which might cause problems), refs #8545, refs #22607