### PR TITLE
add back enum ident inference, only on undeclared identifiers

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3034,6 +3034,13 @@ proc resolveIdentToSym(c: PContext, n: PNode, resultNode: var PNode,
     filter.excl {skModule, skPackage}
   let candidates = lookUpCandidates(c, ident, filter)
   if candidates.len == 0:
+    if expectedType != nil and (
+        let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
+        expected.kind == tyEnum):
+      let nameId = ident.id
+      for f in expected.n:
+        if f.kind == nkSym and f.sym.name.id == nameId:
+          return f.sym
     result = errorUndeclaredIdentifierHint(c, ident, n.info)
   elif candidates.len == 1 or {efNoEvaluateGeneric, efInCall} * flags != {}:
     # unambiguous, or we don't care about ambiguity

--- a/tests/lookups/menumdirty1.nim
+++ b/tests/lookups/menumdirty1.nim
@@ -1,0 +1,18 @@
+type P = object
+
+template d(Name: untyped) {.dirty.} =
+  type Name* = object
+
+import menumdirty2
+
+d(Json)
+
+type K[Flavor = P] = object
+  lex: V
+
+template F*(T: type Json, F: distinct type = P): type = K[F]
+
+proc init*(T: type K): T = discard
+
+proc s*[T](r: var K, value: var T) =
+  x(r.lex)

--- a/tests/lookups/menumdirty2.nim
+++ b/tests/lookups/menumdirty2.nim
@@ -1,0 +1,8 @@
+type
+  U* = enum
+    errNone
+  V* = object
+    err: U
+
+template x*(lex: V) {.dirty.} =
+  lex.err = errNone

--- a/tests/lookups/tenumdirty.nim
+++ b/tests/lookups/tenumdirty.nim
@@ -1,0 +1,12 @@
+# issue #23611
+
+import menumdirty1
+
+type
+  B = object
+  L = object
+
+template F(T: type B): type = F(Json, B)
+var j = F(B).init()
+var f: L
+s(j, f)


### PR DESCRIPTION
closes #23611, refs #23588

This adds back the enum identifier inference removed in #23588 but altered so that it only triggers when no symbol in scope with the same name is found. This is just to prevent further breakage while not causing bugs as the old behavior did (however #23596 still needs #23597 to work with this). Otherwise this behavior was never documented and only introduced in 1.6.14.

There are still some cases that would compile with the old behavior but not with this, such as the case where the symbol is found in scope but does not match with the enum type:

```nim
# a.nim
type Foo* = enum abc
``` 

```nim
# b.nim
import a

type
  Bar* = enum abc
  Obj* = object
    val*: Foo
```

```nim
# c.nim
import b

var x: Obj
x.val = abc
```

We could maybe make this work but it would be even more complexity for the compiler that was never promised.