### PR TITLE
streams: implement readStr for VM, document VM limitations

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -181,7 +181,7 @@ pkg "unicodeplus", "nim c -d:release -r tests/tests.nim"
 pkg "union", "nim c -r tests/treadme.nim", url = "https://github.com/alaviss/union"
 pkg "unittest2"
 pkg "unpack"
-pkg "weave", "nimble install cligen@#HEAD; nimble test_gc_arc", useHead = true
+pkg "weave", "nimble install -y cligen@#HEAD; nimble test_gc_arc", useHead = true
 pkg "websock"
 pkg "websocket", "nim c websocket.nim"
 # pkg "winim", allowFailure = true

--- a/tests/stdlib/tstreams.nim
+++ b/tests/stdlib/tstreams.nim
@@ -92,6 +92,10 @@ static: # Ensure streams it doesnt break with nimscript on arc/orc #19716
   let s = newStringStream("a")
   doAssert s.data == "a"
 
+static: # issue #24054, readStr
+  var s = newStringStream("foo bar baz")
+  doAssert s.readStr(3) == "foo"
+
 template main =
   var strm = newStringStream("abcde")
   var buffer = "12345"


### PR DESCRIPTION
fixes #24054

`readData` is not implemented for the VM as mentioned in the issue, but `readDataStr` is, so that is used for `readStr` instead on the VM. We could also just use it in general since it falls back to `readData` anyway but it's kept the same otherwise for now.

Also where and why streams in general don't work in VM is now documented on the top level `streams` module documentation.