### PR TITLE
Add support for nvcc & hipcc (cuda/rocm)

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -172,6 +172,22 @@ compiler vcc:
     cppXsupport: "",
     props: {hasCpp, hasAssume, hasDeclspec})
 
+# Nvidia CUDA NVCC Compiler
+compiler nvcc:
+  result = gcc()
+  result.name = "nvcc"
+  result.compilerExe = "nvcc"
+  result.cppCompiler = "nvcc"
+  result.compileTmpl = "-c -x cu -Xcompiler=\"$options\" $include -o $objfile $file"
+  result.linkTmpl = "$buildgui $builddll -o $exefile $objfiles -Xcompiler=\"$options\""
+
+# AMD HIPCC Compiler (rocm/cuda)
+compiler hipcc:
+  result = clang()
+  result.name = "hipcc"
+  result.compilerExe = "hipcc"
+  result.cppCompiler = "hipcc"
+
 compiler clangcl:
   result = vcc()
   result.name = "clang_cl"
@@ -285,7 +301,9 @@ const
     envcc(),
     icl(),
     icc(),
-    clangcl()]
+    clangcl(),
+    hipcc(),
+    nvcc()]
 
   hExt* = ".h"
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -254,7 +254,7 @@ type
 
   TSystemCC* = enum
     ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccBcc, ccVcc,
-    ccTcc, ccEnv, ccIcl, ccIcc, ccClangCl
+    ccTcc, ccEnv, ccIcl, ccIcc, ccClangCl, ccHipcc, ccNvcc
 
   ExceptionSystem* = enum
     excNone,   # no exception system selected yet

--- a/doc/nimc.md
+++ b/doc/nimc.md
@@ -490,36 +490,18 @@ Here's a very simple CUDA kernel example using emit, which can be compiled with 
 
 ```nim
 {.emit: """
-__global__ void add(int a, int b, int *c) {
-    *c = a + b;
+__global__ void add(int a, int b) {
+  int c;
+  c = a + b;
 }
 """.}
 
-type
-  cudaMemcpyKind* {.size: sizeof(cint), importcpp: "cudaMemcpyKind".} = enum
-    cudaMemcpyHostToHost = 0,    ## < Host-to-Host Copy
-    cudaMemcpyHostToDevice = 1,  ## < Host-to-Device Copy
-    cudaMemcpyDeviceToHost = 2,  ## < Device-to-Host Copy
-    cudaMemcpyDeviceToDevice = 3, ## < Device-to-Device Copy
-    cudaMemcpyDefault = 4        ## < Runtime will automatically determine copy-kind based on virtual addresses.
-
-proc cudaMalloc*(`ptr`: ptr pointer; size: cint): cint {.importcpp: "cudaMalloc(@)".}
-proc cudaMemcpy*(dst: pointer; src: pointer; size: cint; kind: cudaMemcpyKind): cint {.importcpp: "cudaMemcpy(@)".}
-proc cudaFree*(`ptr`: pointer): cint {.importcpp: "cudaFree(@)".}
-
 proc main() =
-  var c: int32
-  var dev_c: ptr[int32]
-  discard cudaMalloc(cast[ptr pointer](addr dev_c), sizeof(int32).cint)
   {.emit: """
-  add<<<1,1>>>(2,7,dev_c);
+  add<<<1,1>>>(2,7);
   """.}
-  discard cudaMemcpy(addr c, dev_c, sizeof(int32).cint, cudaMemcpyDeviceToHost)
-  echo "2 + 7 = ", c
-  discard cudaFree(dev_c)
 
-when isMainModule:
-  main()
+main()
 ```
 
 DLL generation


### PR DESCRIPTION
I've been working on making some basic cuda examples work, both with cuda (nvcc) and with AMD HIP (hipcc) https://github.com/monofuel/hippo

- hipcc is just a drop-in replacement for clang and works out of the box with clang settings in Nim. hipcc is capable of compiling for AMD ROCm or to CUDA, depending on how HIP_PLATFORM is set.
- nvcc is a little quirky. we can use `-x cu` to tell it to handle nim's `.cpp` files as if they were `.cu` files. nvcc expects all backend compiler flags to be wrapped with a special `-Xcompiler=""` flag when compiling and also when linking.

I manually tested on a linux desktop with amd and a laptop with nvidia.