### PR TITLE
don't construct array type for already typed `nkBracket` node

### DIFF
--- a/tests/vm/tconstarrayresem.nim
+++ b/tests/vm/tconstarrayresem.nim
@@ -1,0 +1,29 @@
+# issue #23010
+
+type
+  Result[T, E] = object
+    case oResult: bool
+    of false:
+      discard
+    of true:
+      vResult: T
+
+  Opt[T] = Result[T, void]
+
+template ok[T, E](R: type Result[T, E], x: untyped): R =
+  R(oResult: true, vResult: x)
+
+template c[T](v: T): Opt[T] = Opt[T].ok(v)
+
+type
+  FixedBytes[N: static[int]] = distinct array[N, byte]
+
+  H = object
+    d: FixedBytes[2]
+
+const b = default(H)
+template g(): untyped =
+  const t = default(H)
+  b
+
+discard c(g())


### PR DESCRIPTION
fixes #23010, split from #24195

When resemming bracket nodes, the compiler currently unconditionally makes a new node with an array type based on the node. However the VM can generate bracket nodes with `seq` types, which this erases. To fix this, if a bracket node already has a type, we still resem the bracket node, but don't construct a new type for it, instead using the type of the original node.

A version of this was rejected that didn't resem the node at all if it was typed, but I can't find it. The difference with this one is that the individual elements are still resemmed.

This should fix the break caused by #24184 so we could redo it after this PR but it might still have issues, not to mention the related pre-existing issues like #22793, #12559 etc.