### PR TITLE
Dont mangle when targeting cpp

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -71,7 +71,7 @@ proc mangleProc(m: BModule; s: PSym; makeUnique: bool): string =
 proc fillBackendName(m: BModule; s: PSym) =
   if s.loc.r == "":
     var result: Rope
-    if s.kind in routineKinds and optCDebug in m.g.config.globalOptions and
+    if not m.compileToCpp and s.kind in routineKinds and optCDebug in m.g.config.globalOptions and
       m.g.config.symbolFiles == disabledSf: 
       result = mangleProc(m, s, false).rope
     else:

--- a/tests/codegen/titaniummangle.nim
+++ b/tests/codegen/titaniummangle.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c cpp"
+  targets: "c"
   matrix: "--debugger:native"
   ccodecheck: "'_ZN14titaniummangle8testFuncE'"
   ccodecheck: "'_ZN14titaniummangle8testFuncE6stringN14titaniummangle3FooE'"


### PR DESCRIPTION
Unfortunately we cant trick the debugger when targeting C++ so this one also needs to wait for our own debugger adapter. 