### PR TITLE
fix tuple conversion to JsonNode from `%` in pure/json.nim

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -390,7 +390,7 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
   assert(obj.kind == JObject)
   obj.fields[key] = val
 
-proc `%`*[T: object](o: T): JsonNode =
+proc `%`*[T: object | tuple](o: T): JsonNode =
   ## Construct JsonNode from tuples and objects.
   result = newJObject()
   for k, v in o.fieldPairs: result[k] = %v

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -357,7 +357,9 @@ proc `%`*(keyVals: openArray[tuple[key: string, val: JsonNode]]): JsonNode =
 
 template `%`*(j: JsonNode): JsonNode = j
 
-proc `%`*[T](elements: openArray[T]): JsonNode =
+#Disallow tuples inside the array to avoid something like %{"test":"test1"} to get converted to [{"Field0":"test","Field1":"test1"}]. 
+#See issue #24082
+proc `%`*[T: not tuple](elements: openArray[T]): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JArray JsonNode`
   result = newJArray()
   for elem in elements: result.add(%elem)

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -174,16 +174,16 @@ doAssert($ %*[] == "[]")
 doAssert($ %*{} == "{}")
 
 #issue #24082 for more info
-block test_tuple:
+block testTuple:
   let 
-    test_tuple_named: tuple = (a1: 10, a2: "foo") #tuple with field names = named tuple
-    test_tuple_anon: tuple = (10, "foo") #tuple without field names = anonymous tuple
+    testTupleNamed: tuple = (a1: 10, a2: "foo") #tuple with field names = named tuple
+    testTupleAnon: tuple = (10, "foo") #tuple without field names = anonymous tuple
 
-  doAssert $(% test_tuple_named) == """{"a1":10,"a2":"foo"}"""
-  doAssert $(% test_tuple_anon) == """{"Field0":10,"Field1":"foo"}"""
+  doAssert $(% testTupleNamed) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(% testTupleAnon) == """{"Field0":10,"Field1":"foo"}"""
 
-  doAssert $(%* test_tuple_named) == """{"a1":10,"a2":"foo"}"""
-  doAssert $(%* test_tuple_anon) == """{"Field0":10,"Field1":"foo"}"""
+  doAssert $(%* testTupleNamed) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(%* testTupleAnon) == """{"Field0":10,"Field1":"foo"}"""
 
 
 

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -180,10 +180,10 @@ block test_tuple:
     test_tuple_anon: tuple = (10, "foo") #tuple without field names = anonymous tuple
 
   doAssert $(% test_tuple_named) == """{"a1":10,"a2":"foo"}"""
-  doAssert $(% test_tuple_anon) == """{"Field0":10,"Field1":"foo"]"""
+  doAssert $(% test_tuple_anon) == """{"Field0":10,"Field1":"foo"}"""
 
   doAssert $(%* test_tuple_named) == """{"a1":10,"a2":"foo"}"""
-  doAssert $(%* test_tuple_anon) == """{"Field0":10,"Field1":"foo"]"""
+  doAssert $(%* test_tuple_anon) == """{"Field0":10,"Field1":"foo"}"""
 
 
 

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -173,7 +173,19 @@ when not defined(js):
 doAssert($ %*[] == "[]")
 doAssert($ %*{} == "{}")
 
-doAssert(not compiles(%{"error": "No messages"}))
+#issue #24082 for more info
+block test_tuple:
+  let 
+    test_tuple_named: tuple = (a1: 10, a2: "foo") #tuple with field names = named tuple
+    test_tuple_anon: tuple = (10, "foo") #tuple without field names = anonymous tuple
+
+  doAssert $(% test_tuple_named) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(% test_tuple_anon) == """{"Field0":10,"Field1":"foo"]"""
+
+  doAssert $(%* test_tuple_named) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(%* test_tuple_anon) == """{"Field0":10,"Field1":"foo"]"""
+
+
 
 # bug #9111
 block:


### PR DESCRIPTION
`%` - Conversion of an object or tuple to JsonNode doesn't work correctly for tuples atm, since the generic type is missing.  Added the tuple generic type to correctly allow tuples as input as well.  Credits to Elegantbeef from the Nim Discord.