### PR TITLE
fixes #23492;  fixes JS float range causes compiler crash

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1023,7 +1023,7 @@ proc genCaseJS(p: PProc, n: PNode, r: var TCompRes) =
     a, b, cond, stmt: TCompRes = default(TCompRes)
   genLineDir(p, n)
   gen(p, n[0], cond)
-  let typeKind = skipTypes(n[0].typ, abstractVar).kind
+  let typeKind = skipTypes(n[0].typ, abstractVar+{tyRange}).kind
   var transferRange = false
   let anyString = typeKind in {tyString, tyCstring}
   case typeKind


### PR DESCRIPTION
fixes #23492

```nim
proc foo =
  var x: range[1.0 .. 5.0] = 2.0
  case x
  of 1.0..2.0:
    echo 1
  else:
    echo 3

foo()
```