### PR TITLE
don't trust completeStruct for typeinfo gen of imported C++ types [backport]

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1474,7 +1474,10 @@ proc genObjectInfo(m: BModule; typ, origType: PType, name: Rope; info: TLineInfo
                       typeToString(typ))
   genTypeInfoAux(m, typ, origType, name, info)
   var tmp = getNimNode(m)
-  if (not isImportedType(typ)) or tfCompleteStruct in typ.flags:
+  if (not isImportedType(typ)) or
+      # don't trust C++ imported fields even if completeStruct to
+      # workaround C++ atomic implementation
+      (tfCompleteStruct in typ.flags and not isImportedCppType(typ)):
     genObjectFields(m, typ, origType, typ.n, tmp, info)
   m.s[cfsTypeInit3].addf("$1.node = &$2;$n", [tiNameForHcr(m, name), tmp])
   var t = typ.baseClass

--- a/tests/ccgbugs/tatomictypeinfo.nim
+++ b/tests/ccgbugs/tatomictypeinfo.nim
@@ -1,0 +1,14 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+  targets: "c cpp"
+"""
+
+# issue #24159 
+
+import std/atomics
+
+type N = object
+  u: ptr Atomic[int]
+proc w(args: N) = discard
+var e: Thread[N]
+createThread(e, w, default(N))

--- a/tests/ccgbugs/tcgbug.nim
+++ b/tests/ccgbugs/tcgbug.nim
@@ -4,6 +4,7 @@ success
 M1 M2
 ok
 '''
+targets: "c cpp"
 matrix: "--mm:refc;--mm:orc"
 """
 


### PR DESCRIPTION
fixes #24159, refs #23761, refs #15928

Since #23761 the compiler generates typeinfo for imported types if they are marked `completeStruct`. However the C++ imported `Atomic[T]` type is also marked `completeStruct` and has a fake field `raw: T` as a hack to calculate the correct size, which the typeinfo generation tries to refer to. To prevent this, don't generate typeinfo for any imported C++ type regardless of `completeStruct`. Alternatively the "size known" meaning of `completeStruct` could be split into another pragma like `sizeKnown` for `Atomic[T]` to use.

Ideally this would be fixed by `Atomic[T]` no longer being `completeStruct` and its size being calculated via `size: sizeof(T)` instead, but the compiler does not support this and it would take a lot of effort to implement, so this is a temporary fix until that is done.

This is marked as backport since #23761 was backported.