### PR TITLE
document partial generics breaking changes, add `auto` convenience

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,28 @@
   errors for ambiguous type symbols, and macros operating on generic proc AST
   may encounter symchoice nodes instead of the arbitrarily resolved type symbol nodes.
 
+- Partial generic instantiation of routines is no longer allowed. Previously
+  it compiled in niche situations due to bugs in the compiler.
+
+  ```nim
+  proc foo[T, U](x: T, y: U) = echo (x, y)
+  proc foo[T, U](x: var T, y: U) = echo "var ", (x, y)
+
+  proc bar[T]() =
+    foo[float](1, "abc")
+
+  bar[int]() # before: (1.0, "abc"), now: type mismatch, missing generic parameter
+  ```
+
+  As an experimental feature, in situations where generic parameters can be
+  inferred from arguments in the call, `auto` can be used in place of
+  generic parameters that would be too complex to type normally.
+
+  ```nim
+  proc foo[T, U](x: T, y: U) = echo (x, y)
+  foo[int, auto](123, ("abc", (false, 1.0))) # (123, ("abc", (false, 1.0)))
+  ```
+
 ## Standard library additions and changes
 
 [//]: # "Changes:"

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2642,3 +2642,18 @@ proc nothing() =
 ```
 
 The current C(C++) backend implementation cannot generate code for gcc and for vcc at the same time. For example, `{.asmSyntax: "vcc".}` with the ICC compiler will not generate code with intel asm syntax, even though ICC can use both gcc-like and vcc-like asm.
+
+`auto` in generic routine instantiations
+========================================
+
+When generic parameters are provided to routines in calls, the number of
+parameters must match the number of generic parameters of the routine.
+However, in some cases, some types may be too complex to write as explicit
+type parameters, even though they can be inferred from the arguments of
+the routine call. In such cases, `auto` can be used to infer the type of the
+generic parameter.
+
+```nim
+proc foo[T, U](x: T, y: U) = echo (x, y)
+foo[int, auto](123, ("abc", (false, 1.0))) # (123, ("abc", (false, 1.0)))
+```  

--- a/tests/proc/texplicitgenerics.nim
+++ b/tests/proc/texplicitgenerics.nim
@@ -47,3 +47,13 @@ block: # ditto but may be wrong minimization
     # alternative version, also causes instantiation issue
     proc baz[T](x: typeof(foo[T]())) = discard
     baz[int](Foo[int]())
+
+block: # auto
+  proc foo[T, U](x: T, y: U): (T, U) = (x, y)
+  doAssert foo(1, 2) is (int, int)
+  doAssert foo[auto, auto](1, 2) is (int, int)
+  doAssert foo[int, auto](1, 2) is (int, int)
+  doAssert foo[auto, int](1, 2) is (int, int)
+  doAssert foo[auto, auto](1, "a") is (int, string)
+  doAssert foo[int, auto](1, "a") is (int, string)
+  doAssert foo[auto, string](1, "a") is (int, string)

--- a/tests/proc/texplicitgenerics.nim
+++ b/tests/proc/texplicitgenerics.nim
@@ -57,3 +57,4 @@ block: # auto
   doAssert foo[auto, auto](1, "a") is (int, string)
   doAssert foo[int, auto](1, "a") is (int, string)
   doAssert foo[auto, string](1, "a") is (int, string)
+  doAssert foo[int, auto](123, ("abc", (false, 1.0))) == (123, ("abc", (false, 1.0)))


### PR DESCRIPTION
refs #24010, refs https://github.com/c-blake/cligen/pull/233#issuecomment-2314777278

The breaking changes from #24010 regarding partial generic instantiation of routines no longer being allowed are now added to the changelog. 

A convenience has also been added as an experimental feature of using `auto` in place of parameters that can be inferred in routine generic instantiations, for when the types are too complex to type normally. An example of where this would be useful is the [PR to combparser](https://github.com/PMunch/combparser/pull/7/files) that was needed for #24010. Unfortunately it wouldn't work in an older version so one would have to use a `when` version check to use `auto` in new versions and partial instantiation in old versions.