### PR TITLE
fix `is` with `type`/`typedesc` crashing the compiler

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -611,8 +611,7 @@ proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
       n[1] = makeTypeSymNode(c, lhsType, n[1].info)
       lhsType = n[1].typ
   else:
-    if lhsType.base.kind == tyNone or
-        (c.inGenericContext > 0 and lhsType.base.containsGenericType):
+    if c.inGenericContext > 0 and lhsType.base.containsGenericType:
       # BUGFIX: don't evaluate this too early: ``T is void``
       return
 

--- a/tests/types/tisopr.nim
+++ b/tests/types/tisopr.nim
@@ -165,3 +165,7 @@ block: # previously tisop.nim
       doAssert f.y.typeof is float
       doAssert f.z.typeof is float
   p(A, f)
+
+block: # issue #22850
+  doAssert not (type is int)
+  doAssert not (typedesc is int)


### PR DESCRIPTION
fixes #22850

The `is` operator checks the type of the left hand side, and if it's generic or if it's a `typedesc` type with no base type, it leaves it to be evaluated later. But `typedesc` types with no base type precisely describe the default typeclass `type`/`typeclass`, so this condition is removed. Maybe at some point this represented an unresolved generic type?