### PR TITLE
implement template default values using other params

### DIFF
--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -33,6 +33,19 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     let x = param
     if x.kind == nkArgList:
       for y in items(x): result.add(y)
+    elif nfDefaultRefsParam in x.flags:
+      # value of default param needs to be evaluated
+      # if it contains other template params
+      var res: PNode
+      if isAtom(x):
+        res = newNodeI(nkPar, x.info)
+        evalTemplateAux(x, actual, c, res)
+        if res.len == 1: res = res[0]
+      else:
+        res = copyNode(x)
+        for i in 0..<x.safeLen:
+          evalTemplateAux(x[i], actual, c, res)
+      result.add res
     else:
       result.add copyTree(x)
 

--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -34,7 +34,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     if x.kind == nkArgList:
       for y in items(x): result.add(y)
     elif nfDefaultRefsParam in x.flags:
-      # value of default param needs to be evaluated
+      # value of default param needs to be evaluated like template body
       # if it contains other template params
       var res: PNode
       if isAtom(x):

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -813,7 +813,7 @@ proc isUnresolvedSym(s: PSym): bool =
   result = s.kind == skGenericParam
   if not result and s.typ != nil:
     result = tfInferrableStatic in s.typ.flags or
-        (s.kind == skParam and s.typ.isMetaType) or
+        (s.kind == skParam and (s.typ.isMetaType or sfTemplateParam in s.flags)) or
         (s.kind == skType and
         s.typ.flags * {tfGenericTypeParam, tfImplicitTypeParam} != {})
 

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -743,6 +743,16 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     c: c,
     owner: s
   )
+  for i in 1..<s.typ.n.len:
+    let param = s.typ.n[i].sym
+    if param.ast != nil:
+      # param default values need to be treated like template body:
+      if sfDirty in s.flags:
+        param.ast = semTemplBodyDirty(ctx, param.ast)
+      else:
+        param.ast = semTemplBody(ctx, param.ast)
+      if param.ast.referencesAnotherParam(s):
+        param.ast.flags.incl nfDefaultRefsParam
   if sfDirty in s.flags:
     n[bodyPos] = semTemplBodyDirty(ctx, n[bodyPos])
   else:

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -743,6 +743,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     c: c,
     owner: s
   )
+  # handle default params:
   for i in 1..<s.typ.n.len:
     let param = s.typ.n[i].sym
     if param.ast != nil:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1365,6 +1365,9 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           "either use ';' (semicolon) or explicitly write each default value")
         message(c.config, a.info, warnImplicitDefaultValue, msg)
       block determineType:
+        if kind == skTemplate and hasUnresolvedArgs(c, def):
+          def.typ = makeTypeFromExpr(c, def.copyTree)
+          break determineType
         let isGeneric = isCurrentlyGeneric()
         inc c.inGenericContext, ord(isGeneric)
         def = semExprWithType(c, def, {efDetermineType, efAllowSymChoice}, typ)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1366,6 +1366,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
         message(c.config, a.info, warnImplicitDefaultValue, msg)
       block determineType:
         if kind == skTemplate and hasUnresolvedArgs(c, def):
+          # template default value depends on other parameter
+          # don't do any typechecking
           def.typ = makeTypeFromExpr(c, def.copyTree)
           break determineType
         let isGeneric = isCurrentlyGeneric()

--- a/tests/template/tdefaultparam.nim
+++ b/tests/template/tdefaultparam.nim
@@ -1,0 +1,15 @@
+block:
+  template foo(a: untyped, b: untyped = a(0)): untyped =
+    let x = a(0)
+    let y = b
+    (x, y)
+  proc bar(x: int): int = x + 1
+  doAssert foo(bar, b = bar(0)) == (1, 1)
+  doAssert foo(bar) == (1, 1)
+
+block: # issue #23506
+  var a: string
+  template foo(x: int; y = x) =
+    a = $($x, $y)
+  foo(1)
+  doAssert a == "(\"1\", \"1\")"


### PR DESCRIPTION
fixes #23506

#24065 broke compilation of template parameter default values that depended on other template parameters. But this was never implemented anyway, actually attempting to use those default values breaks the compiler as in #23506. So these are now implemented as well as fixing the regression.

First, if a default value expression uses any unresolved arguments (generic or normal template parameters) in a template header, we leave it untyped, instead of applying the generic typechecking (fixing the regression). Then, just before the body of the template is about to be explored, the default value expressions are handled in the same manner as the body as well. This captures symbols including the parameters, so the expression is checked again if it contains a parameter symbol, and marked with `nfDefaultRefsParam` if it does (as an optimization to not check it later).

Then when the template is being evaluated, when substituting a parameter, if we try to substitute with a node marked `nfDefaultRefsParam`, we also evaluate it as we would the template body instead of passing it as just a copy (the reason why it never worked before). This way we save time if a default value doesn't refer to another parameter and could just be copied regardless.