### PR TITLE
fully disable static paramTypesMatch for tyFromExpr in generics

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2293,6 +2293,9 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
          a.n == nil and
          tfGenericTypeParam notin a.flags:
         return newNodeIT(nkType, argOrig.info, makeTypeFromExpr(c, arg))
+    elif a.kind == tyFromExpr and c.inGenericContext > 0:
+      # don't try to evaluate
+      discard
     elif arg.kind != nkEmpty:
       var evaluated = c.semTryConstExpr(c, arg)
       if evaluated != nil:
@@ -2305,11 +2308,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
         a = typ
       else:
         if m.callee.kind == tyGenericBody:
-          # we can't use `makeStaticExpr` if `arg` has a generic type
-          # because it generates `tyStatic`, which semtypinst doesn't touch
-          # not sure if checking for `tyFromExpr` is enough
-          if f.kind == tyStatic and typeRel(m, f.base, a) != isNone and
-              a.kind != tyFromExpr:
+          if f.kind == tyStatic and typeRel(m, f.base, a) != isNone:
             result = makeStaticExpr(m.c, arg)
             result.typ.flags.incl tfUnresolved
             result.typ.n = arg

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -325,6 +325,14 @@ block: # issue #12714
     MyChannel[T: Enqueueable] = object
       dummy: type(default(T)[])
 
+block: # issue #24044
+  type ArrayBuf[N: static int, T = byte] = object
+    buf: array[N, T]
+  template maxLen(T: type): int =
+    sizeof(T) * 2
+  type MyBuf[I] = ArrayBuf[maxLen(I)]
+  var v: MyBuf[int]
+
 when false: # issue #22342, type section version of #22607
   type GenAlias[isInt: static bool] = (
     when isInt:


### PR DESCRIPTION
fixes #24044

When matching a `tyFromExpr` against a `static` generic parameter, `paramTypesMatch` tries to evaluate it as a constant expression, which causes a segfault in the case of #24044. In #24005 a consequence of the same behavior was an issue where `nkStaticExpr` was created for `tyFromExpr` which made it not instantiate, so only the generation of `nkStaticExpr` was disabled. Instead we now just completely ignore `tyFromExpr` matching a `static` generic parameter in generic contexts and keep it untouched.