### PR TITLE
Fix duplicated member declarations in structs for C++ backend

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2402,7 +2402,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if sfBorrow in s.flags and c.config.cmd notin cmdDocLike:
     result[bodyPos] = c.graph.emptyNode
 
-  if sfCppMember * s.flags != {}:
+  if sfCppMember * s.flags != {} and sfWasForwarded notin s.flags:
     semCppMember(c, s, n)
 
   if n[bodyPos].kind != nkEmpty and sfError notin s.flags:

--- a/tests/cpp/tmember_forward_declaration.nim
+++ b/tests/cpp/tmember_forward_declaration.nim
@@ -1,0 +1,27 @@
+discard """
+  targets: "cpp"
+  cmd: "nim cpp $file"
+  output: '''
+abc called
+def called
+abc called
+'''
+"""
+
+type Foo = object
+
+proc abc(this: Foo, x: int): void {.member: "$1('2 #2)".}
+proc def(this: Foo, y: int): void {.virtual: "$1('2 #2)".}
+
+proc abc(this: Foo, x: int): void =
+  echo "abc called"
+  if x > 0:
+    this.def(x - 1)
+
+proc def(this: Foo, y: int): void =
+  echo "def called"
+  this.abc(y)
+
+var x = Foo()
+x.abc(1)
+


### PR DESCRIPTION
When forward declaration is used with pragmas `virtual` or `member`, the declaration in struct is added twice. It happens because of missing check for `sfWasForwarded` pragma.

Current compiler generates the following C++ code:
```cpp
struct tyObject_Foo__fFO9b6HU7kRnKB9aJA1RApKw {
N_LIB_PRIVATE N_NOCONV(void, abc)(NI x_p1);
N_LIB_PRIVATE N_NOCONV(virtual void, def)(NI y_p1);
N_LIB_PRIVATE N_NOCONV(void, abc)(NI x_p1);
N_LIB_PRIVATE N_NOCONV(virtual void, def)(NI y_p1);
};
```