### PR TITLE
test fixes for #24184

### DIFF
--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -143,7 +143,11 @@ proc evalTemplateArgs(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode 
 
   result = newNodeI(nkArgList, n.info)
   for i in 1..givenRegularParams:
-    result.add n[i]
+    let arg = n[i]
+    if arg.typ != nil and arg.typ.kind == tyStatic and arg.typ.n != nil:
+      result.add arg.typ.n
+    else:
+      result.add arg
 
   # handle parameters with default values, which were
   # not supplied by the user

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -446,6 +446,10 @@ when false:
                         sons: seq[PType]): PType =
     result = newType(kind, c.idgen, getCurrOwner(c), sons = sons)
 
+proc makeStaticType*(c: PContext, baseType: PType, val: PNode): PType =
+  result = newTypeS(tyStatic, c, son = baseType)
+  result.n = val
+
 proc makeStaticExpr*(c: PContext, n: PNode): PNode =
   result = newNodeI(nkStaticExpr, n.info)
   result.sons = @[n]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -722,29 +722,46 @@ proc arrayConstrType(c: PContext, n: PNode): PType =
 
 proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = newNodeI(nkBracket, n.info)
-  result.typ = newTypeS(tyArray, c)
+  # nkBracket nodes can also be produced by the VM as seq constant nodes
+  # in which case, we cannot produce a new array type for the node,
+  # as this might lose type info even when the node has array type
+  let constructType = n.typ.isNil
   var expectedElementType, expectedIndexType: PType = nil
-  if expectedType != nil:
-    let expected = expectedType.skipTypes(abstractRange-{tyDistinct})
+  if constructType:
+    result.typ = newTypeS(tyArray, c)
+    if expectedType != nil:
+      let expected = expectedType.skipTypes(abstractRange-{tyDistinct})
+      case expected.kind
+      of tyArray:
+        expectedIndexType = expected[0]
+        expectedElementType = expected[1]
+      of tyOpenArray:
+        expectedElementType = expected[0]
+      else: discard
+    rawAddSon(result.typ, nil)     # index type
+  else:
+    result.typ = n.typ
+    let expected = n.typ.skipTypes(abstractRange) # include tyDistinct this time
     case expected.kind
     of tyArray:
       expectedIndexType = expected[0]
       expectedElementType = expected[1]
-    of tyOpenArray:
+    of tyOpenArray, tySequence:
+      # typed bracket expressions can also have seq type
       expectedElementType = expected[0]
     else: discard
-  rawAddSon(result.typ, nil)     # index type
   var
     firstIndex, lastIndex: Int128 = Zero
     indexType = getSysType(c.graph, n.info, tyInt)
     lastValidIndex = lastOrd(c.config, indexType)
   if n.len == 0:
-    rawAddSon(result.typ,
-      if expectedElementType != nil and
-          typeAllowed(expectedElementType, skLet, c) == nil:
-        expectedElementType
-      else:
-        newTypeS(tyEmpty, c)) # needs an empty basetype!
+    if constructType:
+      rawAddSon(result.typ,
+        if expectedElementType != nil and
+            typeAllowed(expectedElementType, skLet, c) == nil:
+          expectedElementType
+        else:
+          newTypeS(tyEmpty, c)) # needs an empty basetype!
     lastIndex = toInt128(-1)
   else:
     var x = n[0]
@@ -761,9 +778,13 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
         x = x[1]
 
     let yy = semExprWithType(c, x, {efTypeAllowed}, expectedElementType)
-    var typ = yy.typ
-    if expectedElementType == nil:
-      expectedElementType = typ
+    var typ: PType
+    if constructType:
+      typ = yy.typ
+      if expectedElementType == nil:
+        expectedElementType = typ
+    else:
+      typ = expectedElementType
     result.add yy
     #var typ = skipTypes(result[0].typ, {tyGenericInst, tyVar, tyLent, tyOrdinal})
     for i in 1..<n.len:
@@ -783,15 +804,20 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
 
       let xx = semExprWithType(c, x, {efTypeAllowed}, expectedElementType)
       result.add xx
-      typ = commonType(c, typ, xx.typ)
+      if constructType:
+        typ = commonType(c, typ, xx.typ)
       #n[i] = semExprWithType(c, x, {})
       #result.add fitNode(c, typ, n[i])
       inc(lastIndex)
-    addSonSkipIntLit(result.typ, typ, c.idgen)
+    if constructType:
+      addSonSkipIntLit(result.typ, typ, c.idgen)
     for i in 0..<result.len:
       result[i] = fitNode(c, typ, result[i], result[i].info)
-  result.typ.setIndexType makeRangeType(c, toInt64(firstIndex), toInt64(lastIndex), n.info,
-                                     indexType)
+  if constructType:
+    result.typ.setIndexType(
+      makeRangeType(c,
+        toInt64(firstIndex), toInt64(lastIndex),
+        n.info, indexType))
 
 proc fixAbstractType(c: PContext, n: PNode) =
   for i in 1..<n.len:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1408,7 +1408,9 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           let baseType = typ.skipTypes({tyStatic})
           if not containsGenericType(baseType):
             def = fitNode(c, baseType, def, def.info)
-          def.typ = makeStaticType(c, baseType, def.copyTree)
+            def.typ = makeStaticType(c, baseType, def.copyTree)
+          else:
+            def = fitNode(c, typ, def, def.info)
         elif not containsGenericType(typ):
           # check type compatibility between def.typ and typ:
           def = fitNode(c, typ, def, def.info)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1408,7 +1408,10 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           def = fitNode(c, typ, def, def.info)
         elif typ.kind == tyStatic:
           def = semConstExpr(c, def)
-          def = fitNode(c, typ, def, def.info)
+          # do we need to set `def.typ` to `tyStatic` here?
+          def = fitNode(c, typ.skipTypes({tyStatic}), def, def.info)
+      # keep proc AST updated
+      a[^1] = def.copyTree
 
     if not hasType and not hasDefault:
       if isType: localError(c.config, a.info, "':' expected")

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1408,10 +1408,11 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           def = fitNode(c, typ, def, def.info)
         elif typ.kind == tyStatic:
           def = semConstExpr(c, def)
-          # do we need to set `def.typ` to `tyStatic` here?
-          def = fitNode(c, typ.skipTypes({tyStatic}), def, def.info)
+          let baseType = typ.skipTypes({tyStatic})
+          def = fitNode(c, baseType, def, def.info)
+          def.typ = makeStaticType(c, baseType, def.copyTree)
       # keep proc AST updated
-      a[^1] = def.copyTree
+      a[^1] = def
 
     if not hasType and not hasDefault:
       if isType: localError(c.config, a.info, "':' expected")

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1403,14 +1403,15 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
         # if def.typ != nil and def.typ.kind != tyNone:
         # example code that triggers it:
         # proc sort[T](cmp: proc(a, b: T): int = cmp)
-        if not containsGenericType(typ):
-          # check type compatibility between def.typ and typ:
-          def = fitNode(c, typ, def, def.info)
-        elif typ.kind == tyStatic:
+        if typ.kind == tyStatic:
           def = semConstExpr(c, def)
           let baseType = typ.skipTypes({tyStatic})
-          def = fitNode(c, baseType, def, def.info)
+          if not containsGenericType(baseType):
+            def = fitNode(c, baseType, def, def.info)
           def.typ = makeStaticType(c, baseType, def.copyTree)
+        elif not containsGenericType(typ):
+          # check type compatibility between def.typ and typ:
+          def = fitNode(c, typ, def, def.info)
       # keep proc AST updated
       a[^1] = def
 

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -152,7 +152,7 @@ proc matchGenericParam(m: var TCandidate, formal: PType, n: PNode) =
     if n.kind in nkSymChoices: n.flags.excl nfSem
     let evaluated = m.c.semTryConstExpr(m.c, n, formalBase.skipTypes({tyStatic}))
     if evaluated != nil:
-      arg = makeStaticType(m.c, evaluated.typ, evaluated.copyTree)
+      arg = makeStaticType(m.c, evaluated.typ, evaluated)
   elif formalBase.kind == tyTypeDesc:
     if arg.kind != tyTypeDesc:
       arg = makeTypeDesc(m.c, arg)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -152,8 +152,7 @@ proc matchGenericParam(m: var TCandidate, formal: PType, n: PNode) =
     if n.kind in nkSymChoices: n.flags.excl nfSem
     let evaluated = m.c.semTryConstExpr(m.c, n, formalBase.skipTypes({tyStatic}))
     if evaluated != nil:
-      arg = newTypeS(tyStatic, m.c, son = evaluated.typ)
-      arg.n = evaluated
+      arg = makeStaticType(m.c, evaluated.typ, evaluated.copyTree)
   elif formalBase.kind == tyTypeDesc:
     if arg.kind != tyTypeDesc:
       arg = makeTypeDesc(m.c, arg)
@@ -2293,6 +2292,9 @@ template matchesVoidProc(t: PType): bool =
   (t.kind == tyProc and t.len == 1 and t.returnType == nil) or
     (t.kind == tyBuiltInTypeClass and t.elementType.kind == tyProc)
 
+proc paramTypesMatch*(m: var TCandidate, f, a: PType,
+                      arg, argOrig: PNode): PNode
+
 proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
                         argSemantized, argOrig: PNode): PNode =
   result = nil
@@ -2326,11 +2328,19 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     elif arg.kind != nkEmpty:
       var evaluated = c.semTryConstExpr(c, arg)
       if evaluated != nil:
-        # Don't build the type in-place because `evaluated` and `arg` may point
-        # to the same object and we'd end up creating recursive types (#9255)
-        let typ = newTypeS(tyStatic, c, son = evaluated.typ)
-        typ.n = evaluated
-        arg = copyTree(arg) # fix #12864
+        if false and f.kind == tyStatic:
+          let converted = paramTypesMatch(m, f.base, evaluated.typ, evaluated, argOrig)
+          # if for some reason `evaluated` doesn't match `f.base`:
+          if converted == nil: return nil
+          evaluated = converted
+          if evaluated.kind in {nkHiddenStdConv, nkHiddenSubConv, nkHiddenCallConv}:
+            evaluated = c.semTryConstExpr(c, evaluated)
+            # if for some reason the conversion can't be evaluated,
+            # like if a converter is runtime-only
+            if evaluated == nil: return nil
+        # to avoid creating recursive types, copy the node (#9255, #12864)
+        # original version copied `arg` and not `evaluated`
+        let typ = makeStaticType(c, evaluated.typ, evaluated.copyTree)
         arg.typ = typ
         a = typ
       else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2360,8 +2360,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
   # anywhere and breaks symmetry. It's hard to get rid of though, my
   # custom seqs example fails to compile without this:
   if r != isNone and m.calleeSym != nil and
-      m.calleeSym.kind in {skMacro, skTemplate} and
-      not m.macroTemplateEnableConv:
+    m.calleeSym.kind in {skMacro, skTemplate}:
     # XXX: duplicating this is ugly, but we cannot (!) move this
     # directly into typeRel using return-like templates
     incMatches(m, r)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2338,9 +2338,10 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
             # if for some reason the conversion can't be evaluated,
             # like if a converter is runtime-only
             if evaluated == nil: return nil
-        # to avoid creating recursive types, copy the node (#9255, #12864)
-        # original version copied `arg` and not `evaluated`
-        let typ = makeStaticType(c, evaluated.typ, evaluated.copyTree)
+        # Don't build the type in-place because `evaluated` and `arg` may point,
+        # to the same object and we'd end up creating recursive types (#9255)
+        let typ = makeStaticType(c, evaluated.typ, evaluated)
+        arg = copyTree(arg) # fix #12864
         arg.typ = typ
         a = typ
       else:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2029,6 +2029,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           result = isGeneric
         if result != isNone: put(c, f, aOrig)
       elif aOrig.n != nil and aOrig.n.typ != nil:
+        # XXX this should use paramTypesMatch
         result = if f.base.kind != tyNone:
                    typeRel(c, f.last, aOrig.n.typ, flags)
                  else: isGeneric
@@ -2328,7 +2329,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     elif arg.kind != nkEmpty:
       var evaluated = c.semTryConstExpr(c, arg)
       if evaluated != nil:
-        if false and f.kind == tyStatic:
+        if f.kind == tyStatic:
           let converted = paramTypesMatch(m, f.base, evaluated.typ, evaluated, argOrig)
           # if for some reason `evaluated` doesn't match `f.base`:
           if converted == nil: return nil

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -17,7 +17,7 @@ when defined(nimPreviewSlimSystem):
 # xxx `genEnumCaseStmt` needs tests and runnableExamples
 
 macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
-            userMin, userMax: static[int], normalizer: static[proc(s :string): string]): untyped =
+            userMin, userMax: static[int], normalizer: static[proc(s :string): string {.nimcall.}]): untyped =
   # Generates a case stmt, which assigns the correct enum field given
   # a normalized string comparison to the `argSym` input.
   # string normalization is done using passed normalizer.
@@ -26,6 +26,7 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
   let impl = typSym.getImpl[2]
   expectKind impl, nnkEnumTy
   let normalizerNode = quote: `normalizer`
+  expectKind normalizerNode, nnkSym
   result = nnkCaseStmt.newTree(newCall(normalizerNode, argSym))
   # stores all processed field strings to give error msg for ambiguous enums
   var foundFields: seq[string] = @[]

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -26,7 +26,6 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
   let impl = typSym.getImpl[2]
   expectKind impl, nnkEnumTy
   let normalizerNode = quote: `normalizer`
-  expectKind normalizerNode, nnkSym
   result = nnkCaseStmt.newTree(newCall(normalizerNode, argSym))
   # stores all processed field strings to give error msg for ambiguous enums
   var foundFields: seq[string] = @[]

--- a/tests/errmsgs/tunknown_named_parameter.nim
+++ b/tests/errmsgs/tunknown_named_parameter.nim
@@ -10,8 +10,8 @@ func rsplit(s: string; sep: string; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: string
   but expression '{':'}' is of type: set[char]
-func rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[
-    string]
+func rsplit(s: string; seps: set[char] = {' ', '\t', '\v', '\r', '\n', '\f'};
+            maxsplit: int = -1): seq[string]
   first type mismatch at position: 3
   unknown named parameter: maxsplits
 

--- a/tests/proc/tdefaultvalueprocast.nim
+++ b/tests/proc/tdefaultvalueprocast.nim
@@ -1,0 +1,50 @@
+discard """
+  nimout: '''
+ProcDef
+  Sym "foo"
+  Empty
+  Empty
+  FormalParams
+    Empty
+    IdentDefs
+      Sym "x"
+      Empty
+      Call
+        Sym "none"
+        Sym "Natural"
+  Empty
+  Empty
+  DiscardStmt
+    Empty
+ProcDef
+  Sym "example"
+  Empty
+  Empty
+  FormalParams
+    Empty
+    IdentDefs
+      Sym "a"
+      Empty
+      Sym "thing"
+  Empty
+  Empty
+  DiscardStmt
+    TupleConstr
+      Sym "a"
+      Sym "thing"
+'''
+"""
+
+import options, macros
+
+macro typedTree(n: typed): untyped =
+  result = n
+  echo treeRepr n
+
+# issue #19118
+proc foo(x = none(Natural)) {.typedTree.} = discard
+
+# issue #12942
+var thing = 2
+proc example(a = thing) {.typedTree.} =
+  discard (a, thing)

--- a/tests/proc/tdefaultvalueresem.nim
+++ b/tests/proc/tdefaultvalueresem.nim
@@ -1,0 +1,50 @@
+discard """
+  output: '''
+seq[string]
+@[]
+seq[string]
+@[]
+seq[string]
+@[]
+seq[string]
+@[]
+seq[string]
+@[]
+seq[string]
+@[]
+'''
+"""
+
+# regression from #24184, see #24191
+
+const a: seq[string] = @[]
+
+proc foo(x = a) =
+  echo typeof(x)
+  echo x
+
+proc bar(x: static seq[string] = a) =
+  echo typeof(x)
+  echo x
+
+# issue #22793
+proc baz(x: static seq[string] = @[]) =
+  echo typeof(x)
+  echo x
+
+import macros
+
+macro resem(x: typed) =
+  expectKind x, nnkSym
+  result = getImpl(x)
+
+foo()
+bar()
+baz()
+block:
+  resem(foo) # Error: cannot infer the type of parameter 'x'
+  resem(bar)
+  resem(baz)
+  foo()
+  bar()
+  baz()

--- a/tests/proc/tdefaultvalueresem.nim
+++ b/tests/proc/tdefaultvalueresem.nim
@@ -1,36 +1,23 @@
-discard """
-  output: '''
-seq[string]
-@[]
-seq[string]
-@[]
-seq[string]
-@[]
-seq[string]
-@[]
-seq[string]
-@[]
-seq[string]
-@[]
-'''
-"""
-
 # regression from #24184, see #24191
 
 const a: seq[string] = @[]
 
 proc foo(x = a) =
-  echo typeof(x)
-  echo x
+  doAssert x is seq[string]
+  doAssert x == @[]
 
 proc bar(x: static seq[string] = a) =
-  echo typeof(x)
-  echo x
+  doAssert x is seq[string]
+  doAssert x == @[]
+  const y = x
+  doAssert y == x
 
 # issue #22793
 proc baz(x: static seq[string] = @[]) =
-  echo typeof(x)
-  echo x
+  doAssert x is seq[string]
+  doAssert x == @[]
+  const y = x
+  doAssert y == x
 
 import macros
 

--- a/tests/proc/tdefaultvaluestatic.nim
+++ b/tests/proc/tdefaultvaluestatic.nim
@@ -32,3 +32,14 @@ block:
   doAssert foo(true) == "a"
   doAssert foo(false) == "b"
   doAssert foo() == "b"
+
+block:
+  proc foo(x: uint) = discard
+  proc bar(x: static int = 123) =
+    foo(x)
+  bar(123)
+  bar()
+  template baz(x: static int = 123) =
+    foo(x)
+  baz(123)
+  baz()

--- a/tests/proc/tdefaultvaluestatic.nim
+++ b/tests/proc/tdefaultvaluestatic.nim
@@ -1,0 +1,22 @@
+block: # issue #22793
+  const x = @["a", "b"]
+
+  proc myProc(x: seq[string]): seq[string] =
+    result = x
+  doAssert x.myProc() == @["a", "b"]
+  doAssert x.myProc() == x
+
+  proc myProc2(x: seq[string] = @[]): seq[string] = # Compiler correctly infers that `@[]` is `seq[string]`
+    result = x
+  doAssert x.myProc2() == @["a", "b"]
+  doAssert x.myProc2() == x
+    
+  proc myProc3(x: static seq[string]): seq[string] =
+    result = x
+  doAssert x.myProc3() == @["a", "b"]
+  doAssert x.myProc3() == x
+
+  proc myProc4(x: static seq[string] = @[]): seq[string] = # This proc causes a compiler error. Compiler does not infer that `@[]` is `static seq[string]`
+    result = x
+  doAssert x.myProc4() == @["a", "b"]
+  doAssert x.myProc4() == x

--- a/tests/proc/tdefaultvaluestatic.nim
+++ b/tests/proc/tdefaultvaluestatic.nim
@@ -20,3 +20,15 @@ block: # issue #22793
     result = x
   doAssert x.myProc4() == @["a", "b"]
   doAssert x.myProc4() == x
+
+block:
+  proc foo(x: static[bool] = false): string =
+    when x:
+      "a"
+    else:
+      "b"
+  
+  doAssert foo() == "b"
+  doAssert foo(true) == "a"
+  doAssert foo(false) == "b"
+  doAssert foo() == "b"

--- a/tests/statictypes/tparamconv.nim
+++ b/tests/statictypes/tparamconv.nim
@@ -1,0 +1,70 @@
+# test that static conversions work
+
+block: # issue #12559
+  type T = ref object
+    x: int
+  proc f(arg: static T) =
+    static:
+      assert arg == nil or arg.x > 0
+    discard arg.x
+  f nil
+
+block: # issue #16969
+  proc foo(n: static[1..50]) = discard
+
+  foo(1)
+  doAssert not compiles(foo(0))
+  doAssert not compiles(foo(999))
+
+block: # issue #7611
+  type Foo[N: static[int8]] = object
+
+  proc `$`[N: static[int8]](f: Foo[N]): string =
+    "Success"
+
+  let a = Foo[10]()
+  doAssert $a == "Success"
+
+block: # issue #17423
+  type NaturalArray[N: static[Natural]] = array[N, int]
+
+  doAssert not (compiles do:
+    var a: NaturalArray[-1000])
+
+block: # test from https://github.com/nim-works/nimskull/pull/1433
+  proc foo(x: static pointer): pointer = x
+  proc foo(x: static array[0, int]): array[0, int] = x
+  proc foo(x: static seq[int]): seq[int] = x
+  proc foo(x: static set[char]): set[char] = x
+
+  # simple case: empty-container typed expression is passed directly
+  doAssert foo(nil) == nil
+  doAssert foo([]) == []
+  doAssert foo(@[]) == @[]
+  doAssert foo({}) == {}
+
+block: # generic version
+  proc foo[T](x: static[ptr T]): ptr T = x
+  proc foo[T](x: static array[0, T]): array[0, T] = x
+  proc foo[T](x: static seq[T]): seq[T] = x
+  proc foo[T](x: static set[T]): set[T] = x
+  doAssert foo[int8](nil) == nil
+  doAssert foo[int8]([]) == []
+  doAssert foo[int8](@[]) == @[]
+  doAssert foo[int8]({}) == {}
+
+converter toInt(x: float): int = int(x)
+block: # converter
+  proc test(x: static int) =
+    doAssert x == 1
+  test(1.5)
+
+block: # subtype
+  type
+    A = ref object of RootObj
+    B = ref object of A
+
+  proc test(x: static A) = discard
+  test(B())
+
+# proc explicit generic params don't work yet because typeRel doesn't use paramTypesMatch, #23343

--- a/tests/statictypes/tparamconv.nim
+++ b/tests/statictypes/tparamconv.nim
@@ -1,3 +1,7 @@
+discard """
+  disabled: true
+"""
+
 # test that static conversions work
 
 block: # issue #12559

--- a/tests/stdlib/ttasks.nim
+++ b/tests/stdlib/ttasks.nim
@@ -247,7 +247,7 @@ block:
   block:
     var a1: seq[int]
     var a2: int
-    proc hello(a: int, c: static varargs[int]) =
+    proc hello(a: int, c: static openArray[int]) =
       a1 = @c
       a2 = a
 
@@ -260,7 +260,7 @@ block:
   block:
     var a1: seq[int]
     var a2: int
-    proc hello(a: int, c: static varargs[int]) =
+    proc hello(a: int, c: static openArray[int]) =
       a1 = @c
       a2 = a
 

--- a/tests/stdlib/ttasks.nim
+++ b/tests/stdlib/ttasks.nim
@@ -247,7 +247,7 @@ block:
   block:
     var a1: seq[int]
     var a2: int
-    proc hello(a: int, c: static openArray[int]) =
+    proc hello(a: int, c: static varargs[int]) =
       a1 = @c
       a2 = a
 
@@ -260,7 +260,7 @@ block:
   block:
     var a1: seq[int]
     var a2: int
-    proc hello(a: int, c: static openArray[int]) =
+    proc hello(a: int, c: static varargs[int]) =
       a1 = @c
       a2 = a
 

--- a/tests/vm/tconstarrayresem.nim
+++ b/tests/vm/tconstarrayresem.nim
@@ -1,0 +1,29 @@
+# issue #23010
+
+type
+  Result[T, E] = object
+    case oResult: bool
+    of false:
+      discard
+    of true:
+      vResult: T
+
+  Opt[T] = Result[T, void]
+
+template ok[T, E](R: type Result[T, E], x: untyped): R =
+  R(oResult: true, vResult: x)
+
+template c[T](v: T): Opt[T] = Opt[T].ok(v)
+
+type
+  FixedBytes[N: static[int]] = distinct array[N, byte]
+
+  H = object
+    d: FixedBytes[2]
+
+const b = default(H)
+template g(): untyped =
+  const t = default(H)
+  b
+
+discard c(g())


### PR DESCRIPTION
refs #24184, refs (fixes) #23010, #22793

Something similar to the `semArrayConstr` changes was rejected before, but I think that version just early returned and didn't sem any elements if `n.typ` wasn't nil. In this version the elements are still resemmed, a new type just isn't constructed.

I'm going to split this into multiple PRs where the redo of #24184 will depend on the others, but not sure if I should split into 2 or 3 PRs since the fix for #22793 is a single line. Edit: No longer the case but I have no idea what depends on what now.

There is also a fix I couldn't get to work (for #7611, #12559, #16969, #17423 but not #23343 (explicit generics for procs)) that isn't necessary for #24184 but I wanted to see if they all worked in tandem.