### PR TITLE
only merge valid implicit pragmas to routine AST, include templates

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -693,6 +693,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   pushOwner(c, s)
   openScope(c)
   n[namePos] = newSymNode(s)
+  s.ast = n # for implicitPragmas to use
   pragmaCallable(c, s, n, templatePragmas)
   implicitPragmas(c, s, n.info, templatePragmas)
 
@@ -762,11 +763,6 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   semIdeForTemplateOrGeneric(c, n[bodyPos], ctx.cursorInBody)
   closeScope(c)
   popOwner(c)
-
-  # set the symbol AST after pragmas, at least. This stops pragma that have
-  # been pushed (implicit) to be explicitly added to the template definition
-  # and misapplied to the body. see #18113
-  s.ast = n
 
   if sfCustomPragma in s.flags:
     if n[bodyPos].kind != nkEmpty:

--- a/tests/pragmas/tpush.nim
+++ b/tests/pragmas/tpush.nim
@@ -125,8 +125,20 @@ foo41()
 
 {.pop.}
 
+import macros
+
 block:
   {.push deprecated.}
   template test() = discard
   test()
   {.pop.}
+  macro foo(): bool =
+    let ast = getImpl(bindSym"test")
+    var found = false
+    if ast[4].kind == nnkPragma:
+      for x in ast[4]:
+        if x.eqIdent"deprecated":
+          found = true
+          break
+    result = newLit(found)
+  doAssert foo()

--- a/tests/template/m19277_1.nim
+++ b/tests/template/m19277_1.nim
@@ -1,0 +1,2 @@
+template foo*(x: untyped) =
+  echo "got: ", x

--- a/tests/template/m19277_2.nim
+++ b/tests/template/m19277_2.nim
@@ -1,0 +1,2 @@
+proc foo*(a: string) =
+  echo "got string: ", a

--- a/tests/template/t19277.nim
+++ b/tests/template/t19277.nim
@@ -1,3 +1,9 @@
+discard """
+  output: '''
+got: 0
+'''
+"""
+
 # issue #19277
 
 import m19277_1, m19277_2

--- a/tests/template/t19277.nim
+++ b/tests/template/t19277.nim
@@ -1,0 +1,13 @@
+# issue #19277
+
+import m19277_1, m19277_2
+
+template injector(val: untyped): untyped =
+  template subtemplate: untyped = val
+  subtemplate()
+
+template methodCall(val: untyped): untyped = val
+
+{.push raises: [Defect].}
+
+foo(injector(0).methodCall())


### PR DESCRIPTION
fixes #19277, refs #24169, refs #18124

When pragmas are pushed to a routine, if the routine symbol AST isn't nil by the time the pushed pragmas are being processed, the pragmas are implicitly added to the symbol AST. However this is done without restriction on the pragma, if the pushed pragma isn't supposed to apply to the routine, it's still added to the routine. This is why the symbol AST for templates wasn't set before the pushed pragma processing in #18124. Now, the pragmas added to the AST are restricted to ones that apply to the given routine. This means we can set the template symbol AST earlier so that the pragmas get added to the template AST.