### PR TITLE
fixes #23419; internal error with void in generic array instantiation

### DIFF
--- a/tests/errmsgs/t23419.nim
+++ b/tests/errmsgs/t23419.nim
@@ -1,0 +1,5 @@
+discard """
+  errormsg: "invalid type: 'void' in this context: '(array[0..-1, void],)' for var"
+"""
+
+var a: (array[0, void], )


### PR DESCRIPTION
fixes #23419

`void` is only supported as fields of objects/tuples. It shouldn't allow void in the array.

I didn't merge it with taField because that flag is also used for tyLent, which is allowed in the fields of other types.