### PR TITLE
assume a module's usage if it contains a passC/passL/compile pragma w…

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1129,13 +1129,20 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wFatal: fatal(c.config, it.info, expectStrLit(c, it))
       of wDefine: processDefine(c, it, sym)
       of wUndef: processUndef(c, it)
-      of wCompile: processCompile(c, it)
+      of wCompile:
+        let m = sym.getModule()
+        incl(m.flags, sfUsed)
+        processCompile(c, it)
       of wLink: processLink(c, it)
       of wPassl:
+        let m = sym.getModule()
+        incl(m.flags, sfUsed)
         let s = expectStrLit(c, it)
         extccomp.addLinkOption(c.config, s)
         recordPragma(c, it, "passl", s)
       of wPassc:
+        let m = sym.getModule()
+        incl(m.flags, sfUsed)
         let s = expectStrLit(c, it)
         extccomp.addCompileOption(c.config, s)
         recordPragma(c, it, "passc", s)


### PR DESCRIPTION
…hich conveys effects beyond its module scope for C/C++ codegen(suppresses current UnusedImport warning)

Just a minor inconvenience working in the area of C/C++ integration I guess, but here we go:

I noticed receiving ```UnusedImport``` warnings for modules having only ```passC```/```passL```/```compile``` pragmas around. I gather the compiler cannot actually infer those modules being unused as they *may* have consequences for the whole build process (as they did in my simple case).

Thus, I hereby suggest adding the `sfUsed` flag to the respective module in order to suppress the compiler's warning.

I reckon other pragmas should be put into consideration as well: I will keep up the investigation with PR followups.