### PR TITLE
fixes #23869; sink generic typeclass

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1166,11 +1166,11 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
         paramType[i] = t
         result = paramType
 
-  of tyAlias, tyOwned, tySink:
+  of tyAlias, tyOwned:
     result = recurse(paramType.base)
 
   of tySequence, tySet, tyArray, tyOpenArray,
-     tyVar, tyLent, tyPtr, tyRef, tyProc:
+     tyVar, tyLent, tyPtr, tyRef, tyProc, tySink:
     # XXX: this is a bit strange, but proc(s: seq)
     # produces tySequence(tyGenericParam, tyNone).
     # This also seems to be true when creating aliases

--- a/tests/proc/t23874.nim
+++ b/tests/proc/t23874.nim
@@ -2,7 +2,7 @@ block:
   type Head[T] = object
     wasc: bool
 
-  proc `=destroy`[T](x: Head[T]) =
+  proc `=destroy`[T](x: var Head[T]) =
     discard
 
   proc `=copy`[T](x: var Head[T], y: Head[T]) =

--- a/tests/proc/t23874.nim
+++ b/tests/proc/t23874.nim
@@ -1,0 +1,26 @@
+block:
+  type Head[T] = object
+    wasc: bool
+
+  proc `=destroy`[T](x: Head[T]) =
+    discard
+
+  proc `=copy`[T](x: var Head[T], y: Head[T]) =
+    x.wasc = true
+
+  proc `=dup`[T](x: Head[T]): Head[T] =
+    result.wasc = true
+
+  proc update(h: var Head) =
+    discard
+
+  proc digest(h: sink Head) =
+    assert h.wasc
+
+  var h = Head[int](wasc: false)
+  h.digest() # sink h
+  h.update() # use after sink
+
+block:
+  proc two(a: sink auto) =discard
+  assert typeof(two[int]) is proc(a: sink int) {.nimcall.}


### PR DESCRIPTION
Still have to look this over some. We'll see. I put sink in this branch simply because I saw `tyVar` there and for no other reason. In any case the problem appears to be coming from `liftParamType` as it removes the `sink` type from the formals.
#23869