### PR TITLE
fix #23518 - `<expr> is` crashes nimsuggest

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -518,8 +518,9 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
   result.typ = n.typ
 
 proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  if n.len != 3:
+  if n.len != 3 or n[2].kind == nkEmpty:
     localError(c.config, n.info, "'is' operator takes 2 arguments")
+    return errorNode(c, n)
 
   let boolType = getSysType(c.graph, n.info, tyBool)
   result = n


### PR DESCRIPTION
This solution should resolve the nimsuggest crash issue. However, perhaps the problem is in the parser?

fix #23518