### PR TITLE
fixes #23838: Compilation by MinGW for cpu=i386 with time_t bug

### DIFF
--- a/lib/std/time_t.nim
+++ b/lib/std/time_t.nim
@@ -14,7 +14,7 @@ when defined(nimdoc):
       ## Wrapper for `time_t`. On posix, this is an alias to `posix.Time`.
 elif defined(windows):
   when defined(i386) and defined(gcc):
-    type Time* {.importc: "time_t", header: "<time.h>".} = distinct int32
+    type Time* {.importc: "time_t", header: "<time.h>".} = distinct clong
   else:
     # newest version of Visual C++ defines time_t to be of 64 bits
     type Time* {.importc: "time_t", header: "<time.h>".} = distinct int64


### PR DESCRIPTION
Change Time type in std/time_t to `distinct clong` instead of `distinct int32`