### PR TITLE
[backport] fixes #23748; do not skip materializing temporaries for proc arguments

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -334,14 +334,13 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; need
     # bug #23748: we need to introduce a temporary here. The expression type
     # will be a reference in C++ and we cannot create a temporary reference
     # variable. Thus, we create a temporary pointer variable instead.
-    let hadVarIsPtr = tfVarIsPtr in n.typ.flags
     let needsIndirect = mapType(p.config, n[0].typ, mapTypeChooser(n[0]) == skParam) != ctArray
-    if needsIndirect: n.typ.flags.incl tfVarIsPtr
+    if needsIndirect:
+      n.typ = n.typ.exactReplica
+      n.typ.flags.incl tfVarIsPtr
     a = initLocExprSingleUse(p, n)
     a = withTmpIfNeeded(p, a, needsTmp)
-    if needsIndirect:
-      if not hadVarIsPtr: n.typ.flags.excl tfVarIsPtr
-      a.flags.incl lfIndirect
+    if needsIndirect: a.flags.incl lfIndirect
     # if the proc is 'importc'ed but not 'importcpp'ed then 'var T' still
     # means '*T'. See posix.nim for lots of examples that do that in the wild.
     let callee = call[0]

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -315,8 +315,6 @@ proc genArgStringToCString(p: BProc, n: PNode; result: var Rope; needsTmp: bool)
   var a = initLocExpr(p, n[0])
   appcg(p.module, result, "#nimToCStringConv($1)", [withTmpIfNeeded(p, a, needsTmp).rdLoc])
 
-proc isCppRef(p: BProc; typ: PType): bool {.inline.}
-
 proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; needsTmp = false) =
   var a: TLoc
   if n.kind == nkStringToCString:
@@ -337,7 +335,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; need
     # will be a reference in C++ and we cannot create a temporary reference
     # variable. Thus, we create a temporary pointer variable instead.
     let hadVarIsPtr = tfVarIsPtr in n.typ.flags
-    let needsIndirect = mapType(p.config, n[0].typ, mapTypeChooser(n[0]) == skParam) != ctArray and isCppRef(p, param.typ)
+    let needsIndirect = mapType(p.config, n[0].typ, mapTypeChooser(n[0]) == skParam) != ctArray
     if needsIndirect: n.typ.flags.incl tfVarIsPtr
     a = initLocExprSingleUse(p, n)
     a = withTmpIfNeeded(p, a, needsTmp)

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -430,9 +430,11 @@ proc genParams(p: BProc, ri: PNode, typ: PType; result: var Rope) =
         if not needTmp[i - 1]:
           needTmp[i - 1] = potentialAlias(n, potentialWrites)
       getPotentialWrites(ri[i], false, potentialWrites)
-    if ri[i].kind in {nkHiddenAddr, nkAddr}:
-      # Optimization: don't use a temp, if we would only take the address anyway
-      needTmp[i - 1] = false
+    when false:
+      # this optimization is wrong, see bug #23748
+      if ri[i].kind in {nkHiddenAddr, nkAddr}:
+        # Optimization: don't use a temp, if we would only take the address anyway
+        needTmp[i - 1] = false
 
   var oldLen = result.len
   for i in 1..<ri.len:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -812,6 +812,8 @@ proc genAddr(p: BProc, e: PNode, d: var TLoc) =
     #Message(e.info, warnUser, "HERE NEW &")
   elif mapType(p.config, e[0].typ, mapTypeChooser(e[0]) == skParam) == ctArray or isCppRef(p, e.typ):
     expr(p, e[0], d)
+    # bug #19497
+    d.lode = e
   else:
     var a: TLoc = initLocExpr(p, e[0])
     putIntoDest(p, d, e, addrLoc(p.config, a), a.storage)

--- a/tests/destructor/t23748.nim
+++ b/tests/destructor/t23748.nim
@@ -3,6 +3,7 @@ discard """
   output: '''
 hello 42
 hello 42
+len = 2
 '''
 """
 
@@ -25,5 +26,6 @@ proc push2(o: O, i: int) =
   o.cb.add(p)
 
 let o = O(s: "hello", cb: @[])
-o.push1(42)  # This segfaults
-o.push2(42)  # This also segfaults
+o.push1(42)
+o.push2(42)
+echo "len = ", o.cb.len

--- a/tests/destructor/t23748.nim
+++ b/tests/destructor/t23748.nim
@@ -1,0 +1,25 @@
+discard """
+  matrix: "--gc:refc; --gc:arc"
+"""
+
+# bug #23748
+
+type
+  O = ref object
+    s: string
+    cb: seq[proc()]
+
+proc push1(o: O, i: int) =
+  let o = o
+  echo o.s, " ", i
+  o.cb.add(proc() = echo o.s, " ", i)
+
+proc push2(o: O, i: int) =
+  let o = o
+  echo o.s, " ", i
+  proc p() = echo o.s, " ", i
+  o.cb.add(p)
+
+let o = O(s: "hello", cb: @[])
+o.push1(42)  # This segfaults
+o.push2(42)  # This also segfaults

--- a/tests/destructor/t23748.nim
+++ b/tests/destructor/t23748.nim
@@ -1,5 +1,9 @@
 discard """
   matrix: "--gc:refc; --gc:arc"
+  output: '''
+hello 42
+hello 42
+'''
 """
 
 # bug #23748

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -52,11 +52,10 @@ proc asyncTest() {.async.} =
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
 
-  when false: # sometimes may return status 500 instead of 404
-    resp = await client.request("http://example.com/404")
-    doAssert(resp.code.is4xx)
-    doAssert(resp.code == Http404)
-    doAssert(resp.status == $Http404)
+  resp = await client.request("http://example.com/404")
+  doAssert(resp.code.is4xx or resp.code.is5xx)
+  doAssert(resp.code == Http404 or resp.code == Http500)
+  doAssert(resp.status == $Http404 or resp.status == $Http500)
 
   when false: # occasionally does not give success code 
     resp = await client.request("https://google.com/")
@@ -115,11 +114,10 @@ proc syncTest() =
   doAssert(resp.code.is2xx)
   doAssert("<title>Example Domain</title>" in resp.body)
 
-  when false: # sometimes may return status 500 instead of 404
-    resp = client.request("http://example.com/404")
-    doAssert(resp.code.is4xx)
-    doAssert(resp.code == Http404)
-    doAssert(resp.status == $Http404)
+  resp = client.request("http://example.com/404")
+  doAssert(resp.code.is4xx or resp.code.is5xx)
+  doAssert(resp.code == Http404 or resp.code == Http500)
+  doAssert(resp.status == $Http404 or resp.status == $Http500)
 
   when false: # occasionally does not give success code
     resp = client.request("https://google.com/")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -115,10 +115,11 @@ proc syncTest() =
   doAssert(resp.code.is2xx)
   doAssert("<title>Example Domain</title>" in resp.body)
 
-  resp = client.request("http://example.com/404")
-  doAssert(resp.code.is4xx)
-  doAssert(resp.code == Http404)
-  doAssert(resp.status == $Http404)
+  when false: # sometimes may return status 500 instead of 404
+    resp = client.request("http://example.com/404")
+    doAssert(resp.code.is4xx)
+    doAssert(resp.code == Http404)
+    doAssert(resp.status == $Http404)
 
   when false: # occasionally does not give success code
     resp = client.request("https://google.com/")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -52,10 +52,11 @@ proc asyncTest() {.async.} =
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
 
-  resp = await client.request("http://example.com/404")
-  doAssert(resp.code.is4xx)
-  doAssert(resp.code == Http404)
-  doAssert(resp.status == $Http404)
+  when false: # sometimes may return status 500 instead of 404
+    resp = await client.request("http://example.com/404")
+    doAssert(resp.code.is4xx)
+    doAssert(resp.code == Http404)
+    doAssert(resp.status == $Http404)
 
   when false: # occasionally does not give success code 
     resp = await client.request("https://google.com/")


### PR DESCRIPTION
fixes #23748