### PR TITLE
adapt semOpAux to opt-in symchoices

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -562,7 +562,7 @@ proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
   result = isOpImpl(c, n, flags)
 
 proc semOpAux(c: PContext, n: PNode) =
-  const flags = {efDetermineType}
+  const flags = {efDetermineType, efAllowSymChoice}
   for i in 1..<n.len:
     var a = n[i]
     if a.kind == nkExprEqExpr and a.len == 2:

--- a/tests/lookups/t23749.nim
+++ b/tests/lookups/t23749.nim
@@ -1,0 +1,33 @@
+{.pragma: callback, gcsafe, raises: [].}
+
+type
+  DataProc* = proc(val: openArray[byte]) {.callback.}
+  GetProc = proc (db: RootRef, key: openArray[byte], onData: DataProc): bool {.nimcall, callback.}
+  KvStoreRef* = ref object
+    obj: RootRef
+    getProc: GetProc
+
+template get(dbParam: KvStoreRef, key: openArray[byte], onData: untyped): bool =
+  let db = dbParam
+  db.getProc(db.obj, key, onData)
+
+func decode(input: openArray[byte], maxSize = 128): seq[byte] =
+  @[]
+
+proc getSnappySSZ(db: KvStoreRef, key: openArray[byte]): string =
+  var status = "not found"
+  proc decode(data: openArray[byte]) =
+    status =
+      if true: "found"
+      else: "corrupted"
+  discard db.get(key, decode)
+  status
+
+
+var ksr: KvStoreRef
+var k = [byte(1), 2, 3, 4, 5]
+
+proc foo(): string =
+  getSnappySSZ(ksr, toOpenArray(k, 1, 3))
+
+echo foo()

--- a/tests/lookups/t23749.nim
+++ b/tests/lookups/t23749.nim
@@ -1,3 +1,7 @@
+discard """
+  action: compile
+"""
+
 {.pragma: callback, gcsafe, raises: [].}
 
 type


### PR DESCRIPTION
fixes #23749, refs #22716

`semIndirectOp` is used here because of the callback expressions, in this case `db.getProc(...)`, and `semIndirectOp` calls `semOpAux` to type its arguments before overloading starts. Hence it can opt in to symchoices since overloading will resolve them.