### PR TITLE
don't instantiate generic body type symbols in generic expressions

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -79,6 +79,7 @@ type
     info*: TLineInfo
     allowMetaTypes*: bool     # allow types such as seq[Number]
                               # i.e. the result contains unresolved generics
+    allowGenericBody*: bool   # don't error if generic body type found
     skipTypedesc*: bool       # whether we should skip typeDescs
     isReturnType*: bool
     owner*: PSym              # where this instantiation comes from
@@ -118,10 +119,10 @@ proc replaceTypeVarsT*(cl: var TReplTypeVars, t: PType): PType =
   result = replaceTypeVarsTAux(cl, t)
   checkMetaInvariants(cl, result)
 
-proc prepareNode*(cl: var TReplTypeVars, n: PNode): PNode =
+proc prepareNodeAux(cl: var TReplTypeVars, n: PNode): PNode =
   let t = replaceTypeVarsT(cl, n.typ)
   if t != nil and t.kind == tyStatic and t.n != nil:
-    return if tfUnresolved in t.flags: prepareNode(cl, t.n)
+    return if tfUnresolved in t.flags: prepareNodeAux(cl, t.n)
            else: t.n
   result = copyNode(n)
   result.typ = t
@@ -158,14 +159,14 @@ proc prepareNode*(cl: var TReplTypeVars, n: PNode): PNode =
     if ignoreFirst:
       result.add(n[0])
     else:
-      result.add(prepareNode(cl, n[0]))
+      result.add(prepareNodeAux(cl, n[0]))
     if n.len > 1:
       if ignoreSecond:
         result.add(n[1])
       else:
-        result.add(prepareNode(cl, n[1]))
+        result.add(prepareNodeAux(cl, n[1]))
     for i in 2..<n.len:
-      result.add(prepareNode(cl, n[i]))
+      result.add(prepareNodeAux(cl, n[i]))
   of nkBracketExpr:
     # don't instantiate Generic body type in expression like Generic[T]
     # exception exists for the call name being a dot expression since
@@ -179,20 +180,29 @@ proc prepareNode*(cl: var TReplTypeVars, n: PNode): PNode =
     if ignoreFirst:
       result.add(n[0])
     else:
-      result.add(prepareNode(cl, n[0]))
+      result.add(prepareNodeAux(cl, n[0]))
     for i in 1..<n.len:
-      result.add(prepareNode(cl, n[i]))
+      result.add(prepareNodeAux(cl, n[i]))
   of nkDotExpr:
     # don't try to instantiate RHS of dot expression, it can outright be
     # undeclared, but definitely instantiate LHS
     assert n.len >= 2
-    result.add(prepareNode(cl, n[0]))
+    result.add(prepareNodeAux(cl, n[0]))
     result.add(n[1])
     for i in 2..<n.len:
-      result.add(prepareNode(cl, n[i]))
+      result.add(prepareNodeAux(cl, n[i]))
   else:
     for i in 0..<n.safeLen:
-      result.add(prepareNode(cl, n[i]))
+      result.add(prepareNodeAux(cl, n[i]))
+
+proc prepareNode*(cl: var TReplTypeVars, n: PNode): PNode =
+  ## instantiates a given generic expression, not a type node
+  # we allow generic bodies since they can exist in regular user expressions,
+  # if they are uninstantiated param types etc, proc instantiation will fail anyway
+  let oldAllowGenericBody = cl.allowGenericBody
+  cl.allowGenericBody = true
+  result = prepareNodeAux(cl, n)
+  cl.allowGenericBody = oldAllowGenericBody
 
 proc isTypeParam(n: PNode): bool =
   # XXX: generic params should use skGenericParam instead of skType
@@ -631,6 +641,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
 
   of tyGenericBody:
     if cl.allowMetaTypes: return
+    if cl.allowGenericBody: return
     localError(
       cl.c.config,
       cl.info,
@@ -731,7 +742,8 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
 
       for i, resulti in result.ikids:
         if resulti != nil:
-          if resulti.kind == tyGenericBody and not cl.allowMetaTypes:
+          if resulti.kind == tyGenericBody and not cl.allowMetaTypes and
+              not cl.allowGenericBody:
             localError(cl.c.config, if t.sym != nil: t.sym.info else: cl.info,
               "cannot instantiate '" &
               typeToString(result[i], preferDesc) &

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -421,3 +421,6 @@ block: # issue #24090
   doAssert a.x is M[int]
   var b: Foo[float]
   doAssert b.x is M[float]
+  proc foo[T: M](x: T = default(T)) = discard x
+  foo[M[int]]()
+  doAssert not compiles(foo())

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -409,3 +409,15 @@ block: # weird regression
     # but expected: <T, U>
     x
   doAssert foo(Foo[int](1), Bar[int, int](2)).int == 1
+
+block: # issue #24090
+  type M[V] = object
+  template y[V](N: type M, v: V): M[V] = default(M[V])
+  proc d(x: int | int, f: M[int] = M.y(0)) = discard
+  d(0, M.y(0))
+  type Foo[T] = object
+    x: typeof(M.y(default(T)))
+  var a: Foo[int]
+  doAssert a.x is M[int]
+  var b: Foo[float]
+  doAssert b.x is M[float]

--- a/tests/generics/tuninstantiatedgenericcalls.nim
+++ b/tests/generics/tuninstantiatedgenericcalls.nim
@@ -421,6 +421,17 @@ block: # issue #24090
   doAssert a.x is M[int]
   var b: Foo[float]
   doAssert b.x is M[float]
+  doAssert not (compiles do:
+    type Bar[T] = object
+      x: typeof(M()) # actually fails here immediately
+    var bar: Bar[int])
+  doAssert not (compiles do:
+    type Bar[T] = object
+      x: typeof(default(M))
+    var bar: Bar[int]
+    # gives "undeclared identifier x" because of #24091,
+    # normally it should fail in the line above
+    echo bar.x)
   proc foo[T: M](x: T = default(T)) = discard x
   foo[M[int]]()
   doAssert not compiles(foo())


### PR DESCRIPTION
fixes #24090

Generic body types are normally a sign of an uninstantiated type, and so give errors when trying to instantiate them. However when instantiating free user expressions like the nodes of `tyFromExpr`, generic default params, static values etc, they can be used as arguments to macros or templates etc (as in the issue). So, we don't try to instantiate generic body type symbols at all in free expressions such as these (but not in for example type nodes), and avoid the error.

In the future there should be a "concrete type" check for generic body types different from the check in type instantiation to deal with things like #24091, if we do want to allow this use of them.