### PR TITLE
fixes sink regression for ORC; ref #23354

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -163,8 +163,8 @@ proc isLastReadImpl(n: PNode; c: var Con; scope: var Scope): bool =
     result = false
 
 proc isLastRead(n: PNode; c: var Con; s: var Scope): bool =
-  # bug #23354; a type could have a non-trival assignements when it is passed to a sink parameter
-  if not hasDestructor(c, n.typ) and isTrival(getAttachedOp(c.graph, n.typ, attachedAsgn)): return true
+  # bug #23354; an object type could have a non-trival assignements when it is passed to a sink parameter
+  if not hasDestructor(c, n.typ) and (n.typ.kind != tyObject or isTrival(getAttachedOp(c.graph, n.typ, attachedAsgn))): return true
 
   let m = skipConvDfa(n)
   result = (m.kind == nkSym and sfSingleUsedTemp in m.sym.flags) or

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -163,7 +163,7 @@ proc isLastReadImpl(n: PNode; c: var Con; scope: var Scope): bool =
     result = false
 
 proc isLastRead(n: PNode; c: var Con; s: var Scope): bool =
-  if not hasDestructor(c, n.typ): return true
+  if not hasDestructor(c, n.typ) and isTrival(getAttachedOp(c.graph, n.typ, attachedAsgn)): return true
 
   let m = skipConvDfa(n)
   result = (m.kind == nkSym and sfSingleUsedTemp in m.sym.flags) or

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -163,6 +163,7 @@ proc isLastReadImpl(n: PNode; c: var Con; scope: var Scope): bool =
     result = false
 
 proc isLastRead(n: PNode; c: var Con; s: var Scope): bool =
+  # bug #23354; a type could have a non-trival assignements when it is passed to a sink parameter
   if not hasDestructor(c, n.typ) and isTrival(getAttachedOp(c.graph, n.typ, attachedAsgn)): return true
 
   let m = skipConvDfa(n)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1252,7 +1252,7 @@ proc inst(g: ModuleGraph; c: PContext; t: PType; kind: TTypeAttachedOp; idgen: I
     else:
       localError(g.config, info, "unresolved generic parameter")
 
-proc isTrival(s: PSym): bool {.inline.} =
+proc isTrival*(s: PSym): bool {.inline.} =
   s == nil or (s.ast != nil and s.ast[bodyPos].len == 0)
 
 proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInfo;

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1017,6 +1017,8 @@ proc trackCall(tracked: PEffects; n: PNode) =
       case paramType.kind
       of tySink:
         createTypeBoundOps(tracked, paramType.elementType, n.info)
+        if not isTrival(getAttachedOp(tracked.graph, paramType.elementType, attachedAsgn)):
+          paramType.elementType.flags.incl tfHasAsgn
         checkForSink(tracked, n[i])
       of tyVar:
         if isOutParam(paramType):

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1017,8 +1017,6 @@ proc trackCall(tracked: PEffects; n: PNode) =
       case paramType.kind
       of tySink:
         createTypeBoundOps(tracked, paramType.elementType, n.info)
-        if not isTrival(getAttachedOp(tracked.graph, paramType.elementType, attachedAsgn)):
-          paramType.elementType.flags.incl tfHasAsgn
         checkForSink(tracked, n[i])
       of tyVar:
         if isOutParam(paramType):

--- a/tests/destructor/tsink.nim
+++ b/tests/destructor/tsink.nim
@@ -1,0 +1,16 @@
+discard """
+  matrix: "--mm:arc"
+"""
+
+type AnObject = object of RootObj
+  value*: int
+
+proc mutate(shit: sink AnObject) =
+  shit.value = 1
+
+proc foo = # bug #23359
+  var bar = AnObject(value: 42)
+  mutate(bar)
+  doAssert bar.value == 42
+
+foo()


### PR DESCRIPTION
ref #23354

The new move analyzer requires types that have the tfAsgn flag (otherwise `lastRead` will return true); tfAsgn is included when the destructor is not trival. But it should consider the assignement for objects in this case because objects might have a trival destructors but it's the assignement that matters when it is passed to sink parameters.