### PR TITLE
`varargs[typed]` should behave more like `typed`

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2689,8 +2689,10 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
             else:
               incrIndexType(container.typ)
             container.add n[a]
+            f = max(f, formalLen - n.len + a + 1)
           elif m.baseTypeMatch:
             assert formal.typ.kind == tyVarargs
+            #assert(container == nil)
             if container.isNil:
               container = newNodeIT(nkBracket, n[a].info, arrayConstr(c, arg))
               container.typ.flags.incl tfVarargs

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2359,8 +2359,10 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
     
     var best = -1
     result = arg
-    
-    if f.kind in {tyTyped, tyUntyped}:
+    var chkType = f.kind
+    if chkType == tyVarargs:
+      chkType = f.base.kind
+    if chkType in {tyTyped, tyUntyped}:
       var
         bestScope = -1
         counts = 0

--- a/tests/types/tissues_types.nim
+++ b/tests/types/tissues_types.nim
@@ -106,3 +106,10 @@ block:
     let t = Foo[float](x1: 1)
     doAssert t.x1 == 1
 
+block:
+  template s(d: varargs[typed])=discard
+
+  proc something()=discard
+  proc something(x:int)=discard
+
+  s(something)

--- a/tests/types/tissues_types.nim
+++ b/tests/types/tissues_types.nim
@@ -109,7 +109,10 @@ block:
 block:
   template s(d: varargs[typed])=discard
 
-  proc something()=discard
+  proc something(x:float)=discard
   proc something(x:int)=discard
+  proc otherthing()=discard
 
   s(something)
+  s(otherthing, something)
+  s(something, otherthing)


### PR DESCRIPTION
This fixes an oversight with a change that I made a while ago.

Basically, these two snippets should both compile. Currently the `varargs` version will fail.

```nim
template s(d: typed)=discard
proc something()=discard
proc something(x:int)=discard

s(something)
```

```nim
template s(d: varargs[typed])=discard
proc something()=discard
proc something(x:int)=discard

s(something)
```

Potentially unrelated, but this works currently for some reason:
```nim
template s(a: varargs[typed])=discard
proc something()=discard
proc something(x:int)=discard

s:
  something
```

also, this works:
```nim
template s(b:untyped, a: varargs[typed])=discard
proc something()=discard
proc something(x:int)=discard

s (g: int):
  something
```
but this doesn't, and the error message is not what I would expect:
```nim
template s(b:untyped, a: varargs[typed])=discard
proc something()=discard
proc something(x:int)=discard

s (g: int), something
```

So far as I can tell, none of these issues persist for me after the code changes in this PR.