### PR TITLE
fix regression with uint constant losing abstract type

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -423,7 +423,6 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): P
       if dstTyp.kind in {tyUInt..tyUInt64}:
         result = newIntNodeT(maskBytes(val, int getSize(g.config, dstTyp)), n, idgen, g)
         result.transitionIntKind(nkUIntLit)
-        result.typ = dstTyp
       else:
         if check: rangeCheck(n, val, g)
         result = newIntNodeT(val, n, idgen, g)

--- a/tests/int/t1.nim
+++ b/tests/int/t1.nim
@@ -52,3 +52,10 @@ block: # bug #23954
   doAssert testRT_u8 == 7
   const testCT_u8 : uint8 = 0x107.uint8
   doAssert testCT_u8 == 7
+
+block: # issue #24104
+  type P = distinct uint  # uint, uint8, uint16, uint32, uint64 
+  let v = 0.P
+  case v
+  of 0.P: discard
+  else:   discard


### PR DESCRIPTION
fixes #24104, refs #23955

The line `result.typ = dstTyp` added in #23955 changes the type of `result`, which was the type of `n` due to the argument passed to `newIntNodeT`, to the abstract type skipped `dstTyp`. The line is removed to just keep the type as abstract.