### PR TITLE
This test for issue 9739 never needed to depend upon hash order

### DIFF
--- a/tests/cpp/tcasts.nim
+++ b/tests/cpp/tcasts.nim
@@ -1,6 +1,5 @@
 discard """
   cmd: "nim cpp $file"
-  output: '''{"vas": "kas", "123": "123"}'''
   targets: "cpp"
 """
 
@@ -18,4 +17,4 @@ import tables
 var t = initTable[string, string]()
 discard t.hasKeyOrPut("123", "123")
 discard t.mgetOrPut("vas", "kas")
-echo t
+doAssert t.len == 2


### PR DESCRIPTION
(for `string` or any other key type).  Independence is nice to ever change orders.  So, change it to just `len` & a `doAssert` like the other test in the same file.