### PR TITLE
Fixed issues when using `std/parseopt` in nimscripts with cmdline = ""

### DIFF
--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -176,6 +176,7 @@
 
 include "system/inclrtl"
 
+import std/strutils
 import std/os
 
 type
@@ -249,9 +250,20 @@ proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
       result.cmds[i] = cmdline[i]
   else:
     when declared(paramCount):
-      result.cmds = newSeq[string](paramCount())
-      for i in countup(1, paramCount()):
-        result.cmds[i-1] = paramStr(i)
+      when defined(nimscript):
+        var ctr = 0
+        var firstNimsFound = false
+        for i in countup(0, paramCount()):
+          if firstNimsFound: 
+            result.cmds[ctr] = paramStr(i)
+            inc ctr, 1
+          if paramStr(i).endsWith(".nims") and not firstNimsFound:
+            firstNimsFound = true 
+            result.cmds = newSeq[string](paramCount()-i)
+      else:
+        result.cmds = newSeq[string](paramCount())
+        for i in countup(1, paramCount()):
+          result.cmds[i-1] = paramStr(i)
     else:
       # we cannot provide this for NimRtl creation on Posix, because we can't
       # access the command line arguments then!


### PR DESCRIPTION
Using initOptParser with an empty cmdline (so that it gets the cmdline from the command line) in nimscripts does not yield the expected results.

Fixes #23774.