### PR TITLE
Fixes a nimsuggest crash when using chronos

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -58,10 +58,8 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
       ]#
       for paramSym in searchInScopesAllCandidatesFilterBy(c, symx.name, {skConst}):
         let paramTyp = paramSym.typ
-        if paramTyp.sym == nil and paramTyp.n.kind == nkIntLit: continue 
         if paramTyp.n.sym.kind in filter:
           result.add((paramTyp.n.sym, o.lastOverloadScope))
-
 
     symx = nextOverloadIter(o, c, headSymbol)
   if result.len > 0:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -58,7 +58,8 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
       ]#
       for paramSym in searchInScopesAllCandidatesFilterBy(c, symx.name, {skConst}):
         let paramTyp = paramSym.typ
-        if paramTyp.sym != nil and paramTyp.n.sym.kind in filter:
+        if paramTyp.sym == nil and paramTyp.n.kind == nkIntLit: continue 
+        if paramTyp.n.sym.kind in filter:
           result.add((paramTyp.n.sym, o.lastOverloadScope))
 
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -58,7 +58,7 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
       ]#
       for paramSym in searchInScopesAllCandidatesFilterBy(c, symx.name, {skConst}):
         let paramTyp = paramSym.typ
-        if paramTyp.n.sym.kind in filter:
+        if paramTyp.sym != nil and paramTyp.n.sym.kind in filter:
           result.add((paramTyp.n.sym, o.lastOverloadScope))
 
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -58,7 +58,7 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
       ]#
       for paramSym in searchInScopesAllCandidatesFilterBy(c, symx.name, {skConst}):
         let paramTyp = paramSym.typ
-        if paramTyp.n.sym.kind in filter:
+        if paramTyp.n.kind == nkSym and paramTyp.n.sym.kind in filter:
           result.add((paramTyp.n.sym, o.lastOverloadScope))
 
     symx = nextOverloadIter(o, c, headSymbol)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2180,6 +2180,10 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     else:
       let symKind = if n.kind == nkIteratorTy: skIterator else: skProc
       result = semProcTypeWithScope(c, n, prev, symKind)
+      if result == nil:
+        localError(c.config, n.info, "type expected, but got: " & renderTree(n))
+        result = newOrPrevType(tyError, prev, c)
+
       if n.kind == nkIteratorTy and result.kind == tyProc:
         result.flags.incl(tfIterator)
       if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:


### PR DESCRIPTION
The following would crash nimsuggest on init:
```nim
import chronos
type
  HistoryQuery = object
    start: int
    limit: int

  HistoryResult = object
    messages: string

type HistoryQueryHandler* = proc(req: HistoryQuery): Future[HistoryResult] {.async, gcsafe.}
```