### PR TITLE
fixes #19171; have `openArray` converted from `ptr UncheckedArray` be mutable

### DIFF
--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -285,7 +285,10 @@ proc isAssignable*(owner: PSym, n: PNode): TAssignableResult =
   of nkCallKinds:
     # builtin slice keeps lvalue-ness:
     if getMagic(n) in {mArrGet, mSlice}:
-      result = isAssignable(owner, n[1])
+      if n[1].typ.kind == tyPtr:
+        result = arLValue
+      else:
+        result = isAssignable(owner, n[1])
     elif n.typ != nil:
       case n.typ.kind
       of tyVar: result = arLValue

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -283,12 +283,16 @@ proc isAssignable*(owner: PSym, n: PNode): TAssignableResult =
   of nkObjUpConv, nkObjDownConv, nkCheckedFieldExpr:
     result = isAssignable(owner, n[0])
   of nkCallKinds:
-    # builtin slice keeps lvalue-ness:
-    if getMagic(n) in {mArrGet, mSlice}:
+    let m = getMagic(n)
+    if m == mSlice:
+      # builtin slice keeps lvalue-ness:
       if n[1].typ.kind == tyPtr:
+        # slices of non-lvalue pointers are still l-values
         result = arLValue
       else:
         result = isAssignable(owner, n[1])
+    elif m == mArrGet:
+      result = isAssignable(owner, n[1])
     elif n.typ != nil:
       case n.typ.kind
       of tyVar: result = arLValue

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -285,9 +285,9 @@ proc isAssignable*(owner: PSym, n: PNode): TAssignableResult =
   of nkCallKinds:
     let m = getMagic(n)
     if m == mSlice:
-      # builtin slice keeps lvalue-ness:
+      # builtin slice keeps l-value-ness
+      # except for pointers because slice dereferences
       if n[1].typ.kind == tyPtr:
-        # slices of non-lvalue pointers are still l-values
         result = arLValue
       else:
         result = isAssignable(owner, n[1])

--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -83,6 +83,19 @@ proc main =
       var d: array[1, int]
       foo task(d)[].toOpenArray(0, 0)
 
+proc runtimeOnly =
+  block: # issue 19171
+    let a = ['A']
+    proc mutB(x: var openArray[char]) =
+      x[0] = 'B'
+    mutB(toOpenArray(cast[ptr UncheckedArray[char]](addr a), 0, 0))
+    doAssert a[0] == 'B'
+    proc mutC(x: var openArray[char]; c: char) =
+      x[0] = c
+    let p = cast[ptr UncheckedArray[char]](addr a)
+    mutC(toOpenArray(p, 0, 0), 'C')
+    doAssert p[0] == 'C'
 
 main()
 static: main()
+runtimeOnly()

--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -83,5 +83,6 @@ proc main =
       var d: array[1, int]
       foo task(d)[].toOpenArray(0, 0)
 
+
 main()
 static: main()

--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -83,19 +83,5 @@ proc main =
       var d: array[1, int]
       foo task(d)[].toOpenArray(0, 0)
 
-proc runtimeOnly =
-  block: # issue 19171
-    let a = ['A']
-    proc mutB(x: var openArray[char]) =
-      x[0] = 'B'
-    mutB(toOpenArray(cast[ptr UncheckedArray[char]](addr a), 0, 0))
-    doAssert a[0] == 'B'
-    proc mutC(x: var openArray[char]; c: char) =
-      x[0] = c
-    let p = cast[ptr UncheckedArray[char]](addr a)
-    mutC(toOpenArray(p, 0, 0), 'C')
-    doAssert p[0] == 'C'
-
 main()
 static: main()
-runtimeOnly()

--- a/tests/openarray/tuncheckedarray.nim
+++ b/tests/openarray/tuncheckedarray.nim
@@ -5,7 +5,7 @@ discard """
 
 proc main =
   block: # issue 19171
-    let a = ['A']
+    var a = ['A']
     proc mutB(x: var openArray[char]) =
       x[0] = 'B'
     mutB(toOpenArray(cast[ptr UncheckedArray[char]](addr a), 0, 0))

--- a/tests/openarray/tuncheckedarray.nim
+++ b/tests/openarray/tuncheckedarray.nim
@@ -1,0 +1,19 @@
+discard """
+  exitcode: 0
+  targets: "c cpp"
+"""
+
+proc main =
+  block: # issue 19171
+    let a = ['A']
+    proc mutB(x: var openArray[char]) =
+      x[0] = 'B'
+    mutB(toOpenArray(cast[ptr UncheckedArray[char]](addr a), 0, 0))
+    doAssert a[0] == 'B'
+    proc mutC(x: var openArray[char]; c: char) =
+      x[0] = c
+    let p = cast[ptr UncheckedArray[char]](addr a)
+    mutC(toOpenArray(p, 0, 0), 'C')
+    doAssert p[0] == 'C'
+
+main()


### PR DESCRIPTION
Makes `toOpenArray(x: ptr UncheckedArray)` always return a `var openArray` regardless of if `x` is mutable.