### PR TITLE
Check that `ref` types are not passed to threads

### DIFF
--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -250,11 +250,6 @@ else:
 
 proc containsRef(typ: typedesc): bool = typ is ref
 
-proc containsRef(typ: typedesc[object or tuple]): bool =
-    for field in default(typ).fields:
-        if containsRef(typeof(field)):
-            return true
-
 proc createThread*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =

--- a/tests/threads/tthreaderronref.nim
+++ b/tests/threads/tthreaderronref.nim
@@ -1,0 +1,16 @@
+discard """
+  errormsg: "The param passed to createThread must not be a ref type."
+  cmd: "nim $target --hints:on --threads:on $options $file"
+"""
+
+type RefType = ref object
+
+var
+  global: string = "test string"
+
+proc fn(rt: RefType) {.thread.} = discard
+
+var t: Thread[RefType]
+createThread[RefType](t, fn, new(RefType))
+joinThread(t)
+echo "ok!"


### PR DESCRIPTION
For memory reasons, types containing `ref`s should not be passed to the argument of a thread.
This PR enforces this.

Because the macro system is not available from thread as thread is imported by the system module, we use typedesc (an implementation suggested [by beef331 here](https://github.com/nim-lang/Nim/pull/23482)).

The code recursively checks that the object passed does not contains `ref` inside nested fields.

A test is added to make sure this actually works.