### PR TITLE
fixes #23923; type-aliased seq[T] get different backend C/C++ pointer type names causing invalid codegen

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -353,7 +353,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; need
       addRdLoc(a, result)
   else:
     a = initLocExprSingleUse(p, n)
-    if param.typ.kind in abstractPtrs:
+    if param.typ.kind in {tyVar, tyPtr, tyRef, tySink}:
       let typ = skipTypes(param.typ, abstractPtrs)
       if not sameBackendTypePickyAliases(typ, n.typ.skipTypes(abstractPtrs)):
         a.snippet = "(($1) ($2))" %

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -315,6 +315,12 @@ proc genArgStringToCString(p: BProc, n: PNode; result: var Rope; needsTmp: bool)
   var a = initLocExpr(p, n[0])
   appcg(p.module, result, "#nimToCStringConv($1)", [withTmpIfNeeded(p, a, needsTmp).rdLoc])
 
+# proc filterArgType(t: PType): bool =
+#   case t.kind
+#   of tyEmpty, tyChar, tyBool, tyNil, tyPointer, tyString, tyCstring,
+#      tyInt..tyUInt64, tyTyped, tyUntyped, tyVoid:
+#     result = 
+
 proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; needsTmp = false) =
   var a: TLoc
   if n.kind == nkStringToCString:
@@ -355,7 +361,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; need
     a = initLocExprSingleUse(p, n)
     if param.typ.kind in abstractPtrs:
       let typ = skipTypes(param.typ, abstractPtrs)
-      if typ.sym != nil and sfImportc in typ.sym.flags:
+      if not sameBackendTypePickyAliases(typ, n.typ.skipTypes(abstractPtrs)):
         a.snippet = "(($1) ($2))" %
           [getTypeDesc(p.module, param.typ), rdCharLoc(a)]
     addRdLoc(withTmpIfNeeded(p, a, needsTmp), result)

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -315,12 +315,6 @@ proc genArgStringToCString(p: BProc, n: PNode; result: var Rope; needsTmp: bool)
   var a = initLocExpr(p, n[0])
   appcg(p.module, result, "#nimToCStringConv($1)", [withTmpIfNeeded(p, a, needsTmp).rdLoc])
 
-# proc filterArgType(t: PType): bool =
-#   case t.kind
-#   of tyEmpty, tyChar, tyBool, tyNil, tyPointer, tyString, tyCstring,
-#      tyInt..tyUInt64, tyTyped, tyUntyped, tyVoid:
-#     result = 
-
 proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Rope; needsTmp = false) =
   var a: TLoc
   if n.kind == nkStringToCString:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -984,7 +984,7 @@ type
     AllowCommonBase
     PickyCAliases  # be picky about the distinction between 'cint' and 'int32'
     IgnoreFlags    # used for borrowed functions and methods; ignores the tfVarIsPtr flag
-    PickyBackendAliases # be picky different aliases
+    PickyBackendAliases # be picky about different aliases
 
   TTypeCmpFlags* = set[TTypeCmpFlag]
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -984,6 +984,7 @@ type
     AllowCommonBase
     PickyCAliases  # be picky about the distinction between 'cint' and 'int32'
     IgnoreFlags    # used for borrowed functions and methods; ignores the tfVarIsPtr flag
+    PickyBackendAliases # be picky different aliases
 
   TTypeCmpFlags* = set[TTypeCmpFlag]
 
@@ -1260,6 +1261,11 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
       let symFlagsB = if b.sym != nil: b.sym.flags else: {}
       if (symFlagsA+symFlagsB) * {sfImportc, sfExportc} != {}:
         result = symFlagsA == symFlagsB
+    elif result and PickyBackendAliases in c.flags:
+      let symFlagsA = if a.sym != nil: a.sym.flags else: {}
+      let symFlagsB = if b.sym != nil: b.sym.flags else: {}
+      if (symFlagsA+symFlagsB) * {sfImportc, sfExportc} != {}:
+        result = a.id == b.id
 
   of tyStatic, tyFromExpr:
     result = exprStructuralEquivalent(a.n, b.n) and sameFlags(a, b)
@@ -1343,6 +1349,12 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
 proc sameBackendType*(x, y: PType): bool =
   var c = initSameTypeClosure()
   c.flags.incl IgnoreTupleFields
+  c.cmp = dcEqIgnoreDistinct
+  result = sameTypeAux(x, y, c)
+
+proc sameBackendTypePickyAliases*(x, y: PType): bool =
+  var c = initSameTypeClosure()
+  c.flags.incl {IgnoreTupleFields, PickyCAliases, PickyBackendAliases}
   c.cmp = dcEqIgnoreDistinct
   result = sameTypeAux(x, y, c)
 


### PR DESCRIPTION
… type names causing invalid codegen

fixes #23923