### PR TITLE
remove noise from bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,17 +7,16 @@ body:
 - type: markdown
   attributes:
     value: |
-      - **Please provide a minimal code example that reproduces the Bug!** :bug:
-        Reports with a reproducible example and descriptive detailed information will likely receive fixes faster.
+      - Please provide a minimal code example that reproduces the bug.
+        Reports with a reproducible example or detailed information will likely receive fixes faster.
 
 - type: textarea
   id: description
   attributes:
     label: Description
     description: |
-      Use DETAILED DESCRIPTIVE information about the problem.
-      Here, you go into more details about your Bug report. This section can be a few paragraphs long.
-    placeholder: Bug reports with reproducible code and detailed information will be fixed faster.
+      Describe the problem. Code example can be given here.
+    placeholder: Bug reports with reproducible code or detailed information will be fixed faster.
   validations:
     required: true
     
@@ -25,7 +24,7 @@ body:
   id: nim-version
   attributes:
     label: Nim Version
-    description: Copy and paste the output of `nim -v` on the command line. For development versions, make sure to include the commit hash.
+    description: Can be obtained from `nim -v` on the command line. For development versions, make sure to include the commit hash.
   validations:
     required: true
 
@@ -34,7 +33,7 @@ body:
   attributes:
     label: Current Output
     description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-    placeholder: Bug reports with reproducible code and detailed information will be fixed faster.
+    placeholder: Bug reports with reproducible code or detailed information will be fixed faster.
     render: text
 
 - type: textarea
@@ -42,14 +41,14 @@ body:
   attributes:
     label: Expected Output
     description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-    placeholder: Bug reports with reproducible code and detailed information will be fixed faster.
+    placeholder: Bug reports with reproducible code or detailed information will be fixed faster.
     render: text
 
 - type: textarea
-  id: possible-solution
+  id: known-workarounds
   attributes:
-    label: Possible Solution
-    description: Propose a possible solution.
+    label: Known Workarounds
+    description: Provide any known workarounds.
   validations:
     required: false
 
@@ -64,13 +63,15 @@ body:
 - type: markdown
   attributes:
     value: |
-      - Thanks for your contributions!, your Bug report will receive feedback from the community soon...
-      - Please check whether the problem still exists in the devel branch, see [rebuilding the compiler](https://nim-lang.github.io/Nim/intern.html#rebuilding-the-compiler).
+      - Please check whether the problem still exists in the devel branch,
+        which can be installed via [choosenim](https://github.com/nim-lang/choosenim/),
+        [nightlies](https://github.com/nim-lang/nightlies/),
+        or by [bootstrapping the compiler](https://nim-lang.github.io/Nim/intern.html#bootstrapping-the-compiler).
       - Consider writing a PR targetting devel branch after filing this, see [contributing](https://nim-lang.github.io/Nim/contributing.html).
-      - If it's a pre-existing compiler bug, see [Debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler)
+      - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler)
         which should give more context on a compiler crash.
-      - If it's a regression, you can help us by identifying which version introduced the bug,
-        see [Bisecting for regressions](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions),
-        or at least try known past releases (e.g. `choosenim 2.0.0`). The Nim repo also supports online bisecting
+      - If it's a regression, you can help us by identifying which version introduced the bug
+        by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions)
+        or at least trying known past releases (e.g. `choosenim 2.0.0`). The Nim repo also supports online bisecting
         via making a comment, which contains a code block starting by `!nim c`, `!nim js` etc. , see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
       - [Please, consider a Donation for the Nim project.](https://nim-lang.org/donate.html)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
   attributes:
     label: Nim Version
     description: |
-      Can be obtained from `nim -v` on the command line, you can just copy paste the output.
+      Can be obtained from `nim -v` on the command line along with the OS/architecture.
       For development versions, make sure to include the commit hash.
   validations:
     required: true
@@ -69,5 +69,5 @@ body:
       - Consider writing a PR targetting devel branch after filing this, see [contributing](https://nim-lang.github.io/Nim/contributing.html).
       - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler) which should give more context on a compiler crash.
       - If it's a regression, you can help us by identifying which version introduced the bug by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions) or at least trying known past releases (e.g. `choosenim 2.0.0`).
-        The Nim repo also supports online bisecting via making a comment, which contains a code block starting by `!nim c`, `!nim js` etc. , see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
+        The Nim repo also supports bisecting in issue comments by adding `!nim c`, `!nim js` etc. before a code block, see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
       - [Please, consider a Donation for the Nim project.](https://nim-lang.org/donate.html)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      Please provide a minimal code example that reproduces the bug.
+      Please provide a minimal code example that reproduces the bug if possible.
       Reports with a reproducible example or detailed information will likely receive fixes faster.
 
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,8 +7,8 @@ body:
 - type: markdown
   attributes:
     value: |
-      - Please provide a minimal code example that reproduces the bug.
-        Reports with a reproducible example or detailed information will likely receive fixes faster.
+      Please provide a minimal code example that reproduces the bug.
+      Reports with a reproducible example or detailed information will likely receive fixes faster.
 
 - type: textarea
   id: description
@@ -66,7 +66,7 @@ body:
       - Please check whether the problem still exists in the devel branch,
         which can be installed via [choosenim](https://github.com/nim-lang/choosenim/),
         [nightlies](https://github.com/nim-lang/nightlies/),
-        or by [bootstrapping the compiler](https://nim-lang.github.io/Nim/intern.html#bootstrapping-the-compiler).
+        or by [creating a temporary build of the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler-building-an-instrumented-compiler).
       - Consider writing a PR targetting devel branch after filing this, see [contributing](https://nim-lang.github.io/Nim/contributing.html).
       - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler)
         which should give more context on a compiler crash.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,9 @@ body:
   id: nim-version
   attributes:
     label: Nim Version
-    description: Can be obtained from `nim -v` on the command line. For development versions, make sure to include the commit hash.
+    description: |
+      Can be obtained from `nim -v` on the command line (you can just copy paste the output).
+      For development versions, make sure to include the commit hash.
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,15 +65,9 @@ body:
 - type: markdown
   attributes:
     value: |
-      - Please check whether the problem still exists in the devel branch, \
-        which can be installed via [choosenim](https://github.com/nim-lang/choosenim/), \
-        [nightlies](https://github.com/nim-lang/nightlies/), \
-        or by [creating a temporary build of the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler-building-an-instrumented-compiler).
+      - Please check whether the problem still exists in the devel branch, which can be installed via [choosenim](https://github.com/nim-lang/choosenim/), [nightlies](https://github.com/nim-lang/nightlies/), or by [creating a temporary build of the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler-building-an-instrumented-compiler).
       - Consider writing a PR targetting devel branch after filing this, see [contributing](https://nim-lang.github.io/Nim/contributing.html).
-      - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler) \
-        which should give more context on a compiler crash.
-      - If it's a regression, you can help us by identifying which version introduced the bug \
-        by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions) \
-        or at least trying known past releases (e.g. `choosenim 2.0.0`). The Nim repo also supports online bisecting \
-        via making a comment, which contains a code block starting by `!nim c`, `!nim js` etc. , see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
+      - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler) which should give more context on a compiler crash.
+      - If it's a regression, you can help us by identifying which version introduced the bug by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions) or at least trying known past releases (e.g. `choosenim 2.0.0`).
+        The Nim repo also supports online bisecting via making a comment, which contains a code block starting by `!nim c`, `!nim js` etc. , see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
       - [Please, consider a Donation for the Nim project.](https://nim-lang.org/donate.html)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
   attributes:
     label: Nim Version
     description: |
-      Can be obtained from `nim -v` on the command line (you can just copy paste the output).
+      Can be obtained from `nim -v` on the command line, you can just copy paste the output.
       For development versions, make sure to include the commit hash.
   validations:
     required: true
@@ -65,15 +65,15 @@ body:
 - type: markdown
   attributes:
     value: |
-      - Please check whether the problem still exists in the devel branch,
-        which can be installed via [choosenim](https://github.com/nim-lang/choosenim/),
-        [nightlies](https://github.com/nim-lang/nightlies/),
+      - Please check whether the problem still exists in the devel branch, \
+        which can be installed via [choosenim](https://github.com/nim-lang/choosenim/), \
+        [nightlies](https://github.com/nim-lang/nightlies/), \
         or by [creating a temporary build of the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler-building-an-instrumented-compiler).
       - Consider writing a PR targetting devel branch after filing this, see [contributing](https://nim-lang.github.io/Nim/contributing.html).
-      - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler)
+      - If it's a pre-existing compiler bug, see [debugging the compiler](https://nim-lang.github.io/Nim/intern.html#debugging-the-compiler) \
         which should give more context on a compiler crash.
-      - If it's a regression, you can help us by identifying which version introduced the bug
-        by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions)
-        or at least trying known past releases (e.g. `choosenim 2.0.0`). The Nim repo also supports online bisecting
+      - If it's a regression, you can help us by identifying which version introduced the bug \
+        by [bisecting](https://nim-lang.github.io/Nim/intern.html#bisecting-for-regressions) \
+        or at least trying known past releases (e.g. `choosenim 2.0.0`). The Nim repo also supports online bisecting \
         via making a comment, which contains a code block starting by `!nim c`, `!nim js` etc. , see [nimrun-action](https://github.com/juancarlospaco/nimrun-action).
       - [Please, consider a Donation for the Nim project.](https://nim-lang.org/donate.html)


### PR DESCRIPTION
Removes some noise from the bug report issue template so people who aren't familiar can submit issues with less friction. Some of these might be a bit subjective, feel free to call out any nitpicky parts, I didn't want to rewrite entirely. Mostly fixed typos & language issues, other than that:

* Just "detailed information", no need to say "descriptive", and changed "reproducible code and detailed information" to "or detailed information" because code is good enough
* Simplified description label, mention code example can go there
* Changed "Possible Solution" to "Known Workarounds" because it's what issue authors are more likely to know (and usually write anyway) and is more useful to most readers.
* Doc link for "rebuilding the compiler" was broken, replaced it with mentioning choosenim, nightlies and building a temp compiler which is hopefully less offputting

Weird looking preview [here](https://github.com/metagn/Nim/blob/issue-templates/.github/ISSUE_TEMPLATE/bug_report.yml)

Just to complain: Github issue forms have some problems themselves, there's no option to disable the "No response" text when an optional area is unfilled, and the textboxes are really small at least on Firefox (though you can expand them). The alternative, issue templates, isn't much better. Github also hides the ability to open a blank issue in a text link in a small line after all the issue form buttons, I'm guessing this is intentional for repositories which don't want blank issues but we don't have such a problem. Worst comes to worst we can add a button for a minimal/empty issue template.