### PR TITLE
remove `prev == nil` requirement for typedesc params as type nodes

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2167,7 +2167,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       if s.kind != skError: localError(c.config, n.info, errTypeExpected)
       result = newOrPrevType(tyError, prev, c)
     elif s.kind == skParam and s.typ.kind == tyTypeDesc:
-      internalAssert c.config, s.typ.base.kind != tyNone and prev == nil
+      internalAssert c.config, s.typ.base.kind != tyNone
       result = s.typ.base
     elif prev == nil:
       result = s.typ
@@ -2191,7 +2191,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         if s.kind == skType:
           s.typ
         else:
-          internalAssert c.config, s.typ.base.kind != tyNone and prev == nil
+          internalAssert c.config, s.typ.base.kind != tyNone
           s.typ.base
       let alias = maybeAliasType(c, t, prev)
       if alias != nil:

--- a/tests/metatype/tmetatype_issues.nim
+++ b/tests/metatype/tmetatype_issues.nim
@@ -157,3 +157,12 @@ block t3338:
   var t2 = Bar[int32]()
   t2.add()
   doAssert t2.x == 5
+
+block: # issue #24203
+  proc b(G: typedesc) =
+    type U = G
+  template s(h: untyped) = h
+  s(b(typeof (0, 0)))
+  b(seq[int])
+  b((int, int))
+  b(typeof (0, 0))


### PR DESCRIPTION
fixes #24203

`semTypeNode` is called twice for RHS'es of type sections, [here](https://github.com/nim-lang/Nim/blob/b0e6d28782ce8c3d8e0b4a64e01f21d6f900648f/compiler/semstmts.nim#L1612) and [here](https://github.com/nim-lang/Nim/blob/b0e6d28782ce8c3d8e0b4a64e01f21d6f900648f/compiler/semstmts.nim#L1646). Each time `prev` is `s.typ`, but the assertion expects `prev == nil` which is false since `s.typ` is not nil the second time. To fix this, the `prev == nil` part of the assertion is removed.

The reason this only happens for types like `seq[int]`, `(int, int)` etc is because they don't have syms: `semTypeIdent` attempts to directly [replace the typedesc param itself](https://github.com/nim-lang/Nim/blob/b0e6d28782ce8c3d8e0b4a64e01f21d6f900648f/compiler/semtypes.nim#L1916) with the sym of the base type of the resolved typedesc type if it exists, which means `semTypeNode` doesn't receive the typedesc param sym to perform the assert.