### PR TITLE
consider instantiation errors in overload resolution as type mismatch

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -123,7 +123,8 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
         errors.add(CandidateError(
           sym: sym,
           firstMismatch: z.firstMismatch,
-          diagnostics: z.diagnostics))
+          diagnostics: z.diagnostics,
+          instError: z.instError))
     else:
       # this branch feels like a ticking timebomb
       # one of two bad things could happen
@@ -389,6 +390,9 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
 
         of kUnknown: discard "do not break 'nim check'"
         candidates.add "\n"
+      if err.instError != nil:
+        candidates.add("  instantiation error at " & (c.config $ err.instError.info) & ":\n")
+        candidates.add("  " & $err.instError & "\n")
       if err.firstMismatch.arg == 1 and nArg != nil and
           nArg.kind == nkTupleConstr and n.kind == nkCommand:
         maybeWrongSpace = true

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1969,7 +1969,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
 
       return result
 
-proc semInferredLambda(c: PContext, pt: LayeredIdTable, n: PNode): PNode =
+proc semInferredLambda(c: PContext, pt: LayeredIdTable, n: PNode, instError: var InstantiationError): PNode =
   ## used for resolving 'auto' in lambdas based on their callsite
   var n = n
   let original = n[namePos].sym
@@ -1977,7 +1977,8 @@ proc semInferredLambda(c: PContext, pt: LayeredIdTable, n: PNode): PNode =
   #incl(s.flags, sfFromGeneric)
   #s.owner = original
 
-  n = replaceTypesInBody(c, pt, n, original)
+  n = replaceTypesInBody(c, pt, n, original, instError)
+  if instError != nil: return
   result = n
   s.ast = result
   n[namePos].sym = s

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -39,6 +39,7 @@ type
     sym*: PSym
     firstMismatch*: MismatchInfo
     diagnostics*: seq[string]
+    instError*: InstantiationError
     enabled*: bool
 
   CandidateErrors* = seq[CandidateError]
@@ -84,6 +85,7 @@ type
                               # to prefer closest father object type
     inheritancePenalty: int
     firstMismatch*: MismatchInfo # mismatch info for better error messages
+    instError*: InstantiationError
     diagnosticsEnabled*: bool
 
   TTypeRelFlag* = enum
@@ -1006,9 +1008,10 @@ proc tryResolvingStaticExpr(c: var TCandidate, n: PNode,
   # Here, N-1 will be initially nkStaticExpr that can be evaluated only after
   # N is bound to a concrete value during the matching of the first param.
   # This proc is used to evaluate such static expressions.
-  let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil,
+  var instError: InstantiationError = nil
+  let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil, instError, 
                                         allowMetaTypes = allowUnresolved)
-  if not allowCalls and instantiated.kind in nkCallKinds:
+  if instError != nil or (not allowCalls and instantiated.kind in nkCallKinds):
     return nil
   result = c.c.semExpr(c.c, instantiated)
 
@@ -1093,11 +1096,10 @@ proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =
 
   return false
 
-proc failureToInferStaticParam(conf: ConfigRef; n: PNode) =
+proc failureToInferStaticParam(c: var TCandidate; n: PNode) =
   let staticParam = n.findUnresolvedStatic
-  let name = if staticParam != nil: staticParam.sym.name.s
-             else: "unknown"
-  localError(conf, n.info, "cannot infer the value of the static param '" & name & "'")
+  let t = if staticParam != nil: staticParam.sym.typ else: nil
+  c.instError = InstantiationError(info: n.info, errorType: t, contextType: t)
 
 proc inferStaticsInRange(c: var TCandidate,
                          inferred, concrete: PType): TTypeRelation =
@@ -1111,7 +1113,8 @@ proc inferStaticsInRange(c: var TCandidate,
     if inferStaticParam(c, exp, toInt64(rhs)):
       return isGeneric
     else:
-      failureToInferStaticParam(c.c.config, exp)
+      failureToInferStaticParam(c, exp)
+      return isNone
 
   result = isNone
   if lowerBound.kind == nkIntLit:
@@ -2457,7 +2460,9 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       lastBindingCount = m.bindings.currentLen
       inc(instantiationCounter)
       if arg.kind in {nkProcDef, nkFuncDef, nkIteratorDef} + nkLambdaKinds:
-        result = c.semInferredLambda(c, m.bindings, arg)
+        result = c.semInferredLambda(c, m.bindings, arg, m.instError)
+        if m.instError != nil:
+          return nil
       elif arg.kind != nkSym:
         return nil
       elif arg.sym.kind in {skMacro, skTemplate}:

--- a/tests/errmsgs/toverloadinstantiation1.nim
+++ b/tests/errmsgs/toverloadinstantiation1.nim
@@ -1,0 +1,28 @@
+discard """
+  action: "reject"
+  matrix: "--hints:off -d:testsConciseTypeMismatch"
+  nimoutFull: true
+  nimout: '''
+toverloadinstantiation1.nim(28, 6) Error: type mismatch
+Expression: foo([1, 2, 3, 4])
+  [1] [1, 2, 3, 4]: array[0..3, int]
+
+Expected one of (first mismatch at [position]):
+[1] proc foo[I: static int](x: array[double(I), int])
+  instantiation error at toverloadinstantiation1.nim(27, 42):
+  cannot infer the value of the static param 'I'
+
+'''
+"""
+
+proc double(x: int): int = x * 2
+
+block: # this not erroring is checked by nimoutFull
+  proc foo[I: static int](x: array[I, int]) = discard
+  proc foo[I: static int](x: array[double(I), int]) = discard
+  foo([1, 2, 3, 4])
+  foo[2]([1, 2, 3, 4]) # this picks double overload
+
+block: 
+  proc foo[I: static int](x: array[double(I), int]) = discard
+  foo([1, 2, 3, 4])

--- a/tests/errmsgs/toverloadinstantiation1_legacy.nim
+++ b/tests/errmsgs/toverloadinstantiation1_legacy.nim
@@ -1,0 +1,29 @@
+discard """
+  action: "reject"
+  matrix: "--hints:off"
+  nimoutFull: true
+  nimout: '''
+toverloadinstantiation1_legacy.nim(29, 6) Error: type mismatch: got <array[0..3, int]>
+but expected one of:
+proc foo[I: static int](x: array[double(I), int])
+  first type mismatch at position: 1
+  required type for x: array[0..static(pred(double(I))), int]
+  but expression '[1, 2, 3, 4]' is of type: array[0..3, int]
+  instantiation error at toverloadinstantiation1_legacy.nim(28, 42):
+  cannot infer the value of the static param 'I'
+
+expression: foo([1, 2, 3, 4])
+'''
+"""
+
+proc double(x: int): int = x * 2
+
+block: # this not erroring is checked by nimoutFull
+  proc foo[I: static int](x: array[I, int]) = discard
+  proc foo[I: static int](x: array[double(I), int]) = discard
+  foo([1, 2, 3, 4])
+  foo[2]([1, 2, 3, 4]) # this picks double overload
+
+block: 
+  proc foo[I: static int](x: array[double(I), int]) = discard
+  foo([1, 2, 3, 4])


### PR DESCRIPTION
refs #24086

Instantiation errors encountered during overload resolution (such as when instantiating array range expressions based on existing generic parameters) are now saved for the current overload until overload resolution is finished and no overloads match, instead of immediately erroring globally. Encountering such errors also now treats the overload as non-matching. This allows other overloads that would instantiate normally to match even when no generic parameters are given.

Unfortunately I couldn't think of any tests that would encounter the errors created in `semtypinst` as the handling of `tyFromExpr` already doesn't create any errors. This doesn't give a great error message either, but going out of our way to error in `semtypinst` might make things worse.

Note: Covers #10220 but not #22964, which errors when calling `generateTypeInstance` in `getInstantiatedType`, which could also be handled. If we ever fix param constraints with instantiations, we should also handle this, which currently crashes the compiler:

```nim
proc foo[I](): array[I, int] = discard

let x = foo[int]()
```

In general this paves the way for generic instantiations to fail on constraint mismatches.