### PR TITLE
make default values typed in proc AST same as param sym AST

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1404,6 +1404,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
         elif typ.kind == tyStatic:
           def = semConstExpr(c, def)
           def = fitNode(c, typ, def, def.info)
+      # keep proc AST updated
+      a[^1] = def
 
     if not hasType and not hasDefault:
       if isType: localError(c.config, a.info, "':' expected")

--- a/tests/errmsgs/tunknown_named_parameter.nim
+++ b/tests/errmsgs/tunknown_named_parameter.nim
@@ -10,8 +10,8 @@ func rsplit(s: string; sep: string; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: string
   but expression '{':'}' is of type: set[char]
-func rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[
-    string]
+func rsplit(s: string; seps: set[char] = {' ', '\t', '\v', '\r', '\n', '\f'};
+            maxsplit: int = -1): seq[string]
   first type mismatch at position: 3
   unknown named parameter: maxsplits
 

--- a/tests/proc/tdefaultvalueprocast.nim
+++ b/tests/proc/tdefaultvalueprocast.nim
@@ -1,0 +1,50 @@
+discard """
+  nimout: '''
+ProcDef
+  Sym "foo"
+  Empty
+  Empty
+  FormalParams
+    Empty
+    IdentDefs
+      Sym "x"
+      Empty
+      Call
+        Sym "none"
+        Sym "Natural"
+  Empty
+  Empty
+  DiscardStmt
+    Empty
+ProcDef
+  Sym "example"
+  Empty
+  Empty
+  FormalParams
+    Empty
+    IdentDefs
+      Sym "a"
+      Empty
+      Sym "thing"
+  Empty
+  Empty
+  DiscardStmt
+    TupleConstr
+      Sym "a"
+      Sym "thing"
+'''
+"""
+
+import options, macros
+
+macro typedTree(n: typed): untyped =
+  result = n
+  echo treeRepr n
+
+# issue #19118
+proc foo(x = none(Natural)) {.typedTree.} = discard
+
+# issue #12942
+var thing = 2
+proc example(a = thing) {.typedTree.} =
+  discard (a, thing)


### PR DESCRIPTION
fixes #12942, fixes #19118

This is the exact same as #20735 but maybe the situation has improved after #24065.