### PR TITLE
upgrade macos github CI to macos 14

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -45,7 +45,7 @@ jobs:
           - target: windows
             os: windows-2019
           - target: osx
-            os: macos-12
+            os: macos-14
 
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-14]
         cpu: [amd64]
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14]
-        cpu: [amd64]
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'
     runs-on: ${{ matrix.os }}
@@ -38,7 +37,7 @@ jobs:
           node-version: '20.x'
 
       - name: 'Install dependencies (Linux amd64)'
-        if: runner.os == 'Linux' && matrix.cpu == 'amd64'
+        if: runner.os == 'Linux' && (runner.arch == 'X86' || runner.arch == 'X64')
         run: |
           sudo apt-fast update -qq
           DEBIAN_FRONTEND='noninteractive' \
@@ -65,9 +64,15 @@ jobs:
         shell: bash
         run: . ci/funs.sh && nimCiSystemInfo
 
-      - name: 'Build csourcesAny'
+      - name: 'Build csourcesAny (amd64)'
+        if: runner.arch == 'X86' || runner.arch == 'X64'
         shell: bash
-        run: . ci/funs.sh && nimBuildCsourcesIfNeeded CC=gcc ucpu='${{ matrix.cpu }}'
+        run: . ci/funs.sh && nimBuildCsourcesIfNeeded CC=gcc ucpu=amd64
+
+      - name: 'Build csourcesAny (arm64)'
+        if: runner.arch == 'ARM' || runner.arch == 'ARM64'
+        shell: bash
+        run: . ci/funs.sh && nimBuildCsourcesIfNeeded CC=gcc ucpu=arm64
 
       - name: 'koch, Run CI'
         shell: bash


### PR DESCRIPTION
Macos 12 gives a warning:

```
You are using macOS 12.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```

Apparently macos 14 [is M1](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) so macos 13 is another option, as well as `macos-14-large` which is amd.