### PR TITLE
dynlib keeps exported functions alive in emscripten

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -14,6 +14,7 @@ __GNUC__
 __TINYC__
 __clang__
 __AVR__
+__EMSCRIPTEN__
 */
 
 
@@ -177,12 +178,13 @@ __AVR__
 #  define N_THISCALL_PTR(rettype, name) rettype (__thiscall *name)
 #  define N_SAFECALL_PTR(rettype, name) rettype (__stdcall *name)
 
-#  ifdef __cplusplus
-#    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
+#  ifdef __EMSCRIPTEN__
+#    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport) __attribute__((used))
+#    define N_LIB_EXPORT_VAR  __declspec(dllexport) __attribute__((used))
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
+#    define N_LIB_EXPORT_VAR  __declspec(dllexport)
 #  endif
-#  define N_LIB_EXPORT_VAR  __declspec(dllexport)
 #  define N_LIB_IMPORT  extern __declspec(dllimport)
 #else
 #  define N_LIB_PRIVATE __attribute__((visibility("hidden")))
@@ -211,8 +213,13 @@ __AVR__
 #    define N_FASTCALL_PTR(rettype, name) rettype (*name)
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
-#  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
-#  define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  ifdef __EMSCRIPTEN__
+#    define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default"), used))
+#    define N_LIB_EXPORT_VAR  __attribute__((visibility("default"), used))
+#  else
+#    define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
+#    define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  endif
 #  define N_LIB_IMPORT  extern
 #endif
 


### PR DESCRIPTION
ref https://forum.nim-lang.org/t/11338

ref https://github.com/beef331/wasm3/blob/master/src/wasm3/exporter.nim

ref https://github.com/emscripten-core/emscripten/issues/6233

ref https://github.com/emscripten-core/emscripten/blob/3.1.56/system/include/emscripten/em_macros.h#L10

`EMSCRIPTEN_KEEPALIVE` is a macro that is used to prevent unused functions from being deadcode eliminated in emscripten, which is a simple wrapper around `__attribute__((used))`. This PR follows suits and expects dynlib is supposed to keep these functions alive. In the future, `exportwasm` might be introduced.

After this PR, a function with `{.dynlib, exportc.}` can be reused from other wasm programs reliably.
