### PR TITLE
fixes #23925; VM generates wrong cast for negative enum values

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -901,8 +901,8 @@ proc genCard(c: PCtx; n: PNode; dest: var TDest) =
 
 proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
   const allowedIntegers = {tyInt..tyInt64, tyUInt..tyUInt64, tyChar, tyEnum, tyBool}
-  var signedIntegers = {tyInt..tyInt64}
-  var unsignedIntegers = {tyUInt..tyUInt64, tyChar, tyEnum, tyBool}
+  var signedIntegers = {tyInt..tyInt64, tyEnum}
+  var unsignedIntegers = {tyUInt..tyUInt64, tyChar, tyBool}
   let src = n[1].typ.skipTypes(abstractRange)#.kind
   let dst = n[0].typ.skipTypes(abstractRange)#.kind
   let srcSize = getSize(c.config, src)

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -766,3 +766,12 @@ block: # issue #15730
 static: # more nil cstring issues
   let x = cstring(nil)
   doAssert x.len == 0
+
+block: # bug #23925
+  type Foo = enum A = -1
+  proc foo =
+    doAssert cast[Foo](-1) == A
+    doAssert ord(A) == -1
+
+  static: foo()
+  foo()


### PR DESCRIPTION
fixes #23925