### PR TITLE
fixes #23848; The comand `nim gendepend` defaults to ORC

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -117,7 +117,8 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 
   if conf.selectedGC == gcUnselected:
     if conf.backend in {backendC, backendCpp, backendObjc} or
-        (conf.cmd in cmdDocLike and conf.backend != backendJs):
+        (conf.cmd in cmdDocLike and conf.backend != backendJs) or
+        conf.cmd == cmdGendepend:
       initOrcDefines(conf)
 
   mainCommand(graph)


### PR DESCRIPTION
fixes #23848