### PR TITLE
add experimental switch `openSymOverride` that works at instantiation time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -185,6 +185,34 @@ is often an easy workaround.
   experimental feature should still handle `nnkOpenSym`, as the node kind would
   simply not be generated as opposed to being removed.
 
+  Another experimental switch `openSymOverride` exists that enables this behavior
+  at instantiation time, meaning templates etc can enable it specifically when
+  they are being called. However this does not generate `nnkOpenSym` nodes
+  (unless the other switches are enabled) and so doesn't reflect the regular
+  behavior of the switch.
+
+  ```nim
+  const value = "captured"
+  template foo(x: int, body: untyped): untyped =
+    let value {.inject.} = "injected"
+    {.push experimental: "openSymOverride".}
+    body
+    {.pop.}
+
+  proc bar[T](): string =
+    foo(123):
+      return value
+  echo bar[int]() # "injected"
+
+  template barTempl(): string =
+    block:
+      var res: string
+      foo(123):
+        res = value
+      res
+  assert barTempl() == "injected"
+  ```
+
 ## Compiler changes
 
 - `--nimcache` using a relative path as the argument in a config file is now relative to the config file instead of the current directory.

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -228,6 +228,7 @@ type
     openSym, # remove nfDisabledOpenSym when this is default
     # separated alternatives to above:
     genericsOpenSym, templateOpenSym,
+    openSymOverride
     vtables
 
   LegacyFeature* = enum

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2590,6 +2590,34 @@ modified `nnkOpenSymChoice` node but macros that want to support the
 experimental feature should still handle `nnkOpenSym`, as the node kind would
 simply not be generated as opposed to being removed.
 
+Another experimental switch `openSymOverride` exists that enables this behavior
+at instantiation time, meaning templates etc can enable it specifically when
+they are being called. However this does not generate `nnkOpenSym` nodes
+(unless the other switches are enabled) and so doesn't reflect the regular
+behavior of the switch.
+
+```nim
+const value = "captured"
+template foo(x: int, body: untyped): untyped =
+  let value {.inject.} = "injected"
+  {.push experimental: "openSymOverride".}
+  body
+  {.pop.}
+
+proc bar[T](): string =
+  foo(123):
+    return value
+echo bar[int]() # "injected"
+
+template barTempl(): string =
+  block:
+    var res: string
+    foo(123):
+      res = value
+    res
+assert barTempl() == "injected"
+```
+
 
 VTable for methods
 ==================

--- a/tests/template/topensymoverride.nim
+++ b/tests/template/topensymoverride.nim
@@ -1,0 +1,39 @@
+discard """
+  matrix: "--skipParentCfg --filenames:legacyRelProj"
+"""
+
+const value = "captured"
+template fooOld(x: int, body: untyped): untyped =
+  let value {.inject.} = "injected"
+  body
+template foo(x: int, body: untyped): untyped =
+  let value {.inject.} = "injected"
+  {.push experimental: "openSymOverride".}
+  body
+  {.pop.}
+
+proc old[T](): string =
+  fooOld(123):
+    return value
+doAssert old[int]() == "captured"
+
+template oldTempl(): string =
+  block:
+    var res: string
+    fooOld(123):
+      res = value
+    res
+doAssert oldTempl() == "captured"
+
+proc bar[T](): string =
+  foo(123):
+    return value
+doAssert bar[int]() == "injected"
+
+template barTempl(): string =
+  block:
+    var res: string
+    foo(123):
+      res = value
+    res
+doAssert barTempl() == "injected"


### PR DESCRIPTION
#23892 changed the opensym experimental switch so that it has to be enabled in the context of the generic/template declarations capturing the symbols, not the context of the instantiation of the generics/templates. This was to be in line with where the compiler gives the warnings and changes behavior in a potentially breaking way.

However `results` [depends on the old behavior](https://github.com/arnetheduck/nim-results/blob/71d404b314479a6205bfd050f4fe5fe49cdafc69/results.nim#L1428), so that the callers of the macros provided by results always take advantage of the opensym behavior. To accomodate this, we add another experimental option `openSymOverride` that ignores the information of whether or not symbols are intentionally opened and always gives the opensym behavior as long as it's enabled at instantiation time. However this differs from the normal opensym switch in that it doesn't generate `nnkOpenSym`.

This marks the 3rd auxiliary experimental switch to `--experimental:openSym` in addition to `genericsOpenSym` and `templateOpenSym`. If this is considered excessive we can maybe remove `genericsOpenSym` and `templatesOpenSym` since their functionality wasn't really needed and only kept for compatibility with code already using `genericsOpenSym`.

Sidenote: I realized there is no `{.pop.}` after the `push experimental` presumably to allow the template to be an expression, maybe we should implement something like `{.push foo.}: ...` similar to `cast(uncheckedAssign)` etc. I believe we also can't do something like `{.raises: [].}: ...` to enforce a block not raising exceptions (maybe `forbids`?). But this is unrelated.