### PR TITLE
Don't crash nimsuggest in case of internal compiler error. Raise a recoverable error instead.

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -430,7 +430,10 @@ proc handleError(conf: ConfigRef; msg: TMsgKind, eh: TErrorHandling, s: string, 
   if msg in fatalMsgs:
     if conf.cmd == cmdIdeTools: log(s)
     if conf.cmd != cmdIdeTools or msg != errFatal:
-      quit(conf, msg)
+      when defined(nimsuggest):
+        raiseRecoverableError(s)
+      else:
+        quit(conf, msg)
   if msg >= errMin and msg <= errMax or
       (msg in warnMin..hintMax and msg in conf.warningAsErrors and not ignoreMsg):
     inc(conf.errorCounter)


### PR DESCRIPTION
Even though internal compiler errors should not happen and should be fixed, nimsuggest doesn't exactly reproduce the compiler behaviour, because it ignores fatal errors and continues compilation. This causes extra internal compiler errors, which wouldn't happen during normal compilation. It is not good when these internal errors cause nimsuggest to crash, since it's expected to work on unfinished and/or broken code inside an IDE and it should have good error recovery and still provide hints and code tools support for the parts that it has successfully compiled, and this data should be reliable up until the first error, at least.