### PR TITLE
fix segfault in generic param mismatch error, skip typedesc

### DIFF
--- a/tests/errmsgs/tgenericmismatchsegfault.nim
+++ b/tests/errmsgs/tgenericmismatchsegfault.nim
@@ -1,0 +1,13 @@
+discard """
+  matrix: "-d:testsConciseTypeMismatch"
+"""
+
+template v[T](c: SomeOrdinal): T = T(c)
+discard v[int, char]('A') #[tt.Error
+                    ^ type mismatch
+Expression: v[int, char]('A')
+  [1] 'A': char
+
+Expected one of (first mismatch at [position]):
+[2] template v[T](c: SomeOrdinal): T
+  generic parameter mismatch, expected SomeOrdinal but got 'char' of type: char]#

--- a/tests/errmsgs/tgenericmismatchsegfault_legacy.nim
+++ b/tests/errmsgs/tgenericmismatchsegfault_legacy.nim
@@ -1,0 +1,10 @@
+template v[T](c: SomeOrdinal): T = T(c)
+discard v[int, char]('A') #[tt.Error
+                    ^ type mismatch: got <char>
+but expected one of:
+template v[T](c: SomeOrdinal): T
+  first type mismatch at position: 2 in generic parameters
+  required type for SomeOrdinal: SomeOrdinal
+  but expression 'char' is of type: char
+
+expression: v[int, char]('A')]#

--- a/tests/errmsgs/twrong_explicit_typeargs.nim
+++ b/tests/errmsgs/twrong_explicit_typeargs.nim
@@ -9,7 +9,7 @@ Expression: newImage[string](320, 200)
 
 Expected one of (first mismatch at [position]):
 [1] proc newImage[T: int32 | int64](w, h: int): ref Image[T]
-  generic parameter mismatch, expected int32 or int64 but got 'string' of type: typedesc[string]
+  generic parameter mismatch, expected int32 or int64 but got 'string' of type: string
 '''
 """
 

--- a/tests/errmsgs/twrong_explicit_typeargs_legacy.nim
+++ b/tests/errmsgs/twrong_explicit_typeargs_legacy.nim
@@ -6,7 +6,7 @@ but expected one of:
 proc newImage[T: int32 | int64](w, h: int): ref Image[T]
   first type mismatch at position: 1 in generic parameters
   required type for T: int32 or int64
-  but expression 'string' is of type: typedesc[string]
+  but expression 'string' is of type: string
 
 expression: newImage[string](320, 200)
 '''


### PR DESCRIPTION
refs #24010, refs https://github.com/nim-lang/Nim/issues/24125#issuecomment-2358377076

The generic mismatch errors added in #24010 made it possible for `nArg` to be `nil` in the error reporting since it checked the call argument list, not the generic parameter list for the mismatching argument node, which causes a segfault. This is fixed by checking the generic parameter list immediately on any generic mismatch error.

Also the `typedesc` type is skipped for the value of the generic params since it's redundant and the generic parameter constraints don't have it.