### PR TITLE
require `not nil` to be on the same line after a type

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1401,7 +1401,7 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
     result = primarySuffix(p, result, baseInd, mode)
 
 proc binaryNot(p: var Parser; a: PNode): PNode =
-  if p.tok.tokType == tkNot:
+  if p.tok.tokType == tkNot and p.tok.indent < 0:
     let notOpr = newIdentNodeP(p.tok.ident, p)
     getTok(p)
     optInd(p, notOpr)

--- a/tests/parser/tbinarynotindented.nim
+++ b/tests/parser/tbinarynotindented.nim
@@ -1,0 +1,3 @@
+type Foo = ref int
+  not nil #[tt.Error
+  ^ invalid indentation]#

--- a/tests/parser/tbinarynotsameline.nim
+++ b/tests/parser/tbinarynotsameline.nim
@@ -1,0 +1,10 @@
+# issue #23565
+
+func foo: bool =
+  true
+
+const bar = block:
+  type T = int
+  not foo()
+
+doAssert not bar


### PR DESCRIPTION
fixes #23565