### PR TITLE
Fix line info used for `UnunsedImport` from subdirectories 

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -246,7 +246,8 @@ proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden: bool)
     result = createModuleAliasImpl(realModule.name)
   if importHidden:
     result.options.incl optImportHidden
-  c.unusedImports.add((result, n.info))
+  let moduleIdent = (if n.kind == nkInfix: n[^1] else: n)
+  c.unusedImports.add((result, moduleIdent.info)
   c.importModuleMap[result.id] = realModule.id
   c.importModuleLookup.mgetOrPut(result.name.id, @[]).addUnique realModule.id
 

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -246,8 +246,8 @@ proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden: bool)
     result = createModuleAliasImpl(realModule.name)
   if importHidden:
     result.options.incl optImportHidden
-  let moduleIdent = (if n.kind == nkInfix: n[^1] else: n)
-  c.unusedImports.add((result, moduleIdent.info)
+  let moduleIdent = if n.kind == nkInfix: n[^1] else: n
+  c.unusedImports.add((result, moduleIdent.info))
   c.importModuleMap[result.id] = realModule.id
   c.importModuleLookup.mgetOrPut(result.name.id, @[]).addUnique realModule.id
 

--- a/tests/msgs/tused2.nim
+++ b/tests/msgs/tused2.nim
@@ -7,12 +7,12 @@ mused2a.nim(12, 6) Hint: 'fn1' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(16, 5) Hint: 'fn4' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(20, 7) Hint: 'fn7' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(23, 6) Hint: 'T1' is declared but not used [XDeclaredButNotUsed]
-mused2a.nim(1, 11) Warning: imported and not used: 'strutils' [UnusedImport]
-mused2a.nim(3, 9) Warning: imported and not used: 'os' [UnusedImport]
+mused2a.nim(1, 12) Warning: imported and not used: 'strutils' [UnusedImport]
+mused2a.nim(3, 10) Warning: imported and not used: 'os' [UnusedImport]
 mused2a.nim(5, 23) Warning: imported and not used: 'typetraits2' [UnusedImport]
-mused2a.nim(6, 9) Warning: imported and not used: 'setutils' [UnusedImport]
+mused2a.nim(6, 10) Warning: imported and not used: 'setutils' [UnusedImport]
 tused2.nim(42, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
-tused2.nim(45, 11) Warning: imported and not used: 'strutils' [UnusedImport]
+tused2.nim(45, 12) Warning: imported and not used: 'strutils' [UnusedImport]
 '''
 """
 

--- a/tests/tools/tunused_imports.nim
+++ b/tests/tools/tunused_imports.nim
@@ -3,9 +3,9 @@ discard """
   nimout: '''
 tunused_imports.nim(11, 10) Warning: BEGIN [User]
 tunused_imports.nim(38, 10) Warning: END [User]
-tunused_imports.nim(34, 8) Warning: imported and not used: 'strutils' [UnusedImport]
-tunused_imports.nim(36, 13) Warning: imported and not used: 'strtabs' [UnusedImport]
-tunused_imports.nim(36, 22) Warning: imported and not used: 'cstrutils' [UnusedImport]
+tunused_imports.nim(36, 8) Warning: imported and not used: 'strutils' [UnusedImport]
+tunused_imports.nim(37, 13) Warning: imported and not used: 'strtabs' [UnusedImport]
+tunused_imports.nim(37, 22) Warning: imported and not used: 'cstrutils' [UnusedImport]
 '''
   action: "compile"
 """

--- a/tests/tools/tunused_imports.nim
+++ b/tests/tools/tunused_imports.nim
@@ -1,11 +1,12 @@
 discard """
   cmd: '''nim c --hint:Processing:off $file'''
   nimout: '''
-tunused_imports.nim(11, 10) Warning: BEGIN [User]
-tunused_imports.nim(38, 10) Warning: END [User]
-tunused_imports.nim(36, 8) Warning: imported and not used: 'strutils' [UnusedImport]
-tunused_imports.nim(37, 13) Warning: imported and not used: 'strtabs' [UnusedImport]
-tunused_imports.nim(37, 22) Warning: imported and not used: 'cstrutils' [UnusedImport]
+tunused_imports.nim(14, 10) Warning: BEGIN [User]
+tunused_imports.nim(41, 10) Warning: END [User]
+tunused_imports.nim(37, 8) Warning: imported and not used: 'strutils' [UnusedImport]
+tunused_imports.nim(38, 13) Warning: imported and not used: 'strtabs' [UnusedImport]
+tunused_imports.nim(38, 22) Warning: imported and not used: 'cstrutils' [UnusedImport]
+tunused_imports.nim(39, 12) Warning: imported and not used: 'macrocache' [UnusedImport]
 '''
   action: "compile"
 """
@@ -35,5 +36,6 @@ bar()
 
 import strutils
 import std/[strtabs, cstrutils]
+import std/macrocache
 
 {.warning: "END".}

--- a/tests/tools/tunused_imports.nim
+++ b/tests/tools/tunused_imports.nim
@@ -2,8 +2,10 @@ discard """
   cmd: '''nim c --hint:Processing:off $file'''
   nimout: '''
 tunused_imports.nim(11, 10) Warning: BEGIN [User]
-tunused_imports.nim(36, 10) Warning: END [User]
+tunused_imports.nim(38, 10) Warning: END [User]
 tunused_imports.nim(34, 8) Warning: imported and not used: 'strutils' [UnusedImport]
+tunused_imports.nim(36, 13) Warning: imported and not used: 'strtabs' [UnusedImport]
+tunused_imports.nim(36, 22) Warning: imported and not used: 'cstrutils' [UnusedImport]
 '''
   action: "compile"
 """
@@ -32,5 +34,6 @@ macro bar(): untyped =
 bar()
 
 import strutils
+import std/[strtabs, cstrutils]
 
 {.warning: "END".}


### PR DESCRIPTION
When importing from subdirectories, the line info used in `UnusedImport` warning would be the `/` node and not the actual module node. More obvious with grouped imports where all unused imports would show the same column
![image](https://github.com/user-attachments/assets/42850130-1e0e-46b9-bd72-54864a1ad41c)

Fix is to just use the last child node for infixes when getting the line info