### PR TITLE
fix windows `poEvalCommand`

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -707,12 +707,25 @@ when defined(windows) and not defined(useNimRtl):
 
     var cmdl: cstring
     var cmdRoot: string
+
     if poEvalCommand in options:
-      cmdl = command
-      assert args.len == 0
+      const useCmdPath {.strdefine.} = ""
+
+      # `poEvalCommand`, which invokes the system shell to run the specified `command`.
+
+      var cmdPath = useCmdPath
+      if useCmdPath.len == 0:
+        cmdPath = getEnv("COMSPEC")
+
+      let newArgs = @["/c", command]
+      assert args.len == 0, "`args` has to be empty when using poEvalCommand."
+
+      cmdRoot = buildCommandLine(cmdPath, newArgs)
+      cmdl = cstring(cmdRoot)
     else:
       cmdRoot = buildCommandLine(command, args)
       cmdl = cstring(cmdRoot)
+
     var wd: cstring = nil
     var e = (str: nil.cstring, len: -1)
     if len(workingDir) > 0: wd = workingDir

--- a/tests/osproc/twaitforexit.nim
+++ b/tests/osproc/twaitforexit.nim
@@ -18,16 +18,20 @@ block: # bug #5091
         doAssert(getTime() <  atStart + milliseconds(msWait))
 
 block: # bug #23825
-    var thr: array[0..99, Thread[int]]
 
-    proc threadFunc(i: int) {.thread.} =
-        let sleepTime = float(i) / float(thr.len + 1)
-        doAssert sleepTime < 1.0
-        let p = startProcess("sleep", workingDir = "", args = @[$sleepTime], options = {poUsePath, poParentStreams})
-        # timeout = 1_000_000 seconds ~= 278 hours ~= 11.5 days
-        doAssert p.waitForExit(timeout=1_000_000_000) == 0
+    # the sleep command might not be available in all Windows installations
 
-    for i in low(thr)..high(thr):
-        createThread(thr[i], threadFunc, i)
+    when defined(linux):
+        var thr: array[0..99, Thread[int]]
 
-    joinThreads(thr) 
+        proc threadFunc(i: int) {.thread.} =
+            let sleepTime = float(i) / float(thr.len + 1)
+            doAssert sleepTime < 1.0
+            let p = startProcess("sleep", workingDir = "", args = @[$sleepTime], options = {poUsePath, poParentStreams})
+            # timeout = 1_000_000 seconds ~= 278 hours ~= 11.5 days
+            doAssert p.waitForExit(timeout=1_000_000_000) == 0
+
+        for i in low(thr)..high(thr):
+            createThread(thr[i], threadFunc, i)
+
+        joinThreads(thr) 


### PR DESCRIPTION
The previous implementation did not follow the documentation.

`poEvalCommand`, which invokes the system shell to run the specified `command`.
https://github.com/nim-lang/Nim/blob/832ba815d1cf7ec0846cdade49f697228bb04d22/lib/pure/osproc.nim#L138-L144

Keep consistent with the Linux platform implementation:
https://github.com/nim-lang/Nim/blob/832ba815d1cf7ec0846cdade49f697228bb04d22/lib/pure/osproc.nim#L975-L986
