### PR TITLE
ignore uninstantiated static on match to base type [backport:2.0]

### DIFF
--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -56,8 +56,11 @@ iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TypeMapping): PS
       elif t.kind in {tyGenericParam, tyConcept}:
         localError(c.config, a.info, errCannotInstantiateX % q.name.s)
         t = errorType(c)
-      elif isUnresolvedStatic(t) and c.inGenericContext == 0 and
-          c.matchedConcept == nil:
+      elif isUnresolvedStatic(t) and (q.typ.kind == tyStatic or
+            (q.typ.kind == tyGenericParam and
+              q.typ.genericParamHasConstraints and
+              q.typ.genericConstraint.kind == tyStatic)) and
+          c.inGenericContext == 0 and c.matchedConcept == nil:
         # generic/concept type bodies will try to instantiate static values but
         # won't actually use them
         localError(c.config, a.info, errCannotInstantiateX % q.name.s)

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -140,3 +140,8 @@ block: # issue #1771
 
   var a: Foo[range[0..2], float]
   doAssert test(a) == 0.0
+
+block: # issue #23730
+  proc test(M: static[int]): array[1 shl M, int] = discard
+  doAssert len(test(3)) == 8
+  doAssert len(test(5)) == 32


### PR DESCRIPTION
fixes #23730

Since #23188 the compiler errors when matching a type variable to an uninstantiated static value. However sometimes an uninstantiated static value is given even when only a type match is being performed to the base type of the static type, in the given issue this case is:

```nim
proc foo[T: SomeInteger](x: T): int = int(x)
proc bar(x: static int): array[foo(x), int] = discard
discard bar(123)
```

To deal with this issue we only error when matching against a type variable constrained to `static`.

Not sure if the `q.typ.kind == tyGenericParam and q.typ.genericConstraint == tyStatic` check is necessary, the code above for deciding whether the variable becomes `skConst` doesn't use it.