### PR TITLE
whitelist generic params matching `typedesc` for templates/macros

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1905,10 +1905,12 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       # when `f` is an unresolved typedesc, `a` could be any
       # type, so we should not perform this check earlier
       if c.c.inGenericContext > 0 and
-          a.skipTypes({tyTypeDesc}).kind == tyGenericParam:
+          a.skipTypes({tyTypeDesc}).kind == tyGenericParam and
+          not (c.calleeSym != nil and c.calleeSym.kind in {skMacro, skTemplate}):
         # generic type bodies can sometimes compile call expressions
         # prevent unresolved generic parameters from being passed to procs as
         # typedesc parameters
+        # macros and templates receive a pass for practicality
         result = isNone
       elif a.kind != tyTypeDesc:
         if a.kind == tyGenericParam and tfWildcard in a.flags:

--- a/tests/generics/tmacrotype.nim
+++ b/tests/generics/tmacrotype.nim
@@ -1,0 +1,28 @@
+import std/[sequtils, macros]
+
+block: # issue #23432
+  type
+    Future[T] = object
+    InternalRaisesFuture[T, E] = object
+
+  macro Raising[T](F: typedesc[Future[T]], E: varargs[typedesc]): untyped =
+    ## Given a Future type instance, return a type storing `{.raises.}`
+    ## information
+    ##
+    ## Note; this type may change in the future
+    E.expectKind(nnkBracket)
+
+    let raises = nnkTupleConstr.newTree(E.mapIt(it))
+    nnkBracketExpr.newTree(
+      ident "InternalRaisesFuture",
+      nnkDotExpr.newTree(F, ident"T"),
+      raises
+    )
+
+  type X[E] = Future[void].Raising(E)
+
+  proc f(x: X) = discard
+
+
+  var v: Future[void].Raising([ValueError])
+  f(v)


### PR DESCRIPTION
fixes #23432

After #22029 generic parameter types no longer match `typedesc` parameters in overloading, as this previously instantiated procs with an unresolved type as a `typedesc` value. However macros and templates don't use the same mechanism for generic instantiation, cannot delay their instantiations further than the point that they get compiled (i.e. are generically instantiated) and can inspect types more precisely anyway, so for practicality purposes we can whitelist them for `typedesc` and keep old code working.

If whitelisting macros and templates isn't sufficient (i.e. in cases where `c.calleeSym` is nil) we can also blacklist runtime routines (`c.calleeSym != nil and c.calleeSym.kind in (routineKinds - {skMacro, skTemplate})`).