### PR TITLE
Add '.' (period, dot, ..) to `FormatLiterals` so that `ss.fff` can work.

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1631,7 +1631,7 @@ const
         "Sunday"],
   )
 
-  FormatLiterals = {' ', '-', '/', ':', '(', ')', '[', ']', ','}
+  FormatLiterals = {' ', '-', '/', ':', '(', ')', '[', ']', ',', '.'}
 
 proc `$`*(f: TimeFormat): string =
   ## Returns the format string that was used to construct `f`.


### PR DESCRIPTION
Honestly, to me the entire design of a (highly!) restricted set of `FormatLiterals` characters seems antithetical to the very idea of a format string template.  Fixing that is a much larger change, though.

So, this PR just adds `'.'` so that the standard (both input & output!) notation for decimal numbers in Nim can be used for the seconds part of a time format in `lib/pure/times.format(.., f)`.  It should only make legal what was illegal and should be harmless since `'.'` is not used in any special way otherwise.