### PR TITLE
reject `or` types matching multiple types for int literals

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1700,14 +1700,18 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       result = isNone
       let oldInheritancePenalty = c.inheritancePenalty
       var minInheritance = maxInheritancePenalty
+      var intLitConvCount = 0
       for branch in f.kids:
         c.inheritancePenalty = -1
         let x = typeRel(c, branch, aOrig, flags)
+        if x == isFromIntLit:
+          inc intLitConvCount
         if x >= result:
           if  c.inheritancePenalty > -1:
             minInheritance = min(minInheritance, c.inheritancePenalty)
           result = x
-      if result >= isIntConv:
+      if result >= isIntConv and not
+          (result == isFromIntLit and intLitConvCount > 1):
         if minInheritance < maxInheritancePenalty:
           c.inheritancePenalty = oldInheritancePenalty + minInheritance
         if result > isGeneric: result = isGeneric

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -409,9 +409,16 @@ proc handleRange(c: PContext, f, a: PType, min, max: TTypeKind): TTypeRelation =
     let k = ab.kind
     let nf = c.config.normalizeKind(f.kind)
     let na = c.config.normalizeKind(k)
-    if k == f.kind: result = isSubrange
-    elif k == tyInt and f.kind in {tyRange, tyInt..tyInt64,
-                                   tyUInt..tyUInt64} and
+    if k == f.kind:
+      # `a` is a range type matching its base type
+      # see very bottom for range types matching different types
+      if isIntLit(ab):
+        # range type can only give isFromIntLit for base type
+        result = isFromIntLit
+      else:
+        result = isSubrange
+    elif a.kind == tyInt and f.kind in {tyRange, tyInt..tyInt64,
+                                        tyUInt..tyUInt64} and
         isIntLit(ab) and getInt(ab.n) >= firstOrd(nil, f) and
                          getInt(ab.n) <= lastOrd(nil, f):
       # passing 'nil' to firstOrd/lastOrd here as type checking rules should

--- a/tests/overload/tambiguousintlit.nim
+++ b/tests/overload/tambiguousintlit.nim
@@ -1,0 +1,8 @@
+block: # issue #4858
+  type
+    SomeType = object
+      field1: uint
+  proc namedProc(an: var SomeType, b: SomeUnsignedInt) = discard
+  var t = SomeType()
+  namedProc(t, 0) #[tt.Error
+           ^ type mismatch: got <SomeType, int literal(0)>]#


### PR DESCRIPTION
fixes #4858, refs #12552

Testing CI first, might fix more issues (#6407 has another underlying issue)