### PR TITLE
Add strutils.join for set type

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1887,6 +1887,17 @@ proc join*[T: not string](a: openArray[T], sep: string = ""): string =
       add(result, sep)
     add(result, $x)
 
+proc join*[T](a: set[T], sep: string = ""): string =
+  ## Converts all elements in the container `a` to strings using `$`,
+  ## and concatenates them with `sep`.
+  result = ""
+  var i = 0
+  for x in a:
+    if i > 0:
+      add(result, sep)
+    add(result, $x)
+    inc i
+
 type
   SkipTable* = array[char, int] ## Character table for efficient substring search.
 

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -888,6 +888,7 @@ bar
     doAssert join(@["foo", "bar", "baz"], ", ") == "foo, bar, baz"
     doAssert join([1, 2, 3]) == "123"
     doAssert join(@[1, 2, 3], ", ") == "1, 2, 3"
+    doAssert join({1, 2, 3}, ", ") == "1, 2, 3"
 
   block: # startsWith / endsWith
     var s = "abcdef"


### PR DESCRIPTION
Seems like an oversight not to have strutils.join for `set` types, so here is an implementation.