### PR TITLE
[Backport 1.6] Fix reset code gen for range types (#22462, #23214) (#23215) 

### DIFF
--- a/compiler/ccgreset.nim
+++ b/compiler/ccgreset.nim
@@ -83,7 +83,7 @@ proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =
       lineCg(p, cpsStmts, "$1.ClP_0 = NIM_NIL;$n", [accessor])
     else:
       lineCg(p, cpsStmts, "$1 = NIM_NIL;$n", [accessor])
-  of tyChar, tyBool, tyEnum, tyInt..tyUInt64:
+  of tyChar, tyBool, tyEnum, tyRange, tyInt..tyUInt64:
     lineCg(p, cpsStmts, "$1 = 0;$n", [accessor])
   of tyCstring, tyPointer, tyPtr, tyVar, tyLent:
     lineCg(p, cpsStmts, "$1 = NIM_NIL;$n", [accessor])
@@ -97,7 +97,7 @@ proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =
     else:
       doAssert false, "unexpected set type kind"
   of {tyNone, tyEmpty, tyNil, tyUntyped, tyTyped, tyGenericInvocation,
-      tyGenericParam, tyOrdinal, tyRange, tyOpenArray, tyForward, tyVarargs,
+      tyGenericParam, tyOrdinal, tyOpenArray, tyForward, tyVarargs,
       tyUncheckedArray, tyProxy, tyBuiltInTypeClass, tyUserTypeClass,
       tyUserTypeClassInst, tyCompositeTypeClass, tyAnd, tyOr, tyNot,
       tyAnything, tyStatic, tyFromExpr, tyConcept, tyVoid, tyIterable}:

--- a/tests/ccgbugs/t22462.nim
+++ b/tests/ccgbugs/t22462.nim
@@ -1,0 +1,19 @@
+discard """
+  action: "run"
+  output: '''
+1
+1
+1
+'''
+  targets: "c cpp"
+"""
+
+type Object = object
+  someComplexType: seq[int]
+  index: Natural
+
+func newObject(): Object = result.index.inc
+
+for i in 1..3:
+  let o = newObject()
+  echo o.index


### PR DESCRIPTION
This is a backport of https://github.com/nim-lang/Nim/pull/23215. I thought I'd put a PR instead of [just asking for it](https://github.com/nim-lang/Nim/pull/23215#issuecomment-2125829028). :slightly_smiling_face: 