### PR TITLE
show symchoices as ambiguous in overload type mismatches

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -563,23 +563,33 @@ proc errorUseQualifier*(c: PContext; info: TLineInfo; s: PSym) =
   var amb: bool = false
   discard errorUseQualifier(c, info, s, amb)
 
-proc errorUseQualifier*(c: PContext; info: TLineInfo; candidates: seq[PSym]; prefix = "use one of") =
-  var err = "ambiguous identifier: '" & candidates[0].name.s & "'"
+proc ambiguousIdentifierMsg*(candidates: seq[PSym], prefix = "use one of", indent = 0): string =
+  result = ""
+  for i in 0 ..< indent:
+    result.add(' ')
+  result.add "ambiguous identifier: '" & candidates[0].name.s & "'"
   var i = 0
   for candidate in candidates:
-    if i == 0: err.add " -- $1 the following:\n" % prefix
-    else: err.add "\n"
-    err.add "  " & candidate.owner.name.s & "." & candidate.name.s
-    err.add ": " & typeToString(candidate.typ)
+    if i == 0: result.add " -- $1 the following:\n" % prefix
+    else: result.add "\n"
+    for i in 0 ..< indent:
+      result.add(' ')
+    result.add "  " & candidate.owner.name.s & "." & candidate.name.s
+    result.add ": " & typeToString(candidate.typ)
     inc i
-  localError(c.config, info, errGenerated, err)
 
-proc errorUseQualifier*(c: PContext; info:TLineInfo; choices: PNode) =
+proc errorUseQualifier*(c: PContext; info: TLineInfo; candidates: seq[PSym]) =
+  localError(c.config, info, errGenerated, ambiguousIdentifierMsg(candidates))
+
+proc ambiguousIdentifierMsg*(choices: PNode, indent = 0): string =
   var candidates = newSeq[PSym](choices.len)
   let prefix = if choices[0].typ.kind != tyProc: "use one of" else: "you need a helper proc to disambiguate"
   for i, n in choices:
     candidates[i] = n.sym
-  errorUseQualifier(c, info, candidates, prefix)
+  result = ambiguousIdentifierMsg(candidates, prefix, indent)
+
+proc errorUseQualifier*(c: PContext; info:TLineInfo; choices: PNode) =
+  localError(c.config, info, errGenerated, ambiguousIdentifierMsg(choices))
 
 proc errorUndeclaredIdentifier*(c: PContext; info: TLineInfo; name: string, extra = "") =
   var err: string

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -285,6 +285,8 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           candidates.add "\n"
         of kTypeMismatch:
           doAssert nArg != nil
+          if nArg.kind in nkSymChoices:
+            candidates.add ambiguousIdentifierMsg(nArg, indent = 2)
           let wanted = err.firstMismatch.formal.typ
           doAssert err.firstMismatch.formal != nil
           doAssert wanted != nil
@@ -317,6 +319,9 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           candidates.add renderTree(arg)
           candidates.add "' of type: "
           candidates.addTypeDeclVerboseMaybe(c.config, got)
+          if nArg.kind in nkSymChoices:
+            candidates.add "\n"
+            candidates.add ambiguousIdentifierMsg(nArg, indent = 2)
           if got != nil and got.kind == tyProc and wanted.kind == tyProc:
             # These are proc mismatches so,
             # add the extra explict detail of the mismatch
@@ -370,6 +375,9 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
             candidates.add "' is of type: "
             let got = arg.typ
             candidates.addTypeDeclVerboseMaybe(c.config, got)
+            if arg.kind in nkSymChoices:
+              candidates.add "\n"
+              candidates.add ambiguousIdentifierMsg(arg, indent = 2)
             doAssert wanted != nil
             if got != nil:
               if got.kind == tyProc and wanted.kind == tyProc:

--- a/tests/enum/tpure_enums_conflict_legacy.nim
+++ b/tests/enum/tpure_enums_conflict_legacy.nim
@@ -1,7 +1,3 @@
-discard """
-  matrix: "-d:testsConciseTypeMismatch"
-"""
-
 # bug #8066
 
 when true:
@@ -16,12 +12,14 @@ when true:
   echo valueA # MyEnum.valueA
   echo MyEnum.amb # OK.
   echo amb #[tt.Error
-  ^ type mismatch
-Expression: echo amb
-  [1] amb: MyEnum | OtherEnum
-
-Expected one of (first mismatch at [position]):
-[1] proc echo(x: varargs[typed, `$$`])
+  ^ type mismatch: got <MyEnum | OtherEnum>
+but expected one of:
+proc echo(x: varargs[typed, `$$`])
+  first type mismatch at position: 1
+  required type for x: varargs[typed]
+  but expression 'amb' is of type: None
   ambiguous identifier: 'amb' -- use one of the following:
     MyEnum.amb: MyEnum
-    OtherEnum.amb: OtherEnum]#
+    OtherEnum.amb: OtherEnum
+
+expression: echo amb]#

--- a/tests/errmsgs/mambparam1.nim
+++ b/tests/errmsgs/mambparam1.nim
@@ -1,0 +1,1 @@
+const test* = "foo"

--- a/tests/errmsgs/mambparam2.nim
+++ b/tests/errmsgs/mambparam2.nim
@@ -1,0 +1,2 @@
+import mambparam1
+export test

--- a/tests/errmsgs/mambparam3.nim
+++ b/tests/errmsgs/mambparam3.nim
@@ -1,0 +1,1 @@
+const test* = "bar"

--- a/tests/errmsgs/tambparam.nim
+++ b/tests/errmsgs/tambparam.nim
@@ -1,0 +1,16 @@
+discard """
+  matrix: "-d:testsConciseTypeMismatch"
+"""
+
+import mambparam2, mambparam3
+
+echo test #[tt.Error
+^ type mismatch
+Expression: echo test
+  [1] test: string | string
+
+Expected one of (first mismatch at [position]):
+[1] proc echo(x: varargs[typed, `$$`])
+  ambiguous identifier: 'test' -- use one of the following:
+    mambparam1.test: string
+    mambparam3.test: string]#

--- a/tests/errmsgs/tambparam_legacy.nim
+++ b/tests/errmsgs/tambparam_legacy.nim
@@ -1,0 +1,14 @@
+import mambparam2, mambparam3
+
+echo test #[tt.Error
+^ type mismatch: got <string | string>
+but expected one of:
+proc echo(x: varargs[typed, `$$`])
+  first type mismatch at position: 1
+  required type for x: varargs[typed]
+  but expression 'test' is of type: None
+  ambiguous identifier: 'test' -- use one of the following:
+    mambparam1.test: string
+    mambparam3.test: string
+
+expression: echo test]#


### PR DESCRIPTION
fixes #23397

All ambiguous symbols generate symchoices for call arguments since #23123. So, if a type mismatch receives a symchoice node for an argument, we now treat it as an ambiguous identifier and list the ambiguous symbols in the error message.