### PR TITLE
fixes #21353; fixes default closure in the VM

### DIFF
--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -790,3 +790,7 @@ block: # bug #23925
 
   static: bar()
   bar()
+
+static: # bug #21353
+  var s: proc () = default(proc ())
+  doAssert s == nil


### PR DESCRIPTION
fixes #21353

```nim
  result = newNodeIT(nkTupleConstr, info, t)
  result.add(newNodeIT(nkNilLit, info, t))
  result.add(newNodeIT(nkNilLit, info, t))
```
The old implementation uses `t` which is the type of the closure function as its type. It is not correct and generates ((nil, nil), (nil, nil)) for `default(closures)`. This PR creates `(tyPointer, tyPointer)` for fake closure types just like what cctypes do.

