### PR TITLE
fixes #18070; An exception might exist after an except clause and break cycles 

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1324,6 +1324,8 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
 
     linefmt(p, cpsStmts, "#popCurrentException();$n", [])
     linefmt(p, cpsStmts, "LA$1_:;$n", [nextExcept])
+    lineCg(p, cpsStmts, "if (NIM_UNLIKELY(*nimErr_)) #popLastException();$n",
+      []) # something raises in the except branch
     endBlock(p)
 
     inc(i)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -155,11 +155,21 @@ proc pushCurrentException(e: sink(ref Exception)) {.compilerRtl, inl.} =
   #showErrorMessage2 "A"
 
 proc popCurrentException {.compilerRtl, inl.} =
-  currException = currException.up
+  if currException != currException.up:
+    currException = currException.up
+  else:
+    currException.up = nil
   #showErrorMessage2 "B"
 
 proc popCurrentExceptionEx(id: uint) {.compilerRtl.} =
   discard "only for bootstrapping compatbility"
+
+proc popLastException {.compilerRtl, inl.} =
+  if currException.up != nil:
+    if currException.up != currException.up.up:
+      currException.up = currException.up.up
+    else: # a cycle: e.g. reraise the exception in the except branch
+      currException.up = nil
 
 proc closureIterSetupExc(e: ref Exception) {.compilerproc, inline.} =
   currException = e


### PR DESCRIPTION
fixes #18070

supersedes https://github.com/nim-lang/Nim/pull/22502, but I still don't understand why it still leaks