### PR TITLE
fixes #23982; codegen regression passing pointer expressions to inline iterators

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -632,9 +632,11 @@ proc putArgInto(arg: PNode, formal: PType): TPutArgInto =
   case arg.kind
   of nkEmpty..nkNilLit:
     result = paDirectMapping
-  of nkDotExpr, nkDerefExpr, nkHiddenDeref, nkAddr, nkHiddenAddr:
+  of nkDotExpr, nkDerefExpr, nkHiddenDeref:
     result = putArgInto(arg[0], formal)
-    #if result == paViaIndirection: result = paFastAsgn
+  of nkAddr, nkHiddenAddr:
+    result = putArgInto(arg[0], formal)
+    if result == paViaIndirection: result = paFastAsgn
   of nkCurly, nkBracket:
     for i in 0..<arg.len:
       if putArgInto(arg[i], formal) != paDirectMapping:

--- a/tests/arc/titeration_doesnt_copy.nim
+++ b/tests/arc/titeration_doesnt_copy.nim
@@ -54,3 +54,14 @@ proc toBinString*(data: openArray[uint8], col: int): string =
 
 doAssert @[0b0000_1111'u8, 0b1010_1010].toBinString(8) == "0000111110101010"
 doAssert @[0b1000_0000'u8, 0b0000_0000].toBinString(1) == "10"
+
+block: # bug #23982
+  iterator `..`(a, b: ptr int16): ptr int16 = discard
+  var a: seq[int16] #; let p = a[0].addr
+  var b: seq[ptr int16]
+
+  try:
+    for x in a[0].addr .. b[1]: # `p .. b[1]` works
+      discard
+  except IndexDefect:
+    discard


### PR DESCRIPTION
fixes #23982