### PR TITLE
Fixes an issue where two types can collide in the cgen

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -57,11 +57,11 @@ proc mangleField(m: BModule; name: PIdent): string =
 
 proc mangleProc(m: BModule; s: PSym; makeUnique: bool): string =
   result = "_Z"  # Common prefix in Itanium ABI
-  result.add encodeSym(m, s, makeUnique)
+  result.add encodeSym(m, s, maItanium, makeUnique)
   if s.typ.len > 1: #we dont care about the return param
     for i in 1..<s.typ.len:
       if s.typ[i].isNil: continue
-      result.add encodeType(m, s.typ[i])
+      result.add encodeType(m, s.typ[i], maItanium)
 
   if result in m.g.mangledPrcs:
     result = mangleProc(m, s, true)
@@ -1111,10 +1111,7 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
       # always call for sideeffects:
       assert t.kind != tyTuple
       discard getRecordDesc(m, t, result, check)
-      # The resulting type will include commas and these won't play well
-      # with the C macros for defining procs such as N_NIMCALL. We must
-      # create a typedef for the type and use it in the proc signature:
-      let typedefName = "TY$1_$2" % [$sig, m.encodeType(origTyp)]
+      let typedefName = "TY_$2" % [$sig, m.encodeType(origTyp, maNone)]
       m.s[cfsTypes].addf("typedef $1 $2;$n", [result, typedefName])
       m.typeCache[sig] = typedefName
       result = typedefName

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1114,7 +1114,7 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
       # The resulting type will include commas and these won't play well
       # with the C macros for defining procs such as N_NIMCALL. We must
       # create a typedef for the type and use it in the proc signature:
-      let typedefName = "TY" & $sig
+      let typedefName = "TY$1_$2" % [$sig, m.encodeType(origTyp)]
       m.s[cfsTypes].addf("typedef $1 $2;$n", [result, typedefName])
       m.typeCache[sig] = typedefName
       result = typedefName

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -152,8 +152,7 @@ proc getTypeName(m: BModule; typ: PType; sig: SigHash): Rope =
   let typ = if typ.kind in {tyAlias, tySink, tyOwned}: typ.elementType else: typ
   if typ.loc.snippet == "":
     m.typeName(typ, typ.loc.snippet)
-    if typ.kind notin { tyObject, tyEnum, tyDistinct, tyUserTypeClass, tyGenericInst, 
-      tyUserTypeClassInst, tySequence, tyOpenArray, tyArray } or 
+    if typ.kind notin { tyObject, tyEnum, tySequence, tyOpenArray, tyArray } or 
       typ.len == 1 and typ.kind == tyObject:
         typ.loc.snippet.add $sig
   else:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -152,8 +152,11 @@ proc getTypeName(m: BModule; typ: PType; sig: SigHash): Rope =
   let typ = if typ.kind in {tyAlias, tySink, tyOwned}: typ.elementType else: typ
   if typ.loc.snippet == "":
     m.typeName(typ, typ.loc.snippet)
-    if typ.kind in {tyProc} or typ.len == 1 and typ.kind == tyObject:
+    let inTypeNameCache = typ.loc.snippet in m.typeNameCache and sig notin m.typeCache
+    if typ.kind in {tyProc} or inTypeNameCache:
       typ.loc.snippet.add $sig
+    if not inTypeNameCache:
+      m.typeNameCache.incl $typ.loc.snippet
   else:
     when defined(debugSigHashes):
       # check consistency:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -152,7 +152,7 @@ proc getTypeName(m: BModule; typ: PType; sig: SigHash): Rope =
   let typ = if typ.kind in {tyAlias, tySink, tyOwned}: typ.elementType else: typ
   if typ.loc.snippet == "":
     m.typeName(typ, typ.loc.snippet)
-    if typ.kind notin { tyObject, tyEnum, tySequence, tyOpenArray, tyArray } or 
+    if typ.kind notin { tyObject, tyEnum } or 
       typ.len == 1 and typ.kind == tyObject:
         typ.loc.snippet.add $sig
   else:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -152,11 +152,10 @@ proc getTypeName(m: BModule; typ: PType; sig: SigHash): Rope =
   let typ = if typ.kind in {tyAlias, tySink, tyOwned}: typ.elementType else: typ
   if typ.loc.snippet == "":
     m.typeName(typ, typ.loc.snippet)
-    let inTypeNameCache = typ.loc.snippet in m.typeNameCache and sig notin m.typeCache
-    if typ.kind in {tyProc} or inTypeNameCache:
-      typ.loc.snippet.add $sig
-    if not inTypeNameCache:
-      m.typeNameCache.incl $typ.loc.snippet
+    if typ.kind notin { tyObject, tyEnum, tyDistinct, tyUserTypeClass, tyGenericInst, 
+      tyUserTypeClassInst, tySequence, tyOpenArray, tyArray } or 
+      typ.len == 1 and typ.kind == tyObject:
+        typ.loc.snippet.add $sig
   else:
     when defined(debugSigHashes):
       # check consistency:

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -173,7 +173,6 @@ type
     sigConflicts*: CountTable[SigHash]
     g*: BModuleList
     ndi*: NdiFile
-    typeNameCache*: HashSet[string]
 
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -173,6 +173,7 @@ type
     sigConflicts*: CountTable[SigHash]
     g*: BModuleList
     ndi*: NdiFile
+    typeNameCache*: HashSet[string]
 
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config


### PR DESCRIPTION
When generating a header with `--header` and then using it from another Nim project to import the generated types, generic instances can collide and produce an error.
i.e. `typedef MyGeneric[TypeA] typename` `typedef MyGeneric[TypeB] typename` `signature` here cant be the same as they are different types.  

This issue can be avoided by using the Nim type as part of the name which is what this PR does.

Update:
Encode types so   `MyClass[T]` becomes `typedef MyClass<NI>  TY_MyClass_int;` instead of `Ty_QjHlYnbKApuWy39cRg7R7dw`

Update 2:
```c++
struct seq_int { //seq[int]
  NI len; seq_int_Content* p;
};
struct TypeTest_int { // TypeTest[T] = object 
    NI Whatever;
};
struct cpptest_ObjectType { //ObjectType = object
    NI32 x;
};
struct Table_intint { //Table[int, int]
    char dummy;
};
```

