### PR TITLE
make distinct conversions addressable in VM

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -698,9 +698,7 @@ proc genAsgnPatch(c: PCtx; le: PNode, value: TRegister) =
       c.freeTemp(dest)
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     if sameBackendType(le.typ, le[1].typ):
-      let dest = c.genx(le[1], {gfNodeAddr})
-      c.gABC(le, opcWrDeref, dest, 0, value)
-      c.freeTemp(dest)
+      genAsgnPatch(c, le[1], value)
   else:
     discard
 
@@ -1659,11 +1657,7 @@ proc genAsgn(c: PCtx; le, ri: PNode; requiresCopy: bool) =
         gen(c, ri, dest)
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     if sameBackendType(le.typ, le[1].typ):
-      let dest = c.genx(le[1], {gfNode})
-      let tmp = c.genx(ri)
-      c.preventFalseAlias(le, opcWrDeref, dest, 0, tmp)
-      c.freeTemp(dest)
-      c.freeTemp(tmp)
+      genAsgn(c, le[1], ri, requiresCopy)
   else:
     let dest = c.genx(le, {gfNodeAddr})
     genAsgn(c, dest, ri, requiresCopy)

--- a/tests/vm/tconvaddr.nim
+++ b/tests/vm/tconvaddr.nim
@@ -1,0 +1,16 @@
+block: # issue #24097
+  type Foo = distinct int
+  proc foo(x: var Foo) =
+    int(x) += 1
+  proc bar(x: var int) =
+    x += 1
+  static:
+    var x = Foo(1)
+    int(x) = int(x) + 1
+    doAssert x.int == 2
+    int(x) += 1
+    doAssert x.int == 3
+    foo(x)
+    doAssert x.int == 4
+    bar(int(x)) # need vmgen flags propagated for this
+    doAssert x.int == 5

--- a/tests/vm/tconvaddr.nim
+++ b/tests/vm/tconvaddr.nim
@@ -14,3 +14,25 @@ block: # issue #24097
     doAssert x.int == 4
     bar(int(x)) # need vmgen flags propagated for this
     doAssert x.int == 5
+  type Bar = object
+    x: Foo
+  static:
+    var obj = Bar(x: Foo(1))
+    int(obj.x) = int(obj.x) + 1
+    doAssert obj.x.int == 2
+    int(obj.x) += 1
+    doAssert obj.x.int == 3
+    foo(obj.x)
+    doAssert obj.x.int == 4
+    bar(int(obj.x)) # need vmgen flags propagated for this
+    doAssert obj.x.int == 5
+  static:
+    var arr = @[Foo(1)]
+    int(arr[0]) = int(arr[0]) + 1
+    doAssert arr[0].int == 2
+    int(arr[0]) += 1
+    doAssert arr[0].int == 3
+    foo(arr[0])
+    doAssert arr[0].int == 4
+    bar(int(arr[0])) # need vmgen flags propagated for this
+    doAssert arr[0].int == 5

--- a/tests/vm/tconvaddr.nim
+++ b/tests/vm/tconvaddr.nim
@@ -36,3 +36,14 @@ block: # issue #24097
     doAssert arr[0].int == 4
     bar(int(arr[0])) # need vmgen flags propagated for this
     doAssert arr[0].int == 5
+  proc testResult(): Foo =
+    result = Foo(1)
+    int(result) = int(result) + 1
+    doAssert result.int == 2
+    int(result) += 1
+    doAssert result.int == 3
+    foo(result)
+    doAssert result.int == 4
+    bar(int(result)) # need vmgen flags propagated for this
+    doAssert result.int == 5
+  doAssert testResult().int == 5


### PR DESCRIPTION
fixes #24097

For `nkConv` addresses where the conversion is between 2 types that are equal between backends, treat assignments the same as assignments to the argument of the conversion. In the VM this seems to be in `genAsgn` and `genAsgnPatch`, as evidenced by the special logic for `nkDerefExpr` etc.

This doesn't handle ranges after #24037 because `sameBackendType` is used and not `sameBackendTypeIgnoreRange`. This is so this is backportable without #24037 and another PR can be opened that implements it for ranges and adds tests as well. We can also merge `sameBackendTypeIgnoreRange` with `sameBackendType` since it doesn't seem like anything that uses it would be affected (only cycle checks and the VM), but then we still have to add tests.