### PR TITLE
Let nimsuggest refer to generic instance symbols

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -683,10 +683,10 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
   assert x.state == csMatch
   var finalCallee = x.calleeSym
   let info = getCallLineInfo(n)
-  markUsed(c, info, finalCallee)
-  onUse(info, finalCallee)
   assert finalCallee.ast != nil
   if x.hasFauxMatch:
+    markUsed(c, info, finalCallee)
+    onUse(info, finalCallee)
     result = x.call
     result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))
     if containsGenericType(result.typ) or x.fauxMatch == tyUnknown:
@@ -721,6 +721,8 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
           x.call.add tn
         else:
           internalAssert c.config, false
+  markUsed(c, info, finalCallee)
+  onUse(info, finalCallee)
 
   result = x.call
   instGenericConvertersSons(c, result, x)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -789,8 +789,8 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   var newInst = generateInstance(c, s, m.bindings, n.info)
   newInst.typ.flags.excl tfUnresolved
   let info = getCallLineInfo(n)
-  markUsed(c, info, s)
-  onUse(info, s)
+  markUsed(c, info, newInst)
+  onUse(info, newInst)
   result = newSymNode(newInst, info)
 
 proc setGenericParams(c: PContext, n, expectedParams: PNode) =

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -67,6 +67,8 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     # for instance 'nextTry' is both in tables.nim and astalgo.nim ...
     if not isField or sfGenSym notin s.flags:
       result = newSymNode(s, info)
+      markUsed(c, info, s)
+      onUse(info, s)
     else:
       result = n
   elif i == 0:

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -67,8 +67,6 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     # for instance 'nextTry' is both in tables.nim and astalgo.nim ...
     if not isField or sfGenSym notin s.flags:
       result = newSymNode(s, info)
-      markUsed(c, info, s)
-      onUse(info, s)
     else:
       result = n
   elif i == 0:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -740,7 +740,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         addSep(prag)
         prag.add("gcsafe")
       if not hasImplicitRaises and prefer == preferInferredEffects and not isNil(t.owner) and not isNil(t.owner.typ) and not isNil(t.owner.typ.n) and (t.owner.typ.n.len > 0):
-        let effects = t.owner.typ.n[0]
+        let effects = t.n[0]
         if effects.kind == nkEffectList and effects.len == effectListLen:
           var inferredRaisesStr = ""
           let effs = effects[exceptionEffects]

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -936,7 +936,6 @@ proc suggestInlayHintResultException(graph: ModuleGraph, sym: PSym, info: TLineI
     if effects.kind == nkEffectList and effects.len == effectListLen:
       let effs = effects[exceptionEffects]
       if not isNil(effs):
-        raisesList = @[]
         for eff in items(effs):
           if not isNil(eff):
             raisesList.add(eff.typ)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -928,7 +928,7 @@ proc suggestInlayHintResultException(graph: ModuleGraph, sym: PSym, info: TLineI
   if sym.kind == skParam and sfEffectsDelayed in sym.flags:
     return
 
-  var raisesList: seq[PType] = @[getEbase(graph, info)]
+  var raisesList: seq[PType] = @[]
 
   let t = sym.typ
   if not isNil(t) and not isNil(t.n) and t.n.len > 0 and t.n[0].len > exceptionEffects:

--- a/nimsuggest/tests/tgenerics.nim
+++ b/nimsuggest/tests/tgenerics.nim
@@ -14,5 +14,5 @@ main()
 discard """
 $nimsuggest --tester $file
 >def $1
-def;;skProc;;tgenerics.printHelloValue;;proc (hello: Hello[printHelloValue.T]);;$file;;5;;5;;"";;100
+def;;skProc;;tgenerics.printHelloValue.printHelloValue;;proc (hello: Hello[system.float]){.gcsafe, raises: <inferred> [].};;$file;;5;;5;;"";;100
 """

--- a/nimsuggest/tests/tv3_generics.nim
+++ b/nimsuggest/tests/tv3_generics.nim
@@ -14,5 +14,6 @@ main()
 discard """
 $nimsuggest --v3 --tester $file
 >def $1
-def;;skProc;;tv3_generics.printHelloValue;;proc (hello: Hello[printHelloValue.T]);;$file;;5;;5;;"";;100
+
+def;;skProc;;tv3_generics.printHelloValue.printHelloValue;;proc (hello: Hello[system.float]){.gcsafe, raises: <inferred> [].};;$file;;5;;5;;"";;100
 """

--- a/nimsuggest/tests/tv3_generics.nim
+++ b/nimsuggest/tests/tv3_generics.nim
@@ -14,6 +14,5 @@ main()
 discard """
 $nimsuggest --v3 --tester $file
 >def $1
-
 def;;skProc;;tv3_generics.printHelloValue.printHelloValue;;proc (hello: Hello[system.float]){.gcsafe, raises: <inferred> [].};;$file;;5;;5;;"";;100
 """


### PR DESCRIPTION
Ref https://github.com/nim-lang/Nim/pull/23202#issuecomment-2000263308

Makes nimsuggest show generic instances for symbols instead of the plain non-instantiated version, fixes displayed (inferred) exceptions on hover and makes the exception inlay hints added by #23202 accurate for generics.

I could see this breaking ide tooling in regards to finding usages of a symbol (seems to work as before though) and it now displays the substituted parameters instead of generic T ones upon hover of a function call, so might need a better solution or a followup by someone with more knowledge.
