### PR TITLE
Revert threaded alloc

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -1059,7 +1059,7 @@ template instantiateForRegion(allocator: untyped) {.dirty.} =
   # -------------------- shared heap region ----------------------------------
 
   proc allocSharedImpl(size: Natural): pointer =
-    when hasThreadSupport and not defined(gcDestructors):
+    when hasThreadSupport:
       acquireSys(heapLock)
       result = alloc(sharedHeap, size)
       releaseSys(heapLock)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -12,7 +12,6 @@
 
 include osalloc
 import std/private/syslocks
-import std/sysatomics
 
 template track(op, address, size) =
   when defined(memTracker):


### PR DESCRIPTION
This commit reverts: [threaded alloc](https://github.com/nim-lang/Nim/pull/20492)
For now the default allocator uses a global lock with the performance cost that entails.

Other noteworthy PRs that were kept:
- [make -d:debugHeapLinks compile again](https://github.com/nim-lang/Nim/pull/23126)
- [Add check for nimMaxJeap on occupied memory + allocation size](https://github.com/nim-lang/Nim/pull/21521)