### PR TITLE
Check if files being copied are FIFOs in `copyFile`

### DIFF
--- a/lib/std/private/osfiles.nim
+++ b/lib/std/private/osfiles.nim
@@ -222,6 +222,15 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}; bufferSize = 1
     if copyFileW(s, d, 0'i32) == 0'i32:
       raiseOSError(osLastError(), $(source, dest))
   else:
+    when defined(posix):
+      var sourceSt, destSt: Stat
+      if stat(source, sourceSt) < 0'i32 or stat(dest, destSt) < 0'i32:
+        raiseOSError(osLastError(), "stat")
+      if sourceSt.st_mode.S_ISFIFO() or destSt.st_mode.S_ISFIFO():
+        raise newException(OSError, "Copying FIFOs is not possible")
+    else:
+      discard "XXX: add this check for non-POSIX systems"
+
     if isSymlink and cfSymlinkAsIs in options:
       createSymlink(expandSymlink(source), dest)
     else:

--- a/lib/std/private/osfiles.nim
+++ b/lib/std/private/osfiles.nim
@@ -224,7 +224,7 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}; bufferSize = 1
   else:
     when defined(posix):
       var sourceSt, destSt: Stat
-      if stat(source, sourceSt) < 0'i32 or stat(dest, destSt) < 0'i32:
+      if (stat(source, sourceSt) < 0 or stat(dest, destSt) < 0) and errno != ENOENT:
         raiseOSError(osLastError(), "stat")
       if sourceSt.st_mode.S_ISFIFO() or destSt.st_mode.S_ISFIFO():
         raise newException(OSError, "Copying FIFOs is not possible")

--- a/lib/std/private/osfiles.nim
+++ b/lib/std/private/osfiles.nim
@@ -228,8 +228,6 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}; bufferSize = 1
         raiseOSError(osLastError(), "stat")
       if sourceSt.st_mode.S_ISFIFO() or destSt.st_mode.S_ISFIFO():
         raise newException(OSError, "Copying FIFOs is not possible")
-    else:
-      discard "XXX: add this check for non-POSIX systems"
 
     if isSymlink and cfSymlinkAsIs in options:
       createSymlink(expandSymlink(source), dest)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -66,9 +66,12 @@ block fileOperations:
 
     when defined(posix):
       # test attempt of copying FIFOs; should fail
-      let fifoName = "unanonymouspipe"
+      let
+        fifoName = dname / "unanonymouspipe"
+        toDest = dname / (fifoName & "_pipecopy")
       doAssert execShellCmd("mkfifo " & fifoName) == 0
-      doAssertRaises(OSError): copyFile(fifoName, todest)
+      doAssertRaises(OSError): copyFile(fifoName, toDest)
+      removeFile(fifoName)
 
   # Test creating files and dirs
   for dir in dirs:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -64,6 +64,12 @@ block fileOperations:
     removeFile(file)
     removeFile(file2)
 
+    when defined(posix):
+      # test attempt of copying FIFOs; should fail
+      let fifoName = "unanonymouspipe"
+      doAssert execShellCmd("mkfifo " & fifoName) == 0
+      doAssertRaises(OSError): copyFile(fifoName, todest)
+
   # Test creating files and dirs
   for dir in dirs:
     createDir(dname/dir)


### PR DESCRIPTION
Check if files being copied are FIFOs in `copyFile`
Avoids the deadlock behavior by simply raising an `OSError` if either `source` or `dest` is a FIFO before the actual copying operation.
Relevant issue reported on [this thread](https://forum.nim-lang.org/t/12517) by user firasuke.
