### PR TITLE
ignore modules when looking up symbol with expected type

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3029,7 +3029,7 @@ proc resolveIdentToSym(c: PContext, n: PNode, resultNode: var PNode,
   # result is nil on error or if a node that can't produce a sym is resolved
   let ident = considerQuotedIdent(c, n)
   var filter = {low(TSymKind)..high(TSymKind)}
-  if efNoEvaluateGeneric in flags:
+  if efNoEvaluateGeneric in flags or expectedType != nil:
     # `a[...]` where `a` is a module or package is not possible
     filter.excl {skModule, skPackage}
   let candidates = lookUpCandidates(c, ident, filter)

--- a/tests/lookups/tmoduleclash1.nim
+++ b/tests/lookups/tmoduleclash1.nim
@@ -1,0 +1,13 @@
+# issue #23596
+
+import std/heapqueue
+type Algo = enum heapqueue, quick
+when false:
+  let x = heapqueue
+let y: Algo = heapqueue
+proc bar*(algo=quick) =
+  var x: HeapQueue[int]
+  case algo
+  of heapqueue: echo 1 # `Algo.heapqueue` works on devel
+  of quick: echo 2
+  echo x.len

--- a/tests/lookups/tmoduleclash2.nim
+++ b/tests/lookups/tmoduleclash2.nim
@@ -1,0 +1,6 @@
+import std/heapqueue
+proc heapqueue(x: int) = discard
+let x: proc (x: int) = heapqueue
+let y: proc = heapqueue
+when false:
+  let z = heapqueue


### PR DESCRIPTION
fixes #23596

When importing a module and declaring an overloadable symbol with the same name as the module in the same scope, the module symbol can take over and make the declared overload impossible to access. Previously enum overloading had a quirk that bypassed this in a context where a specific enum type was expected but this was removed in #23588. Now this is bypassed in every place where a specific type is expected since module symbols don't have a type and so wouldn't be compatible anyway.

But the issue still exists in places where no type is expected like `let x = modulename`. I don't see a way of fixing this without nerfing module symbols to the point where they're not accessible by default, which might break some macro code.