### PR TITLE
fixes #23825; Busy wait on waitid, sleeping at regular intervals

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1396,10 +1396,12 @@ elif not defined(useNimRtl):
                 raiseOSError(osLastError())
             else:
               let newWait = getTime() + delay
-              var waitSpec: TimeSpec
+              var 
+                waitSpec: TimeSpec
+                unused: Timespec
               waitSpec.tv_sec = posix.Time(newWait.toUnix())
               waitSpec.tv_nsec = newWait.nanosecond.clong
-              discard posix.clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, waitSpec, cast[var TimeSpec](nil))
+              discard posix.clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, waitSpec, unused)
               let remaining = deadline - getTime()
               delay = min([delay * 2, remaining, maxWait])
 

--- a/tests/osproc/twaitforexit.nim
+++ b/tests/osproc/twaitforexit.nim
@@ -16,3 +16,18 @@ block: # bug #5091
 
         # check that we don't have to wait msWait milliseconds
         doAssert(getTime() <  atStart + milliseconds(msWait))
+
+block: # bug #23825
+    var thr: array[0..99, Thread[int]]
+
+    proc threadFunc(i: int) {.thread.} =
+        let sleepTime = float(i) / float(thr.len + 1)
+        doAssert sleepTime < 1.0
+        let p = startProcess("sleep", workingDir = "", args = @[$sleepTime], options = {poUsePath, poParentStreams})
+        # timeout = 1_000_000 seconds ~= 278 hours ~= 11.5 days
+        doAssert p.waitForExit(timeout=1_000_000_000) == 0
+
+    for i in low(thr)..high(thr):
+        createThread(thr[i], threadFunc, i)
+
+    joinThreads(thr) 


### PR DESCRIPTION
Addresses #23825 by using the approaching described in https://github.com/nim-lang/Nim/pull/23743#issuecomment-2199523110.

This takes the approach from Python's `subprocess` library which calls `waitid` in loop, while sleeping at regular intervals.

CC @alex65536 