### PR TITLE
fix system for nimscript config files on js backend

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2085,7 +2085,8 @@ when notJSnotNims:
   proc cmpMem(a, b: pointer, size: Natural): int =
     nimCmpMem(a, b, size).int
 
-when not defined(js):
+when not defined(js) or defined(nimscript):
+  # nimscript can be defined if config file for js compilation
   proc cmp(x, y: string): int =
     when nimvm:
       if x < y: result = -1
@@ -2365,7 +2366,8 @@ proc finished*[T: iterator {.closure.}](x: T): bool {.noSideEffect, inline, magi
 from std/private/digitsutils import addInt
 export addInt
 
-when defined(js):
+when defined(js) and not defined(nimscript):
+  # nimscript can be defined if config file for js compilation
   include "system/jssys"
   include "system/reprjs"
 

--- a/tests/js/tjsnimscombined.nim
+++ b/tests/js/tjsnimscombined.nim
@@ -1,0 +1,1 @@
+import std/jsffi

--- a/tests/js/tjsnimscombined.nims
+++ b/tests/js/tjsnimscombined.nims
@@ -1,0 +1,1 @@
+# test the condition where both `js` and `nimscript` are defined (nimscript receives priority)


### PR DESCRIPTION
fixes #21441

When compiling for JS, nimscript config files have both `defined(js)` and `defined(nimscript)` be true at the same time. This is required so that the nimscript config file knows the current compilation is for the JS backend. However the system module doesn't account for this in some cases, defining JS-specific code or not defining nimscript-specific code when compiling such nimscript files. To fix this, have the `nimscript` define take priority over the `js` one.