### PR TITLE
bind generic param/`or` to constraint for conversion match

### DIFF
--- a/compiler/layeredtable.nim
+++ b/compiler/layeredtable.nim
@@ -80,3 +80,23 @@ proc put(typeMap: var LayeredIdTable, key: ItemId, value: PType) {.inline.} =
 template put*(typeMap: var LayeredIdTable, key, value: PType) =
   ## binds `key` to `value` only in current layer
   put(typeMap, key.itemId, value)
+
+proc putRecursive(typeMap: ref LayeredIdTableObj, key: ItemId, value: PType) =
+  var tm = typeMap
+  while tm != nil:
+    tm.topLayer[key] = value
+    tm = tm.nextLayer
+
+template putRecursive*(typeMap: ref LayeredIdTableObj, key, value: PType) =
+  ## binds `key` to `value` in all previous layers
+  putRecursive(typeMap, key.itemId, value)
+
+when not useRef:
+  proc putRecursive(typeMap: var LayeredIdTableObj, key: ItemId, value: PType) {.inline.} =
+    put(typeMap, key, value)
+    if typeMap.nextLayer != nil:
+      putRecursive(typeMap.nextLayer, key, value)
+
+  template putRecursive*(typeMap: var LayeredIdTableObj, key, value: PType) =
+    ## binds `key` to `value` in all previous layers
+    putRecursive(typeMap, key.itemId, value)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1280,11 +1280,16 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
   if a.isResolvedUserTypeClass:
     return typeRel(c, f, a.skipModifier, flags)
 
-  template bindingRet(res) =
+  template bindingRet(res, bound) =
     if doBind:
-      let bound = aOrig.skipTypes({tyRange}).skipIntLit(c.c.idgen)
       put(c, f, bound)
     return res
+
+  template defaultBinding(): PType =
+    aOrig#[.skipTypes({tyRange})]#.skipIntLit(c.c.idgen)
+
+  template bindingRet(res) =
+    bindingRet(res, defaultBinding())
 
   template considerPreviousT(body: untyped) =
     var prev = lookup(c.bindings, f)
@@ -1831,18 +1836,42 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       result = isNone
       let oldInheritancePenalty = c.inheritancePenalty
       var minInheritance = maxInheritancePenalty
+      var bestMatch: PType = nil
+        # the best match in the branches so far, preferring earlier branches
+        # this is to resolve ambiguity in cases like matching an int literal
+        # against `int8 | int16`, picking the earlier `int8`
+        # this keeps compatibility with legacy behavior
       for branch in f.kids:
         c.inheritancePenalty = -1
         let x = typeRel(c, branch, aOrig, flags)
         if x >= result:
           if  c.inheritancePenalty > -1:
-            minInheritance = min(minInheritance, c.inheritancePenalty)
+            if c.inheritancePenalty < minInheritance:
+              minInheritance = c.inheritancePenalty
+              if x > result:
+                # has to be strictly better so we prefer earlier matches
+                # also true for inheritance penalty in this case
+                bestMatch = branch
+          elif x > result:
+            # has to be strictly better so we prefer earlier matches
+            bestMatch = branch
           result = x
       if result >= isIntConv:
         if minInheritance < maxInheritancePenalty:
           c.inheritancePenalty = oldInheritancePenalty + minInheritance
+        var bound: PType = nil
+        if (result in {isConvertible, isIntConv, isSubrange, isFromIntLit} or
+            (result == isSubtype and a.isEmptyContainer)) and bestMatch != nil:
+          # match needs a conversion, bind to the constraint so the
+          # conversion can be generated
+          # supertypes act like typeclasses, only consider as concrete for
+          # empty collections
+          bound = bestMatch
+        else:
+          # default, bind to matched type
+          bound = defaultBinding()
         if result > isGeneric: result = isGeneric
-        bindingRet result
+        bindingRet result, bound
       else:
         result = isNone
   of tyNot:
@@ -1924,6 +1953,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     let doBindGP = doBind or trBindGenericParam in flags
     var x = lookup(c.bindings, f)
     if x == nil:
+      var bound: PType = nil
       if c.callee.kind == tyGenericBody and not c.typedescMatched:
         # XXX: The fact that generic types currently use tyGenericParam for
         # their parameters is really a misnomer. tyGenericParam means "match
@@ -1957,11 +1987,35 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       else:
         # check if 'T' has a constraint as in 'proc p[T: Constraint](x: T)'
         if f.len > 0 and f[0].kind != tyNone:
-          result = typeRel(c, f[0], a, flags + {trDontBind, trBindGenericParam})
+          # constraints need a new type binding context layer,
+          # so that matches to typeclasses in the constraint don't
+          # bind to that typeclass for the entire candidate
+          c.bindings = newTypeMapLayer(c.bindings)
+          # generic params in the constraint are an exception,
+          # so that we can infer things like `T: U`
+          result = typeRel(c, f[0], a, flags + {trBindGenericParam})
+          if f[0].skipTypes({tyAlias}).kind == tyOr:
+            # `or` types have special binding rules, they bind to
+            # one of their branches if the match needs a conversion
+            # we reuse this binding for the generic parameter
+            bound = lookup(c.bindings, f[0])
+            if bound == nil: bound = a
+          elif result in {isConvertible, isIntConv, isSubrange, isFromIntLit} or
+              (result == isSubtype and a.isEmptyContainer):
+            # match needs a conversion, bind to the constraint so the
+            # conversion can be generated
+            # supertypes act like typeclasses, only consider as concrete for
+            # empty collections
+            bound = f[0]
+          else:
+            # default, bind to matched type
+            bound = a
+          setToPreviousLayer(c.bindings)
           if doBindGP and result notin {isNone, isGeneric}:
-            let concrete = concreteType(c, a, f)
+            let concrete = concreteType(c, bound, f)
             if concrete == nil: return isNone
-            put(c, f, concrete)
+            # generic params have to be bound up to the root binding context
+            putRecursive(c.bindings, f, concrete)
           if result in {isEqual, isSubtype}:
             result = isGeneric
         elif a.kind == tyTypeDesc:
@@ -1973,7 +2027,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           result = isGeneric
 
       if result == isGeneric:
-        var concrete = a
+        if bound == nil: bound = a
         if tfWildcard in a.flags:
           a.sym.transitionGenericParamToType()
           a.flags.excl tfWildcard
@@ -1983,11 +2037,12 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           # reason about and maintain. Refactoring typeRel to not be responsible for setting, or
           # at least validating, bindings can have multiple benefits. This is debatable. I'm not 100% sure.
           # A design that allows a proper complexity analysis of types like `tyOr` would be ideal.
-          concrete = concreteType(c, a, f)
-          if concrete == nil:
+          bound = concreteType(c, bound, f)
+          if bound == nil:
             return isNone
         if doBindGP:
-          put(c, f, concrete)
+          # generic params have to be bound up to the root binding context
+          putRecursive(c.bindings, f, bound)
       elif result > isGeneric:
         result = isGeneric
     elif a.kind == tyEmpty:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -978,7 +978,7 @@ proc setLastModificationTime*(file: string, t: times.Time) {.noWeirdTarget.} =
   ## an error.
   when defined(posix):
     let unixt = posix.Time(t.toUnix)
-    let micro = convert(Nanoseconds, Microseconds, t.nanosecond)
+    let micro = convert(Nanoseconds, Microseconds, t.nanosecond).int32
     var timevals = [Timeval(tv_sec: unixt, tv_usec: micro),
       Timeval(tv_sec: unixt, tv_usec: micro)] # [last access, last modification]
     if utimes(file, timevals.addr) != 0: raiseOSError(osLastError(), file)

--- a/tests/overload/torconv.nim
+++ b/tests/overload/torconv.nim
@@ -1,0 +1,64 @@
+block:
+  proc foo(x: int16 | int32): string = $typeof(x)
+  proc bar[T: int16 | int32](x: T): string = $typeof(x)
+
+  doAssert foo(123) == "int16"
+  doAssert bar(123) == "int16"
+
+block: # issue #4858
+  type
+    SomeType = object
+      field1: uint
+
+  proc namedProc(an: var SomeType, b: SomeUnsignedInt) = discard
+
+  proc `+=`(an: var SomeType, b: SomeUnsignedInt) =
+    namedProc(an, b) # <---- error here
+
+  var t = SomeType()
+  namedProc(t, 0)
+  t += 0
+
+block: # issue #10027
+  type Uint24 = range[0'u32 .. 0xFFFFFF'u32]
+
+  proc a(v: SomeInteger|Uint24): string = $type(v)
+
+  doAssert a(42) == "int"
+  doAssert a(42.Uint24) == $Uint24
+
+block: # issue #12552
+  let x = 1'i8
+  proc foo(n : int): string = $typeof(n)
+  proc bar[T : int](n : T): string = $ typeof(n)
+  doAssert foo(x) == "int"
+  doAssert bar(x) == "int"
+
+block: # issue #15721
+  proc fn(a = 4, b: seq[string] or tuple[] = ()) =
+    discard # eg: when b is tuple[]: ...
+  fn(1)
+  fn(1, @[""])
+  var a: seq[string] = @[]
+  fn(1, a)
+  fn(1, seq[string](@[]))
+  fn(1, @[]) # BUG: error: conflicting types for 'fn__d58I39cH9a6bcpi3QDPJ5dBA'
+
+block: # issue #15721, set
+  proc fn(a = 4, b: set[uint8] or tuple[] = ()) =
+    discard # eg: when b is tuple[]: ...
+  fn(1)
+  fn(1, {1'u8})
+  var a: set[uint8] = {}
+  fn(1, a)
+  fn(1, set[uint8]({}))
+  fn(1, {}) # BUG: internal error: invalid kind for lastOrd(tyEmpty)
+
+block: # issue #21331
+  let a : int8 | uint8 = 3
+  doAssert sizeof(a)==sizeof(int8) # this fails
+
+block:
+  let x: range[0..5] = 1
+  proc foo[T: SomeInteger](x: T): string = $typeof(x)
+  discard foo(x)


### PR DESCRIPTION
fixes #4858, fixes #10027, fixes #12552, fixes #15721, fixes #21331, fixes but does not test #18121 (maybe it should fail the match in this case?), refs #1214, follows up #24216, split from #24198

When an `or` type or a generic param constraint match a type with a convertible match, bind it to the branch that was deemed convertible rather than the matched type, so that a conversion can be generated. There were some required changes to make this work.

`or` types now choose a "best matching" branch to use for the conversion. This branch is the earliest branch in the type list with the highest level type match. The "earliest" choice resolves the ambiguity in cases like matching an integer literal against `int16 | uint16`. The compiler used to compile on these cases before (by just matching them as `int`), so to keep code working this ambiguity has to be resolved.

When matching types to the constraint type of generic parameters, the compiler previously disabled all bindings to typeclasses (including `or` types). This is so the bindings for the typeclasses in the constraint don't leak into the entire candidate, i.e. the binding for `T: SomeInteger` should not be used for all `SomeInteger`s afterward. However this means we can't reuse the binding from an `or` typeclass when it's a convertible match, because we will lose both the information of it being a conversion match (since it becomes a generic match instead) and which branch of the `or` type matched (i.e. the type to convert to).

To deal with this, we push a new type binding layer (see the refactor in #24216) for generic parameter constraints which contains all bindings to itself (except generic parameter bindings which are propagated up to the root). Then, if the constraint is an `or` type, we bind the generic param to the type that the `or` type was bound to in the type binding layer. We may not need to restrict to `or` types here and just use the binding for any type that has a binding, but this is risky and I can't think of a reason any other typeclass would give something other than the matched type.

There was also code that skipped `range` types for all bound generic types as mentioned in #10027, but this code broke the test for #10027, so it is removed, i.e. `range` types can be bound to typeclasses now. Fixing the other issues may have removed the need for this skip, I don't know why it was there.

`or` types also do not consider any type match below `isIntConv`, for example `isConvertible`, to match, which is the cause of #4902, #15722 and #18697 (not sure about `iterable` though). If this was just a limitation caused by the issues fixed in this PR ([seems to be](https://github.com/nim-lang/Nim/commit/39e4e3f20570e804e3059574eafe8f78b2d8a9df)) then maybe we can loosen it to fix these issues, i.e. make `isConvertible` match for `or` types. But in another PR.