### PR TITLE
Fixed an issue where `errorCode` was always 0 when `startProcess` did…

### DIFF
--- a/tests/osproc/tnoexe.nim
+++ b/tests/osproc/tnoexe.nim
@@ -1,0 +1,18 @@
+discard """
+  output: '''true
+true'''
+"""
+
+import std/osproc
+
+const command = "lsaaa -lah"
+
+try:
+  let process = startProcess(command, options = {poUsePath})
+  discard process.waitForExit()
+except OSError as e:
+  echo e.errorCode != 0
+
+let process = startProcess(command, options = {poUsePath, poEvalCommand})
+let exitCode = process.waitForExit()
+echo exitCode != 0


### PR DESCRIPTION
…n't use the `poEvalCommand` flag

https://forum.nim-lang.org/t/12310

Added a test case, tested on my fedora system.