### PR TITLE
Allocator: Always place free cells into the active chunk and add documentation

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -990,7 +990,8 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
         # This pointer is not part of the active chunk, lend it out
         #  and do not adjust the current chunk (same logic as compensateCounters.)
         # Put the cell into the active chunk,
-        #  may prevent a queue of available chunks from forming in a.freeSmallChunks[s div MemAlign]
+        #  may prevent a queue of available chunks from forming in a.freeSmallChunks[s div MemAlign].
+        #  This queue would otherwise waste memory until we return to those chunks.
         f.next = activeChunk.freeList
         activeChunk.freeList = f # lend the cell
         inc(activeChunk.free, s) # By not adjusting the current chunk's capacity it is prevented from being freed


### PR DESCRIPTION
Lets single threaded applications benefit from tracking foreign cells as well.
After this, `SmallChunk` technically doesn't need to act as a linked list anymore I think, gotta investigate that more though.
The likelihood of overflowing `chunk.free` also rises, so to work around that it might make sense to check `foreignCells` instead of adjusting free space or replace free with a counter for the local capacity.

For Nim compile I can observe a ~10mb reduction, and smaller ones for other projects.