### PR TITLE
Update encodings.nim, fix `open` with bad arg raising no `EncodingError`

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -340,6 +340,9 @@ proc getCurrentEncoding*(uiApp = false): string =
 proc open*(destEncoding = "UTF-8", srcEncoding = "CP1252"): EncodingConverter =
   ## Opens a converter that can convert from `srcEncoding` to `destEncoding`.
   ## Raises `EncodingError` if it cannot fulfill the request.
+  runnableExamples:
+    doAssertRaises EncodingError:
+      discard open(destEncoding="this is a invalid enc")
   when not defined(windows):
     result = iconvOpen(destEncoding, srcEncoding)
     if result == cast[EncodingConverter](-1):

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -342,7 +342,7 @@ proc open*(destEncoding = "UTF-8", srcEncoding = "CP1252"): EncodingConverter =
   ## Raises `EncodingError` if it cannot fulfill the request.
   when not defined(windows):
     result = iconvOpen(destEncoding, srcEncoding)
-    if result == nil:
+    if result == cast[EncodingConverter](-1):
       raise newException(EncodingError,
         "cannot create encoding converter from " &
         srcEncoding & " to " & destEncoding)

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -340,9 +340,6 @@ proc getCurrentEncoding*(uiApp = false): string =
 proc open*(destEncoding = "UTF-8", srcEncoding = "CP1252"): EncodingConverter =
   ## Opens a converter that can convert from `srcEncoding` to `destEncoding`.
   ## Raises `EncodingError` if it cannot fulfill the request.
-  runnableExamples:
-    doAssertRaises EncodingError:
-      discard open(destEncoding="this is a invalid enc")
   when not defined(windows):
     result = iconvOpen(destEncoding, srcEncoding)
     if result == cast[EncodingConverter](-1):

--- a/tests/stdlib/tencodings.nim
+++ b/tests/stdlib/tencodings.nim
@@ -101,3 +101,7 @@ block:
   doAssert orig == "\195\182\195\164\195\188\195\159"
   doAssert ibm850 == "\148\132\129\225"
   doAssert convert(ibm850, current, "ibm850") == orig
+
+block: # fixes about #23481
+  doAssertRaises EncodingError:
+    discard open(destEncoding="this is a invalid enc")


### PR DESCRIPTION
On POSIX, `std/encodings` uses iconv,  and `iconv_open` returns `(iconv_t) -1` on failure, not `NULL`