### PR TITLE
fix typed case range not counting for exhaustiveness

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -619,6 +619,8 @@ proc semCaseBranch(c: PContext, n, branch: PNode, branchIndex: int,
     var b = branch[i]
     if b.kind == nkRange:
       branch[i] = b
+      # same check as in semBranchRange for exhaustiveness
+      covered = covered + getOrdValue(b[1]) + 1 - getOrdValue(b[0])
     elif isRange(b):
       branch[i] = semCaseBranchRange(c, n, b, covered)
     else:

--- a/tests/casestmt/trangeexhaustiveness.nim
+++ b/tests/casestmt/trangeexhaustiveness.nim
@@ -1,0 +1,7 @@
+block: # issue #22661
+  template foo(a: typed) =
+    a
+    
+  foo:
+    case false
+    of false..true: discard


### PR DESCRIPTION
fixes #22661

Range expressions in `of` branches in `case` statements start off as calls to `..` then become `nkRange` when getting typed. For this reason the compiler leaves `nkRange` alone when type checking the case statements again, but it still does the exhaustiveness checking for the entire case statement, and leaving the range alone means it doesn't count the values of the range for exhaustiveness. So the counting is now also done on `nkRange` nodes in the same way as when typechecking it the first time.