### PR TITLE
fix atomicarc increment

### DIFF
--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -221,7 +221,7 @@ proc nimDecRefIsLast(p: pointer): bool {.compilerRtl, inl.} =
 
     when defined(gcAtomicArc) and hasThreadSupport:
       # `atomicDec` returns the new value
-      if atomicDec(cell.rc, rcIncrement) == -1:
+      if atomicDec(cell.rc, rcIncrement) == -rcIncrement:
         result = true
         when traceCollector:
           cprintf("[ABOUT TO DESTROY] %p\n", cell)


### PR DESCRIPTION
The fix to the atomicArc looks to use `-1` as the check value from the `SharedPtr` solution. However, it should be `-rcIncrement` since the refcount is bit shifted in ARC/ORC. 

I discovered this playing around doing atomic updates of refcounts in a user library. 

Related to https://github.com/nim-lang/Nim/issues/22711 

@ringabout I believe you ported the sharedptr fix? 