### PR TITLE
use cbuilder for tuple/object generation

### DIFF
--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -7,12 +7,37 @@ template newBuilder(s: string): Builder =
 
 proc addField(obj: var Builder; typ, name: Snippet; pragmas: Snippet = "") =
   if pragmas.len != 0:
-    obj.add pragmas
-    obj.add " "
-  obj.add typ
-  obj.add " "
-  obj.add name
-  obj.add ";\n"
+    obj.add(pragmas)
+    obj.add(" ")
+  obj.add(typ)
+  obj.add(" ")
+  obj.add(name)
+  obj.add(";\n")
+
+template addFieldWithType(obj: var Builder; name: Snippet; body: typed) =
+  body
+  obj.add(" ")
+  obj.add(name)
+  obj.add(";\n")
+
+proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bool; initializer: Snippet) =
+  if field.alignment > 0:
+    obj.add("NIM_ALIGN(")
+    obj.addInt(field.alignment)
+    obj.add(")")
+  obj.add(typ)
+  if sfNoalias in field.flags:
+    obj.add(" NIM_NOALIAS")
+  obj.add(" ")
+  obj.add(name)
+  if isFlexArray:
+    obj.add("[SEQ_DECL_SIZE]")
+  if field.bitsize != 0:
+    obj.add(":")
+    obj.addInt(field.bitsize)
+  if initializer.len != 0:
+    obj.add(initializer)
+  obj.add(";\n")
 
 proc structOrUnion(t: PType): Snippet =
   let t = t.skipTypes({tyAlias, tySink})
@@ -64,13 +89,33 @@ template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseT
   of bcSupField:
     obj.addField(name = "Sup", typ = baseType)
   body
-  if currLen == obj.len:
-    # no fields were added, add dummy field
-    obj.addField(name = "dummy", typ = "char")
-  elif typ.n.len == 1 and typ.n[0].kind == nkSym and
-      typ.n[0].sym.typ.skipTypes(abstractInst).kind == tyUncheckedArray:
-    # only consists of flexible array field, add dummy field
-    obj.addField(name = "dummy", typ = "char")
+  if typ.itemId notin m.g.graph.memberProcsPerType:
+    if currLen == obj.len:
+      # no fields were added, add dummy field
+      obj.addField(name = "dummy", typ = "char")
+    elif typ.n != nil and typ.n.len == 1 and typ.n[0].kind == nkSym and
+        typ.n[0].sym.typ.skipTypes(abstractInst).kind == tyUncheckedArray:
+      # only consists of flexible array field, add dummy field
+      obj.addField(name = "dummy", typ = "char")
   obj.add("};\n")
   if tfPacked in typ.flags and hasAttribute notin CC[m.config.cCompiler].props:
     result.add("#pragma pack(pop)\L")
+
+template addAnonStruct(obj: var Builder; m: BModule; parentTyp: PType; body: typed) =
+  if tfPacked in parentTyp.flags:
+    if hasAttribute in CC[m.config.cCompiler].props:
+      obj.add("struct __attribute__((__packed__)) {\n")
+    else:
+      obj.add("#pragma pack(push, 1)\nstruct {")
+  else:
+    obj.add("struct {\n")
+  let currLen = obj.len
+  body
+  obj.add("};\n")
+  if tfPacked in parentTyp.flags and hasAttribute notin CC[m.config.cCompiler].props:
+    result.add("#pragma pack(pop)\L")
+
+template addAnonUnion(obj: var Builder; body: typed) =
+  obj.add "union{\n"
+  body
+  obj.add("};\n")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -5,15 +5,72 @@ type
 template newBuilder(s: string): Builder =
   s
 
-proc addField(obj: var Builder; field: Snippet;) =
-  obj.add field
+proc addField(obj: var Builder; typ, name: Snippet; pragmas: Snippet = "") =
+  if pragmas.len != 0:
+    obj.add pragmas
+    obj.add " "
+  obj.add typ
+  obj.add " "
+  obj.add name
   obj.add ";\n"
 
+proc structOrUnion(t: PType): Snippet =
+  let t = t.skipTypes({tyAlias, tySink})
+  if tfUnion in t.flags: "union"
+  else: "struct"
 
-template withStruct(obj: var Builder; structOrUnion: string; name: string; inheritance: string; body: typed) =
-  if inheritance.len > 0:
-    obj.add "$1 $2 : public $1 {$n" % [structOrUnion, name, inheritance]
+proc ptrType(t: Snippet): Snippet =
+  t & "*"
+
+template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseType: string; body: typed) =
+  if tfPacked in typ.flags:
+    if hasAttribute in CC[m.config.cCompiler].props:
+      obj.add(structOrUnion(typ))
+      obj.add(" __attribute__((__packed__))")
+    else:
+      obj.add("#pragma pack(push, 1)\n")
+      obj.add(structOrUnion(typ))
   else:
-    obj.add "$1 $2 {$n" % [structOrUnion, name]
+    obj.add(structOrUnion(typ))
+  obj.add(" ")
+  obj.add(name)
+  type BaseClassKind = enum
+    bcNone, bcCppInherit, bcSupField, bcNoneRtti, bcNoneTinyRtti
+  var baseKind: BaseClassKind
+  if typ.kind == tyObject:
+    if typ.baseClass == nil:
+      if lacksMTypeField(typ):
+        baseKind = bcNone
+      elif optTinyRtti in m.config.globalOptions:
+        baseKind = bcNoneTinyRtti
+      else:
+        baseKind = bcNoneRtti
+    elif m.compileToCpp:
+      baseKind = bcCppInherit
+    else:
+      baseKind = bcSupField
+  if baseKind == bcCppInherit:
+    obj.add(" : public ")
+    obj.add(baseType)
+  obj.add(" ")
+  obj.add("{\n")
+  let currLen = obj.len
+  case baseKind
+  of bcNone, bcCppInherit: discard
+  of bcNoneRtti:
+    obj.addField(name = "m_type", typ = ptrType(cgsymValue(m, "TNimType")))
+  of bcNoneTinyRtti:
+    obj.addField(name = "m_type", typ = ptrType(cgsymValue(m, "TNimTypeV2")))
+  of bcSupField:
+    obj.addField(name = "Sup", typ = baseType)
   body
+  if currLen == obj.len:
+    # no fields were added, add dummy field
+    obj.addField(name = "dummy", typ = "char")
+  elif typ.n.len == 1 and typ.n[0].kind == nkSym and
+      typ.n[0].sym.typ.skipTypes(abstractInst).kind == tyUncheckedArray:
+    # only consists of flexible array field, add dummy field
+    obj.addField(name = "dummy", typ = "char")
   obj.add("};\n")
+  if tfPacked in typ.flags and hasAttribute notin CC[m.config.cCompiler].props:
+    result.add("#pragma pack(pop)\L")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -5,10 +5,7 @@ type
 template newBuilder(s: string): Builder =
   s
 
-proc addField(obj: var Builder; typ, name: Snippet; pragmas: Snippet = "") =
-  if pragmas.len != 0:
-    obj.add(pragmas)
-    obj.add(" ")
+proc addField(obj: var Builder; typ, name: Snippet) =
   obj.add(typ)
   obj.add(" ")
   obj.add(name)

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -58,7 +58,7 @@ template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseT
   obj.add(name)
   type BaseClassKind = enum
     bcNone, bcCppInherit, bcSupField, bcNoneRtti, bcNoneTinyRtti
-  var baseKind: BaseClassKind
+  var baseKind = bcNone
   if typ.kind == tyObject:
     if typ.baseClass == nil:
       if lacksMTypeField(typ):

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -11,12 +11,6 @@ proc addField(obj: var Builder; typ, name: Snippet) =
   obj.add(name)
   obj.add(";\n")
 
-template addFieldWithType(obj: var Builder; name: Snippet; body: typed) =
-  body
-  obj.add(" ")
-  obj.add(name)
-  obj.add(";\n")
-
 proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bool; initializer: Snippet) =
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
@@ -98,7 +92,7 @@ template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseT
   if tfPacked in typ.flags and hasAttribute notin CC[m.config.cCompiler].props:
     result.add("#pragma pack(pop)\L")
 
-template addAnonStruct(obj: var Builder; m: BModule; parentTyp: PType; body: typed) =
+template addFieldWithStructType(obj: var Builder; m: BModule; parentTyp: PType; fieldName: string, body: typed) =
   if tfPacked in parentTyp.flags:
     if hasAttribute in CC[m.config.cCompiler].props:
       obj.add("struct __attribute__((__packed__)) {\n")
@@ -108,7 +102,9 @@ template addAnonStruct(obj: var Builder; m: BModule; parentTyp: PType; body: typ
     obj.add("struct {\n")
   let currLen = obj.len
   body
-  obj.add("};\n")
+  obj.add("} ")
+  obj.add(fieldName)
+  obj.add(";\n")
   if tfPacked in parentTyp.flags and hasAttribute notin CC[m.config.cCompiler].props:
     result.add("#pragma pack(pop)\L")
 

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -17,7 +17,7 @@ proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bo
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
     obj.addInt(field.alignment)
-    obj.add(") ")
+    obj.add(") ") # no space here breaks tmarshalsegfault on cpp somehow
   obj.add(typ)
   if sfNoalias in field.flags:
     obj.add(" NIM_NOALIAS")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -79,15 +79,15 @@ template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseT
     obj.addField(name = "m_type", typ = ptrType(cgsymValue(m, "TNimTypeV2")))
   of bcSupField:
     obj.addField(name = "Sup", typ = baseType)
-  body
-  if typ.itemId notin m.g.graph.memberProcsPerType:
-    if currLen == obj.len:
-      # no fields were added, add dummy field
-      obj.addField(name = "dummy", typ = "char")
-    elif typ.n != nil and typ.n.len == 1 and typ.n[0].kind == nkSym and
+  if currLen == obj.len and typ.itemId notin m.g.graph.memberProcsPerType:
+    if typ.n != nil and typ.n.len == 1 and typ.n[0].kind == nkSym and
         typ.n[0].sym.typ.skipTypes(abstractInst).kind == tyUncheckedArray:
-      # only consists of flexible array field, add dummy field
+      # only consists of flexible array field, add *initial* dummy field
       obj.addField(name = "dummy", typ = "char")
+  body
+  if currLen == obj.len and typ.itemId notin m.g.graph.memberProcsPerType:
+    # no fields were added, add dummy field
+    obj.addField(name = "dummy", typ = "char")
   obj.add("};\n")
   if tfPacked in typ.flags and hasAttribute notin CC[m.config.cCompiler].props:
     result.add("#pragma pack(pop)\L")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -17,7 +17,7 @@ proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bo
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
     obj.addInt(field.alignment)
-    obj.add(") ") # no space here breaks tmarshalsegfault on cpp somehow
+    obj.add(") ")
   obj.add(typ)
   if sfNoalias in field.flags:
     obj.add(" NIM_NOALIAS")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -6,12 +6,14 @@ template newBuilder(s: string): Builder =
   s
 
 proc addField(obj: var Builder; typ, name: Snippet) =
+  obj.add('\t')
   obj.add(typ)
   obj.add(" ")
   obj.add(name)
   obj.add(";\n")
 
 proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bool; initializer: Snippet) =
+  obj.add('\t')
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
     obj.addInt(field.alignment)
@@ -94,6 +96,7 @@ template addStruct(obj: var Builder; m: BModule; typ: PType; name: string; baseT
     result.add("#pragma pack(pop)\n")
 
 template addFieldWithStructType(obj: var Builder; m: BModule; parentTyp: PType; fieldName: string, body: typed) =
+  obj.add('\t')
   if tfPacked in parentTyp.flags:
     if hasAttribute in CC[m.config.cCompiler].props:
       obj.add("struct __attribute__((__packed__)) {\n")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -1,0 +1,19 @@
+type
+  Snippet = string
+  Builder = string
+
+template newBuilder(s: string): Builder =
+  s
+
+proc addField(obj: var Builder; field: Snippet;) =
+  obj.add field
+  obj.add ";\n"
+
+
+template withStruct(obj: var Builder; structOrUnion: string; name: string; inheritance: string; body: typed) =
+  if inheritance.len > 0:
+    obj.add "$1 $2 : public $1 {$n" % [structOrUnion, name, inheritance]
+  else:
+    obj.add "$1 $2 {$n" % [structOrUnion, name]
+  body
+  obj.add("};\n")

--- a/compiler/cbuilder.nim
+++ b/compiler/cbuilder.nim
@@ -17,7 +17,7 @@ proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bo
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
     obj.addInt(field.alignment)
-    obj.add(")")
+    obj.add(") ")
   obj.add(typ)
   if sfNoalias in field.flags:
     obj.add(" NIM_NOALIAS")

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -739,9 +739,12 @@ proc genRecordFieldsAux(m: BModule; n: PNode,
         typ = getTypeDescAux(m, fieldType.elemType, check, dkField)
         isFlexArray = true
       elif fieldType.kind == tySequence:
+        # we need to use a weak dependency here for trecursive_table.
         typ = getTypeDescWeak(m, field.loc.t, check, dkField)
       else:
         typ = getTypeDescAux(m, field.loc.t, check, dkField)
+        # don't use fieldType here because we need the
+        # tyGenericInst for C++ template support
         let noInit = sfNoInit in field.flags or (field.typ.sym != nil and sfNoInit in field.typ.sym.flags)
         if not noInit and (fieldType.isOrHasImportedCppType() or hasCppCtor(m, field.owner.typ)):
           var didGenTemp = false

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -870,12 +870,11 @@ proc getTupleDesc(m: BModule; typ: PType, name: Rope,
                   check: var IntSet): Rope =
   let structOrUnionString = structOrUnion(typ)
   result = newBuilder("")
-  if kidsLen(typ) > 0:
-    withStruct(result, structOrUnionString, name, ""):
+  withStruct(result, structOrUnionString, name, ""):
+    if kidsLen(typ) > 0:
       for i, a in typ.ikids:
         result.addField "$1 Field$2" % [getTypeDescAux(m, a, check, dkField), rope(i)]
-  else:
-    withStruct(result, structOrUnionString, name, ""):
+    else:
       result.addField "char dummy"
 
 proc scanCppGenericSlot(pat: string, cursor, outIdx, outStars: var int): bool =

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -713,9 +713,8 @@ proc genRecordFieldsAux(m: BModule; n: PNode,
           var a = newBuilder("")
           genRecordFieldsAux(m, k, rectype, check, a, unionPrefix & $structName & ".")
           if a.len != 0:
-            unionBody.addFieldWithType(structName):
-              unionBody.addAnonStruct(m, rectype):
-                unionBody.add(a)
+            unionBody.addFieldWithStructType(m, rectype, structName):
+              unionBody.add(a)
         else:
           genRecordFieldsAux(m, k, rectype, check, unionBody, unionPrefix)
       else: internalError(m.config, "genRecordFieldsAux(record case branch)")

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -868,14 +868,15 @@ proc getRecordDesc(m: BModule; typ: PType, name: Rope,
 
 proc getTupleDesc(m: BModule; typ: PType, name: Rope,
                   check: var IntSet): Rope =
-  result = "$1 $2 {$n" % [structOrUnion(typ), name]
-  var desc: Rope = ""
-  for i, a in typ.ikids:
-    desc.addf("$1 Field$2;$n",
-         [getTypeDescAux(m, a, check, dkField), rope(i)])
-  if desc == "": result.add("char dummy;\L")
-  else: result.add(desc)
-  result.add("};\L")
+  let structOrUnionString = structOrUnion(typ)
+  result = newBuilder("")
+  if kidsLen(typ) > 0:
+    withStruct(result, structOrUnionString, name, ""):
+      for i, a in typ.ikids:
+        result.addField "$1 Field$2" % [getTypeDescAux(m, a, check, dkField), rope(i)]
+  else:
+    withStruct(result, structOrUnionString, name, ""):
+      result.addField "char dummy"
 
 proc scanCppGenericSlot(pat: string, cursor, outIdx, outStars: var int): bool =
   # A helper proc for handling cppimport patterns, involving numeric

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -868,9 +868,8 @@ proc getRecordDesc(m: BModule; typ: PType, name: Rope,
 
 proc getTupleDesc(m: BModule; typ: PType, name: Rope,
                   check: var IntSet): Rope =
-  let structOrUnionString = structOrUnion(typ)
   result = newBuilder("")
-  withStruct(result, structOrUnionString, name, ""):
+  withStruct(result, structOrUnion(typ), name, ""):
     if kidsLen(typ) > 0:
       for i, a in typ.ikids:
         result.addField "$1 Field$2" % [getTypeDescAux(m, a, check, dkField), rope(i)]

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -733,7 +733,7 @@ proc genRecordFieldsAux(m: BModule; n: PNode,
     # with heavily templatized C++ code:
     if not isImportedCppType(rectype):
       let fieldType = field.loc.lode.typ.skipTypes(abstractInst)
-      var typ: Rope
+      var typ: Rope = ""
       var isFlexArray = false
       var initializer = ""
       if fieldType.kind == tyUncheckedArray:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -373,6 +373,7 @@ proc dataField(p: BProc): Rope =
 
 proc genProcPrototype(m: BModule, sym: PSym)
 
+include cbuilder
 include ccgliterals
 include ccgtypes
 


### PR DESCRIPTION
based on #24127

Needs some tweaks to replace the other `struct` type generations, e.g. seqs, maybe by exposing `BaseTypeKind` as a parameter. C++ and codegenDecl etc seem like they are going to need attention.

Also `Builder` should really be `distinct string` that one has to call `extract` on, but for this to be optimal in the current codegen, we would need something like:

```nim
template buildInto(s: var string, builderName: untyped, body) =
  template `builderName`: untyped = Builder(s)
  body

buildInto(result, builder):
  builder.add ...
```

but this could be a separate PR since it might not work with the compiler. The possibly-not-optimal alternative is to do:

```nim
template build(builderName: untyped, body): string =
  var `builderName` = Builder("")
  body
  extract(`builderName`)

result = build(builder):
  builder.add ...
```

where the compiler maybe copies the built string but shouldn't.