### PR TITLE
fixes #20945; fixes #18262; provides C API `NimDestroyGlobals` for static/dynlib libraries

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2195,12 +2195,12 @@ proc updateCachedModule(m: BModule) =
   addFileToCompile(m.config, cf)
 
 proc generateLibraryDestroyGlobals(graph: ModuleGraph; m: BModule; body: PNode; isDynlib: bool): PSym =
-  let procname = getIdent(graph.cache, "nimDestroyGlobals")
+  let procname = getIdent(graph.cache, "NimDestroyGlobals")
   result = newSym(skProc, procname, m.idgen, m.module.owner, m.module.info)
   result.typ = newProcType(m.module.info, m.idgen, m.module.owner)
   result.typ.callConv = ccCDecl
   incl result.flags, sfExportc
-  result.loc.r = "nimDestroyGlobals"
+  result.loc.r = "NimDestroyGlobals"
   if isDynlib:
     incl(result.loc.flags, lfExportLib)
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2225,6 +2225,7 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
       var body = newNodeI(nkStmtList, m.module.info)
       for i in countdown(high(graph.globalDestructors), 0):
         body.add graph.globalDestructors[i]
+      body.flags.incl nfTransf # should not be further transformed
       let dtor = generateLibraryDestroyGlobals(graph, m, body, optGenDynLib in m.config.globalOptions)
       genProcAux(m, dtor)
   if pipelineutils.skipCodegen(m.config, n): return

--- a/doc/backends.md
+++ b/doc/backends.md
@@ -250,6 +250,8 @@ which will likely make your program crash at runtime.
 The name `NimMain` can be influenced via the `--nimMainPrefix:prefix` switch.
 Use `--nimMainPrefix:MyLib` and the function to call is named `MyLibNimMain`.
 
+When compiling to static or dynamic libraries, they don't call destructors of global variables as normal Nim programs would do. A C API `NimDestroyGlobals` is provided to call these global destructors.
+
 
 ### Nim invocation example from C
 


### PR DESCRIPTION
fixes #20945
fixes #18262

todo
- [x] perhaps export with lib prefix when the option is enabled