### PR TITLE
fixes #23844; Nim devel nightly i386 build failing

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1406,7 +1406,7 @@ elif not defined(useNimRtl):
                 waitSpec: TimeSpec
                 unused: Timespec
               waitSpec.tv_sec = posix.Time(secs)
-              waitSpec.tv_nsec = ns 
+              waitSpec.tv_nsec = int ns 
               discard posix.clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, waitSpec, unused)
               let remaining = deadline - getMonoTime()
               delay = min([delay * 2, remaining, maxWait])

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1406,7 +1406,7 @@ elif not defined(useNimRtl):
                 waitSpec: TimeSpec
                 unused: Timespec
               waitSpec.tv_sec = posix.Time(secs)
-              waitSpec.tv_nsec = int ns 
+              waitSpec.tv_nsec = clong ns 
               discard posix.clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, waitSpec, unused)
               let remaining = deadline - getMonoTime()
               delay = min([delay * 2, remaining, maxWait])


### PR DESCRIPTION
fixes #23844
follow up https://github.com/nim-lang/Nim/pull/23834

```nim
type
  Timespec* {.importc: "struct timespec",
               header: "<time.h>", final, pure.} = object ## struct timespec
    tv_sec*: Time  ## Seconds.
    tv_nsec*: clong  ## Nanoseconds.
```