### PR TITLE
remove bad type inference behavior for enum identifiers (2.0)

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3037,14 +3037,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
   case n.kind
   of nkIdent, nkAccQuoted:
     var s: PSym
-    if expectedType != nil and (
-        let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
-        expected.kind == tyEnum):
-      let nameId = considerQuotedIdent(c, n).id
-      for f in expected.n:
-        if f.kind == nkSym and f.sym.name.id == nameId:
-          s = f.sym
-          break
     if s == nil:
       let checks = if efNoEvaluateGeneric in flags:
           {checkUndeclared, checkPureEnumFields}

--- a/tests/errmsgs/t21257.nim
+++ b/tests/errmsgs/t21257.nim
@@ -1,5 +1,4 @@
 discard """
-  action: compile
   cmd: "nim check $file" 
 """
 
@@ -16,5 +15,6 @@ type AC_WINCTRL_WINTSEL0* {.pure.} = enum
   BELOW = 0x2,
   OUTSIDE = 0x3,
 
-proc write*(WINTSEL0: AC_WINCTRL_WINTSEL0 = ABOVE) =
+proc write*(WINTSEL0: AC_WINCTRL_WINTSEL0 = ABOVE) = #[tt.Error
+                                            ^ ambiguous identifier: 'ABOVE']#
   discard

--- a/tests/lookups/tenumlocalsym.nim
+++ b/tests/lookups/tenumlocalsym.nim
@@ -1,0 +1,22 @@
+block:
+  type Enum = enum a, b
+
+  block:
+    let a = b
+    let x: Enum = a
+    doAssert x == b
+  
+block:
+  type
+    Enum = enum
+      a = 2
+      b = 10
+
+  iterator items2(): Enum =
+    for a in [a, b]:
+      yield a
+
+  var s = newSeq[Enum]()
+  for i in items2():
+    s.add i
+  doAssert s == @[a, b]

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -119,8 +119,8 @@ when false: # unsupported
     doAssert x[1] == (cstring"def", 2.0'f32)
 
 block: # enum
-  type Foo {.pure.} = enum a
-  type Bar {.pure.} = enum a, b, c
+  type Foo = enum a
+  type Bar = enum a, b, c
 
   var s: seq[Bar] = @[a, b, c]
 


### PR DESCRIPTION
Adapts #23588 to version-2-0 branch

The test for #21257 is changed to give an ambiguous identifier error (the original issue was that it segfaulted), this is because ambiguous identifier resolution (#23123) is not in the 2.0 branch.