### PR TITLE
stricter set type match, implicit conversion for literals

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -256,7 +256,9 @@ type
 
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result = default(array[0..3, TNoteKinds])
-  result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
+  {.push warning[EnumConv]: off.}
+  result[3] = {TMsgKind(low(TNoteKind))..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
+  {.pop.}
   result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -256,9 +256,7 @@ type
 
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result = default(array[0..3, TNoteKinds])
-  {.push warning[EnumConv]: off.}
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
-  {.pop.}
   result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -257,19 +257,20 @@ type
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result = default(array[0..3, TNoteKinds])
   {.push warning[EnumConv]: off.}
-  result[3] = {low(TNoteKind)..high(TNoteKind)} - {TNoteKind warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
+  result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
   {.pop.}
-  result[2] = result[3] - {TNoteKind hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
-  result[1] = result[2] - {TNoteKind warnProveField, warnProveIndex,
+  result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
+  result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin, hintPerformance}
-  result[0] = result[1] - {TNoteKind hintSuccessX, hintSuccess, hintConf,
+  result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
     hintProcessing, hintPattern, hintExecuting, hintLinking, hintCC}
 
 const
   NotesVerbosity* = computeNotesVerbosity()
   errXMustBeCompileTime* = "'$1' can only be used in compile-time context"
   errArgsNeedRunOption* = "arguments can only be given if the '--run' option is selected"
+  errFloatToString* = "cannot convert '$1' to '$2'"
 
 type
   TFileInfo* = object

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -259,11 +259,11 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   {.push warning[EnumConv]: off.}
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {TNoteKind warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
   {.pop.}
-  result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
-  result[1] = result[2] - {warnProveField, warnProveIndex,
+  result[2] = result[3] - {TNoteKind hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
+  result[1] = result[2] - {TNoteKind warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin, hintPerformance}
-  result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
+  result[0] = result[1] - {TNoteKind hintSuccessX, hintSuccess, hintConf,
     hintProcessing, hintPattern, hintExecuting, hintLinking, hintCC}
 
 const

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -257,7 +257,7 @@ type
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result = default(array[0..3, TNoteKinds])
   {.push warning[EnumConv]: off.}
-  result[3] = {TMsgKind(low(TNoteKind))..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
+  result[3] = {low(TNoteKind)..high(TNoteKind)} - {TNoteKind warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix}
   {.pop.}
   result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
   result[1] = result[2] - {warnProveField, warnProveIndex,

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -497,7 +497,6 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
 
 const
   errMissingGenericParamsForTemplate = "'$1' has unspecified generic parameters"
-  errFloatToString = "cannot convert '$1' to '$2'"
 
 proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
                   flags: TExprFlags = {}; expectedType: PType = nil): PNode =

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1561,7 +1561,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       else:
         result = typeRel(c, f[0], a[0], flags)
         if result < isGeneric:
-          if result <= isConvertible:
+          if result <= isSubrange:
+            # set['a'..'z'] and set[char] have different representations
             result = isNone
           elif tfIsConstructor notin a.flags:
             # set constructors are a bit special...

--- a/tests/sets/trangeincompatible.nim
+++ b/tests/sets/trangeincompatible.nim
@@ -5,21 +5,28 @@ block: # issue #20142
     s3 = {'b', 'c', 'd', 'f'}
 
   doAssert s1 != s2
-  # compiler can't automatically convert this yet:
   doAssert s1 == {range['a'..'g'] 'a', 'e'}
   doAssert s2 == {range['a'..'g'] 'b', 'c', 'd', 'f'}
+  # literal conversion:
+  doAssert s1 == {'a', 'e'}
+  doAssert s2 == {'b', 'c', 'd', 'f'}
   doAssert s3 == {'b', 'c', 'd', 'f'}
   doAssert not compiles(s1 == s3)
   doAssert not compiles(s2 == s3)
+  # can't convert literal 'z', overload match fails
+  doAssert not compiles(s1 == {'a', 'z'})
 
 block: # issue #18396
   var s1: set[char] = {'a', 'b'}
   var s2: set['a'..'z'] = {'a', 'b'}
   doAssert s1 == {'a', 'b'}
   doAssert s2 == {range['a'..'z'] 'a', 'b'}
+  doAssert s2 == {'a', 'b'}
   doAssert not compiles(s1 == s2)
 
 block: # issue #16270
   var s1: set[char] = {'a', 'b'}
   var s2: set['a'..'z'] = {'a', 'c'}
   doAssert not (compiles do: s2 = s2 + s1)
+  s2 = s2 + {'a', 'b'}
+  doAssert s2 == {'a', 'b', 'c'}

--- a/tests/sets/trangeincompatible.nim
+++ b/tests/sets/trangeincompatible.nim
@@ -1,0 +1,25 @@
+block: # issue #20142
+  let
+    s1: set['a' .. 'g'] = {'a', 'e'}
+    s2: set['a' .. 'g'] = {'b', 'c', 'd', 'f'} # this works fine
+    s3 = {'b', 'c', 'd', 'f'}
+
+  doAssert s1 != s2
+  # compiler can't automatically convert this yet:
+  doAssert s1 == {range['a'..'g'] 'a', 'e'}
+  doAssert s2 == {range['a'..'g'] 'b', 'c', 'd', 'f'}
+  doAssert s3 == {'b', 'c', 'd', 'f'}
+  doAssert not compiles(s1 == s3)
+  doAssert not compiles(s2 == s3)
+
+block: # issue #18396
+  var s1: set[char] = {'a', 'b'}
+  var s2: set['a'..'z'] = {'a', 'b'}
+  doAssert s1 == {'a', 'b'}
+  doAssert s2 == {range['a'..'z'] 'a', 'b'}
+  doAssert not compiles(s1 == s2)
+
+block: # issue #16270
+  var s1: set[char] = {'a', 'b'}
+  var s2: set['a'..'z'] = {'a', 'c'}
+  doAssert not (compiles do: s2 = s2 + s1)

--- a/tests/sets/twrongenumrange.nim
+++ b/tests/sets/twrongenumrange.nim
@@ -45,7 +45,6 @@ block:
     TNoteKind = range[k1..k2]
   var notes: set[TNoteKind]
   notes = {k0} #[tt.Error
-           ^ cannot convert 'k0' to 'TNoteKind = range 1..2(TMsgKind)]#
+          ^ type mismatch: got <set[TMsgKind]> but expected 'set[TNoteKind]']#
   notes = {k0..k3} #[tt.Error
-           ^ cannot convert 'k0' to 'TNoteKind = range 1..2(TMsgKind)'; tt.Error
-               ^ cannot convert 'k3' to 'TNoteKind = range 1..2(TMsgKind)']#
+          ^ type mismatch: got <set[TMsgKind]> but expected 'set[TNoteKind]']#


### PR DESCRIPTION
fixes #18396, fixes #20142

Set types with base types matching less than a generic match (so subrange matches, conversion matches, int conversion matches) are now considered mismatching, as their representation is different on the backends (except VM and JS), causing codegen issues. An exception is granted for set literal types, which now implicitly convert each element to the matched base type, so things like `s == {'a', 'b'}` are still possible where `s` is `set[range['a'..'z']]`. Also every conversion match in this case is unified under the normal "conversion" match, so a literal doesn't match one set type better than the other, unless it's equal.

However `{'a', 'b'} == s` or `{'a', 'b'} - s` etc is now not possible. when it used to work in the VM. So this is somewhat breaking, and needs a changelog entry.