### PR TITLE
don't apply early ambiguity check for type symbols in semtempl

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -362,7 +362,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
         result = newSymNode(s, n.info)
         onUse(n.info, s)
       else:
-        if s.kind in {skType, skVar, skLet, skConst}:
+        if s.kind in {skVar, skLet, skConst}:
           discard qualifiedLookUp(c.c, n, {checkAmbiguity, checkModule})
         result = semTemplSymbol(c.c, n, s, c.noGenSym > 0)
   of nkBind:
@@ -572,7 +572,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       elif contains(c.toMixin, s.name.id):
         return symChoice(c.c, n, s, scForceOpen, c.noGenSym > 0)
       else:
-        if s.kind in {skType, skVar, skLet, skConst}:
+        if s.kind in {skVar, skLet, skConst}:
           discard qualifiedLookUp(c.c, n, {checkAmbiguity, checkModule})
         return semTemplSymbol(c.c, n, s, c.noGenSym > 0)
     if n.kind == nkDotExpr:

--- a/tests/lookups/m23898_1.nim
+++ b/tests/lookups/m23898_1.nim
@@ -1,0 +1,1 @@
+type K* = object

--- a/tests/lookups/m23898_2.nim
+++ b/tests/lookups/m23898_2.nim
@@ -1,0 +1,4 @@
+import ./m23898_1
+export m23898_1
+template K*(kind: static int): auto = typedesc[m23898_1.K]
+template B*(kind: static int): auto = typedesc[m23898_1.K]

--- a/tests/lookups/t23898.nim
+++ b/tests/lookups/t23898.nim
@@ -1,0 +1,8 @@
+import ./m23898_2
+discard default(B(0))       # compiles
+discard default(m23898_2.B(0))     # compiles
+discard default(K(0))       # compiles
+template r() =
+  discard default(B(0))     # compiles
+  discard default(m23898_2.B(0))   # compiles
+  discard default(K(0))     # does not compile


### PR DESCRIPTION
fixes #23898

Will explain later, CI is clogged right now and I need to wait to see if it works separated from #23966