### PR TITLE
Fix nimsuggest highlight for import statements

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -307,7 +307,15 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
     if belongsToStdlib(c.graph, result) and not startsWith(moduleName, stdPrefix) and
         not startsWith(moduleName, "system/") and not startsWith(moduleName, "packages/"):
       message(c.config, n.info, warnStdPrefix, realModule.name.s)
-    suggestSym(c.graph, n.info, result, c.graph.usageSym, false)
+
+    proc suggestMod(n: PNode; s: PSym) =
+      if n.kind == nkImportAs:
+        suggestMod(n[0], realModule)
+      elif n.kind == nkInfix:
+        suggestMod(n[2], s)
+      else:
+        suggestSym(c.graph, n.info, s, c.graph.usageSym, false)
+    suggestMod(n, result)
     importStmtResult.add newSymNode(result, n.info)
     #newStrNode(toFullPath(c.config, f), n.info)
   else:

--- a/nimsuggest/tests/timport_highlight.nim
+++ b/nimsuggest/tests/timport_highlight.nim
@@ -1,0 +1,12 @@
+import std/paths
+import json as J
+import std/[os,streams]#[!]#
+
+discard """
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skModule;;1;;11;;5
+highlight;;skModule;;2;;7;;4
+highlight;;skModule;;3;;12;;2
+highlight;;skModule;;3;;15;;7
+"""


### PR DESCRIPTION
Currently, I don't have syntax highlighting (+ no/wrong jump-to-definition) for some import statement forms, namely:

- `import module/name/with/(slashes)`
- `import (mod) as alias`
- `import basemod/[ (sub1), (sub2) ]`

With this patch, highlight/def will work for the regions indicated by parentheses.