### PR TITLE
Docs-improve: os.getCurrentCompilerExe  replace with clearer short-desc

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -453,7 +453,7 @@ proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
       c_free(cast[pointer](r))
 
 proc getCurrentCompilerExe*(): string {.compileTime.} = discard
-  ## This is `getAppFilename()`_ at compile time.
+  ## Returns the current Nim compiler path or nimble executable path.
   ##
   ## Can be used to retrieve the currently executing
   ## Nim compiler from a Nim or nimscript program, or the nimble binary

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -453,7 +453,7 @@ proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
       c_free(cast[pointer](r))
 
 proc getCurrentCompilerExe*(): string {.compileTime.} = discard
-  ## Returns the current Nim compiler path or nimble executable path.
+  ## Returns the path of the currently running Nim compiler or nimble executable.
   ##
   ## Can be used to retrieve the currently executing
   ## Nim compiler from a Nim or nimscript program, or the nimble binary


### PR DESCRIPTION
The doc for `getCurrentCompilerExe`  was originally added at [this commit](https://github.com/nim-lang/Nim/commit/c4e3c4ca2d0a1f44ed1e3dd9db564b66031f0843), saying "`getAppFilename` at CT", and modified as "This is `getAppFilename()`_ at compile time..." since [this](https://github.com/nim-lang/Nim/commit/0c2c2dca2a8a3bcdb9729021d1f4734b8db9efbd#diff-8ed10106605d9e0e3f28a927432acd8312e96791c96dbb126a52a7010cf4b44a)

Which means "at compile time, get result innerly from Nim compiler via `getAppFilename`", not "get from nim programs".

Thus, the doc was confusing, only mentioning `compile time` and `getAppFilename`