### PR TITLE
experimental switch for generic compileTime, remove `typeof` behavior

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -228,6 +228,7 @@ type
     openSym, # remove nfDisabledOpenSym when this is default
     # alternative to above:
     genericsOpenSym
+    genericProcCompileTime
     vtables
 
   LegacyFeature* = enum

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -171,7 +171,6 @@ type
     inUncheckedAssignSection*: int
     importModuleLookup*: Table[int, seq[int]] # (module.ident.id, [module.id])
     skipTypes*: seq[PNode] # used to skip types between passes in type section. So far only used for inheritance, sets and generic bodies.
-    inTypeofContext*: int
   TBorrowState* = enum
     bsNone, bsReturnNotMatch, bsNoDistinct, bsGeneric, bsNotSupported, bsMatch
 

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -49,8 +49,6 @@ proc semTypeOf(c: PContext; n: PNode): PNode =
     else:
       m = mode.intVal
   result = newNodeI(nkTypeOfExpr, n.info)
-  inc c.inTypeofContext
-  defer: dec c.inTypeofContext # compiles can raise an exception
   let typExpr = semExprWithType(c, n[1], if m == 1: {efInTypeof} else: {})
   result.add typExpr
   if typExpr.typ.kind == tyFromExpr:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1870,8 +1870,6 @@ proc semStaticType(c: PContext, childNode: PNode, prev: PType): PType =
 
 proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
-  inc c.inTypeofContext
-  defer: dec c.inTypeofContext # compiles can raise an exception
   let t = semExprWithType(c, n, {efInTypeof})
   closeScope(c)
   fixupTypeOf(c, prev, t)
@@ -1888,8 +1886,6 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
       localError(c.config, n.info, "typeof: cannot evaluate 'mode' parameter at compile-time")
     else:
       m = mode.intVal
-  inc c.inTypeofContext
-  defer: dec c.inTypeofContext # compiles can raise an exception
   let t = semExprWithType(c, n[1], if m == 1: {efInTypeof} else: {})
   closeScope(c)
   fixupTypeOf(c, prev, t)

--- a/tests/vm/tgenericcompiletimeproc.nim
+++ b/tests/vm/tgenericcompiletimeproc.nim
@@ -1,3 +1,15 @@
+block:
+  # don't fold compile time procs in typeof with experimental switch disabled
+  proc fail[T](x: T): T {.compileTime.} =
+    doAssert false
+    x
+  doAssert typeof(fail(123)) is typeof(123)
+  proc p(x: int): int = x
+
+  type Foo = typeof(p(fail(123)))
+
+{.experimental: "genericProcCompileTime".}
+  
 block: # issue #10753
   proc foo(x: int): int {.compileTime.} = x
   const a = foo(123)
@@ -17,16 +29,6 @@ block: # issue #19365
   proc f[T](x: static T): T {.compileTime.} = x + x
   doAssert f(123) == 246
   doAssert f(1.0) == 2.0
-
-block:
-  # don't fold compile time procs in typeof
-  proc fail[T](x: T): T {.compileTime.} =
-    doAssert false
-    x
-  doAssert typeof(fail(123)) is typeof(123)
-  proc p(x: int): int = x
-
-  type Foo = typeof(p(fail(123)))
 
 block: # issue #24150, related regression
   proc w(T: type): T {.compileTime.} = default(ptr T)[]


### PR DESCRIPTION
fixes #24228, refs #22022

The `typeof` behavior from #22022 causes issues like #24228, but it's required for the [proc `declval` in the package `stew`](https://github.com/status-im/nim-stew/pull/190) to keep working as expected with the rest of #22022. To accomodate this, the generic compileTime proc behavior in #22022 is now opt-in with the switch `--experimental:genericProcCompileTime`, so that packages can continue to work until we have a proper design for `compileTime`.

Another option instead of using an experimental switch would be to add a pragma like `constantFold` that needs to be added to individual generic procs to enable compileTime folding for them, maybe for all procs eventually (it would break code currently if required for all procs). But this is a language addition.

Will add to changelog if accepted. Mutually exclusive with #24229.