### PR TITLE
fixes #24008; triggers a recompilation on output executables changes when switching release/debug modes

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1004,7 +1004,7 @@ const cacheVersion = "D20240927T193831" # update when `BuildCache` spec changes
 type BuildCache = object
   cacheVersion: string
   outputFile: string
-  outputChecksum: string
+  outputLastModificationTime: string
   compile: seq[(string, string)]
   link: seq[string]
   linkcmd: string
@@ -1048,7 +1048,7 @@ proc writeJsonBuildInstructions*(conf: ConfigRef; deps: StringTableRef) =
           bcache.depfiles.add (path, $secureHashFile(path))
 
     bcache.nimexe = hashNimExe()
-    bcache.outputChecksum = $secureHashFile(bcache.outputFile)
+    bcache.outputLastModificationTime = $getLastModificationTime(bcache.outputFile)
   conf.jsonBuildFile = conf.jsonBuildInstructionsFile
   conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
 
@@ -1069,7 +1069,7 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: Absolute
     # xxx optimize by returning false if stdin input was the same
   for (file, hash) in bcache.depfiles:
     if $secureHashFile(file) != hash: return true
-  if bcache.outputChecksum != $secureHashFile(bcache.outputFile):
+  if bcache.outputLastModificationTime != $getLastModificationTime(bcache.outputFile):
     return true
 
 proc runJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1000,7 +1000,7 @@ proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   # works out of the box with `hashMainCompilationParams`.
   result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
-const cacheVersion = "D20210525T193831" # update when `BuildCache` spec changes
+const cacheVersion = "D20240927T193831" # update when `BuildCache` spec changes
 type BuildCache = object
   cacheVersion: string
   outputFile: string


### PR DESCRIPTION
fixes #24008

The old logic didn't check the contents of the output executables, when it switched release->debug->release, it picked up the Json files used in the first release building, the content of which didn't change. So it mistook the executables which are built by the second debug building as the functioning one. 

`changeDetectedViaJsonBuildInstructions` needs a way to distinguish the executables generated by different buildings.