### PR TITLE
make all generic aliases tyAlias

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1646,7 +1646,8 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     recomputeFieldPositions(tx, tx.n, position)
 
 proc maybeAliasType(c: PContext; typeExpr, prev: PType): PType =
-  if typeExpr.kind in {tyObject, tyEnum, tyDistinct, tyForward, tyGenericBody} and prev != nil:
+  if prev != nil and (prev.kind == tyGenericBody or
+      typeExpr.kind in {tyObject, tyEnum, tyDistinct, tyForward, tyGenericBody}):
     result = newTypeS(tyAlias, c)
     result.rawAddSon typeExpr
     result.sym = prev.sym

--- a/tests/generics/taliashijack.nim
+++ b/tests/generics/taliashijack.nim
@@ -1,0 +1,8 @@
+# issue #23977
+
+type Foo[T] = int
+
+proc foo(T: typedesc) =
+  var a: T
+
+foo(int)

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -566,7 +566,7 @@ block:
 block:
   static:
     let x = int 1
-    doAssert $(x.type) == "Foo"  # Foo
+    doAssert $(x.type) == "int"  # Foo
 
 block:
   static:


### PR DESCRIPTION
fixes #23977

The problem is that for *any* body of a generic declaration, [semstmts](https://github.com/nim-lang/Nim/blob/2e4d344b43b040a4dce2c478ca13e49979e491fc/compiler/semstmts.nim#L1610-L1611) sets the sym of its value to the generic type name, and [semtypes](https://github.com/nim-lang/Nim/blob/2e4d344b43b040a4dce2c478ca13e49979e491fc/compiler/semtypes.nim#L2143) just directly gives the referenced type *specifically* when the expression is a generic body. I'm blaming `semtypes` here because it's responsible for the type given but the exact opposite behavior specifically written in makes me think generating an alias type here maybe breaks something.
