### PR TITLE
Fix ioselectors_kqueue raising wrong exceptions

### DIFF
--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -194,7 +194,9 @@ when hasThreadSupport:
         if s.changesLength > 0:
           if kevent(s.kqFD, addr(s.changes[0]), cint(s.changesLength),
                     nil, 0, nil) == -1:
-            raiseIOSelectorsError(osLastError())
+            let res = osLastError()
+            if cint(res) != ENOENT: # ignore pipes whose read end is closed
+              raiseIOSelectorsError(res)
           s.changesLength = 0
 else:
   template modifyKQueue[T](s: Selector[T], nident: uint, nfilter: cshort,
@@ -211,7 +213,9 @@ else:
       if length > 0:
         if kevent(s.kqFD, addr(s.changes[0]), length,
                   nil, 0, nil) == -1:
-          raiseIOSelectorsError(osLastError())
+          let res = osLastError()
+          if cint(res) != ENOENT: # ignore pipes whose read end is closed
+            raiseIOSelectorsError(res)
         s.changes.setLen(0)
 
 proc registerHandle*[T](s: Selector[T], fd: int | SocketHandle,


### PR DESCRIPTION
kqueue will remove pipes automatically if their read end is closed. Unfortunately this means that trying to unregister it (which is necessary to clean up resources & for consistency with other ioselectors implementations) will set an ENOENT error, which currently raises an exception.

(ETA: in other words, it is currently impossible to call unregister on a pipe fd without potentially getting the selector into an invalid state on platforms with kqueue.)

Avoid this issue by ignoring ENOENT errors returned from kqueue.

(Tested on FreeBSD. I added a test case to the tioselectors file; the seemingly unrelated change is to fix a race condition that doesn't appear on Linux, so that it would run my code too.)