### PR TITLE
Add `get(Option[T], var T): bool` procedure

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -240,8 +240,7 @@ template `?=`*[T](self: Option[T], x: untyped): bool =
     if container ?= x:
       assert x == 1337
 
-  var y: T
-  unpack(x, y)
+  unpack(self, x)
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -226,10 +226,21 @@ proc unpack*[T](self: Option[T], val: out T): bool {.inline.} =
 
   if not self.isSome:
     val = default(T)
-    return false
+    false
+  else:
+    val = self.get()
+    true
 
-  val = self.get()
-  true
+template `?=`*[T](x: untyped, self: Option[T]): bool =
+  ## Unpacks the contents of the `Option` into a value name provided if there are any, and returns true.
+  ## Otherwise, returns false and no value is created.
+  runnableExamples:
+    var container = some(1337)
+
+    if container ?= x:
+      assert x == 1337
+
+  unpack(self, x)
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -240,8 +240,8 @@ template `?=`*[T](self: Option[T], x: untyped): bool =
     if container ?= x:
       assert x == 1337
 
-  var x: T
-  unpack(y, x)
+  var y: T
+  unpack(x, y)
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -215,9 +215,9 @@ proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
   else:
     otherwise
 
-proc unpack*[T](self: Option[T], val: var T): bool {.inline.} =
+proc unpack*[T](self: Option[T], val: out T): bool {.inline.} =
   ## Unpacks the contents of the `Option` if there are any, and returns true.
-  ## Otherwise, it simply returns false.
+  ## Otherwise, it simply returns false and sets the value to its default one.
   runnableExamples:
     var storage: int
 
@@ -225,10 +225,23 @@ proc unpack*[T](self: Option[T], val: var T): bool {.inline.} =
       assert storage == 1337
 
   if not self.isSome:
+    val = default(T)
     return false
 
   val = self.get()
   true
+
+template `?=`*[T](self: Option[T], x: untyped): bool =
+  ## Unpacks the contents of the `Option` into a value name provided if there are any, and returns true.
+  ## Otherwise, returns false and no value is created.
+  runnableExamples:
+    var container = some(1337)
+
+    if container ?= x:
+      assert x == 1337
+
+  var x: T
+  unpack(y, x)
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -231,7 +231,7 @@ proc unpack*[T](self: Option[T], val: out T): bool {.inline.} =
     val = self.get()
     true
 
-template `?=`*[T](x: untyped, self: Option[T]): bool =
+template `?=`*[T](x: untyped{ident}, self: Option[T]): bool =
   ## Unpacks the contents of the `Option` into a value name provided if there are any, and returns true.
   ## Otherwise, returns false and no value is created.
   runnableExamples:

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -241,6 +241,7 @@ template `?=`*[T](x: untyped, self: Option[T]): bool =
       assert x == 1337
 
   unpack(self, x)
+  true
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -215,6 +215,21 @@ proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
   else:
     otherwise
 
+proc get*[T](self: Option[T], val: var T): bool {.inline.} =
+  ## Gets the content of the `Option`, stores it in `val` and returns true if the `Option` has a value.
+  ## Otherwise, it simply returns false.
+  runnableExamples:
+    var storage: int
+
+    if some(1337).get(storage):
+      assert storage == 1337
+
+  if not self.isSome:
+    return false
+
+  val = self.get()
+  true
+
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,
   ## an `UnpackDefect` exception is raised.

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -235,9 +235,10 @@ template `?=`*[T](x: untyped, self: Option[T]): bool =
   ## Unpacks the contents of the `Option` into a value name provided if there are any, and returns true.
   ## Otherwise, returns false and no value is created.
   runnableExamples:
-    var container = some(1337)
+    let container = some(1337)
+    var store: int
 
-    if container ?= x:
+    if store ?= container:
       assert x == 1337
 
   unpack(self, x)

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -215,8 +215,8 @@ proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
   else:
     otherwise
 
-proc get*[T](self: Option[T], val: var T): bool {.inline.} =
-  ## Gets the content of the `Option`, stores it in `val` and returns true if the `Option` has a value.
+proc unpack*[T](self: Option[T], val: var T): bool {.inline.} =
+  ## Unpacks the contents of the `Option` if there are any, and returns true.
   ## Otherwise, it simply returns false.
   runnableExamples:
     var storage: int

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -236,11 +236,11 @@ template `?=`*[T](x: untyped{ident}, self: Option[T]): bool =
   ## Otherwise, returns false and no value is created.
   runnableExamples:
     let container = some(1337)
-    var store: int
 
     if store ?= container:
-      assert x == 1337
-
+      assert store == 1337
+  
+  var x: T
   unpack(self, x)
 
 proc get*[T](self: var Option[T]): var T {.inline.} =

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -221,7 +221,7 @@ proc unpack*[T](self: Option[T], val: var T): bool {.inline.} =
   runnableExamples:
     var storage: int
 
-    if some(1337).get(storage):
+    if some(1337).unpack(storage):
       assert storage == 1337
 
   if not self.isSome:

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -231,17 +231,6 @@ proc unpack*[T](self: Option[T], val: out T): bool {.inline.} =
   val = self.get()
   true
 
-template `?=`*[T](self: Option[T], x: untyped): bool =
-  ## Unpacks the contents of the `Option` into a value name provided if there are any, and returns true.
-  ## Otherwise, returns false and no value is created.
-  runnableExamples:
-    var container = some(1337)
-
-    if container ?= x:
-      assert x == 1337
-
-  unpack(self, x)
-
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,
   ## an `UnpackDefect` exception is raised.

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -241,7 +241,6 @@ template `?=`*[T](x: untyped, self: Option[T]): bool =
       assert x == 1337
 
   unpack(self, x)
-  true
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns the content of the `var Option` mutably. If it has no value,

--- a/tests/stdlib/toptions.nim
+++ b/tests/stdlib/toptions.nim
@@ -195,6 +195,19 @@ proc main() =
         let x = none(cstring)
         doAssert x.isNone
         doAssert $x == "none(cstring)"
+    
+    # Store option's value in a variable, and return a bool
+    block:
+      let
+        x = some(1984)
+        y = none(int)
+
+      var a, b: int
+
+      doAssert x.get(a)
+      doAssert a == 1984
+
+      doAssert not y.get(b)
 
 static: main()
 main()

--- a/tests/stdlib/toptions.nim
+++ b/tests/stdlib/toptions.nim
@@ -204,10 +204,10 @@ proc main() =
 
       var a, b: int
 
-      doAssert x.get(a)
+      doAssert x.unpack(a)
       doAssert a == 1984
 
-      doAssert not y.get(b)
+      doAssert not y.unpack(b)
 
 static: main()
 main()


### PR DESCRIPTION
This PR adds a new procedure to `std/options` that takes in an `Option[T]` and a `var T`, and if the `Option` is not empty, then it stores its contents into the `var T` and returns true. If it is empty, it simply returns false. I've also added a test for this. It works a bit like this:

```nim
import std/options

var v: string

let opt = some("Nim rocks!")

# This will be true, as `opt` is not empty.
if opt.get(v):
    doAssert v == "Nim rocks!"
```
