### PR TITLE
fix(#23231): add nimdoc.cls to installer script

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -147,4 +147,4 @@ licenses: "bin/nim,MIT;lib/*,MIT;"
 
 [nimble]
 pkgName: "nim"
-pkgFiles: "compiler/*;doc/basicopt.txt;doc/advopt.txt;doc/nimdoc.css"
+pkgFiles: "compiler/*;doc/basicopt.txt;doc/advopt.txt;doc/nimdoc.css;doc/nimdoc.cls"


### PR DESCRIPTION
Change to `compiler/installer.ini` to add `nimdoc.cls` to files copied by installer script.

Closes #23231 