### PR TITLE
fixes #23513, parseutils.nim: parseInt's doc example.

### DIFF
--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -460,6 +460,8 @@ proc parseBiggestInt*(s: openArray[char], number: var BiggestInt): int {.
     var res: BiggestInt
     doAssert parseBiggestInt("9223372036854775807", res) == 19
     doAssert res == 9223372036854775807
+    doAssert parseInt("-2024_05_09", res) == 11
+    doAssert res == -20240509
   var res = BiggestInt(0)
   # use 'res' for exception safety (don't write to 'number' in case of an
   # overflow exception):

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -992,6 +992,10 @@ proc parseBiggestInt*(s: string, number: var BiggestInt, start = 0): int {.noSid
     var res: BiggestInt
     doAssert parseBiggestInt("9223372036854775807", res, 0) == 19
     doAssert res == 9223372036854775807
+    doAssert parseInt("-2024_05_09", res) == 11
+    doAssert res == -20240509
+    doAssert parseInt("-2024_05_02", res, 7) == 4
+    doAssert res == 502
   parseBiggestInt(s.toOpenArray(start, s.high), number)
 
 proc parseInt*(s: string, number: var int, start = 0): int {.noSideEffect, raises: [ValueError].} =
@@ -1000,10 +1004,10 @@ proc parseInt*(s: string, number: var int, start = 0): int {.noSideEffect, raise
   ## `ValueError` is raised if the parsed integer is out of the valid range.
   runnableExamples:
     var res: int
-    doAssert parseInt("2019", res, 0) == 4
-    doAssert res == 2019
-    doAssert parseInt("2019", res, 2) == 2
-    doAssert res == 19
+    doAssert parseInt("-2024_05_02", res) == 11
+    doAssert res == -20240502
+    doAssert parseInt("-2024_05_02", res, 7) == 4
+    doAssert res == 502
   parseInt(s.toOpenArray(start, s.high), number)
 
 

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -460,7 +460,7 @@ proc parseBiggestInt*(s: openArray[char], number: var BiggestInt): int {.
     var res: BiggestInt
     doAssert parseBiggestInt("9223372036854775807", res) == 19
     doAssert res == 9223372036854775807
-    doAssert parseInt("-2024_05_09", res) == 11
+    doAssert parseBiggestInt("-2024_05_09", res) == 11
     doAssert res == -20240509
   var res = BiggestInt(0)
   # use 'res' for exception safety (don't write to 'number' in case of an
@@ -992,9 +992,9 @@ proc parseBiggestInt*(s: string, number: var BiggestInt, start = 0): int {.noSid
     var res: BiggestInt
     doAssert parseBiggestInt("9223372036854775807", res, 0) == 19
     doAssert res == 9223372036854775807
-    doAssert parseInt("-2024_05_09", res) == 11
+    doAssert parseBiggestInt("-2024_05_09", res) == 11
     doAssert res == -20240509
-    doAssert parseInt("-2024_05_02", res, 7) == 4
+    doAssert parseBiggestInt("-2024_05_02", res, 7) == 4
     doAssert res == 502
   parseBiggestInt(s.toOpenArray(start, s.high), number)
 

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -474,10 +474,8 @@ proc parseInt*(s: openArray[char], number: var int): int {.
   ## `ValueError` is raised if the parsed integer is out of the valid range.
   runnableExamples:
     var res: int
-    doAssert parseInt("2019", res, 0) == 4
-    doAssert res == 2019
-    doAssert parseInt("2019", res, 2) == 2
-    doAssert res == 19
+    doAssert parseInt("-2024_05_02", res) == 11
+    doAssert res == -20240502
   var res = BiggestInt(0)
   result = parseBiggestInt(s, res)
   when sizeof(int) <= 4:

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -836,9 +836,9 @@ proc toRunes*(s: openArray[char]): seq[Rune] =
 proc cmpRunesIgnoreCase*(a, b: openArray[char]): int {.rtl, extern: "nuc$1".} =
   ## Compares two UTF-8 strings and ignores the case. Returns:
   ##
-  ## | 0 if a == b
-  ## | < 0 if a < b
-  ## | > 0 if a > b
+  ## | `0` if a == b
+  ## | `< 0` if a < b
+  ## | `> 0` if a > b
   var i = 0
   var j = 0
   var ar, br: Rune
@@ -1375,9 +1375,9 @@ proc toRunes*(s: string): seq[Rune] {.inline.} =
 proc cmpRunesIgnoreCase*(a, b: string): int {.inline.} =
   ## Compares two UTF-8 strings and ignores the case. Returns:
   ##
-  ## | 0 if a == b
-  ## | < 0 if a < b
-  ## | > 0 if a > b
+  ## | `0` if a == b
+  ## | `< 0` if a < b
+  ## | `> 0` if a > b
   cmpRunesIgnoreCase(a.toOa(), b.toOa())
 
 proc reversed*(s: string): string {.inline.} =


### PR DESCRIPTION
fixes #23513

Also, the old `runnableExample` is just a copy of `proc parseInt(openArray[char], var int, int)` variant (in Line 1000).