### PR TITLE
evaluate all hidden conversions in case branches

### DIFF
--- a/tests/casestmt/tcasestmt.nim
+++ b/tests/casestmt/tcasestmt.nim
@@ -41,6 +41,11 @@ block t8333:
   case 0
   of 'a': echo 0
   else: echo 1
+block: # issue #11422
+  var c: int = 5
+  case c
+  of 'a' .. 'c': discard
+  else: discard
 
 
 block emptyset_when:


### PR DESCRIPTION
fixes #11422, refs #8336/#8333, refs #20130

The compiler generates conversion nodes *after* evaluating the branches of case statements as constants, the reasoning is that case branches accept constants of different types, like arrays or sets. But this means that conversion nodes that need to be evaluated like converter calls don't get evaluated as a constant for codegen. #8336 fixed this by re-evaluating the node if an `nkHiddenCallConv` was created, and in #20130 this logic also had to be added for `nkHiddenStdConv` for cstrings. This logic was only for single case elements, it has now been added to range elements as well to fix #11422. Additionally, all conversion nodes are now evaluated for simplicity, but maybe this won't pass CI.