### PR TITLE
fixes #23499; don't skip `addr` when constructing `bracketExpr`

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -73,7 +73,7 @@ proc semArrGet(c: PContext; n: PNode; flags: TExprFlags): PNode =
 proc semArrPut(c: PContext; n: PNode; flags: TExprFlags): PNode =
   # rewrite `[]=`(a, i, x)  back to ``a[i] = x``.
   let b = newNodeI(nkBracketExpr, n.info)
-  b.add(n[1].skipAddr)
+  b.add(n[1].skipHiddenAddr)
   for i in 2..<n.len-1: b.add(n[i])
   result = newNodeI(nkAsgn, n.info, 2)
   result[0] = b

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -273,6 +273,16 @@ proc test15939() = # bug #15939 (v2)
   else: # can't take address of cstring element in js
     when not defined(js): cstringTest()
 
+block: # bug #23499
+  template volatileStore[T](dest: ptr T, val: T) =
+    dest[] = val
+
+  proc foo =
+    var ctr = 0
+    volatileStore(addr ctr, 0)
+
+  foo()
+
 template main =
   # xxx wrap all other tests here like that so they're also tested in VM
   test14420()


### PR DESCRIPTION
fixes #23499

In the https://github.com/nim-lang/Nim/commit/8990626ca9715a3687b28331aee4ccf242997aa2 the effect of `skipAddr` changed to skip `nkAddr` and `nkHiddenAddr`. Some old code was not adapted. In the https://github.com/nim-lang/Nim/pull/23477, the magic `addr` function was handled in the semantic analysis phase, which causes it be skipped incorrectly