### PR TITLE
fixes #23522; fixes pre-existing wrong type for iter in `liftIterSym`

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -258,8 +258,7 @@ proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PN
   let iter = n.sym
   assert iter.isIterator
 
-  result = newNodeIT(nkStmtListExpr, n.info, n.typ)
-
+  result = newNodeIT(nkStmtListExpr, n.info, iter.typ)
   let hp = getHiddenParam(g, iter)
   var env: PNode
   if owner.isIterator:

--- a/tests/js/t7109.nim
+++ b/tests/js/t7109.nim
@@ -3,3 +3,6 @@ iterator iter*(): int {.closure.} =
 
 var x = iter
 doAssert x() == 3
+
+let fIt = iterator(): int = yield 70
+doAssert fIt() == 70


### PR DESCRIPTION
fixes #23522