### PR TITLE
fix: use `ErrorColor` for hints marked as errors

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -560,9 +560,10 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
     ignoreMsg = not conf.hasHint(msg)
     if not ignoreMsg and msg in conf.warningAsErrors:
       title = ErrorTitle
+      color = ErrorColor
     else:
       title = HintTitle
-    color = HintColor
+      color = HintColor
     inc(conf.hintCounter)
 
   let s = if isRaw: arg else: getMessageStr(msg, arg)


### PR DESCRIPTION
# Description

When using `--hintAsError`, we want some red color to appear in the logs.
Same is already done for `warningAsError`.

# Cherry-picking to Nim 1.6

Would be nice to cherry-pick this and the `warningAsError` log highlight to 1.6 branch, as it's used in status-desktop.