### PR TITLE
fix `include` in templates, with prefix operators

### DIFF
--- a/tests/modules/mincludeprefix.nim
+++ b/tests/modules/mincludeprefix.nim
@@ -1,0 +1,1 @@
+const bar = 456

--- a/tests/modules/mincludetemplate.nim
+++ b/tests/modules/mincludetemplate.nim
@@ -1,0 +1,1 @@
+const foo = 123

--- a/tests/modules/tincludeprefix.nim
+++ b/tests/modules/tincludeprefix.nim
@@ -1,0 +1,3 @@
+include ./[mincludeprefix, mincludetemplate]
+doAssert foo == 123
+doAssert bar == 456

--- a/tests/modules/tincludetemplate.nim
+++ b/tests/modules/tincludetemplate.nim
@@ -1,0 +1,5 @@
+# issue #12539
+
+template includePath(n: untyped) = include ../modules/n # But `include n` works
+includePath(mincludetemplate)
+doAssert foo == 123


### PR DESCRIPTION
fixes #12539, refs #21636

`evalInclude` now uses `getPIdent` to check if a symbol isn't `/` anymore instead of assuming it's an ident, which it's not when used in templates. Also it just checks if the symbol is `as` now, because there are other infix operators that could be used like `/../`.

It also works with prefix operators now by copying what was done in #21636.