### PR TITLE
ignore type symbols in lookup when enum type is expected

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3047,6 +3047,10 @@ proc resolveIdentToSym(c: PContext, n: PNode, resultNode: var PNode,
   if efNoEvaluateGeneric in flags or expectedType != nil:
     # `a[...]` where `a` is a module or package is not possible
     filter.excl {skModule, skPackage}
+  if expectedType != nil and (
+      let expected = expectedType.skipTypes(abstractRange-{tyDistinct});
+      expected.kind == tyEnum):
+    filter.excl {skType}
   let candidates = lookUpCandidates(c, ident, filter)
   if candidates.len == 0:
     result = errorUndeclaredIdentifierHint(c, ident, n.info)

--- a/tests/enum/ttypenameconflict.nim
+++ b/tests/enum/ttypenameconflict.nim
@@ -1,0 +1,13 @@
+# issue #23689
+
+type
+  MyEnum {.pure.} = enum
+    A, B, C, D
+
+  B = object
+    field: int
+
+let x: MyEnum = B
+doAssert $x == "B"
+doAssert typeof(x) is MyEnum
+doAssert x in {A, B}


### PR DESCRIPTION
fixes #23689

When an identifier expression expects an enum type, when looking up the identifier as a symbol, type symbols are ignored, i.e.

```nim
type
  Foo = enum A, B
  C = object

let x: Foo = C
```

will give an "undeclared identifier" error. This is to make #23689 work in the least obtrusive way, it might cause other problems. It could also be generalized to all concrete types (`expected.kind in ConcreteTypes` instead of `== tyEnum`).