### PR TITLE
Update cmdline.nim, fix broken (dragged) doc-reference for getAppFile…

### DIFF
--- a/lib/std/cmdline.nim
+++ b/lib/std/cmdline.nim
@@ -181,7 +181,7 @@ when defined(nimdoc):
     ## Similarly to `argv`:idx: in C,
     ## it is possible to call `paramStr(0)` but this will return OS specific
     ## contents (usually the name of the invoked executable). You should avoid
-    ## this and call `getAppFilename()`_ instead.
+    ## this and call `getAppFilename() <os.html#getAppFilename>`_ instead.
     ##
     ## **Availability**: When generating a dynamic library (see `--app:lib`) on
     ## Posix this proc is not defined.
@@ -192,7 +192,7 @@ when defined(nimdoc):
     ## * `parseCmdLine proc`_
     ## * `paramCount proc`_
     ## * `commandLineParams proc`_
-    ## * `getAppFilename proc`_
+    ## * `getAppFilename proc <os.html#getAppFilename>`_
     ##
     ## **Examples:**
     ##
@@ -282,7 +282,7 @@ when declared(paramCount) or defined(nimdoc):
     ## Convenience proc which returns the command line parameters.
     ##
     ## This returns **only** the parameters. If you want to get the application
-    ## executable filename, call `getAppFilename()`_.
+    ## executable filename, call `getAppFilename() <os.html#getAppFilename>`_.
     ##
     ## **Availability**: On Posix there is no portable way to get the command
     ## line from a DLL and thus the proc isn't defined in this environment. You
@@ -294,7 +294,7 @@ when declared(paramCount) or defined(nimdoc):
     ## * `parseCmdLine proc`_
     ## * `paramCount proc`_
     ## * `paramStr proc`_
-    ## * `getAppFilename proc`_
+    ## * `getAppFilename proc <os.html#getAppFilename>`_
     ##
     ## **Examples:**
     ##


### PR DESCRIPTION


In doc, there are 4 references for `getAppFilename`

`getAppFilename` is still in `os`, but the references refer it as if it's in the current module `cmdline`