### PR TITLE
fixes #23894; succ/pred shouldn't raise OverflowDefect for unsigned integers

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -590,7 +590,7 @@ proc binaryArithOverflow(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
   # skipping 'range' is correct here as we'll generate a proper range check
   # later via 'chckRange'
   let t = e.typ.skipTypes(abstractRange)
-  if optOverflowCheck notin p.options:
+  if optOverflowCheck notin p.options or (m in {mSucc, mPred} and t.kind in {tyUInt..tyUInt64}):
     let res = "($1)($2 $3 $4)" % [getTypeDesc(p.module, e.typ), rdLoc(a), rope(opr[m]), rdLoc(b)]
     putIntoDest(p, d, e, res)
   else:

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -219,3 +219,9 @@ proc bug23223 = # bug #23223
   doAssert stuff == "hello"
 
 bug23223()
+
+block: # bug #23894
+  let v = high(uint) div 2
+  let s = v + 1 # 9223372036854775808
+  let m = succ v
+  doAssert s == m


### PR DESCRIPTION
fixes #23894

keeps it consistent with `inc`