### PR TITLE
fix tmarshalsegfault depending on execution time

### DIFF
--- a/tests/stdlib/tmarshalsegfault.nim
+++ b/tests/stdlib/tmarshalsegfault.nim
@@ -48,8 +48,7 @@ removeFile("tmarshalsegfault_data")
 state.shows.aired[ 0 ] = AiredEpisodeState( airedAt: now(), tvShowId: "1", seasonNumber: 1, number: 1, title: "string" )
 
 # 4. And formatting the airedAt date will now trigger the exception
-var s = ""
 for ep in state.shows.aired:
     let x = $ep.seasonNumber & "x" & $ep.number & " (" & $ep.airedAt & ")"
-    if s.len == 0: s = x
-    else: doAssert s == x
+    let y = $ep.seasonNumber & "x" & $ep.number & " (" & $ep.airedAt & ")"
+    doAssert x == y


### PR DESCRIPTION
Added in #24119, the test checks if every string produced is equal, but the value of the strings depend on the `now()` timestamp of when they were produced. 30 of them are produced in a for loop in sequence with each other, but the first one is set after the data is marshalled into and unmarshalled from a file. This means the timestamp strings can differ depending on the execution time and causes this test to be flaky. Instead we just make 2 strings from the same data and check if they equal each other.