### PR TITLE
Optimize closure iterator locals

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -127,6 +127,7 @@ type
     sfMember          # proc is a C++ member of a type
     sfCodegenDecl     # type, proc, global or proc param is marked as codegenDecl
     sfWasGenSym       # symbol was 'gensym'ed
+    sfForceLift       # variable has to be lifted into closure environment
 
   TSymFlags* = set[TSymFlag]
 

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -187,7 +187,7 @@ proc newEnvVar(ctx: var Ctx, name: string, typ: PType): PSym =
   result = newSym(skVar, getIdent(ctx.g.cache, name), ctx.idgen, ctx.fn, ctx.fn.info)
   result.typ = typ
   result.flags.incl sfNoInit
-  assert(not typ.isNil)
+  assert(not typ.isNil, "Env var needs a type")
 
   let envParam = getEnvParam(ctx.fn)
   # let obj = envParam.typ.lastSon
@@ -250,7 +250,7 @@ proc newTempVar(ctx: var Ctx, typ: PType, parent: PNode, initialValue: PNode = n
   result = newSym(skVar, getIdent(ctx.g.cache, ":tmpSlLower" & $ctx.tempVarId), ctx.idgen, ctx.fn, ctx.fn.info)
   inc ctx.tempVarId
   result.typ = typ
-  assert(not typ.isNil)
+  assert(not typ.isNil, "Temp var needs a type")
   parent.add(ctx.newTempVarDef(result, initialValue))
 
 proc hasYields(n: PNode): bool =

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -274,15 +274,6 @@ proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PN
   createTypeBoundOpsLL(g, env.typ, n.info, idgen, owner)
   result.add makeClosure(g, idgen, iter, env, n.info)
 
-proc freshVarForClosureIter*(g: ModuleGraph; s: PSym; idgen: IdGenerator; owner: PSym): PNode =
-  let envParam = getHiddenParam(g, owner)
-  let obj = envParam.typ.skipTypes({tyOwned, tyRef, tyPtr})
-  let field = addField(obj, s, g.cache, idgen)
-
-  var access = newSymNode(envParam)
-  assert obj.kind == tyObject
-  result = rawIndirectAccess(access, field, s.info)
-
 # ------------------ new stuff -------------------------------------------
 
 proc markAsClosure(g: ModuleGraph; owner: PSym; n: PNode) =

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -81,7 +81,7 @@ const
     wRequiresInit, wNoalias, wAlign, wNoInit} - {wExportNims, wNodecl} # why exclude these?
   varPragmas* = declPragmas + {wVolatile, wRegister, wThreadVar,
     wMagic, wHeader, wCompilerProc, wCore, wDynlib,
-    wNoInit, wCompileTime, wGlobal,
+    wNoInit, wCompileTime, wGlobal, wLiftLocals,
     wGensym, wInject, wCodegenDecl,
     wGuard, wGoto, wCursor, wNoalias, wAlign}
   constPragmas* = declPragmas + {wHeader, wMagic,
@@ -1308,7 +1308,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         noVal(c, it)
         if sym == nil: invalidPragma(c, it)
         else: sym.flags.incl sfUsed
-      of wLiftLocals: discard
+      of wLiftLocals:
+        sym.flags.incl(sfForceLift)
       of wRequires, wInvariant, wAssume, wAssert:
         pragmaProposition(c, it)
       of wEnsures:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -97,10 +97,7 @@ proc newTemp(c: PTransf, typ: PType, info: TLineInfo): PNode =
   r.typ = typ #skipTypes(typ, {tyGenericInst, tyAlias, tySink})
   incl(r.flags, sfFromGeneric)
   let owner = getCurrOwner(c)
-  if owner.isIterator and not c.tooEarly:
-    result = freshVarForClosureIter(c.graph, r, c.idgen, owner)
-  else:
-    result = newSymNode(r)
+  result = newSymNode(r)
 
 proc transform(c: PTransf, n: PNode): PNode
 
@@ -176,13 +173,10 @@ proc transformSym(c: PTransf, n: PNode): PNode =
 
 proc freshVar(c: PTransf; v: PSym): PNode =
   let owner = getCurrOwner(c)
-  if owner.isIterator and not c.tooEarly:
-    result = freshVarForClosureIter(c.graph, v, c.idgen, owner)
-  else:
-    var newVar = copySym(v, c.idgen)
-    incl(newVar.flags, sfFromGeneric)
-    newVar.owner = owner
-    result = newSymNode(newVar)
+  var newVar = copySym(v, c.idgen)
+  incl(newVar.flags, sfFromGeneric)
+  newVar.owner = owner
+  result = newSymNode(newVar)
 
 proc transformVarSection(c: PTransf, v: PNode): PNode =
   result = newTransNode(v)

--- a/tests/destructor/tuse_ownedref_after_move.nim
+++ b/tests/destructor/tuse_ownedref_after_move.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: '''nim c --newruntime $file'''
-  errormsg: "'=copy' is not available for type <owned Button>; requires a copy because it's not the last read of ':envAlt.b1'; routine: main"
+  errormsg: "'=copy' is not available for type <owned Button>; requires a copy because it's not the last read of ':envAlt.b0'; routine: main"
   line: 48
 """
 

--- a/tests/iter/tyieldintry.nim
+++ b/tests/iter/tyieldintry.nim
@@ -504,3 +504,24 @@ block: # void iterator
     except:
       discard
   var a = it
+
+block: # Locals present in only 1 state should be on the stack
+  proc checkOnStack(a: pointer, shouldBeOnStack: bool) =
+    # Quick and dirty way to check if a points to stack
+    var dummy = 0
+    let dummyAddr = addr dummy
+    let distance = abs(cast[int](dummyAddr) - cast[int](a))
+    const requiredDistance = 300
+    if shouldBeOnStack:
+      doAssert(distance <= requiredDistance, "a is not on stack, but should")
+    else:
+      doAssert(distance > requiredDistance, "a is on stack, but should not")
+
+  iterator it(): int {.closure.} =
+    var a = 1
+    var b = 2
+    checkOnStack(addr a, true)
+    checkOnStack(addr b, false)
+    yield a
+    yield b
+  test(it, 1, 2)

--- a/tests/iter/tyieldintry.nim
+++ b/tests/iter/tyieldintry.nim
@@ -520,8 +520,10 @@ block: # Locals present in only 1 state should be on the stack
   iterator it(): int {.closure.} =
     var a = 1
     var b = 2
+    var c {.liftLocals.} = 3
     checkOnStack(addr a, true)
     checkOnStack(addr b, false)
+    checkOnStack(addr c, false)
     yield a
     yield b
   test(it, 1, 2)


### PR DESCRIPTION
This pr redefines the relation between lambda lifting and closureiter transformation.

Key takeaways:
- Lambdalifting now has less distinction between closureiters and regular closures. Namely instead of lifting _all_ closureiter variables, it lifts only those variables it would also lift for simple closure, i.e. those not owned by the closure.
- It is now closureiter transformation's responsibility to lift all the locals that need lifting and are not lifted by lambdalifting. So now we lift only those locals that appear in more than one state. The rest remains on stack, yay!
- Closureiter transformation always relies on the closure env param created by lambdalifting. Special care taken to make lambdalifting create it even in cases when it's "too early" to lift.
- Environments created by lambdalifting will contain `:state` only for closureiters, whereas previously any closure env contained it.

IMO this is a more reasonable approach as it simplifies not only lambdalifting, but transf too (e.g. freshVarsForClosureIters is now gone for good).

I tried to organize the changes logically by commits, so it might be easier to review this on per commit basis.

Some ugliness:
- Adding lifting to closureiters transformation I had to repeat this matching of `return result = value` node. I tried to understand why it is needed, but that was just another rabbit hole, so I left it for another time. @Araq your input is welcome.
- In the last commit I've reused currently undocumented `liftLocals` pragma for symbols so that closureiter transformation will forcefully lift those even if they don't require lifting otherwise. This is needed for [yasync](https://github.com/yglukhov/yasync) or else it will be very sad.

Overall I'm quite happy with the results, I'm seeing some noticeable code size reductions in my projects. Heavy closureiter/async users, please give it a go.
