### PR TITLE
give type macro pragmas unary type section with experimental switch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,9 @@
   let obj = Obj(x: 1, y: 2)
   ```
 
+  To keep compatibility, macros can be updated to accept either one of
+  `nnkTypeDef` or `nnkTypeSection` as input.
+
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,28 @@
 
 ## Language changes
 
+- With the experimental option `--experimental:typedTypeMacroPragma`,
+  macro pragmas in type definitions now receive a unary `nnkTypeSection` as
+  the argument instead of `nnkTypeDef`, which means `typed` arguments are now
+  possible for these macros.
+
+  ```nim
+  {.experimental: "typedTypeMacroPragma".}
+
+  import macros
+
+  macro foo(def: typed) =
+    assert def.kind == nnkTypeSection # previously nnkTypeDef
+    assert def.len == 1
+    assert def[0].kind == nnkTypeDef
+    result = def
+    
+  type Obj {.foo.} = object
+    x, y: int
+
+  let obj = Obj(x: 1, y: 2)
+  ```
+
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -32,7 +32,8 @@
   ```
 
   To keep compatibility, macros can be updated to accept either one of
-  `nnkTypeDef` or `nnkTypeSection` as input.
+  `nnkTypeDef` or `nnkTypeSection` as input. Note that these macros can
+  still only return `nnkTypeDef` or `nnkTypeSection` nodes. 
 
 
 ## Compiler changes

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -229,6 +229,7 @@ type
     # alternative to above:
     genericsOpenSym
     vtables
+    typedTypeMacroPragma
 
   LegacyFeature* = enum
     allowSemcheckedAstModification,

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1447,7 +1447,10 @@ proc typeDefLeftSidePass(c: PContext, typeSection: PNode, i: int) =
     s.typ = newTypeS(tyForward, c)
     s.typ.sym = s             # process pragmas:
     if name.kind == nkPragmaExpr:
-      let rewritten = applyTypeSectionPragmas(c, name[1], typeDef)
+      var macroArg = typeDef
+      if typedTypeMacroPragma in c.features:
+        macroArg = newTreeI(nkTypeSection, typeDef.info, typeDef)
+      let rewritten = applyTypeSectionPragmas(c, name[1], macroArg)
       if rewritten != nil:
         case rewritten.kind
         of nkTypeDef:
@@ -1712,8 +1715,8 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
         obj.flags.incl sfPure
       obj.typ = objTy
       objTy.sym = obj
-  for sk in c.skipTypes:
-    discard semTypeNode(c, sk, nil)
+  for i in 0..<c.skipTypes.len:
+    discard semTypeNode(c, c.skipTypes[i], nil)
   c.skipTypes = @[]
 
 proc checkForMetaFields(c: PContext; n: PNode; hasError: var bool) =

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -362,3 +362,7 @@ tcc.options.always = "-w"
   clang.options.linker %= "${clang.options.linker} -s"
   clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
 @end
+
+@if nimHasTypedTypeMacroPragma:
+  experimental:typedTypeMacroPragma
+@end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -362,7 +362,3 @@ tcc.options.always = "-w"
   clang.options.linker %= "${clang.options.linker} -s"
   clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
 @end
-
-@if nimHasTypedTypeMacroPragma:
-  experimental:typedTypeMacroPragma
-@end

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -501,10 +501,13 @@ side of the definition. The macro can return either a type section or
 another `nnkTypeDef` node, both of which will replace the original row
 in the type section.
 
-In the future, this `nnkTypeDef` argument may be replaced with a unary
-type section node containing the type definition, or some other node that may
-be more convenient to work with. The ability to return nodes other than type
-definitions may also be supported, however currently this is not convenient
+With the experimental option `--experimental:typedTypeMacroPragma`,
+this `nnkTypeDef` argument is replaced with a unary type section node
+containing the type definition, which allows macros to receive the node
+as a `typed` argument.
+
+In the future, the ability to return nodes other than type definitions may
+also be supported, however currently this is not convenient
 when dealing with mutual type recursion. For now, macros can return an unused
 type definition where the right-hand node is of kind `nnkStmtListType`.
 Declarations in this node will be attached to the same scope as

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -332,6 +332,33 @@ TypeDef
 
   static: doAssert Baz.x is string
 
+  {.push experimental: "typedTypeMacroPragma".}
+
+  const typeAst2 = """
+TypeSection
+  TypeDef
+    PragmaExpr
+      Ident "Baz2"
+      Pragma
+    Empty
+    ObjectTy
+      Empty
+      Empty
+      RecList
+        IdentDefs
+          Ident "x"
+          Ident "string"
+          Empty
+"""
+
+  type
+    Baz2 {.expectedAst(typeAst2).} = object
+      x: string
+
+  static: doAssert Baz2.x is string
+
+  {.pop.}
+
   const procAst = """
 ProcDef
   Ident "bar"

--- a/tests/pragmas/ttypedef_macro_typed.nim
+++ b/tests/pragmas/ttypedef_macro_typed.nim
@@ -1,0 +1,49 @@
+discard """
+  nimout: '''
+TypeSection
+  TypeDef
+    PragmaExpr
+      Sym "X"
+      Pragma
+    Empty
+    ObjectTy
+      Empty
+      Empty
+      Empty
+'''
+"""
+
+import macros
+
+{.experimental: "typedTypeMacroPragma".}
+
+block: # changelog entry
+  macro foo(def: typed) =
+    assert def.kind == nnkTypeSection # previously nnkTypeDef
+    assert def.len == 1
+    assert def[0].kind == nnkTypeDef
+    result = def
+    
+  type Obj {.foo.} = object
+    x, y: int
+
+  let obj = Obj(x: 1, y: 2)
+
+block: # issue #18864
+  macro test(n: typed): untyped =
+    echo n.treeRepr
+    result = n
+
+  type
+    X {.test.} = object
+  var x = X()
+
+block: # issue #15334
+  macro entity(entityType: typed) =
+    result = entityType
+    
+  type
+    RootEntity = ref object of RootObj
+    Player {.entity.} = ref object of RootEntity
+      x, y: int
+  var foo = Player()

--- a/tests/pragmas/ttypedef_macro_typed.nim
+++ b/tests/pragmas/ttypedef_macro_typed.nim
@@ -19,9 +19,9 @@ import macros
 
 block: # changelog entry
   macro foo(def: typed) =
-    assert def.kind == nnkTypeSection # previously nnkTypeDef
-    assert def.len == 1
-    assert def[0].kind == nnkTypeDef
+    doAssert def.kind == nnkTypeSection # previously nnkTypeDef
+    doAssert def.len == 1
+    doAssert def[0].kind == nnkTypeDef
     result = def
     
   type Obj {.foo.} = object


### PR DESCRIPTION
closes #13830, fixes #15334, fixes #18864

With the experimental switch `--experimental:typedTypeMacroPragma` (shortest name I could think of), macro pragmas in type definitions now receive a unary `nnkTypeSection` node as input rather than `nnkTypeDef`. This means these macros can receive `typed` arguments, since a standalone `nnkTypeDef` as a statement is rejected by the compiler.

This is experimental because macros may not expect `nnkTypeSection` as input, only expecting `nnkTypeDef` and operating on it. However it is possible to be compatible with either input, see what I do in [skinsuit](https://github.com/metagn/skinsuit/blob/b4742c2d7f353352b911310f29b8a5a7db87c383/src/skinsuit/private/utils.nim#L54-L81). Unfortunately it's not as easy to tell if a macro is called as a pragma in a type section now, but this problem also exists with proc/var macro pragmas and a workaround exists which is to check if the macro did not originally receive `nnkStmtList`. Worst case we can come up with a more general solution.

We don't have to merge this immediately, I just figured it was overdue for such an old issue and made a PR as soon as I could.