### PR TITLE
remove nontoplevel type hack + consider symbol disamb in type hash

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1785,10 +1785,6 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
           checkForMetaFields(c, baseType.n, hasError)
         if not hasError:
           checkConstructedType(c.config, s.info, s.typ)
-
-        # fix bug #5170, bug #17162, bug #15526: ensure locally scoped types get a unique name:
-        if s.typ.kind in {tyEnum, tyRef, tyObject} and not isTopLevel(c):
-          incl(s.flags, sfGenSym)
   #instAllTypeBoundOp(c, n.info)
 
 

--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -55,6 +55,8 @@ proc hashSym(c: var MD5Context, s: PSym) =
       c &= it.name.s
       c &= "."
       it = it.owner
+    c &= "#"
+    c &= s.disamb
 
 proc hashTypeSym(c: var MD5Context, s: PSym; conf: ConfigRef) =
   if sfAnon in s.flags or s.kind == skGenericParam:
@@ -69,6 +71,8 @@ proc hashTypeSym(c: var MD5Context, s: PSym; conf: ConfigRef) =
       c &= it.name.s
       c &= "."
       it = it.owner
+    c &= "#"
+    c &= s.disamb
 
 proc hashTree(c: var MD5Context, n: PNode; flags: set[ConsiderFlag]; conf: ConfigRef) =
   if n == nil:

--- a/tests/ccgbugs/tsamename3.nim
+++ b/tests/ccgbugs/tsamename3.nim
@@ -109,3 +109,12 @@ block: # make sure `hashType` doesn't recurse infinitely
       a, b: PFoo
       c: int
   var a: PFoo
+
+block: # issue #22571
+  macro foo(x: typed) =
+    result = x
+
+  block: # or `proc main =`
+    foo:
+      type Foo = object
+    doAssert $Foo() == "()"


### PR DESCRIPTION
fixes #22571

Removes the hack added in #13589 which made non-top-level object type symbols `gensym` because they couldn't be mangled into different names for codegen vs. top-level types. Now we consider the new `disamb` field (added in #21667) of the type symbols in the type hash (which is used for the mangled name) to differentiate between the types.

In other parts of the compiler, specifically the [proc mangling](https://github.com/nim-lang/Nim/blob/298ada3412c9cf5971abc2b3b891b9bb8612e170/compiler/mangleutils.nim#L59), `itemId.item` is used instead of the `disamb` field, but I didn't use it in case it's the outdated method.