### PR TITLE
fixes #12334; keeps `nkHiddenStdConv` for cstring conversions

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -339,6 +339,8 @@ proc fitRemoveHiddenConv(c: PContext, typ: PType, n: PNode): PNode =
       result.typ = typ
       if not floatRangeCheck(result.floatVal, typ):
         localError(c.config, n.info, errFloatToString % [$result.floatVal, typeToString(typ)])
+    elif r1.kind == nkSym and typ.skipTypes(abstractRange).kind == tyCstring:
+      discard "keep nkHiddenStdConv for cstring conversions"
     else:
       changeType(c, r1, typ, check=true)
       result = r1

--- a/tests/vm/tconst.nim
+++ b/tests/vm/tconst.nim
@@ -42,6 +42,16 @@ template main() =
       discard (x, increment, a)
     mytemp()
 
+  block: # bug #12334
+    block:
+      const b: cstring = "foo"
+      var c = b
+      doAssert c == "foo"
+    block:
+      const a = "foo"
+      const b: cstring = a
+      var c = b
+      doAssert c == "foo"
 
 
 static: main()


### PR DESCRIPTION
fixes #12334

`nkHiddenStdConv` shouldn't be removed if the sources aren't literals, viz. constant symbols.