### PR TITLE
sizeComplete pragma to workaround C++ Atomic [backport]

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -393,6 +393,7 @@ type
     tfCompleteStruct
       # (for importc types); type is fully specified, allowing to compute
       # sizeof, alignof, offsetof at CT
+    tfSizeComplete
     tfExplicitCallConv
     tfIsConstructor
     tfEffectSystemWorkaround

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -394,6 +394,7 @@ type
       # (for importc types); type is fully specified, allowing to compute
       # sizeof, alignof, offsetof at CT
     tfSizeComplete
+      # workaround for C++ atomic, remove when arbitrary expression `size` is supported
     tfExplicitCallConv
     tfIsConstructor
     tfEffectSystemWorkaround

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -169,3 +169,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasGenericsOpenSym2")
   defineSymbol("nimHasGenericsOpenSym3")
   defineSymbol("nimHasJsNoLambdaLifting")
+  defineSymbol("nimHasSizeComplete")

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -73,7 +73,7 @@ const
     wGcSafe, wCodegenDecl, wNoInit, wCompileTime}
   typePragmas* = declPragmas + {wMagic, wAcyclic,
     wPure, wHeader, wCompilerProc, wCore, wFinal, wSize, wShallow,
-    wIncompleteStruct, wCompleteStruct, wByCopy, wByRef,
+    wIncompleteStruct, wCompleteStruct, wSizeComplete, wByCopy, wByRef,
     wInheritable, wGensym, wInject, wRequiresInit, wUnchecked, wUnion, wPacked,
     wCppNonPod, wBorrow, wGcSafe, wPartial, wExplain, wPackage, wCodegenDecl,
     wSendable, wNoInit}
@@ -1216,6 +1216,10 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         noVal(c, it)
         if sym.typ == nil: invalidPragma(c, it)
         else: incl(sym.typ.flags, tfCompleteStruct)
+      of wSizeComplete:
+        noVal(c, it)
+        if sym.typ == nil: invalidPragma(c, it)
+        else: incl(sym.typ.flags, tfSizeComplete)
       of wUnchecked:
         noVal(c, it)
         if sym.typ == nil or sym.typ.kind notin {tyArray, tyUncheckedArray}:

--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -396,7 +396,7 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
       let paddingAtEnd = int16(accum.finish())
       if typ.sym != nil and
          typ.sym.flags * {sfCompilerProc, sfImportc} == {sfImportc} and
-         tfCompleteStruct notin typ.flags:
+         typ.flags * {tfCompleteStruct, tfSizeComplete} == {}:
         typ.size = szUnknownSize
         typ.align = szUnknownSize
         typ.paddingAtEnd = szUnknownSize

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -46,7 +46,8 @@ type
     wImportc = "importc", wImportJs = "importjs", wExportc = "exportc", wExportCpp = "exportcpp",
     wExportNims = "exportnims",
     wIncompleteStruct = "incompleteStruct", # deprecated
-    wCompleteStruct = "completeStruct", wRequiresInit = "requiresInit", wAlign = "align",
+    wCompleteStruct = "completeStruct", wSizeComplete = "sizeComplete",
+    wRequiresInit = "requiresInit", wAlign = "align",
     wNodecl = "nodecl", wPure = "pure", wSideEffect = "sideEffect", wHeader = "header",
     wNoSideEffect = "noSideEffect", wGcSafe = "gcsafe", wNoreturn = "noreturn",
     wNosinks = "nosinks", wLib = "lib", wDynlib = "dynlib",

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -88,8 +88,11 @@ when defined(cpp) or defined(nimdoc):
         ## Also guarantees that all threads observe the same total ordering
         ## with other moSequentiallyConsistent operations.
 
+  when not defined(nimHasSizeComplete):
+    {.pragma: sizeComplete, completeStruct.}
+
   type
-    Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
+    Atomic*[T] {.importcpp: "std::atomic", sizeComplete.} = object
       ## An atomic object with underlying type `T`.
       raw: T
 

--- a/tests/ccgbugs/tatomictypeinfo.nim
+++ b/tests/ccgbugs/tatomictypeinfo.nim
@@ -1,0 +1,14 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+  targets: "c cpp"
+"""
+
+# issue #24159 
+
+import std/atomics
+
+type N = object
+  u: ptr Atomic[int]
+proc w(args: N) = discard
+var e: Thread[N]
+createThread(e, w, default(N))

--- a/tests/ccgbugs/tcgbug.nim
+++ b/tests/ccgbugs/tcgbug.nim
@@ -4,6 +4,7 @@ success
 M1 M2
 ok
 '''
+targets: "c cpp"
 matrix: "--mm:refc;--mm:orc"
 """
 


### PR DESCRIPTION
fixes #24159, refs #23761, refs #15928, alternative to #24166

As an alternative to #24166, instead of disabling typeinfo generation on all `completeStruct` imported C++ types, add a new pragma `sizeComplete` that acts the same as `completeStruct` except generating typeinfo, and use this pragma for `Atomic[T]`. This seems like the most clearly temporary solution, I also considered a `noTypeInfo` pragma but it seemed like it would overstay its welcome.