### PR TITLE
Add an error message when creating a thread from a ref type

### DIFF
--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -40,6 +40,7 @@ import std/private/[threadtypes]
 export Thread
 
 import system/ansi_c
+import macros
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -167,14 +168,9 @@ when false:
       t.core = nil
 
 when hostOS == "windows":
-  proc createThread*[TArg](t: var Thread[TArg],
+  proc createThreadImpl*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
-    ## Creates a new thread `t` and starts its execution.
-    ##
-    ## Entry point is the proc `tp`.
-    ## `param` is passed to `tp`. `TArg` can be `void` if you
-    ## don't need to pass any data to the thread.
     t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
     when TArg isnot void: t.data = param
@@ -197,7 +193,7 @@ elif defined(genode):
   var affinityOffset: cuint = 1
     ## CPU affinity offset for next thread, safe to roll-over.
 
-  proc createThread*[TArg](t: var Thread[TArg],
+  proc createThreadImpl*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
     t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
@@ -216,14 +212,9 @@ elif defined(genode):
     discard
 
 else:
-  proc createThread*[TArg](t: var Thread[TArg],
+  proc createThreadImpl*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
-    ## Creates a new thread `t` and starts its execution.
-    ##
-    ## Entry point is the proc `tp`. `param` is passed to `tp`.
-    ## `TArg` can be `void` if you
-    ## don't need to pass any data to the thread.
     t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
     when TArg isnot void: t.data = param
@@ -257,6 +248,26 @@ else:
       cpusetZero(s)
       cpusetIncl(cpu.cint, s)
       setAffinity(t.sys, csize_t(sizeof(s)), s)
+
+macro checkIsRef(t: typedesc): bool =
+    var node = t
+    if node.kind == nnkSym:
+        node = getType(node)
+        node = node[1]
+    var isRef = node.kind == nnkBracketExpr and node[0].kind == nnkSym and $node[0] == "ref"
+    quote do:
+        `isRef`
+
+proc createThread*[TArg](t: var Thread[TArg], tp: proc (arg: TArg) {.thread, nimcall.}, param: TArg) =
+  ## Creates a new thread `t` and starts its execution.
+  ##
+  ## Entry point is the proc `tp`.
+  ## `param` is passed to `tp`. `TArg` can be `void` if you
+  ## don't need to pass any data to the thread.
+  ##
+  when checkIsRef(TArg):
+    {.error: "The param passed to createThread must not be a ref type.".}
+  createThreadImpl[TArg](t, tp, param)
 
 proc createThread*(t: var Thread[void], tp: proc () {.thread, nimcall.}) =
   createThread[void](t, tp)


### PR DESCRIPTION
This PR is based on this conversation: https://forum.nim-lang.org/t/11374

The idea is to detect if the param passed to `createThread` is a ref and to produce an error if that's the case.

Feedback is welcome! I'm trying to better understand threading in Nim as I feel like documentation on the topic is lacking.