### PR TITLE
improve mangling packages version names with checksums

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -683,14 +683,14 @@ proc uniqueModuleName*(conf: ConfigRef; fid: FileIndex): string =
   for i in 0..<trunc:
     let c = rel[i]
     case c
-    of 'a'..'z':
+    of 'a'..'z', '0'..'9':
       result.add c
     of {os.DirSep, os.AltSep}:
       result.add 'Z' # because it looks a bit like '/'
     of '.':
       result.add 'O' # a circle
     else:
-      # We mangle upper letters and digits too so that there cannot
+      # We mangle upper letters too so that there cannot
       # be clashes with our special meanings of 'Z' and 'O'
       result.addInt ord(c)
 


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/19821

dights cannot clash with letters 'Z' and 'O'


For `threading-0.2.0-288108d1dfa34d5ade5ce4d922af51909c83cebf`

Before: 

raiseNilAccess__OOZOOZOnimbleZpkgs50Zthreading4548O50O4845505656494856d49dfa5152d53ade53ce52d575050af5349574857c5651cebfZthreadingZsmartptrs_u4


After:

raiseNilAccess__OOZOOZOnimbleZpkgs2Zthreading450O2O045288108d1dfa34d5ade5ce4d922af51909c83cebfZthreadingZsmartptrs_u4


<del> nimble or something might use `git rev-parse --short HEAD` to shorten the length of package version names ref https://github.com/nim-lang/nimble/pull/913 </del>
