### PR TITLE
remove winim from important packages; since CI doesn't check windows platform

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -172,7 +172,7 @@ pkg "union", "nim c -r tests/treadme.nim", url = "https://github.com/alaviss/uni
 pkg "unpack"
 pkg "weave", "nimble test_gc_arc", useHead = true
 pkg "websocket", "nim c websocket.nim"
-pkg "winim", allowFailure = true
+# pkg "winim", allowFailure = true
 pkg "with"
 pkg "ws", allowFailure = true
 pkg "yaml"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -172,7 +172,7 @@ pkg "union", "nim c -r tests/treadme.nim", url = "https://github.com/alaviss/uni
 pkg "unpack"
 pkg "weave", "nimble test_gc_arc", useHead = true
 pkg "websocket", "nim c websocket.nim"
-pkg "winim", "nim c winim.nim"
+pkg "winim", allowFailure = true
 pkg "with"
 pkg "ws", allowFailure = true
 pkg "yaml"


### PR DESCRIPTION
Cannot compile on Linux reliably