### PR TITLE
Fix incorrect inheritance penalty for some objects

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1528,7 +1528,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         reduceToBase(a)
     if effectiveArgType.kind == tyObject:
       if sameObjectTypes(f, effectiveArgType):
-        c.inheritancePenalty = if tfFinal in f.flags: 0 else: -1
+        c.inheritancePenalty = if tfFinal in f.flags: -1 else: 0
         result = isEqual
         # elif tfHasMeta in f.flags: result = recordRel(c, f, a)
       elif trIsOutParam notin flags:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1528,7 +1528,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         reduceToBase(a)
     if effectiveArgType.kind == tyObject:
       if sameObjectTypes(f, effectiveArgType):
-        c.inheritancePenalty = 0
+        c.inheritancePenalty = if tfInheritable in f.flags: 0 else: -1
         result = isEqual
         # elif tfHasMeta in f.flags: result = recordRel(c, f, a)
       elif trIsOutParam notin flags:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1528,7 +1528,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         reduceToBase(a)
     if effectiveArgType.kind == tyObject:
       if sameObjectTypes(f, effectiveArgType):
-        c.inheritancePenalty = if tfInheritable in f.flags: 0 else: -1
+        c.inheritancePenalty = if tfFinal in f.flags: 0 else: -1
         result = isEqual
         # elif tfHasMeta in f.flags: result = recordRel(c, f, a)
       elif trIsOutParam notin flags:


### PR DESCRIPTION
This fixes a logic error in  #23870
The inheritance penalty should be -1 if there is no inheritance relationship. Not sure how to write a test case for this one honestly.