### PR TITLE
Add logical AND-assignment and logical OR-Assignment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,9 @@ slots when enlarging a sequence.
   objects the cyclic collector did free. If the number is zero that is a strong indicator that you can use `--mm:arc`
   instead of `--mm:orc`.
 - A `$` template is provided for `Path` in `std/paths`.
+- Added [logical AND-assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment)
+  and [logical OR-Assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment) for JavaScript targets.
+
 
 [//]: # "Deprecations:"
 

--- a/lib/js/jscore.nim
+++ b/lib/js/jscore.nim
@@ -151,3 +151,13 @@ since (1, 7):
     ## * https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask
     ## * https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
     runnableExamples"-r:off": queueMicrotask(proc() = echo "Microtask")
+
+
+since (2, 2):
+  func `&&=`*[T](lhs, rhs: T): T {.importjs: "(# &&= #)", discardable.}
+    ## * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment
+    ## * https://caniuse.com/mdn-javascript_operators_logical_and_assignment
+
+  func `||=`*[T](lhs, rhs: T): T {.importjs: "(# ||= #)", discardable.}
+    ## * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment
+    ## * https://caniuse.com/mdn-javascript_operators_logical_or_assignment


### PR DESCRIPTION
- Added [logical AND-assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment) and [logical OR-Assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment) for JavaScript targets.
- https://caniuse.com/mdn-javascript_operators_logical_and_assignment 
- https://caniuse.com/mdn-javascript_operators_logical_or_assignment

