### PR TITLE
fixes #3011; handles meta fields defined in the ref object

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1778,8 +1778,7 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         let baseType = s.typ.safeSkipTypes(abstractPtrs)
         if baseType.kind in {tyObject, tyTuple} and not baseType.n.isNil and
           (x.kind in {nkObjectTy, nkTupleTy} or
-           (x.kind in {nkRefTy, nkPtrTy} and x.len == 1 and
-           x[0].kind in {nkObjectTy, nkTupleTy})
+           tfRefsAnonObj in s.typ.flags
           ):
           checkForMetaFields(c, baseType.n, hasError)
         if not hasError:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1779,7 +1779,7 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         if baseType.kind in {tyObject, tyTuple} and not baseType.n.isNil and
           (x.kind in {nkObjectTy, nkTupleTy} or
            (x.kind in {nkRefTy, nkPtrTy} and x.len == 1 and
-           x[0].kind == nkObjectTy)
+           x[0].kind in {nkObjectTy, nkTupleTy})
           ):
           checkForMetaFields(c, baseType.n, hasError)
         if not hasError:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1778,7 +1778,8 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         let baseType = s.typ.safeSkipTypes(abstractPtrs)
         if baseType.kind in {tyObject, tyTuple} and not baseType.n.isNil and
           (x.kind in {nkObjectTy, nkTupleTy} or
-           tfRefsAnonObj in s.typ.flags
+           (x.kind in {nkRefTy, nkPtrTy} and x.len == 1 and
+           x[0].kind in {nkObjectTy, nkTupleTy})
           ):
           checkForMetaFields(c, baseType.n, hasError)
         if not hasError:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1775,8 +1775,13 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
               assignType(s.typ, t)
               s.typ.itemId = t.itemId     # same id
         var hasError = false
-        if s.typ.kind in {tyObject, tyTuple} and not s.typ.n.isNil:
-          checkForMetaFields(c, s.typ.n, hasError)
+        let baseType = s.typ.safeSkipTypes(abstractPtrs)
+        if baseType.kind in {tyObject, tyTuple} and not baseType.n.isNil and
+          (x.kind in {nkObjectTy, nkTupleTy} or
+           (x.kind in {nkRefTy, nkPtrTy} and x.len == 1 and
+           x[0].kind == nkObjectTy)
+          ):
+          checkForMetaFields(c, baseType.n, hasError)
         if not hasError:
           checkConstructedType(c.config, s.info, s.typ)
 

--- a/tests/errmsgs/tmetaobjectfields.nim
+++ b/tests/errmsgs/tmetaobjectfields.nim
@@ -2,16 +2,18 @@ discard """
   cmd: "nim check --hints:off $file"
   action: "reject"
   nimout: '''
-tmetaobjectfields.nim(24, 5) Error: 'array' is not a concrete type
-tmetaobjectfields.nim(28, 5) Error: 'seq' is not a concrete type
-tmetaobjectfields.nim(32, 5) Error: 'set' is not a concrete type
-tmetaobjectfields.nim(35, 3) Error: 'sink' is not a concrete type
-tmetaobjectfields.nim(37, 3) Error: 'lent' is not a concrete type
-tmetaobjectfields.nim(54, 16) Error: 'seq' is not a concrete type
-tmetaobjectfields.nim(58, 5) Error: 'ptr' is not a concrete type
-tmetaobjectfields.nim(59, 5) Error: 'ref' is not a concrete type
-tmetaobjectfields.nim(60, 5) Error: 'auto' is not a concrete type
-tmetaobjectfields.nim(61, 5) Error: 'UncheckedArray' is not a concrete type
+tmetaobjectfields.nim(26, 5) Error: 'array' is not a concrete type
+tmetaobjectfields.nim(30, 5) Error: 'seq' is not a concrete type
+tmetaobjectfields.nim(34, 5) Error: 'set' is not a concrete type
+tmetaobjectfields.nim(37, 3) Error: 'sink' is not a concrete type
+tmetaobjectfields.nim(39, 3) Error: 'lent' is not a concrete type
+tmetaobjectfields.nim(56, 16) Error: 'seq' is not a concrete type
+tmetaobjectfields.nim(60, 5) Error: 'ptr' is not a concrete type
+tmetaobjectfields.nim(61, 5) Error: 'ref' is not a concrete type
+tmetaobjectfields.nim(62, 5) Error: 'auto' is not a concrete type
+tmetaobjectfields.nim(63, 5) Error: 'UncheckedArray' is not a concrete type
+tmetaobjectfields.nim(68, 5) Error: 'object' is not a concrete type
+tmetaobjectfields.nim(72, 5) Error: 'Type3011:ObjectType' is not a concrete type
 '''
 """
 
@@ -59,3 +61,15 @@ type
     b: ref
     c: auto
     d: UncheckedArray
+
+# bug #3011
+type
+  Type3011 = ref object 
+    context: ref object
+
+type
+  Value3011 = ref object
+    typ: Type3011
+
+proc x3011(): Value3011 =
+  nil

--- a/tests/generics/twrong_generic_object.nim
+++ b/tests/generics/twrong_generic_object.nim
@@ -1,6 +1,6 @@
 discard """
-  errormsg: "cannot instantiate: 'GenericNodeObj[T]'; Maybe generic arguments are missing?"
-  line: 21
+  errormsg: "'Node' is not a concrete type"
+  line: 11
 """
 # bug #2509
 type


### PR DESCRIPTION
fixes #3011

In https://github.com/nim-lang/Nim/pull/23532, meta fields that defined in the object are handled. 

In this PR, RefObjectTy is handled as well:
```nim
type
  Type = ref object 
    context: ref object
```
Ref alias won't trigger mata fields checking so there won't have cascaded errors on `TypeBase`.

```nim
type
  TypeBase = object 
    context: ref object
  Type = ref TypeBase 
    context: ref object
```