### PR TITLE
fixes #23223; prevents `insert` self-assignment

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2520,6 +2520,8 @@ when hasAlloc or defined(nimscript):
     ##   var a = "abc"
     ##   a.insert("zz", 0) # a <- "zzabc"
     ##   ```
+    if item.len == 0: # prevents self-assignment
+      return
     var xl = x.len
     setLen(x, xl+item.len)
     var j = xl-1

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -212,3 +212,10 @@ block:
   doAssert not compiles(echo p.rawProc.repr)
   doAssert not compiles(echo p.rawEnv.repr)
   doAssert not compiles(echo p.finished)
+
+proc bug23223 = # bug #23223
+  var stuff = "hello"
+  stuff.insert ""
+  doAssert stuff == "hello"
+
+bug23223()


### PR DESCRIPTION
fixes #23223