### PR TITLE
fix nimsuggest crash with arrow type sugar

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3408,6 +3408,8 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
       of skProc, skFunc, skMethod, skConverter, skIterator:
         if s.magic == mNone: result = semDirectOp(c, n, flags, expectedType)
         else: result = semMagic(c, n, s, flags, expectedType)
+      of skError:
+        return errorNode(c, n)
       else:
         #liMessage(n.info, warnUser, renderTree(n));
         result = semIndirectOp(c, n, flags, expectedType)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -890,6 +890,9 @@ proc analyseIfAddressTaken(c: PContext, n: PNode, isOutParam: bool): PNode =
 
 proc analyseIfAddressTakenInCall(c: PContext, n: PNode, isConverter = false) =
   checkMinSonsLen(n, 1, c.config)
+  if n[0].typ == nil:
+    # n[0] might be erroring node in nimsuggest
+    return
   const
     FakeVarParams = {mNew, mNewFinalize, mInc, ast.mDec, mIncl, mExcl,
       mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
@@ -3408,8 +3411,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}, expectedType: PType 
       of skProc, skFunc, skMethod, skConverter, skIterator:
         if s.magic == mNone: result = semDirectOp(c, n, flags, expectedType)
         else: result = semMagic(c, n, s, flags, expectedType)
-      of skError:
-        return errorNode(c, n)
       else:
         #liMessage(n.info, warnUser, renderTree(n));
         result = semIndirectOp(c, n, flags, expectedType)

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -487,13 +487,13 @@ proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) 
                                     100, PrefixMatch.None, c.inTypeContext > 0,
                                     -99))
 
-  if typ == nil:
+  if typ == nil or typ.kind == tyNone:
     # a module symbol has no type for example:
     if n.kind == nkSym and n.sym.kind == skModule:
       if n.sym == c.module:
         # all symbols accessible, because we are in the current module:
         for it in items(c.topLevelScope.symbols):
-          if filterSym(it, field, pm):
+          if it.owner == n.sym and filterSym(it, field, pm):
             outputs.add(symToSuggest(c.graph, it, isLocal=false, ideSug,
                                       n.info, it.getQuality, pm,
                                       c.inTypeContext > 0, -99))

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -487,13 +487,13 @@ proc suggestFieldAccess(c: PContext, n, field: PNode, outputs: var Suggestions) 
                                     100, PrefixMatch.None, c.inTypeContext > 0,
                                     -99))
 
-  if typ == nil or typ.kind == tyNone:
+  if typ == nil:
     # a module symbol has no type for example:
     if n.kind == nkSym and n.sym.kind == skModule:
       if n.sym == c.module:
         # all symbols accessible, because we are in the current module:
         for it in items(c.topLevelScope.symbols):
-          if it.owner == n.sym and filterSym(it, field, pm):
+          if filterSym(it, field, pm):
             outputs.add(symToSuggest(c.graph, it, isLocal=false, ideSug,
                                       n.info, it.getQuality, pm,
                                       c.inTypeContext > 0, -99))

--- a/nimsuggest/tests/tarrowcrash.nim
+++ b/nimsuggest/tests/tarrowcrash.nim
@@ -1,0 +1,20 @@
+# issue #24179
+
+import sugar
+
+type
+    Parser[T] = object
+    
+proc eatWhile[T](p: Parser[T], predicate: T -> bool): seq[T] =
+    return @[]
+
+proc skipWs(p: Parser[char]) =
+    discard p.eatWhile((c: char) => c == 'a')
+#[!]#
+    
+discard """
+$nimsuggest --tester $file
+>chk $1
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/tarrowcrash.nim [Processing]";;0
+chk;;skUnknown;;;;Hint;;$file;;11;;5;;"\'skipWs\' is declared but not used [XDeclaredButNotUsed]";;0
+"""

--- a/tests/errmsgs/tundeclared_routine.nim
+++ b/tests/errmsgs/tundeclared_routine.nim
@@ -9,7 +9,7 @@ tundeclared_routine.nim(29, 28) Error: invalid pragma: myPragma
 tundeclared_routine.nim(36, 13) Error: undeclared field: 'bar3' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(33, 8)]
   found tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(35, 12)]
 tundeclared_routine.nim(41, 13) Error: undeclared field: 'bar4' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(39, 8)]
-tundeclared_routine.nim(44, 15) Error: attempting to call routine: 'bad5'
+tundeclared_routine.nim(44, 11) Error: undeclared identifier: 'bad5'
 '''
 """
 


### PR DESCRIPTION
fixes #24179 

The original fix made it so calls to `skError`/`skUnknown` (in this case `->`, for some reason `sugar` couldn't be imported) returned an error node, however this breaks tsug_accquote for some reason I don't understand (it even parses as `tsug_accquote.discard`) so I've just added a guard based on the stacktrace.