### PR TITLE
fixes #22798; Duplicate libraries linker warning (i.e., '-lm') on macOS

### DIFF
--- a/lib/pure/fenv.nim
+++ b/lib/pure/fenv.nim
@@ -12,7 +12,7 @@
 ## The types, vars and procs are bindings for the C standard library
 ## [<fenv.h>](https://en.cppreference.com/w/c/numeric/fenv) header.
 
-when defined(posix) and not defined(genode):
+when defined(posix) and not defined(genode) and not defined(macosx):
   {.passl: "-lm".}
 
 var

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -155,7 +155,7 @@ func fac*(n: int): int =
 
 {.push checks: off, line_dir: off, stack_trace: off.}
 
-when defined(posix) and not defined(genode):
+when defined(posix) and not defined(genode) and not defined(macosx):
   {.passl: "-lm".}
 
 const


### PR DESCRIPTION
fixes #22798

Per https://stackoverflow.com/questions/33675638/gcc-link-the-math-library-by-default-in-c-on-mac-os-x and https://stackoverflow.com/questions/30694042/c-std-library-dont-appear-to-be-linked-in-object-file

> There's no separate math library on OSX. While a lot of systems ship functions in the standard C math.h header in a separate math library, OSX does not do that, it's part of the libSystem library, which is always linked in.

required by https://github.com/nim-lang/Nim/pull/23290