### PR TITLE
don't typecheck `untyped` + allow void `typed` template param default values

### DIFF
--- a/tests/template/tdefaultparam.nim
+++ b/tests/template/tdefaultparam.nim
@@ -32,3 +32,25 @@ block: # untyped params with default value
   test2:
     s.add "d"
   doAssert s == "abcde"
+  template test3(body: untyped = willNotCompile) =
+    discard
+  test3()
+
+block: # typed params with `void` default value
+  macro foo(x: typed): untyped =
+    result = x
+  template test(body: untyped, alt: typed = (;), maxTries = 3): untyped {.foo.} =
+    body
+    alt
+  var s = "a"
+  test:
+    s.add "b"
+  do:
+    s.add "c"
+  doAssert s == "abc"
+  template test2(body: untyped, alt: typed = s.add("e"), maxTries = 3): untyped =
+    body
+    alt
+  test2:
+    s.add "d"
+  doAssert s == "abcde"

--- a/tests/template/tdefaultparam.nim
+++ b/tests/template/tdefaultparam.nim
@@ -13,3 +13,22 @@ block: # issue #23506
     a = $($x, $y)
   foo(1)
   doAssert a == "(\"1\", \"1\")"
+
+block: # untyped params with default value
+  macro foo(x: typed): untyped =
+    result = x
+  template test(body: untyped, alt: untyped = (;), maxTries = 3): untyped {.foo.} =
+    body
+    alt
+  var s = "a"
+  test:
+    s.add "b"
+  do:
+    s.add "c"
+  doAssert s == "abc"
+  template test2(body: untyped, alt: untyped = s.add("e"), maxTries = 3): untyped =
+    body
+    alt
+  test2:
+    s.add "d"
+  doAssert s == "abcde"


### PR DESCRIPTION
Previously, the compiler never differentiated between `untyped`/`typed` argument default values and other types, it considered any parameter with a type as typed and called `semExprWithType`, which both typechecked it and disallowed `void` expressions. Now, we perform no typechecking at all on `untyped` template param default values, and call `semExpr` instead for `typed` params, which allows expressions with `void` type.