### PR TITLE
[JS backend] improve `discard` statement; ridding of the awkward special variable `_`

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2985,7 +2985,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     if n[0].kind != nkEmpty:
       genLineDir(p, n)
       gen(p, n[0], r)
-      r.res = "var _ = " & r.res
+      r.res = "(" & r.res & ")"
   of nkAsmStmt:
     warningDeprecated(p.config, n.info, "'asm' for the JS target is deprecated, use the 'emit' pragma")
     genAsmOrEmitStmt(p, n, true)

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -269,5 +269,5 @@ block: # test **
 block: # issue #21208
   type MyEnum = enum baz
   var obj: JsObject
-  {.emit: "`obj` = {bar: {baz: 123}}".}
+  {.emit: "`obj` = {bar: {baz: 123}};".}
   discard obj.bar.baz


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/Expression_statement, some expression statements need parentheses to make it unambiguous. `_` introduced in the https://github.com/nim-lang/Nim/pull/15789 is unnecessary. We can get rid of it by adding parentheses so that object literals are not ambiguous with  block statements.