### PR TITLE
Comment out flaky test in tests/stdlib/thttpclient

### DIFF
--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -52,11 +52,10 @@ proc asyncTest() {.async.} =
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
 
-  when false: # sometimes may return status 500 instead of 404
-    resp = await client.request("http://example.com/404")
-    doAssert(resp.code.is4xx)
-    doAssert(resp.code == Http404)
-    doAssert(resp.status == $Http404)
+  resp = await client.request("http://example.com/404")
+  doAssert(resp.code.is4xx or resp.code.is5xx)
+  doAssert(resp.code == Http404 or resp.code == Http500)
+  doAssert(resp.status == $Http404 or resp.status == $Http500)
 
   when false: # occasionally does not give success code 
     resp = await client.request("https://google.com/")
@@ -115,11 +114,10 @@ proc syncTest() =
   doAssert(resp.code.is2xx)
   doAssert("<title>Example Domain</title>" in resp.body)
 
-  when false: # sometimes may return status 500 instead of 404
-    resp = client.request("http://example.com/404")
-    doAssert(resp.code.is4xx)
-    doAssert(resp.code == Http404)
-    doAssert(resp.status == $Http404)
+  resp = client.request("http://example.com/404")
+  doAssert(resp.code.is4xx or resp.code.is5xx)
+  doAssert(resp.code == Http404 or resp.code == Http500)
+  doAssert(resp.status == $Http404 or resp.status == $Http500)
 
   when false: # occasionally does not give success code
     resp = client.request("https://google.com/")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -115,10 +115,11 @@ proc syncTest() =
   doAssert(resp.code.is2xx)
   doAssert("<title>Example Domain</title>" in resp.body)
 
-  resp = client.request("http://example.com/404")
-  doAssert(resp.code.is4xx)
-  doAssert(resp.code == Http404)
-  doAssert(resp.status == $Http404)
+  when false: # sometimes may return status 500 instead of 404
+    resp = client.request("http://example.com/404")
+    doAssert(resp.code.is4xx)
+    doAssert(resp.code == Http404)
+    doAssert(resp.status == $Http404)
 
   when false: # occasionally does not give success code
     resp = client.request("https://google.com/")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -52,10 +52,11 @@ proc asyncTest() {.async.} =
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
 
-  resp = await client.request("http://example.com/404")
-  doAssert(resp.code.is4xx)
-  doAssert(resp.code == Http404)
-  doAssert(resp.status == $Http404)
+  when false: # sometimes may return status 500 instead of 404
+    resp = await client.request("http://example.com/404")
+    doAssert(resp.code.is4xx)
+    doAssert(resp.code == Http404)
+    doAssert(resp.status == $Http404)
 
   when false: # occasionally does not give success code 
     resp = await client.request("https://google.com/")


### PR DESCRIPTION
```
$ curl -v http://example.com/404 |& grep 'HTTP/1.1'
> GET /404 HTTP/1.1
< HTTP/1.1 500 Internal Server Error
```

So, the test with http://example.com/404 should be disabled, I think.