### PR TITLE
fixes #23742; setLen(0) no longer allocates memory for uninitialized strs/seqs for refc

### DIFF
--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -220,7 +220,10 @@ proc appendChar(dest: NimString, c: char) {.compilerproc, inline.} =
 proc setLengthStr(s: NimString, newLen: int): NimString {.compilerRtl.} =
   let n = max(newLen, 0)
   if s == nil:
-    result = mnewString(n)
+    if n == 0:
+      return s
+    else:
+      result = mnewString(n)
   elif n <= s.space:
     result = s
   else:
@@ -301,7 +304,10 @@ proc setLengthSeqV2(s: PGenericSeq, typ: PNimType, newLen: int): PGenericSeq {.
     compilerRtl.} =
   sysAssert typ.kind == tySequence, "setLengthSeqV2: type is not a seq"
   if s == nil:
-    result = cast[PGenericSeq](newSeq(typ, newLen))
+    if newLen == 0:
+      result = s
+    else:
+      result = cast[PGenericSeq](newSeq(typ, newLen))
   else:
     let elemSize = typ.base.size
     let elemAlign = typ.base.align


### PR DESCRIPTION
fixes #23742

Before my PR, `setLen(0)` doesn't free buffer if `s != nil`, but it allocated unnecessary memory for `strs`. This PR rectifies this behavior. `setLen(0)` no longer allocates memory for uninitialized strs/seqs