### PR TITLE
Allow tuples to be converted to JsonNode by `%` in json.nim as discussed in #24082 .

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -399,16 +399,23 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
   assert(obj.kind == JObject)
   obj.fields[key] = val
 
-proc `%`*[T: object | tuple](o: T): JsonNode =
-  ## Construct JsonNode from tuples and objects.
+#Bug #16321 - create seperate proc for tuple and object
+proc `%`*[T: tuple](o: T): JsonNode =
+  ## Construct JsonNode from tuples.
+  ##
   ## If passed an anonymous tuple, creates `JArray JsonNode`,
-  ## otherwise (named tuples and objects) `JObject JsonNode`.
-  when T is object or isNamedTuple(T):
+  ## otherwise (named tuples) `JObject JsonNode`.
+  when T is isNamedTuple(T):
     result = newJObject()
     for k, v in o.fieldPairs: result[k] = %v
   else:
     result = newJArray()
     for v in o.fields: result.add(%v)
+
+proc `%`*[T: object](o: T): JsonNode =
+  ## Construct JsonNode from objects.
+  result = newJObject()
+  for k, v in o.fieldPairs: result[k] = %v
 
 proc `%`*(o: ref object): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JObject JsonNode`

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -405,10 +405,10 @@ proc `%`*[T: object | tuple](o: T): JsonNode =
   ## otherwise (named tuples and objects) `JObject JsonNode`.
   when T is object or isNamedTuple(T):
     result = newJObject()
-    for k, v in a.fieldPairs: result[k] = toJson(v, opt)
+    for k, v in o.fieldPairs: result[k] = %(v)
   else:
     result = newJArray()
-    for v in a.fields: result.add toJson(v, opt)
+    for v in o.fields: result.add(%v)
 
 proc `%`*(o: ref object): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JObject JsonNode`

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -405,7 +405,7 @@ proc `%`*[T: object | tuple](o: T): JsonNode =
   ## otherwise (named tuples and objects) `JObject JsonNode`.
   when T is object or isNamedTuple(T):
     result = newJObject()
-    for k, v in o.fieldPairs: result[k] = %(v)
+    for k, v in o.fieldPairs: result[k] = %v
   else:
     result = newJArray()
     for v in o.fields: result.add(%v)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -401,6 +401,8 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
 
 proc `%`*[T: object | tuple](o: T): JsonNode =
   ## Construct JsonNode from tuples and objects.
+  ## If passed an anonymous tuple, creates `JArray JsonNode`,
+  ## otherwise (named tuples and objects) `JObject JsonNode`.
   when T is object or isNamedTuple(T):
     result = newJObject()
     for k, v in a.fieldPairs: result[k] = toJson(v, opt)

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -175,6 +175,14 @@ doAssert($ %*{} == "{}")
 
 doAssert(not compiles(%{"error": "No messages"}))
 
+# issue #24082
+block test_tuple:
+  doAssert $(%(a1: 10, a2: "foo")) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(%(10, "foo")) == """[10,"foo"]"""
+
+  doAssert $(%* (a1: 10, a2: "foo")) == """{"a1":10,"a2":"foo"}"""
+  doAssert $(%* (10, "foo")) == """[10,"foo"]"""
+
 # bug #9111
 block:
   type


### PR DESCRIPTION
As discussed in issue #24082.

- Added the tuple type as a legit input type for `%`, to be able to convert named and unnamed tuples. Also changed part of the function itself to correctly discern between named and anonymous/unnamed tuples. The code was copied directly from jsonutils.nim (slightly changed).
- Additionally changed the openArray `%` proc to not allow tuples as array elements, such that 
 ```Nim
let 
    myArr = [someTuple1, someTuple2]
    myJsonNode = %myArr
 ```
cannot be compiled.
- Added / Copied the ``isNamedTuple()``  proc from the jsonutils.nim file instead of adding a dependency by using ``import std/typetraits`` .

- Added the respective tests in tjson.nim, both for the macro `%*` and the overloaded proc `%` for both anonymous/unnamed and named tuples.

- As in jsonutils.nim, the named tuples are converted to JObject while the anonymous tuples are converted to JArray.

Quick explanation as to why we had to disallow tuples for the openArray (so people don't have to scroll through the other convo):
Curly brackets together with a key value pair, kind of like this: `{"error": "No message"}` will be compiled to `[("error", "no message")]` by Nim. Which is an array of tuples. 
That means, if we do `%{"error": "No message"}`, the compiler will treat it as an array with a tuple inside. 
It will look like this under the hood: `%[("error", "No message")]`.
If we would pass this to the openarray function (with the new tuple `%` proc implemented), we should get:
`[["error", "No message"]]` .
And that is somehow a problem, idk why though tbh.

Related issues or issues that I copied code/comments from:
#16851, #12290, #16851, #10019, #10823


