### PR TITLE
fixes #23943; simple default value for range

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -492,7 +492,7 @@ proc resetLoc(p: BProc, loc: var TLoc) =
     else:
       linefmt(p, cpsStmts, "$1.len = 0; $1.p = NIM_NIL;$n", [rdLoc(loc)])
   elif not isComplexValueType(typ):
-    if typ.kind == tyRange:
+    if p.config.isDefined("nimPreviewRangeDefault") and skipTypes(loc.t, abstractInst).kind == tyRange:
       linefmt(p, cpsStmts, "$1 = ($2)$3;$n", [rdLoc(loc),
         getTypeDesc(p.module, typ, descKindFromSymKind mapTypeChooser(loc)), firstOrd(p.config, typ)])
     elif containsGcRef:
@@ -533,7 +533,7 @@ proc constructLoc(p: BProc, loc: var TLoc, isTemp = false) =
   if optSeqDestructors in p.config.globalOptions and skipTypes(typ, abstractInst + {tyStatic}).kind in {tyString, tySequence}:
     linefmt(p, cpsStmts, "$1.len = 0; $1.p = NIM_NIL;$n", [rdLoc(loc)])
   elif not isComplexValueType(typ):
-    if typ.kind == tyRange:
+    if p.config.isDefined("nimPreviewRangeDefault") and skipTypes(loc.t, abstractInst).kind == tyRange:
       linefmt(p, cpsStmts, "$1 = ($2)$3;$n", [rdLoc(loc),
         getTypeDesc(p.module, typ, descKindFromSymKind mapTypeChooser(loc)), firstOrd(p.config, typ)])
     elif containsGarbageCollectedRef(loc.t):

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -492,7 +492,10 @@ proc resetLoc(p: BProc, loc: var TLoc) =
     else:
       linefmt(p, cpsStmts, "$1.len = 0; $1.p = NIM_NIL;$n", [rdLoc(loc)])
   elif not isComplexValueType(typ):
-    if containsGcRef:
+    if typ.kind == tyRange:
+      linefmt(p, cpsStmts, "$1 = ($2)$3;$n", [rdLoc(loc),
+        getTypeDesc(p.module, typ, descKindFromSymKind mapTypeChooser(loc)), firstOrd(p.config, typ)])
+    elif containsGcRef:
       var nilLoc: TLoc = initLoc(locTemp, loc.lode, OnStack)
       nilLoc.snippet = rope("NIM_NIL")
       genRefAssign(p, loc, nilLoc)
@@ -530,7 +533,10 @@ proc constructLoc(p: BProc, loc: var TLoc, isTemp = false) =
   if optSeqDestructors in p.config.globalOptions and skipTypes(typ, abstractInst + {tyStatic}).kind in {tyString, tySequence}:
     linefmt(p, cpsStmts, "$1.len = 0; $1.p = NIM_NIL;$n", [rdLoc(loc)])
   elif not isComplexValueType(typ):
-    if containsGarbageCollectedRef(loc.t):
+    if typ.kind == tyRange:
+      linefmt(p, cpsStmts, "$1 = ($2)$3;$n", [rdLoc(loc),
+        getTypeDesc(p.module, typ, descKindFromSymKind mapTypeChooser(loc)), firstOrd(p.config, typ)])
+    elif containsGarbageCollectedRef(loc.t):
       var nilLoc: TLoc = initLoc(locTemp, loc.lode, OnStack)
       nilLoc.snippet = rope("NIM_NIL")
       genRefAssign(p, loc, nilLoc)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1956,7 +1956,14 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
       result = putToSeq("0", indirect)
   of tyFloat..tyFloat128:
     result = putToSeq("0.0", indirect)
-  of tyRange, tyGenericInst, tyAlias, tySink, tyOwned, tyLent:
+  of tyRange:
+    let base = skipModifier(typ)
+    case base.kind
+    of tyFloat..tyFloat64:
+      result = putToSeq(rope(firstFloat(typ)), indirect)
+    else:
+      result = putToSeq(rope(firstOrd(p.config, typ)), indirect)
+  of tyGenericInst, tyAlias, tySink, tyOwned, tyLent:
     result = createVar(p, skipModifier(typ), indirect)
   of tySet:
     result = putToSeq("{}", indirect)

--- a/tests/objects/tobject_default_value.nim
+++ b/tests/objects/tobject_default_value.nim
@@ -761,3 +761,15 @@ template main {.dirty.} =
 
 static: main()
 main()
+
+block:
+  type limited_int = range[1..20]
+  var d: limited_int
+  doAssert d == 1
+
+  proc foo(): int =
+    var d: limited_int
+    doAssert d == 1
+    result = d
+
+  doAssert foo() == 1


### PR DESCRIPTION
fixes #23943

For a simple construction of `range`, we can use `firstOrd(range)` for the initialization value

```nim
type limited_int = range[1..20]
var d: limited_int;
echo d
```