### PR TITLE
fixes #23936; opcParseFloat accepts the wrong register as the first param [backport]

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1363,7 +1363,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         else:
           internalError(c.config, c.debug[pc], "opcParseFloat: Incorrectly created openarray")
       else:
-        regs[ra].intVal = parseBiggestFloat(regs[ra].node.strVal, rcAddr.floatVal)
+        regs[ra].intVal = parseBiggestFloat(regs[rb].node.strVal, rcAddr.floatVal)
 
     of opcRangeChck:
       let rb = instr.regB

--- a/tests/stdlib/tparseutils.nim
+++ b/tests/stdlib/tparseutils.nim
@@ -99,3 +99,14 @@ block:  # With this included, static: test() crashes the compiler (from a
   checkParseSize " 12"    , 0, 1          # Leading white
   # Value Edge cases
   checkParseSize "9223372036854775807", 19, int64.high
+
+block: # bug #23936
+  func parsePyFloat(
+      a: openArray[char],  # here must be openArray instead of string to reproduce this bug
+      res: var BiggestFloat): int =
+    result = parseFloat(a, res)
+
+  static:
+    var f = 0.0
+    doAssert "1.0".parsePyFloat(f) == 3
+    doAssert f == 1.0


### PR DESCRIPTION
fixes #23936
follow up https://github.com/nim-lang/Nim/pull/20527