### PR TITLE
delay `size` pragma for generic types, use it for C++ Atomic[T]

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -365,6 +365,8 @@ type
     tfVarIsPtr,       # 'var' type is translated like 'ptr' even in C++ mode
     tfHasMeta,        # type contains "wildcard" sub-types such as generic params
                       # or other type classes
+                      # also used when checking pragmas of forward types
+                      # to signify that the forward type is generic
     tfHasGCedMem,     # type contains GC'ed memory
     tfPacked
     tfHasStatic
@@ -399,6 +401,9 @@ type
     tfIsOutParam
     tfSendable
     tfImplicitStatic
+    tfHasUnresolvedProperties
+      ## for types that have type properties like `size` that depend on
+      ## generic parameters
 
   TTypeFlags* = set[TTypeFlag]
 

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -169,4 +169,5 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasGenericsOpenSym2")
   defineSymbol("nimHasGenericsOpenSym3")
   defineSymbol("nimHasJsNoLambdaLifting")
+  defineSymbol("nimHasGenericSize")
   defineSymbol("nimHasDefaultFloatRoundtrip")

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -773,7 +773,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
         result.setIndexType result.indexType.skipTypes({tyStatic, tyDistinct})
 
       else: discard
-      if tfHasUnresolvedProperties in result.flags:
+      if not cl.allowMetaTypes and tfHasUnresolvedProperties in result.flags:
         computeUnresolvedProperties(cl, result, t)
     else:
       # If this type doesn't refer to a generic type we may still want to run it
@@ -788,7 +788,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
         # Invalidate the type size as we may alter its structure
         result.size = -1
         result.n = replaceObjBranches(cl, result.n)
-      if tfHasUnresolvedProperties in result.flags:
+      if not cl.allowMetaTypes and tfHasUnresolvedProperties in result.flags:
         # this can be reached for empty `object` generic bodies
         result = instCopyType(cl, result)
         result.size = -1 # needs to be recomputed

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1483,6 +1483,17 @@ proc getSize*(conf: ConfigRef; typ: PType): BiggestInt =
   computeSizeAlign(conf, typ)
   result = typ.size
 
+proc setImportedTypeSize*(conf: ConfigRef, t: PType, size: int) =
+  t.size = size
+  if tfPacked in t.flags or size <= 1:
+    t.align = 1
+  elif size <= 2:
+    t.align = 2
+  elif size <= 4:
+    t.align = 4
+  else:
+    t.align = floatInt64Align(conf)
+
 proc containsGenericTypeIter(t: PType, closure: RootRef): bool =
   case t.kind
   of tyStatic:

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7720,6 +7720,8 @@ The `size pragma` allows specifying the size of the enum type.
   doAssert sizeof(EventType) == sizeof(uint32)
   ```
 
+For this purpose, the `size pragma` accepts only the values 1, 2, 4 or 8.
+
 The `size pragma` can also specify the size of an `importc` incomplete object type
 so that one can get the size of it at compile time even if it was declared without fields.
 
@@ -7731,8 +7733,6 @@ so that one can get the size of it at compile time even if it was declared witho
       # if AtomicFlag didn't have the size pragma, this code would result in a compile time error.
       echo sizeof(AtomicFlag)
   ```
-
-The `size pragma` accepts only the values 1, 2, 4 or 8.
 
 
 Align pragma

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -90,10 +90,14 @@ when (defined(cpp) and defined(nimUseCppAtomics)) or defined(nimdoc):
         ## Also guarantees that all threads observe the same total ordering
         ## with other moSequentiallyConsistent operations.
 
-  type
-    Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T).} = object
+  when defined(nimHasGenericSize):
+    type Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T).} = object
+      ## An atomic object with underlying type `T`.
+  else:
+    type Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
       ## An atomic object with underlying type `T`.
 
+  type
     AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object
       ## An atomic boolean state.
 

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -96,6 +96,7 @@ when (defined(cpp) and defined(nimUseCppAtomics)) or defined(nimdoc):
   else:
     type Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
       ## An atomic object with underlying type `T`.
+      raw: T
 
   type
     AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -91,9 +91,8 @@ when (defined(cpp) and defined(nimUseCppAtomics)) or defined(nimdoc):
         ## with other moSequentiallyConsistent operations.
 
   type
-    Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
+    Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T).} = object
       ## An atomic object with underlying type `T`.
-      raw: T
 
     AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object
       ## An atomic boolean state.

--- a/tests/ccgbugs/tatomictypeinfo.nim
+++ b/tests/ccgbugs/tatomictypeinfo.nim
@@ -1,0 +1,14 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+  targets: "c cpp"
+"""
+
+# issue #24159 
+
+import std/atomics
+
+type N = object
+  u: ptr Atomic[int]
+proc w(args: N) = discard
+var e: Thread[N]
+createThread(e, w, default(N))

--- a/tests/ccgbugs/tcgbug.nim
+++ b/tests/ccgbugs/tcgbug.nim
@@ -4,6 +4,7 @@ success
 M1 M2
 ok
 '''
+targets: "c cpp"
 matrix: "--mm:refc;--mm:orc"
 """
 


### PR DESCRIPTION
fixes #24159, refs #15928 etc, refs #7674 (fixed but not tested)

When a `size` pragma is applied to a generic type, the pragma is untouched and the type is marked as having "unresolved properties". This is regardless of whether the pragma actually uses any generic parameters, because by the time the pragma is being processed, generic parameters aren't in scope yet. For pragma processing to know that the type is generic, the forward type is temporarily given the flag `tfHasMeta` to mark that it has generic parameters.

When this type undergoes generic instantiation, the pragma is found again from the type symbol AST (not sure if this is reliable), the value is instantiated, and the new `size` is applied to the type. Other pragmas can opt in to this later, currently just `size` is checked.

This allows us to do things like `size: sizeof(T)` where T is a generic parameter, and this is now used instead of `completeStruct` and the fake `raw` field added in #15928 for the size of `Atomic[T]` on C++. This fixes the issues related to the `raw` field like #24159. The restriction of only the values 1, 2, 4 and 8 being allowed for the `size` pragma is also removed for imported types for this to be possible.

There are a couple reasons I wasn't sure about this solution and some things I'm still not sure about:

* Going through the symbol pragma AST seems dubious but it's usually what we do in cases like this (example being custom `deprecated` messages), just never in a case that actually has an effect on the type system. I didn't want to complicate the type graph even more by adding a dedicated field that's redundant with pragmas. In the future maybe we can use the `annex` field of `PSym` to store/access pragmas including custom pragmas more efficiently in general, , but then there still needs to be a way to access this in macros.
* I thought about ways to still add the generic parameters to scope early somehow so that we only delay the pragma if unresolved parameters are used, but that seems more prone to bugs and more of an effort. Niche cases like forward types as constraints need to be handled for example.
* I'm not sure if the alignment calculation is right. There doesn't seem to be an `alignas` pragma either. I thought the `align` pragma did this, which is why I initially generalized this for all "properties".
* This isn't very suitable for backporting, so there's the question of what to do about #24159 on the 2.0 branch, since #23761 which caused it was backported.