### PR TITLE
Update tests/js/tos.nim, make isAbsolute tested on nodejs under Windows.

### DIFF
--- a/lib/std/private/ospaths2.nim
+++ b/lib/std/private/ospaths2.nim
@@ -254,10 +254,10 @@ proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raise
     result = path[0] != ':'
   elif defined(RISCOS):
     result = path[0] == '$'
-  elif defined(posix) or defined(js):
-    # `or defined(js)` wouldn't be needed pending https://github.com/nim-lang/Nim/issues/13469
-    # This works around the problem for posix, but Windows is still broken with nim js -d:nodejs
+  elif defined(posix):
     result = path[0] == '/'
+  elif defined(nodejs):
+    {.emit: [result," = require(\"path\").isAbsolute(",path.cstring,");"].}
   else:
     raiseAssert "unreachable" # if ever hits here, adapt as needed
 

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -13,11 +13,9 @@ block:
   doAssert not "foo".isAbsolute
   doAssert relativePath("", "bar") == ""
   doAssert normalizedPath(".///foo//./") == "foo"
-  let cwd = getCurrentDir()
 
-  let isWindows = '\\' in cwd
-  # defined(windows) doesn't work with -d:nodejs but should
-  # these actually break because of that (see https://github.com/nim-lang/Nim/issues/13469)
-  if not isWindows:
+  when nimvm: discard
+  else:
+    let cwd = getCurrentDir()
     doAssert cwd.isAbsolute
-    doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
+    doAssert relativePath(getCurrentDir() / "foo", "bar") == ".." / "foo"


### PR DESCRIPTION
Windows's nodejs `isAbsolute`  issue has been resolved by [this PR](https://github.com/nim-lang/Nim/pull/23365).

So we can improve the coverage for Windows.