### PR TITLE
fixed typos

### DIFF
--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -41,4 +41,4 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
   elif allowBundled:
     discard "this dependency was bundled with Nim, don't do anything"
   else:
-    quit "FAILURE: " & destdir & " already exists but is not a git repo"
+    quit "FAILURE: " & destDir & " already exists but is not a git repo"


### PR DESCRIPTION
When building the project from the source code, an error occurred at the time of compilation of `koch` due to this typo.

```
Error: 'destdir' should be: 'destDir' [var declared in .../tools/deps.nim(26, 7)]
```