### PR TITLE
fixes #24167; `{.push deprecated.}` for templates

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1357,7 +1357,9 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
             internalError(c.config, info, "implicitPragmas")
           inc i
         popInfoContext(c.config)
-        if sym.kind in routineKinds and sym.ast != nil: mergePragmas(sym.ast, o)
+        if sym.kind in routineKinds-{skTemplate} and sym.ast != nil and
+            not (sym.kind == skTemplate and sfGenSym in sym.flags):
+          mergePragmas(sym.ast, o)
 
     if lfExportLib in sym.loc.flags and sfExportc notin sym.flags:
       localError(c.config, info, ".dynlib requires .exportc")

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1357,7 +1357,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
             internalError(c.config, info, "implicitPragmas")
           inc i
         popInfoContext(c.config)
-        if sym.kind in routineKinds-{skTemplate} and sym.ast != nil and
+        if sym.kind in routineKinds and sym.ast != nil and
             not (sym.kind == skTemplate and sfGenSym in sym.flags):
           mergePragmas(sym.ast, o)
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1357,8 +1357,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
             internalError(c.config, info, "implicitPragmas")
           inc i
         popInfoContext(c.config)
-        if sym.kind in routineKinds and sym.ast != nil and
-            not (sym.kind == skTemplate and sfGenSym in sym.flags):
+        if sym.kind in routineKinds and sym.ast != nil:
           mergePragmas(sym.ast, o)
 
     if lfExportLib in sym.loc.flags and sfExportc notin sym.flags:

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -520,7 +520,7 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   #  c.evalContext = c.createEvalContext(emStatic)
   result = evalMacroCall(c.module, c.idgen, c.graph, c.templInstCounter, n, nOrig, sym)
   if efNoSemCheck notin flags:
-    result = semAfterMacroCall(c, n, result, sym, flags, expectedType)
+    result = semAfterMacroCall(c, n, result, sym, flags+{efNoEvalTemplImplicitPragmas}, expectedType)
   if c.config.macrosToExpand.hasKey(sym.name.s):
     message(c.config, nOrig.info, hintExpandMacro, renderTree(result))
   result = wrapInComesFrom(nOrig.info, sym, result)

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -76,6 +76,7 @@ type
     efTypeAllowed # typeAllowed will be called after
     efWantNoDefaults
     efAllowSymChoice # symchoice node should not be resolved
+    efNoEvalTemplImplicitPragmas
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3526,7 +3526,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
   of nkMethodDef: result = semMethod(c, n)
   of nkConverterDef: result = semConverterDef(c, n)
   of nkMacroDef: result = semMacroDef(c, n)
-  of nkTemplateDef: result = semTemplateDef(c, n)
+  of nkTemplateDef: result = semTemplateDef(c, n, flags)
   of nkImportStmt:
     # this particular way allows 'import' in a 'compiles' context so that
     # template canImport(x): bool =

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -693,6 +693,13 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   pushOwner(c, s)
   openScope(c)
   n[namePos] = newSymNode(s)
+
+  # <del> set the symbol AST after pragmas, at least. This stops pragma that have
+  # been pushed (implicit) to be explicitly added to the template definition
+  # and misapplied to the body. see #18113 </del>
+  # I changed it back and disable implicit pragams for sfGenSym templates
+  s.ast = n
+
   pragmaCallable(c, s, n, templatePragmas)
   implicitPragmas(c, s, n.info, templatePragmas)
 
@@ -762,11 +769,6 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   semIdeForTemplateOrGeneric(c, n[bodyPos], ctx.cursorInBody)
   closeScope(c)
   popOwner(c)
-
-  # set the symbol AST after pragmas, at least. This stops pragma that have
-  # been pushed (implicit) to be explicitly added to the template definition
-  # and misapplied to the body. see #18113
-  s.ast = n
 
   if sfCustomPragma in s.flags:
     if n[bodyPos].kind != nkEmpty:

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -672,7 +672,7 @@ proc semTemplBodyDirty(c: var TemplCtx, n: PNode): PNode =
 # in semstmts.nim:
 proc semProcAnnotation(c: PContext, prc: PNode; validPragmas: TSpecialWords): PNode
 
-proc semTemplateDef(c: PContext, n: PNode): PNode =
+proc semTemplateDef(c: PContext, n: PNode; flags: TExprFlags = {}): PNode =
   result = semProcAnnotation(c, n, templatePragmas)
   if result != nil: return result
   result = n
@@ -701,7 +701,8 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   s.ast = n
 
   pragmaCallable(c, s, n, templatePragmas)
-  implicitPragmas(c, s, n.info, templatePragmas)
+  if efNoEvalTemplImplicitPragmas notin flags:
+    implicitPragmas(c, s, n.info, templatePragmas)
 
   setGenericParamsMisc(c, n)
   # process parameters:

--- a/tests/pragmas/tpush.nim
+++ b/tests/pragmas/tpush.nim
@@ -124,3 +124,9 @@ foo31()
 foo41()
 
 {.pop.}
+
+block:
+  {.push deprecated.}
+  template test() = discard
+  test()
+  {.pop.}


### PR DESCRIPTION
fixes #24167

In https://github.com/nim-lang/Nim/pull/18124, it set the symbol AST after pragmas in the templates definition. So `wDeprecate` doesn't appear in the ast. 

Otherwise, we can make extractPragma support nkEmpty to fix this problem at the cost of losing some potential deprecation messages in https://github.com/nim-lang/Nim/pull/24169