### PR TITLE
Fix linux start process errorCode always 0

### DIFF
--- a/tests/osproc/tnoexe.nim
+++ b/tests/osproc/tnoexe.nim
@@ -1,0 +1,22 @@
+discard """
+  output: '''true
+true'''
+"""
+
+import std/osproc
+
+const command = "lsaaa -lah"
+
+try:
+  let process = startProcess(command, options = {poUsePath})
+  discard process.waitForExit()
+except OSError as e:
+  echo e.errorCode != 0
+
+# `poEvalCommand`, invokes the system shell to run the specified command
+try:
+  let process = startProcess(command, options = {poUsePath, poEvalCommand})
+  let exitCode = process.waitForExit()
+  echo exitCode != 0
+except OSError as e:
+  doAssert false, "after #24000 is merged, this will no longer throw an exception"

--- a/tests/osproc/tnoexe.nim
+++ b/tests/osproc/tnoexe.nim
@@ -16,7 +16,12 @@ except OSError as e:
 # `poEvalCommand`, invokes the system shell to run the specified command
 try:
   let process = startProcess(command, options = {poUsePath, poEvalCommand})
+  # linux
   let exitCode = process.waitForExit()
   echo exitCode != 0
 except OSError as e:
-  doAssert false, "after #24000 is merged, this will no longer throw an exception"
+  # Because the implementation of `poEvalCommand` on different platforms is inconsistent, 
+  # Linux will not throw an exception, but Windows will throw an exception
+
+  # windows
+  echo e.errorCode != 0

--- a/tests/osproc/twaitforexit.nim
+++ b/tests/osproc/twaitforexit.nim
@@ -18,16 +18,21 @@ block: # bug #5091
         doAssert(getTime() <  atStart + milliseconds(msWait))
 
 block: # bug #23825
-    var thr: array[0..99, Thread[int]]
 
-    proc threadFunc(i: int) {.thread.} =
-        let sleepTime = float(i) / float(thr.len + 1)
-        doAssert sleepTime < 1.0
-        let p = startProcess("sleep", workingDir = "", args = @[$sleepTime], options = {poUsePath, poParentStreams})
-        # timeout = 1_000_000 seconds ~= 278 hours ~= 11.5 days
-        doAssert p.waitForExit(timeout=1_000_000_000) == 0
+    # the sleep command might not be available in all Windows installations
 
-    for i in low(thr)..high(thr):
-        createThread(thr[i], threadFunc, i)
+    when defined(linux):
 
-    joinThreads(thr) 
+        var thr: array[0..99, Thread[int]]
+
+        proc threadFunc(i: int) {.thread.} =
+            let sleepTime = float(i) / float(thr.len + 1)
+            doAssert sleepTime < 1.0
+            let p = startProcess("sleep", workingDir = "", args = @[$sleepTime], options = {poUsePath, poParentStreams})
+            # timeout = 1_000_000 seconds ~= 278 hours ~= 11.5 days
+            doAssert p.waitForExit(timeout=1_000_000_000) == 0
+
+        for i in low(thr)..high(thr):
+            createThread(thr[i], threadFunc, i)
+
+        joinThreads(thr) 


### PR DESCRIPTION
#23992 The test case provided does not cover the Windows situation, I fixed it in this new PR.

Fixed an issue where errorCode was always 0 when startProcess didn't use the poEvalCommand flag.

Tthe sleep command might not be available in all Windows installations, so I skipped the relevant test.

Added a test case, tested on my fedora and windows systems.