### PR TITLE
fixes #23932; vmopsDanger for os.getCurrentDir errors

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -27,6 +27,7 @@ from std/envvars import getEnv, existsEnv, delEnv, putEnv, envPairs
 from std/os import getAppFilename
 from std/private/oscommon import dirExists, fileExists
 from std/private/osdirs import walkDir, createDir
+from std/private/ospaths2 import getCurrentDir
 
 from std/times import cpuTime
 from std/hashes import hash
@@ -341,8 +342,8 @@ proc registerAdditionalOps*(c: PCtx) =
     ## reproducible builds and users need to understand that this runs at CT.
     ## Note that `staticExec` can already do equal amount of damage so it's more
     ## of a semantic issue than a security issue.
-    registerCallback c, "stdlib.os.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
-      setResult(a, os.getCurrentDir())
+    registerCallback c, "stdlib.ospaths2.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, getCurrentDir())
     registerCallback c, "stdlib.osproc.execCmdEx", proc (a: VmArgs) {.nimcall.} =
       let options = getNode(a, 1).fromLit(set[osproc.ProcessOption])
       a.setResult osproc.execCmdEx(getString(a, 0), options).toLit

--- a/tests/vm/tvmopsDanger.nim
+++ b/tests/vm/tvmopsDanger.nim
@@ -8,3 +8,6 @@ import std/times
 const foo = getTime()
 let bar = foo
 doAssert bar > low(Time)
+
+static: # bug #23932
+  doAssert getCurrentDir().len > 0

--- a/tests/vm/tvmopsDanger.nim
+++ b/tests/vm/tvmopsDanger.nim
@@ -3,7 +3,7 @@ discard """
 """
 when defined(nimPreviewSlimSystem):
   import std/assertions
-import std/times
+import std/[times, os]
 
 const foo = getTime()
 let bar = foo


### PR DESCRIPTION
fixes #23932
ref https://github.com/jmgomez/NimForUE/issues/36