### PR TITLE
fixes #12703; nim cpp rejects valid code would lose const qualifier for cstring to string via cstrToNimstr

### DIFF
--- a/tests/cpp/torc.nim
+++ b/tests/cpp/torc.nim
@@ -59,3 +59,17 @@ block: # bug #10219
 
   var v1 = initVector[int](10)
   doAssert v1[0] == 0
+
+block: # bug #12703 bug #19588
+  type
+    cstringConstImpl {.importc:"const char*".} = cstring
+    constChar = distinct cstringConstImpl
+
+  {.emit: """
+  const char* foo() {
+    return "hello";
+  }
+  """.}
+  proc foo(): constChar {.importcpp.} # change to importcpp for C++ backend
+  doAssert $(foo().cstring) == "hello"
+


### PR DESCRIPTION
fixes #12703
ref #19588