### PR TITLE
push block label sym owner for `const` and `static`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -742,6 +742,8 @@ type
                               # for skModule the string literal to output for
                               # deprecated modules.
     instantiatedFrom*: PSym   # for instances, the generic symbol where it came from.
+                              # for locals in `const`/`static`, the block label
+                              # of the context they're declared in
     when defined(nimsuggest):
       allUsages*: seq[TLineInfo]
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -381,7 +381,7 @@ proc tryConstExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
 const
   errConstExprExpected = "constant expression expected"
 
-proc semConstExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
+proc semConstExpr(c: PContext, n: PNode; expectedType: PType = nil, owner: PSym = nil): PNode =
   var e = semExprWithType(c, n, expectedType = expectedType)
   if e == nil:
     localError(c.config, n.info, errConstExprExpected)
@@ -391,7 +391,7 @@ proc semConstExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   result = getConstExpr(c.module, e, c.idgen, c.graph)
   if result == nil:
     #if e.kind == nkEmpty: globalError(n.info, errConstExprExpected)
-    result = evalConstExpr(c.module, c.idgen, c.graph, e)
+    result = evalConstExpr(c.module, c.idgen, c.graph, e, owner)
     if result == nil or result.kind == nkEmpty:
       if e.info != n.info:
         pushInfoContext(c.config, n.info)

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -123,7 +123,7 @@ type
     patterns*: seq[PSym]       # sequence of pattern matchers
     optionStack*: seq[POptionEntry]
     libs*: seq[PLib]           # all libs used by this module
-    semConstExpr*: proc (c: PContext, n: PNode; expectedType: PType = nil): PNode {.nimcall.} # for the pragmas
+    semConstExpr*: proc (c: PContext, n: PNode; expectedType: PType = nil, owner: PSym = nil): PNode {.nimcall.} # for the pragmas
     semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode {.nimcall.}
     semExprWithType*: proc (c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType = nil): PNode {.nimcall.}
     semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -172,6 +172,7 @@ type
     importModuleLookup*: Table[int, seq[int]] # (module.ident.id, [module.id])
     skipTypes*: seq[PNode] # used to skip types between passes in type section. So far only used for inheritance, sets and generic bodies.
     inTypeofContext*: int
+    localOwner*: PSym # owner of local symbols, can be block label
   TBorrowState* = enum
     bsNone, bsReturnNotMatch, bsNoDistinct, bsGeneric, bsNotSupported, bsMatch
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1020,12 +1020,15 @@ proc evalAtCompileTime(c: PContext, n: PNode): PNode =
 
 proc semStaticExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   inc c.inStaticContext
+  let owner = makeStaticOwner(c, c.cache.getIdent(":static"), n.info)
+  pushOwner(c, owner)
   openScope(c)
   let a = semExprWithType(c, n, expectedType = expectedType)
   closeScope(c)
+  popOwner(c)
   dec c.inStaticContext
   if a.findUnresolvedStatic != nil: return a
-  result = evalStaticExpr(c.module, c.idgen, c.graph, a, c.p.owner)
+  result = evalStaticExpr(c.module, c.idgen, c.graph, a, owner)
   if result.isNil:
     localError(c.config, n.info, errCannotInterpretNodeX % renderTree(n))
     result = c.graph.emptyNode

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1021,11 +1021,12 @@ proc evalAtCompileTime(c: PContext, n: PNode): PNode =
 proc semStaticExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   inc c.inStaticContext
   let owner = makeStaticOwner(c, c.cache.getIdent(":static"), n.info)
-  pushOwner(c, owner)
+  let oldOwner = c.localOwner
+  c.localOwner = owner
   openScope(c)
   let a = semExprWithType(c, n, expectedType = expectedType)
   closeScope(c)
-  popOwner(c)
+  c.localOwner = oldOwner
   dec c.inStaticContext
   if a.findUnresolvedStatic != nil: return a
   result = evalStaticExpr(c.module, c.idgen, c.graph, a, owner)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2385,6 +2385,7 @@ proc evalConstExprAux(module: PSym; idgen: IdGenerator;
   let n = transformExpr(g, idgen, module, n)
   setupGlobalCtx(module, g, idgen)
   var c = PCtx g.vm
+  c.owner = prc
   let oldMode = c.mode
   c.mode = mode
   let start = genExpr(c, n, requiresValue = mode!=emStaticStmt)
@@ -2398,8 +2399,8 @@ proc evalConstExprAux(module: PSym; idgen: IdGenerator;
   if result.info.col < 0: result.info = n.info
   c.mode = oldMode
 
-proc evalConstExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode): PNode =
-  result = evalConstExprAux(module, idgen, g, nil, e, emConst)
+proc evalConstExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym = nil): PNode =
+  result = evalConstExprAux(module, idgen, g, prc, e, emConst)
 
 proc evalStaticExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym): PNode =
   result = evalConstExprAux(module, idgen, g, prc, e, emStaticExpr)

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -252,7 +252,7 @@ type
     currentExceptionA*, currentExceptionB*: PNode
     exceptionInstr*: int # index of instruction that raised the exception
     prc*: PProc
-    module*: PSym
+    module*, owner*: PSym
     callsite*: PNode
     mode*: TEvalMode
     features*: TSandboxFlags

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1558,12 +1558,13 @@ proc checkCanEval(c: PCtx; n: PNode) =
   if {sfCompileTime, sfGlobal} <= s.flags: return
   if compiletimeFFI in c.config.features and s.importcCondVar: return
   if s.kind in {skVar, skTemp, skLet, skParam, skResult} and
-      not s.isOwnedBy(c.prc.sym) and s.owner != c.owner and s.owner != c.module and
+      not s.isOwnedBy(c.prc.sym) and s.owner != c.module and
       c.mode != emRepl:
     # little hack ahead for bug #12612: assume gensym'ed variables
     # are in the right scope:
     if sfGenSym in s.flags and c.prc.sym == nil: discard
     elif s.kind == skParam and s.typ.kind == tyTypeDesc: discard
+    elif s.kind in {skVar, skLet} and s.instantiatedFrom != c.owner: discard
     else: cannotEval(c, n)
   elif s.kind in {skProc, skFunc, skConverter, skMethod,
                   skIterator} and sfForward in s.flags:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1564,7 +1564,7 @@ proc checkCanEval(c: PCtx; n: PNode) =
     # are in the right scope:
     if sfGenSym in s.flags and c.prc.sym == nil: discard
     elif s.kind == skParam and s.typ.kind == tyTypeDesc: discard
-    elif s.kind in {skVar, skLet} and s.instantiatedFrom != c.owner: discard
+    elif s.kind in {skVar, skLet} and s.instantiatedFrom == c.owner: discard
     else: cannotEval(c, n)
   elif s.kind in {skProc, skFunc, skConverter, skMethod,
                   skIterator} and sfForward in s.flags:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1564,7 +1564,8 @@ proc checkCanEval(c: PCtx; n: PNode) =
     # are in the right scope:
     if sfGenSym in s.flags and c.prc.sym == nil: discard
     elif s.kind == skParam and s.typ.kind == tyTypeDesc: discard
-    elif s.kind in {skVar, skLet} and s.instantiatedFrom == c.owner: discard
+    elif s.kind in {skVar, skLet} and s.instantiatedFrom != nil and
+      s.instantiatedFrom == c.owner: discard
     else: cannotEval(c, n)
   elif s.kind in {skProc, skFunc, skConverter, skMethod,
                   skIterator} and sfForward in s.flags:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1558,7 +1558,8 @@ proc checkCanEval(c: PCtx; n: PNode) =
   if {sfCompileTime, sfGlobal} <= s.flags: return
   if compiletimeFFI in c.config.features and s.importcCondVar: return
   if s.kind in {skVar, skTemp, skLet, skParam, skResult} and
-      not s.isOwnedBy(c.prc.sym) and s.owner != c.module and c.mode != emRepl:
+      not s.isOwnedBy(c.prc.sym) and s.owner != c.owner and s.owner != c.module and
+      c.mode != emRepl:
     # little hack ahead for bug #12612: assume gensym'ed variables
     # are in the right scope:
     if sfGenSym in s.flags and c.prc.sym == nil: discard

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -4,7 +4,7 @@ discard """
   matrix: "-d:nimPreviewSlimSystem"
   nimout: '''
 stack trace: (most recent call last)
-t9768.nim(29, 33)        main
+t9768.nim(29, 33)        :static
 t9768.nim(24, 11)        foo1
 '''
 """

--- a/tests/vm/tconststaticvar.nim
+++ b/tests/vm/tconststaticvar.nim
@@ -1,0 +1,79 @@
+block: # issue #8758
+  template baz() =
+    var i = 0
+
+  proc foo() =
+    static:
+      var i = 0
+      baz()
+
+block: # issue #10828
+  proc test(i: byte): bool =  
+    const SET = block: # No issues when defined outside proc
+      var s: set[byte]
+      for i in 0u8 .. 255u8: incl(s, i)
+      s
+    return i in SET
+  doAssert test(0)
+  doAssert test(127)
+  doAssert test(255)
+
+block: # issue #12172
+  const TEST = block:
+    var test: array[5, string]
+    for i in low(test)..high(test):
+      test[i] = $i
+    test
+  proc test =
+    const TEST2 = block:
+      var test: array[5, string] # Error here
+      for i in low(test)..high(test):
+        test[i] = $i
+      test
+    doAssert TEST == TEST2
+    doAssert TEST == @["0", "1", "2", "3", "4"]
+    doAssert TEST2 == @["0", "1", "2", "3", "4"]
+  test()
+
+block: # issue #21610
+  func stuff(): int =
+    const r = block:
+      var r = 1 # Error: cannot evaluate at compile time: r
+      for i in 2..10:
+        r *= i
+      r
+    r
+  doAssert stuff() == 3628800
+
+block: # issue #23803
+  func foo1(c: int): int {.inline.} =
+    const arr = block:
+      var res: array[0..99, int]
+      res[42] = 43
+      res
+    arr[c]
+  doAssert foo1(41) == 0
+  doAssert foo1(42) == 43
+  doAssert foo1(43) == 0
+
+  # works
+  func foo2(c: int): int {.inline.} =
+    func initArr(): auto =
+      var res: array[0..99, int]
+      res[42] = 43
+      res
+    const arr = initArr()
+    arr[c]
+  doAssert foo2(41) == 0
+  doAssert foo2(42) == 43
+  doAssert foo2(43) == 0
+
+  # also works
+  const globalArr = block:
+    var res: array[0..99, int]
+    res[42] = 43
+    res
+  func foo3(c: int): int {.inline.} = globalArr[c]
+  doAssert foo3(41) == 0
+  doAssert foo3(42) == 43
+  doAssert foo3(43) == 0

--- a/tests/vm/tconststaticvar_wrong.nim
+++ b/tests/vm/tconststaticvar_wrong.nim
@@ -1,0 +1,6 @@
+proc test =
+  const TEST = block:
+    let i = 1
+    const j = i + 1 #[tt.Error
+              ^ cannot evaluate at compile time: i]#
+    j

--- a/tests/vm/tnilclosurecallstacktrace.nim
+++ b/tests/vm/tnilclosurecallstacktrace.nim
@@ -2,7 +2,7 @@ discard """
   action: reject
   nimout: '''
 stack trace: (most recent call last)
-tnilclosurecallstacktrace.nim(23, 6) tnilclosurecallstacktrace
+tnilclosurecallstacktrace.nim(23, 6) :static
 tnilclosurecallstacktrace.nim(20, 6) baz
 tnilclosurecallstacktrace.nim(17, 6) bar
 tnilclosurecallstacktrace.nim(14, 4) foo


### PR DESCRIPTION
fixes #8758, fixes #10828, fixes #12172, fixes #21610, fixes #23803, refs https://github.com/nim-lang/RFCs/issues/276

Based off of #24084 for now but maybe doesn't need it

Another option is to reuse the `instantiatedFrom` field 