### PR TITLE
don't split on the dest type of `cast` in the closureiters

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -261,6 +261,12 @@ proc hasYields(n: PNode): bool =
     result = true
   of nkSkip:
     result = false
+  of nkCast: # don't split on the dest type
+    result = false
+    for i in 1..<n.len:
+      if n[i].hasYields:
+        result = true
+        break
   else:
     result = false
     for c in n:


### PR DESCRIPTION
```nim
await problemCall(await expandValue())
```
generates:
```nim
read(cast[typeof(problemCall(
  template yieldFuture() {.redefine.} =
    yield FutureBase()

  var internalTmpFuture`gensym30: FutureBase = expandValue()
  yield internalTmpFuture`gensym30
  read(cast[typeof(expandValue())](internalTmpFuture`gensym30))))](internalTmpFuture`gensym32))
```

Here is the problem. The previous implementation split the state on the case that there is a yield in the dest type of the `cast`. I don't think it's reasonable. It downgrades the performance of chained await calls and happended to work before since it execute the code without the state transition assignment.


It was translated into
```nim
state 3:
read(cast[...](...))
state 4:
:envP.`:state` = 5
```
But it is supposed to have a state assignement in the state 3 part.

Besides in the PR https://github.com/nim-lang/Nim/pull/14618; the type has been ignored in the `hasYieldsInExpressions` and `lowerStmtListExprs`. It's reasonable that `hasYields` follows suits.