### PR TITLE
don't require symbol with enum type to be constant in fitNode

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -103,7 +103,7 @@ proc fitNode(c: PContext, formal: PType, arg: PNode; info: TLineInfo): PNode =
     result = nil
     for ch in arg:
       if sameType(ch.typ, formal):
-        return getConstExpr(c.module, ch, c.idgen, c.graph)
+        return ch
     typeMismatch(c.config, info, formal, arg.typ, arg)
   else:
     result = indexTypesMatch(c, formal, arg.typ, arg)

--- a/tests/enum/toverloadedname.nim
+++ b/tests/enum/toverloadedname.nim
@@ -1,0 +1,7 @@
+block: # issue #23998
+  type
+    Enum {.pure.} = enum
+      a
+    Obj = object
+      a: Enum
+  proc test(a: Enum) = discard Obj(a: a)


### PR DESCRIPTION
fixes #23998

In `fitNode` the first symbol of a symchoice that expects an enum type with the same enum type is given as the result of the `fitNode`. But `getConstExpr` is also called on it, which will return a `nil` node for nodes that aren't constant but have the enum type, like variables or proc parameters. Instead we just return the node directly since it's already typed.

Normally, this `if` branch in `fitNode` shouldn't exist since `paramTypesMatch` handles it, but the way pure enum symbols work makes it really impractical to check their ambiguity, which `paramTypesMatch` won't like. If it causes problems for regular enums we can restrict this branch to just pure enums until they are hopefully eventually removed.