### PR TITLE
Testament: Prevent intermittent permission denied errors on Windows

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -58,7 +58,7 @@ type
 
   ProcessObj = object of RootObj
     when defined(windows):
-      fProcessHandle: Handle
+      fProcessHandle*: Handle
       fThreadHandle: Handle
       inHandle, outHandle, errHandle: FileHandle
       id: Handle

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1105,8 +1105,8 @@ const
   jJobObjectBasicLimitInformation* = 2
   jJobObjectExtendedLimitInformation* = 9
 
-proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: cstring): Handle
-     {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectA".}
+proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
+     {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectW".}
 
 proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
      {.stdcall, dynlib: "kernel32", importc: "AssignProcessToJobObject".}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1081,12 +1081,29 @@ type
     priorityClass*: DWORD
     schedulingClass*: DWORD
 
+  IO_COUNTERS* = object
+    readOperationCount*: uint64
+    writeOperationCount*: uint64
+    otherOperationCount*: uint64
+    readTransferCount*: uint64
+    writeTransferCount*: uint64
+    otherTransferCount*: uint64
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION* = object
+    basicLimitInformation*: JOBOBJECT_BASIC_LIMIT_INFORMATION
+    ioInfo*: IO_COUNTERS
+    processMemoryLimit*: WinSizeT
+    jobMemoryLimit*: WinSizeT
+    peakProcessMemoryUsed*: WinSizeT
+    peakJobMemoryUsed*: WinSizeT
+
 const
   JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE* = 0x2000
 
   ERROR_ALREADY_EXISTS* = 0xB7
 
   jJobObjectBasicLimitInformation* = 2
+  jJobObjectExtendedLimitInformation* = 9
 
 proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
      {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectA".}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1069,5 +1069,33 @@ proc checkTokenMembership*(tokenHandle: Handle, sidToCheck: PSID,
 proc freeSid*(pSid: PSID): PSID
      {.stdcall, dynlib: "Advapi32", importc: "FreeSid".}
 
+type
+  JOBOBJECT_BASIC_LIMIT_INFORMATION* = object
+    perProcessUserTimeLimit*: uint64
+    perJobUserTimeLimit*: uint64
+    limitFlags*: DWORD
+    minimumWorkingSetSize*: WinSizeT
+    maximumWorkingSetSize*: WinSizeT
+    activeProcessLimit*: DWORD
+    affinity*: ULONG_PTR
+    priorityClass*: DWORD
+    schedulingClass*: DWORD
+
+const
+  JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE* = 0x2000
+
+  jJobObjectBasicLimitInformation* = 2
+
+proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
+     {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectA".}
+
+proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
+     {.stdcall, dynlib: "kernel32", importc: "AssignProcessToJobObject".}
+
+proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD)
+     {.stdcall, dynlib: "kernel32", importc: "SetInformationJobObject".}
+
+
+
 when defined(nimHasStyleChecks):
   {.pop.} # {.push styleChecks: off.}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1084,6 +1084,8 @@ type
 const
   JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE* = 0x2000
 
+  ERROR_ALREADY_EXISTS* = 0xB7
+
   jJobObjectBasicLimitInformation* = 2
 
 proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
@@ -1094,6 +1096,9 @@ proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
 
 proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD)
      {.stdcall, dynlib: "kernel32", importc: "SetInformationJobObject".}
+
+proc terminateJobObject*(hJob: Handle, uExitCode: cuint): bool
+     {.stdcall, dynlib: "kernel32", importc: "TerminateJobObject".}
 
 
 

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1111,7 +1111,7 @@ proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCStr
 proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
      {.stdcall, dynlib: "kernel32", importc: "AssignProcessToJobObject".}
 
-proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD)
+proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD): bool
      {.stdcall, dynlib: "kernel32", importc: "SetInformationJobObject".}
 
 proc terminateJobObject*(hJob: Handle, uExitCode: cuint): bool

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1105,7 +1105,7 @@ const
   jJobObjectBasicLimitInformation* = 2
   jJobObjectExtendedLimitInformation* = 9
 
-proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
+proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: cstring): Handle
      {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectA".}
 
 proc assignProcessToJobObject*(hJob, hProcess: Handle): bool

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1069,55 +1069,5 @@ proc checkTokenMembership*(tokenHandle: Handle, sidToCheck: PSID,
 proc freeSid*(pSid: PSID): PSID
      {.stdcall, dynlib: "Advapi32", importc: "FreeSid".}
 
-type
-  JOBOBJECT_BASIC_LIMIT_INFORMATION* = object
-    perProcessUserTimeLimit*: uint64
-    perJobUserTimeLimit*: uint64
-    limitFlags*: DWORD
-    minimumWorkingSetSize*: WinSizeT
-    maximumWorkingSetSize*: WinSizeT
-    activeProcessLimit*: DWORD
-    affinity*: ULONG_PTR
-    priorityClass*: DWORD
-    schedulingClass*: DWORD
-
-  IO_COUNTERS* = object
-    readOperationCount*: uint64
-    writeOperationCount*: uint64
-    otherOperationCount*: uint64
-    readTransferCount*: uint64
-    writeTransferCount*: uint64
-    otherTransferCount*: uint64
-
-  JOBOBJECT_EXTENDED_LIMIT_INFORMATION* = object
-    basicLimitInformation*: JOBOBJECT_BASIC_LIMIT_INFORMATION
-    ioInfo*: IO_COUNTERS
-    processMemoryLimit*: WinSizeT
-    jobMemoryLimit*: WinSizeT
-    peakProcessMemoryUsed*: WinSizeT
-    peakJobMemoryUsed*: WinSizeT
-
-const
-  JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE* = 0x2000
-
-  ERROR_ALREADY_EXISTS* = 0xB7
-
-  jJobObjectBasicLimitInformation* = 2
-  jJobObjectExtendedLimitInformation* = 9
-
-proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
-     {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectW".}
-
-proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
-     {.stdcall, dynlib: "kernel32", importc: "AssignProcessToJobObject".}
-
-proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD): bool
-     {.stdcall, dynlib: "kernel32", importc: "SetInformationJobObject".}
-
-proc terminateJobObject*(hJob: Handle, uExitCode: cuint): bool
-     {.stdcall, dynlib: "kernel32", importc: "TerminateJobObject".}
-
-
-
 when defined(nimHasStyleChecks):
   {.pop.} # {.push styleChecks: off.}

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -83,7 +83,7 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string, isOrc =
 
   if "boehm" notin options:
     # hcr tests
-    
+
     var basicHcrTest = makeTest("tests/dll/nimhcr_basic.nim", options & " --threads:off --forceBuild --hotCodeReloading:on " & rpath, cat)
     # test segfaults for now but compiles:
     if isOrc: basicHcrTest.spec.action = actionCompile
@@ -641,7 +641,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
               "--path:" & root]
   args.add options.parseCmdLine
   args.add megatestFile
-  var (cmdLine, buf, exitCode) = execCmdEx2(command = compilerPrefix, args = args, input = "")
+  var (cmdLine, buf, exitCode) = execCmdEx2(command = compilerPrefix, args = args, exeFile = megatestFile, input = "")
   if exitCode != 0:
     echo "$ " & cmdLine & "\n" & buf
     quit(failString & "megatest compilation failed")

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -128,10 +128,14 @@ proc getFileDir(filename: string): string =
 
 when defined(windows):
   proc initJob(name: string): Handle =
-    result = createJobObject(nil, name.cstring)
+    let
+      name = name.replace("\\", "/")
+      wName = newWideCString(name)
+    result = createJobObject(nil, wName)
     if getLastError() == ERROR_ALREADY_EXISTS:
+      echo "Terminating zombie job with name: " & name
       discard result.terminateJobObject(1234)
-      result = createJobObject(nil, name.cstring)
+      result = createJobObject(nil, wName)
     let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION(
       basicLimitInformation : JOBOBJECT_BASIC_LIMIT_INFORMATION(
         limitFlags : JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -135,7 +135,7 @@ proc execCmdEx2(command: string, args: openArray[string]; workingDir, input: str
     result.cmdLine.add quoteShell(arg)
   verboseCmd(result.cmdLine)
   var p = startProcess(command, workingDir = workingDir, args = args,
-                       options = {poStdErrToStdOut, poUsePath})
+                       options = {poStdErrToStdOut, poUsePath, poDaemon})
   var outp = outputStream(p)
 
   # There is no way to provide input for the child process
@@ -177,12 +177,8 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
                           extraOptions)
   verboseCmd(result.cmd)
 
-  when hostOS == "windows":
-    var p = startProcess(command = result.cmd,
-                        options = {poStdErrToStdOut, poUsePath, poEvalCommand, poDaemon})
-  else:
-    var p = startProcess(command = result.cmd,
-                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
+  var p = startProcess(command = result.cmd,
+                      options = {poStdErrToStdOut, poUsePath, poEvalCommand, poDaemon})
   let outp = p.outputStream
   var foundSuccessMsg = false
   var foundErrorMsg = false
@@ -346,7 +342,7 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
                            test.cat.string,
                            "-Outcome", outcome, "-ErrorMessage", msg,
                            "-Duration", $(duration * 1000).int],
-                           options = {poStdErrToStdOut, poUsePath, poParentStreams})
+                           options = {poStdErrToStdOut, poUsePath, poParentStreams, poDaemon})
       discard waitForExit(p)
       close(p)
 

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -26,6 +26,7 @@ import ../dist/checksums/src/checksums/md5
 
 when defined(windows):
   import std/[widestrs, winlean]
+  import windows_extras
 
 proc trimUnitSep(x: var string) =
   let L = x.len

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -176,8 +176,13 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
   result.cmd = prepareTestCmd(cmdTemplate, filename, options, nimcache, target,
                           extraOptions)
   verboseCmd(result.cmd)
-  var p = startProcess(command = result.cmd,
-                       options = {poStdErrToStdOut, poUsePath, poEvalCommand})
+
+  when hostOS == "windows":
+    var p = startProcess(command = result.cmd,
+                        options = {poStdErrToStdOut, poUsePath, poEvalCommand, poDaemon})
+  else:
+    var p = startProcess(command = result.cmd,
+                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
   let outp = p.outputStream
   var foundSuccessMsg = false
   var foundErrorMsg = false

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -133,7 +133,7 @@ when defined(windows):
       wName = newWideCString(name)
     result = createJobObject(nil, wName)
     if getLastError() == ERROR_ALREADY_EXISTS:
-      echo "Terminating zombie job with name: " & name
+      # Should never happen if the job handle is closed properly.
       discard result.terminateJobObject(1234)
       result = createJobObject(nil, wName)
     let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION(

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -131,6 +131,7 @@ when defined(windows):
     let name = newWideCString(getCurrentDir())
     result = createJobObject(nil, name)
     if getLastError() == ERROR_ALREADY_EXISTS:
+      echo "Terminating existing job"
       discard result.terminateJobObject(1234)
       result = createJobObject(nil, name)
     let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION(

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -127,13 +127,26 @@ proc getFileDir(filename: string): string =
     result = getCurrentDir() / result
 
 when defined(windows):
-  proc wrapJob(process: Process): Handle =
-    result = createJobObject(nil, nil)
+  proc initJob(): Handle =
+    let name = newWideCString(getCurrentDir())
+    result = createJobObject(nil, name)
+    if getLastError() == ERROR_ALREADY_EXISTS:
+      discard result.terminateJobObject(1)
+      result = createJobObject(nil, name)
     let info = JOBOBJECT_BASIC_LIMIT_INFORMATION(
         limitFlags : JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
     )
     result.setInformationJobObject(jJobObjectBasicLimitInformation, addr info, sizeof(info).DWORD)
-    discard result.assignProcessToJobObject(process.fProcessHandle)
+
+template wrapWinJob(processBody: untyped): Process =
+  when defined(windows):
+    let job = initJob()
+    defer: discard job.closeHandle()
+    let process = processBody
+    discard job.assignProcessToJobObject(process.fProcessHandle)
+    process
+  else:
+    processBody
 
 proc execCmdEx2(command: string, args: openArray[string]; workingDir, input: string = ""): tuple[
                 cmdLine: string,
@@ -146,11 +159,8 @@ proc execCmdEx2(command: string, args: openArray[string]; workingDir, input: str
     result.cmdLine.add ' '
     result.cmdLine.add quoteShell(arg)
   verboseCmd(result.cmdLine)
-  var p = startProcess(command, workingDir = workingDir, args = args,
+  var p = wrapWinJob startProcess(command, workingDir = workingDir, args = args,
                        options = {poStdErrToStdOut, poUsePath})
-  when defined(windows):
-    let jobHandle = p.wrapJob()
-    defer: discard jobHandle.closeHandle()
   var outp = outputStream(p)
 
   # There is no way to provide input for the child process
@@ -191,11 +201,8 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
   result.cmd = prepareTestCmd(cmdTemplate, filename, options, nimcache, target,
                           extraOptions)
   verboseCmd(result.cmd)
-  var p = startProcess(command = result.cmd,
+  var p = wrapWinJob startProcess(command = result.cmd,
                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
-  when defined(windows):
-    let jobHandle = p.wrapJob()
-    defer: discard jobHandle.closeHandle()
   let outp = p.outputStream
   var foundSuccessMsg = false
   var foundErrorMsg = false
@@ -354,15 +361,12 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
     if isAzure:
       azure.addTestResult(name, test.cat.string, int(duration * 1000), msg, success)
     else:
-      var p = startProcess("appveyor", args = ["AddTest", test.name.replace("\\", "/") & test.options,
+      var p = wrapWinJob startProcess("appveyor", args = ["AddTest", test.name.replace("\\", "/") & test.options,
                            "-Framework", "nim-testament", "-FileName",
                            test.cat.string,
                            "-Outcome", outcome, "-ErrorMessage", msg,
                            "-Duration", $(duration * 1000).int],
                            options = {poStdErrToStdOut, poUsePath, poParentStreams})
-      when defined(windows):
-        let jobHandle = p.wrapJob()
-        defer: discard jobHandle.closeHandle()
       discard waitForExit(p)
       close(p)
 

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -133,10 +133,12 @@ when defined(windows):
     if getLastError() == ERROR_ALREADY_EXISTS:
       discard result.terminateJobObject(1234)
       result = createJobObject(nil, name)
-    let info = JOBOBJECT_BASIC_LIMIT_INFORMATION(
+    let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION(
+      basicLimitInformation : JOBOBJECT_BASIC_LIMIT_INFORMATION(
         limitFlags : JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+      )
     )
-    result.setInformationJobObject(jJobObjectBasicLimitInformation, addr info, sizeof(info).DWORD)
+    result.setInformationJobObject(jJobObjectExtendedLimitInformation, addr info, sizeof(info).DWORD)
 
 template wrapWinJob(processBody: untyped): Process =
   when defined(windows):

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -131,7 +131,7 @@ when defined(windows):
     let name = newWideCString(getCurrentDir())
     result = createJobObject(nil, name)
     if getLastError() == ERROR_ALREADY_EXISTS:
-      discard result.terminateJobObject(1)
+      discard result.terminateJobObject(1234)
       result = createJobObject(nil, name)
     let info = JOBOBJECT_BASIC_LIMIT_INFORMATION(
         limitFlags : JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -157,7 +157,7 @@ proc execCmdEx2(command: string, args: openArray[string]; workingDir, input: str
   var p = startProcess(command, workingDir = workingDir, args = args,
                        options = {poStdErrToStdOut, poUsePath})
   when defined(windows):
-    discard job.assignProcessToJobObject(process.fProcessHandle)
+    discard job.assignProcessToJobObject(p.fProcessHandle)
   var outp = outputStream(p)
 
   # There is no way to provide input for the child process
@@ -204,7 +204,7 @@ proc callNimCompiler(cmdTemplate, filename, options, nimcache: string,
   var p = startProcess(command = result.cmd,
                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
   when defined(windows):
-    discard job.assignProcessToJobObject(process.fProcessHandle)
+    discard job.assignProcessToJobObject(p.fProcessHandle)
   let outp = p.outputStream
   var foundSuccessMsg = false
   var foundErrorMsg = false
@@ -373,7 +373,7 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
                            "-Duration", $(duration * 1000).int],
                            options = {poStdErrToStdOut, poUsePath, poParentStreams})
       when defined(windows):
-        discard job.assignProcessToJobObject(process.fProcessHandle)
+        discard job.assignProcessToJobObject(p.fProcessHandle)
       discard waitForExit(p)
       close(p)
 

--- a/testament/windows_extras.nim
+++ b/testament/windows_extras.nim
@@ -1,0 +1,50 @@
+import std/winlean
+
+
+type
+  JOBOBJECT_BASIC_LIMIT_INFORMATION* = object
+    perProcessUserTimeLimit*: uint64
+    perJobUserTimeLimit*: uint64
+    limitFlags*: DWORD
+    minimumWorkingSetSize*: WinSizeT
+    maximumWorkingSetSize*: WinSizeT
+    activeProcessLimit*: DWORD
+    affinity*: ULONG_PTR
+    priorityClass*: DWORD
+    schedulingClass*: DWORD
+
+  IO_COUNTERS* = object
+    readOperationCount*: uint64
+    writeOperationCount*: uint64
+    otherOperationCount*: uint64
+    readTransferCount*: uint64
+    writeTransferCount*: uint64
+    otherTransferCount*: uint64
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION* = object
+    basicLimitInformation*: JOBOBJECT_BASIC_LIMIT_INFORMATION
+    ioInfo*: IO_COUNTERS
+    processMemoryLimit*: WinSizeT
+    jobMemoryLimit*: WinSizeT
+    peakProcessMemoryUsed*: WinSizeT
+    peakJobMemoryUsed*: WinSizeT
+
+const
+  JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE* = 0x2000
+
+  ERROR_ALREADY_EXISTS* = 0xB7
+
+  jJobObjectBasicLimitInformation* = 2
+  jJobObjectExtendedLimitInformation* = 9
+
+proc createJobObject*(lpJobAttributes: ptr SECURITY_ATTRIBUTES, lpName: WideCString): Handle
+     {.stdcall, dynlib: "kernel32", importc: "CreateJobObjectW".}
+
+proc assignProcessToJobObject*(hJob, hProcess: Handle): bool
+     {.stdcall, dynlib: "kernel32", importc: "AssignProcessToJobObject".}
+
+proc setInformationJobObject*(hJob: Handle, JobObjectInformationClass: cint, lpJobObjectInformation: pointer, cbJobObjectInformationLength: DWORD): bool
+     {.stdcall, dynlib: "kernel32", importc: "SetInformationJobObject".}
+
+proc terminateJobObject*(hJob: Handle, uExitCode: cuint): bool
+     {.stdcall, dynlib: "kernel32", importc: "TerminateJobObject".}


### PR DESCRIPTION
Wraps windows tests in jobs similar to this old rust issue from 2015 https://github.com/rust-lang/rust/issues/22628

Hard to verify if it actually does anything due to the random nature of these errors. Log is most likely useless because closing job handle kills everything associated anyways.