### PR TITLE
remove bad type inference behavior for enum identifiers

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3028,13 +3028,6 @@ proc resolveIdentToSym(c: PContext, n: PNode, resultNode: var PNode,
                        flags: TExprFlags, expectedType: PType): PSym =
   # result is nil on error or if a node that can't produce a sym is resolved
   let ident = considerQuotedIdent(c, n)
-  if expectedType != nil and (
-      let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
-      expected.kind == tyEnum):
-    let nameId = ident.id
-    for f in expected.n:
-      if f.kind == nkSym and f.sym.name.id == nameId:
-        return f.sym
   var filter = {low(TSymKind)..high(TSymKind)}
   if efNoEvaluateGeneric in flags:
     # `a[...]` where `a` is a module or package is not possible

--- a/tests/lookups/tenumlocalsym.nim
+++ b/tests/lookups/tenumlocalsym.nim
@@ -1,0 +1,22 @@
+block:
+  type Enum = enum a, b
+
+  block:
+    let a = b
+    let x: Enum = a
+    doAssert x == b
+  
+block:
+  type
+    Enum = enum
+      a = 2
+      b = 10
+
+  iterator items2(): Enum =
+    for a in [a, b]:
+      yield a
+
+  var s = newSeq[Enum]()
+  for i in items2():
+    s.add i
+  doAssert s == @[a, b]


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/issues/23586#issuecomment-2102113750

In #20091 a bad kind of type inference was mistakenly left in where if an identifier `abc` had an expected type of an enum type `Enum`, and `Enum` had a member called `abc`, the identifier would change to be that enum member. This causes bugs where a local symbol can have the same name as an enum member but have a different value. I had assumed this behavior was removed since but it wasn't, and CI seems to pass having it removed.

A separate PR needs to be made for the 2.0 branch because these lines were moved around during a refactoring in #23123 which is not in 2.0.