### PR TITLE
fix `nil` literal giving itself type `untyped`/`typed` [backport]

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3314,7 +3314,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
   of nkNilLit:
     if result.typ == nil:
       result.typ = getNilType(c)
-      if expectedType != nil:
+      if expectedType != nil and expectedType.kind notin {tyUntyped, tyTyped}:
         var m = newCandidate(c, result.typ)
         if typeRel(m, expectedType, result.typ) >= isSubtype:
           result.typ = expectedType

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -325,3 +325,9 @@ block: # bug #22180
         else:
           (ref A)(nil)
   doAssert y.isNil
+
+block: # issue #24164, related regression
+  proc foo(x: proc ()) = discard
+  template bar(x: untyped = nil) =
+    foo(x)
+  bar()


### PR DESCRIPTION
fixes #24164, regression from #20091

The expression `nil` as the default value of template parameter `x: untyped` is typechecked with expected type `untyped` since #20091. The expected type is checked if it matches the `nil` literal with a match better than a subtype match, and the type is set to it if it does. However `untyped` matches with a generic match which is better, so the `nil` literal has type `untyped`. This breaks type matching for the literal. So if the expected type is `untyped` or `typed`, it is now ignored and the `nil` literal just has the `nil` type.