### PR TITLE
Fixes bug #23956 bindUnix did not account for null terminated string.

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1321,7 +1321,7 @@ when defined(nimdoc) or (defined(posix) and not useNimNetLite):
     when not defined(nimdoc):
       var socketAddr = makeUnixAddr(path)
       if socket.fd.connect(cast[ptr SockAddr](addr socketAddr),
-          (sizeof(socketAddr.sun_family) + path.len).SockLen) != 0'i32:
+          (sizeof(socketAddr.sun_family) + path.len + 1).SockLen) != 0'i32:
         raiseOSError(osLastError())
 
   proc bindUnix*(socket: Socket, path: string) =

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1330,7 +1330,7 @@ when defined(nimdoc) or (defined(posix) and not useNimNetLite):
     when not defined(nimdoc):
       var socketAddr = makeUnixAddr(path)
       if socket.fd.bindAddr(cast[ptr SockAddr](addr socketAddr),
-          (sizeof(socketAddr.sun_family) + path.len).SockLen) != 0'i32:
+          (sizeof(socketAddr.sun_family) + path.len + 1).SockLen) != 0'i32:
         raiseOSError(osLastError())
 
 when defineSsl:


### PR DESCRIPTION
You can see makeUnixAddr including the null terminator ( + 1) [in the copyMem line](https://github.com/nim-lang/Nim/blob/devel/lib/pure/nativesockets.nim#L570) but in bindUnix it doesn't account for it.