### PR TITLE
don't consider inserted default values in overload disambiguation

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -683,7 +683,9 @@ proc updateDefaultParams(c: PContext, call: PNode) =
       let formal = calleeParams[i].sym
       let def = formal.ast
       if def == nil:
-        # inserted param but not default value
+        # this is true if and only if this is an inserted empty varargs param,
+        # in which case we don't do anything
+        # every other case should be an inserted default value
         continue
       if nfDefaultRefsParam in def.flags: call.flags.incl nfDefaultRefsParam
       # mirrored with sigmatch:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -682,6 +682,9 @@ proc updateDefaultParams(c: PContext, call: PNode) =
     if nfDefaultParam in call[i].flags:
       let formal = calleeParams[i].sym
       let def = formal.ast
+      if def == nil:
+        # inserted param but not default value
+        continue
       if nfDefaultRefsParam in def.flags: call.flags.incl nfDefaultRefsParam
       # mirrored with sigmatch:
       if def.kind == nkEmpty:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2942,8 +2942,11 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
           # container node kind accordingly
           let cnKind = if formal.typ.isVarargsUntyped: nkArgList else: nkBracket
           var container = newNodeIT(cnKind, n.info, arrayConstr(c, n.info))
-          setSon(m.call, formal.position + 1,
-                 implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
+          var arg = implicitConv(nkHiddenStdConv, formal.typ, container, m, c)
+          # inserted, so treat as inserted param, i.e.
+          # `varargs[T]` has default value `[]`:
+          arg.flags.incl nfDefaultParam
+          setSon(m.call, formal.position + 1, arg)
         else:
           # no default value
           m.state = csNoMatch

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -359,12 +359,21 @@ proc sumGeneric(t: PType): int =
     else:
       break
 
-proc complexDisambiguation(a, b: PType): int =
+proc sumGenericConsiderDefault(t: PType, n: PNode, i: int): int =
+  if i < n.len and nfDefaultParam in n[i].flags:
+    # inserted param, consider nonexistant in disambiguation
+    result = 0
+  else:
+    result = sumGeneric(t)
+
+proc complexDisambiguation(a, b: PType, aNode, bNode: PNode): int =
   # 'a' matches better if *every* argument matches better or equal than 'b'.
   var winner = 0
+  var i = 1
   for ai, bi in underspecifiedPairs(a, b, 1):
-    let x = ai.sumGeneric
-    let y = bi.sumGeneric
+    let x = sumGenericConsiderDefault(ai, aNode, i)
+    let y = sumGenericConsiderDefault(bi, bNode, i)
+    inc i
     if x != y:
       if winner == 0:
         if x > y: winner = 1
@@ -419,7 +428,7 @@ proc cmpCandidates*(a, b: TCandidate, isFormal=true): int =
     result = checkGeneric(a, b)
     if result != 0: return
     # prefer more specialized generic over more general generic:
-    result = complexDisambiguation(a.callee, b.callee)
+    result = complexDisambiguation(a.callee, b.callee, a.call, b.call)
   if result != 0: return
   # only as a last resort, consider scoping:
   result = a.calleeScope - b.calleeScope

--- a/tests/overload/tdisambdefault.nim
+++ b/tests/overload/tdisambdefault.nim
@@ -1,0 +1,7 @@
+block:
+  # don't consider inserted default values in overload disambiguation
+  # https://github.com/status-im/nimbus-eth1/pull/2684#issuecomment-2392895327
+  type Foo = ref object
+  template foo(a: static[string], b: varargs[untyped]) = discard
+  template foo(a: string, b: Foo = nil) = discard
+  foo("abc")

--- a/tests/overload/tdisambdefault.nim
+++ b/tests/overload/tdisambdefault.nim
@@ -2,6 +2,13 @@ block:
   # don't consider inserted default values in overload disambiguation
   # https://github.com/status-im/nimbus-eth1/pull/2684#issuecomment-2392895327
   type Foo = ref object
-  template foo(a: static[string], b: varargs[untyped]) = discard
-  template foo(a: string, b: Foo = nil) = discard
-  foo("abc")
+  template foo(a: static[string], b: varargs[untyped]): string = "right"
+  template foo(a: string, b: Foo = nil): string = "wrong"
+  doAssert foo("abc") == "right"
+
+block:
+  # also consider unfilled varargs
+  type Foo = ref object
+  template foo(a: static[string], b: Foo = nil): string = "right"
+  template foo(a: string, b: varargs[untyped]): string = "wrong"
+  doAssert foo("abc") == "right"


### PR DESCRIPTION
refs https://github.com/status-im/nimbus-eth1/pull/2684#issuecomment-2392895327

In overload disambiguation, the entire proc types of the overloads are compared to each other, including the types of parameters that aren't in the original call. To fix this, we make the "specificity" value of inserted params like default values or empty `varargs` equal to 0, which acts as if they weren't there at all.

To check for inserted params the `nfDefaultParam` node flag is used, and now empty `varargs` generated at the end of the match is also marked as `nfDefaultParam`. We could rename this to `nfInsertedParam`, but `updateDefaultParams` had to be changed to a way that happens to work with varargs (checking if the param has a default value, only works because varargs can't have default values), so it's not necessarily that general.

An alternative is to track the insertedness of arguments as an array inside `TCandidate`, as an enum with values like `NotInserted, InsertedDefaultParam, InsertedVarargs`, in which case we don't need `nfDefaultParam` at all. Let me know if this should be done instead.