### PR TITLE
fix regression with generic params in static type

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -485,6 +485,7 @@ proc concreteType(c: TCandidate, t: PType; f: PType = nil): PType =
     else: result = t
   of tyGenericParam, tyAnything, tyConcept:
     result = t
+    if c.isNoCall: return
     while true:
       result = idTableGet(c.bindings, t)
       if result == nil:
@@ -1927,10 +1928,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         elif c.isNoCall:
           if doBindGP:
             let concrete = concreteType(c, a, f)
-            if concrete != nil:
-              put(c, f, concrete)
-            elif c.c.inGenericContext == 0:
-              return isNone
+            if concrete == nil: return isNone
+            put(c, f, concrete)
           result = isGeneric
         else:
           result = isNone
@@ -1964,9 +1963,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           # at least validating, bindings can have multiple benefits. This is debatable. I'm not 100% sure.
           # A design that allows a proper complexity analysis of types like `tyOr` would be ideal.
           concrete = concreteType(c, a, f)
-          if concrete == nil and c.c.inGenericContext == 0:
+          if concrete == nil:
             return isNone
-        if doBindGP and concrete != nil:
+        if doBindGP:
           put(c, f, concrete)
       elif result > isGeneric:
         result = isGeneric

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1927,8 +1927,10 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         elif c.isNoCall:
           if doBindGP:
             let concrete = concreteType(c, a, f)
-            if concrete == nil: return isNone
-            put(c, f, concrete)
+            if concrete != nil:
+              put(c, f, concrete)
+            elif c.c.inGenericContext == 0:
+              return isNone
           result = isGeneric
         else:
           result = isNone
@@ -1962,9 +1964,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           # at least validating, bindings can have multiple benefits. This is debatable. I'm not 100% sure.
           # A design that allows a proper complexity analysis of types like `tyOr` would be ideal.
           concrete = concreteType(c, a, f)
-          if concrete == nil:
+          if concrete == nil and c.c.inGenericContext == 0:
             return isNone
-        if doBindGP:
+        if doBindGP and concrete != nil:
           put(c, f, concrete)
       elif result > isGeneric:
         result = isGeneric

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -403,5 +403,9 @@ block: # weird regression
     Foo[T] = distinct int
     Bar[T, U] = distinct int
   proc foo[T, U](x: static Foo[T], y: static Bar[T, U]): Foo[T] =
+    # signature gives:
+    # Error: cannot instantiate Bar
+    # got: <typedesc[T], U>
+    # but expected: <T, U>
     x
   doAssert foo(Foo[int](1), Bar[int, int](2)).int == 1

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -397,3 +397,11 @@ block: # `when`, test no constant semchecks
       {.error: "bad 2".}
   )
   var y: Bar[int]
+
+block: # weird regression
+  type
+    Foo[T] = distinct int
+    Bar[T, U] = distinct int
+  proc foo[T, U](x: static Foo[T], y: static Bar[T, U]): Foo[T] =
+    x
+  doAssert foo(Foo[int](1), Bar[int, int](2)).int == 1


### PR DESCRIPTION
Caught in https://github.com/metagn/applicates, I'm not sure which commit causes this but it's also in the 2.0 branch (but not 2.0.2), so it's not any recent PRs.

If a proc has a static parameter with type `static Foo[T]`, then another parameter with type `static Bar[T, U]`, the generic instantiation for `Bar` doesn't match `U` which has type `tyGenericParam`, but matches `T` since it has type `tyTypeDesc`. The reason is that `concreteType` returns the type itself for `tyTypeDesc` if `c.isNoCall` (i.e. matching a generic invocation), but returns `nil` for `tyGenericParam`. I'm guessing `tyGenericParam` is received here because of #22618, but that doesn't explain why `T` is still `tyTypeDesc`. I'm not sure.

Regardless, we can just copy the behavior for `tyTypeDesc` to `tyGenericParam` and also return the type itself when `c.isNoCall`. This feels like it defeats the purpose of `concreteType` but the way it's used doesn't make sense without it (generic param can't match another generic param?). Alternatively we could loosen the `if concrete == nil: return isNone` checks in some places for specific conditions, whether `c.isNoCall` or `c.inGenericContext == 0` (though this would need #24005).