### PR TITLE
Allocator: Track number of foreign cells a small chunk has access to

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -93,7 +93,8 @@ type
     freeList: ptr FreeCell
     free: int32              # how many bytes remain
     acc: uint32              # accumulator for small object allocation
-    foreignCells: int        # Counter for cells this chunk can use but doesn't own
+    foreignCells: int        # Number of deferred free cells from other threads this chunk stole from sharedFreeLists.
+                             # Freeing the chunk before this is zero means the stolen cells become inaccessible permanently.
     data {.align: MemAlign.}: UncheckedArray[byte]      # start of usable memory
 
   BigChunk = object of BaseChunk # not necessarily > PageSize!

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -881,6 +881,9 @@ proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
       dec(c.free, size)
       sysAssert((cast[int](result) and (MemAlign-1)) == 0, "rawAlloc 9")
       sysAssert(allocInv(a), "rawAlloc: end c != nil")
+      # We fetch deferred cells *after* advancing c.freeList/acc to adjust c.free.
+      # If after the adjustment it turns out there's free cells available,
+      #  the chunk stays in a.freeSmallChunks[s] and the need for a new chunk is delayed.
       fetchSharedCells(c)
       sysAssert(allocInv(a), "rawAlloc: before c.free < size")
       if c.free < size:


### PR DESCRIPTION
Ref: https://github.com/nim-lang/Nim/issues/23788

There was a small leak in the above issue even after fixing the segfault. The sizes of `free` and `acc` were changed to 32bit because adding the `foreignCells` field will drastically increase the memory usage for programs that hold onto memory for a long time if they stay as 64bit.