### PR TITLE
make use of C++11's auto type deduction for temporary variables

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -574,7 +574,7 @@ proc getTempCpp(p: BProc, t: PType, value: Rope): TLoc =
   inc(p.labels)
   result = TLoc(r: "T" & rope(p.labels) & "_", k: locTemp, lode: lodeTyp t,
                 storage: OnStack, flags: {})
-  linefmt(p, cpsStmts, "$1 $2 = $3;$n", [getTypeDesc(p.module, t, dkVar), result.r, value])
+  linefmt(p, cpsStmts, "auto $1 = $2;$n", [result.r, value])
 
 proc getIntTemp(p: BProc): TLoc =
   inc(p.labels)


### PR DESCRIPTION
This is just one of those tiny steps towards the goal of an "optimized" C and C++ codegen I raised elsewhere before - what does me babbling "optimized" mainly entail?

(not mutually-exclusive ascertainment proposals following:)

- less and simplified resulting code: easier to pick up/grasp for the C/C++ compiler for to do its own optimization heuristics, less parsing effort for us mere humans trying to debug, especially in the case of interop
- build time reduction: less code emission I/O, runtime string formatting for output...
- easier access for fresh contributors and better maintainability
- interop improvements
- further runtime optimizations

I am eagerly looking forward to the results of the LLVM-based undertakings, but I also think we can do a bit better (as outlined above) with our current C/C++ backends till those come to fruition.

**Long story short**: this PR here focuses on the C++ backend, augmenting the current codegen method of establishing "temporary" variables by using C++11's auto type deduction. The reasons for adopting an "Almost Always Auto" style have been collected [here ](https://herbsutter.com/2013/08/12/gotw-94-solution-aaa-style-almost-always-auto/) for the C++ world. For those hopping between C++'s and Nim's realms, this change also results in a bit less code and less work for the codegen part (no redundant `getTypeDesc`s): no need to tell the C++ compiler the type it already knows of (in most cases).