### PR TITLE
fixes #7002; fixes #17602; disallow using an object  allocated on the stack for dynamic dispatch

### DIFF
--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -163,9 +163,12 @@ proc methodDef*(g: ModuleGraph; idgen: IdGenerator; s: PSym) =
       g.config.isDefined("nimInternalNonVtablesTesting"):
     localError(g.config, s.info, errGenerated, "method `" & s.name.s &
           "` can be defined only in the same module with its type (" & s.typ.firstParamType.typeToString() & ")")
-  if sfImportc in s.flags:
+  elif sfImportc in s.flags:
     localError(g.config, s.info, errGenerated, "method `" & s.name.s &
           "` is not allowed to have 'importc' pragmas")
+  elif s.typ.firstParamType.kind == tyObject:
+    localError(g.config, s.info, errGenerated, "method `" & s.name.s &
+          "` is not allowed to have an object allocated on the stack as the first parameter")
 
   for i in 0..<g.methods.len:
     let disp = g.methods[i].dispatcher


### PR DESCRIPTION
fixes #7002; fixes #17602

It causes undefined behaviors with ORC since `objectAssignmentDefect` is disabled for ORC

See also https://github.com/nim-lang/Nim/issues/7002#issuecomment-757914767

Checked with

```nim
import strutils

type
    BaseObj = object of RootRef
      id: int
    DerivedObj = object of BaseObj
      name: float
      id2: int

method `$`(bo: BaseObj): string {.base.} =
    echo (bo.id)
    return "Base"

method `$`(dob: DerivedObj): string =
    echo (dob.id, dob.name, dob.id2)
    return "Derived"

type Container = object
    inner: BaseObj

proc foo =
  var
      dob = DerivedObj(id: 12, name: 1.23, id2: 5)
      cont = Container(inner: dob)
      dob2 = BaseObj()

  echo (dob, cont, dob2)

  echo (dob, cont, dob2)

  dob2 = dob

  echo (dob, cont, dob2)

foo()
```