### PR TITLE
fixes #23897; Useless empty C files with arc/orc

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1940,9 +1940,6 @@ proc genInitCode(m: BModule) =
 
     if optStackTrace in m.initProc.options and preventStackTrace notin m.flags:
       prc.add(deinitFrame(m.initProc))
-  elif m.config.exc == excGoto:
-    if getCompilerProc(m.g.graph, "nimTestErrorFlag") != nil:
-      m.appcg(prc, "\t#nimTestErrorFlag();$n", [])
 
   prc.addf("}$N", [])
 


### PR DESCRIPTION
fixes #23897

follow up https://github.com/nim-lang/Nim/pull/21288
follow up https://github.com/nim-lang/Nim/pull/22472

Since #22472 triggers `nimTestErrorFlag` in every module that isn't empty, this PR removes unnecessary logic