### PR TITLE
document `bind` prevents recursion in templates

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6169,6 +6169,22 @@ As in generics, symbol binding can be influenced via `mixin` or `bind`
 statements.
 
 
+Preventing recursion in templates
+---------------------------------
+
+It may be useful for templates to refer to symbols with the same name,
+such as when shadowing identifiers. However this can cause infinite recursions.
+To prevent this, `bind` can be used to ensure templates never refer to themselves.
+
+  ```nim
+  var a: int = 123
+  block:
+    template a: float =
+      bind a # only binds to outside `a`
+      float(a)
+    echo a # 123.0
+  ```
+
 
 Identifier construction
 -----------------------

--- a/tests/template/topensym.nim
+++ b/tests/template/topensym.nim
@@ -207,3 +207,12 @@ block: # issue #15314
 
   doubleNums()
   doAssert nums == @[2, 4, 6]
+
+block: # shadowing recursion, fixed with `bind`
+  var a: int = 123
+  block:
+    template a: float =
+      bind a 
+      float(a)
+    doAssert a is float
+    doAssert a == 123.0


### PR DESCRIPTION
refs https://github.com/status-im/nimbus-eth2/pull/6573/commits/b7f3f0c2e8f58686393f15d063f17dcf4a19d4f2

The infinite recursion could already be encountered in some niche cases but became more likely to encounter with #24007. `bind` happens to work with the compiler since templates don't [add themselves to scope](https://github.com/nim-lang/Nim/blob/d51d88700b2fb3bd228d5e8f7385e2e4a2e2880c/compiler/semtempl.nim#L778) until *after* the template body is checked, but in the future we could guarantee that this remains working.