### PR TITLE
remove allowMetaTypes for inferStaticParam + properly annotate unresolved range

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -487,7 +487,7 @@ proc makeNotType*(c: PContext, t1: PType): PType =
   result.flags.incl tfHasMeta
 
 proc nMinusOne(c: PContext; n: PNode): PNode =
-  result = newTreeI(nkCall, n.info, newSymNode(getSysMagic(c.graph, n.info, "pred", mPred)), n)
+  result = newTreeI(nkCall, n.info, newSymNode(getSysMagic(c.graph, n.info, "pred", mPred), n.info), n)
 
 # Remember to fix the procs below this one when you make changes!
 proc makeRangeWithStaticExpr*(c: PContext, n: PNode): PType =

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -385,6 +385,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
     let e = semExprWithType(c, n, {efDetermineType})
     if e.typ.kind == tyFromExpr:
       result = makeRangeWithStaticExpr(c, e.typ.n)
+      result.flags.incl tfUnresolved
     elif e.kind in {nkIntLit..nkUInt64Lit}:
       if e.intVal < 0:
         localError(c.config, n.info,
@@ -411,6 +412,10 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
       # properly filled-out in semtypinst (see how tyStaticExpr
       # is handled there).
       result = makeRangeWithStaticExpr(c, e)
+      # makeRangeWithStaticExpr doesn't mark range as unresolved unless
+      # type of e is nil or has nil node, but we know it's unresolved
+      # even if it has a type because of hasUnresolvedArgs
+      result.flags.incl tfUnresolved
     elif e.kind == nkIdent:
       result = e.typ.skipTypes({tyTypeDesc})
     else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1082,7 +1082,9 @@ proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =
       (lhs.typ.n == nil or lookup(c.bindings, lhs.typ) == nil):
     var inferred = newTypeS(tyStatic, c.c, lhs.typ.elementType)
     inferred.n = newIntNode(nkIntLit, rhs)
-    put(c, lhs.typ, inferred)
+    # lhs.typ might be instantiated copy, use original type instead,
+    # obtained from type sym:
+    put(c, lhs.typ.sym.typ, inferred)
     if c.c.matchedConcept != nil:
       # inside concepts, binding is currently done with
       # direct mutation of the involved types:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -997,7 +997,6 @@ proc maybeSkipDistinct(m: TCandidate; t: PType, callee: PSym): PType =
     result = t
 
 proc tryResolvingStaticExpr(c: var TCandidate, n: PNode,
-                            allowUnresolved = false,
                             allowCalls = false,
                             expectedType: PType = nil): PNode =
   # Consider this example:
@@ -1006,8 +1005,7 @@ proc tryResolvingStaticExpr(c: var TCandidate, n: PNode,
   # Here, N-1 will be initially nkStaticExpr that can be evaluated only after
   # N is bound to a concrete value during the matching of the first param.
   # This proc is used to evaluate such static expressions.
-  let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil,
-                                        allowMetaTypes = allowUnresolved)
+  let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil)
   if not allowCalls and instantiated.kind in nkCallKinds:
     return nil
   result = c.c.semExpr(c.c, instantiated)
@@ -1101,10 +1099,8 @@ proc failureToInferStaticParam(conf: ConfigRef; n: PNode) =
 
 proc inferStaticsInRange(c: var TCandidate,
                          inferred, concrete: PType): TTypeRelation =
-  let lowerBound = tryResolvingStaticExpr(c, inferred.n[0],
-                                          allowUnresolved = true)
-  let upperBound = tryResolvingStaticExpr(c, inferred.n[1],
-                                          allowUnresolved = true)
+  let lowerBound = tryResolvingStaticExpr(c, inferred.n[0], allowCalls = true)
+  let upperBound = tryResolvingStaticExpr(c, inferred.n[1], allowCalls = true)
   template doInferStatic(e: PNode, r: Int128) =
     var exp = e
     var rhs = r

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -279,3 +279,8 @@ block: # issue #19923
   var z: array[x.S * 8, int]
   run(x, z)
 
+block:
+  proc foo[I: static int](x: array[I, int]) = discard
+  foo([1, 2, 3, 4])
+  proc bar[I: static int](x: array[I * 2, int]) = discard
+  foo([1, 2, 3, 4])

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -283,4 +283,7 @@ block:
   proc foo[I: static int](x: array[I, int]) = discard
   foo([1, 2, 3, 4])
   proc bar[I: static int](x: array[I * 2, int]) = discard
-  foo([1, 2, 3, 4])
+  bar([1, 2, 3, 4])
+  proc double(x: int): int = x * 2
+  proc baz[I: static int](x: array[double(I), int]) = discard
+  doAssert not compiles(baz([1, 2, 3, 4]))

--- a/tests/proc/tstaticsignature.nim
+++ b/tests/proc/tstaticsignature.nim
@@ -266,3 +266,16 @@ block: # issue #22276
     a = x * 2)
   doAssert a == 18
   foo(B, proc (x: float) = doAssert x == 9)
+
+block: # issue #19923
+  type Test[S: static[Natural]] = object
+  proc run(self: Test, idx: 0..(self.S * 8)) = discard
+  #       This causes segfault ^^^^^^^^^^^^
+  proc run(self: Test, a: array[self.S * 8, int]) = discard
+  #                And this too ^^^^^^^^^^
+  var x = Test[3]()
+  var y: array[24, int]
+  run(x, y.low)
+  var z: array[x.S * 8, int]
+  run(x, z)
+


### PR DESCRIPTION
fixes #19923

The code in #19923 already compiles since #24005, but when actually trying to pass an argument to it, `sigmatch` fails to infer the `array` type (but does infer the range type). There are 2 reasons:

1. The expression `self.S * 8` is a `tyFromExpr` which for some reason results in the range type not being marked `tfUnresolved`, and so array types just test for range span equality. This is because `makeRangeWithStaticExpr` only sets `tfUnresolved` if the given expression type isn't nil and has a nil node which is never true for `tyFromExpr`. This is fixed by just manually setting `tfUnresolved`. (also for when the node `hasUnresolvedArgs` but this isn't necessary here)
2. The compiler can't resolve `self.S` at overload resolution time since `inferStaticParam` enables `allowMetaTypes`, which results in `tyFromExpr`s never getting instantiated. To fix this we turn off `allowMetaTypes`.

Turning off `allowMetaTypes` here has several consequences:

* The types undergo `instCopyType` which changes their ID, so to give their bindings properly we have to get the original static type ID, which is done here by doing `.sym.typ` on the static type, since the `sym` is [invariant](https://github.com/nim-lang/Nim/blob/7cd17772181a8577a79ee166f4dc96b396dd59d2/compiler/ast.nim#L1555) between type copies. Thankfully only `inferStaticParam` gives a binding here.
* Inability to instantiate directly gives an error instead of waiting for overloads to finish. This is both due to the nature of `semtypinst` and the call to `failureToInferStaticParam`. In practice this isn't encountered often (mostly because it wasn't possible before) but it can cause unrelated overloads to be inaccessible if an overload requires explicit generic arguments. If this becomes a problem we can refactor `semtypinst` and `failureToInferStaticParam` to a version that just doesn't globally error on these and passes the information to the mismatch errors. Edit: Done in #24098