### PR TITLE
fix undeclared identifier in templates in generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -613,7 +613,8 @@ proc semGenericStmt(c: PContext, n: PNode,
       else:
         body = getBody(c.graph, s)
     else: body = n[bodyPos]
-    n[bodyPos] = semGenericStmtScope(c, body, flags, ctx)
+    let bodyFlags = if n.kind == nkTemplateDef: flags + {withinMixin} else: flags
+    n[bodyPos] = semGenericStmtScope(c, body, bodyFlags, ctx)
     closeScope(c)
   of nkPragma, nkPragmaExpr: discard
   of nkExprColonExpr, nkExprEqExpr:

--- a/tests/generics/tnestedtemplate.nim
+++ b/tests/generics/tnestedtemplate.nim
@@ -1,0 +1,9 @@
+block: # issue #13979
+  var s: seq[int]
+  proc filterScanline[T](input: openArray[T]) =
+    template currPix: untyped = input[i]
+    for i in 0..<input.len:
+      s.add currPix
+  let pix = [1, 2, 3]
+  filterScanline(pix)
+  doAssert s == @[1, 2, 3]


### PR DESCRIPTION
fixes #13979

Fixes templates in generics that use identifiers that aren't defined yet, giving an early `undeclared identifier` error, by just marking template bodies as in a mixin context in `semgnrc`.