### PR TITLE
Implement `removeHandler` in std/logging module (fixes #23757)

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -854,7 +854,7 @@ proc removeHandler*(handler: Logger) =
   ## are required to remove that logger.
   for i, hnd in handlers:
     if hnd == handler:
-      handlers.del(i)
+      handlers.delete(i)
       return
 
 proc getHandlers*(): seq[Logger] =

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -839,12 +839,23 @@ proc addHandler*(handler: Logger) =
   ##   each of those threads.
   ##
   ## See also:
+  ## * `removeHandler proc`_
   ## * `getHandlers proc<#getHandlers>`_
   runnableExamples:
     var logger = newConsoleLogger()
     addHandler(logger)
     doAssert logger in getHandlers()
   handlers.add(handler)
+
+proc removeHandler*(handler: Logger) =
+  ## Removes a logger from the list of registered handlers.
+  ##
+  ## Note that for n times a logger is registered, n calls to this proc
+  ## are required to remove that logger.
+  for i, hnd in handlers:
+    if hnd == handler:
+      handlers.del(i)
+      return
 
 proc getHandlers*(): seq[Logger] =
   ## Returns a list of all the registered handlers.


### PR DESCRIPTION
Since the module allows for a handler to be added multiple times, for the sake of consistency, `removeHandler` only removes the first found instance of the handler in the `handlers` seq. So for n calls of `addHandler` using the same handler, n calls of `removeHandler` are required.

fixes #23757