### PR TITLE
fix CI, sem whole `when` stmts as generic stmt

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2709,7 +2709,6 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
           elif not cannotResolve and val.intVal != 0 and result == nil:
             setResult(it[1])
             return # we're not in nimvm and we already have a result
-        it[1] = semGenericStmt(c, it[1])
       else:
         let e = forceBool(c, semConstExpr(c, it[0]))
         if e.kind != nkIntLit:
@@ -2722,7 +2721,7 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
     of nkElse, nkElseExpr:
       checkSonsLen(it, 1, c.config)
       if cannotResolve:
-        it[0] = semGenericStmt(c, it[0])
+        discard
       elif result == nil or whenNimvm:
         if semCheck:
           it[0] = semExpr(c, it[0], flags)
@@ -2733,7 +2732,7 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
           result = it[0]
     else: illFormedAst(n, c.config)
   if cannotResolve:
-    result = n
+    result = semGenericStmt(c, n)
     result.typ = makeTypeFromExpr(c, result.copyTree)
     return
   if result == nil:

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -235,3 +235,18 @@ block: # issue #22607, needs nkWhenStmt to be handled like nkRecWhen
   test[true](1.int)
   test[false](1.0)
   doAssert not compiles(test[])
+
+block: # `when` in static signature
+  template ctAnd(a, b): bool =
+    when a:
+      when b: true
+      else: false
+    else: false
+  template test(): untyped =
+    when ctAnd(declared(SharedTable), typeof(result) is SharedTable):
+      result = SharedTable()
+    else:
+      result = 123
+  proc foo[T](): T = test()
+  proc bar[T](x = foo[T]()): T = x
+  doAssert bar[int]() == 123


### PR DESCRIPTION
fixes CI, refs #24066, refs #24065

The combination of #24065 and #24066 caused a CI failure where a `when` branch that was never compiled gave an undeclared identifier error. This is because the `when` branch was being semchecked with `semGenericStmt` without `withinMixin`, which is the flag `semgnrc` normally gives to `when` branch bodies. To fix this, just pass the whole `when` stmt to `semGenericStmt` rather than the individual blocks.

The alternative would be to just replace the calls to `semGenericStmt` with a new proc that does the same thing, just with the flags `{withinMixin}`.