### PR TITLE
process non-language pragma nodes in generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -628,10 +628,12 @@ proc semGenericStmt(c: PContext, n: PNode,
         # if pragma is language-level pragma, skip name node:
         let start = ord(prag != wInvalid)
         for j in start ..< x.len:
-          x[j] = semGenericStmt(c, x[j], flags, ctx)
+          # treat as mixin context for user pragmas & macro args
+          x[j] = semGenericStmt(c, x[j], flags+{withinMixin}, ctx)
       elif prag == wInvalid:
         # only sem if not a language-level pragma 
-        result[i] = semGenericStmt(c, x, flags, ctx)
+        # treat as mixin context for user pragmas & macro args
+        result[i] = semGenericStmt(c, x, flags+{withinMixin}, ctx)
   of nkExprColonExpr, nkExprEqExpr:
     checkMinSonsLen(n, 2, c.config)
     result[1] = semGenericStmt(c, n[1], flags, ctx)

--- a/tests/generics/mpragma1.nim
+++ b/tests/generics/mpragma1.nim
@@ -1,0 +1,3 @@
+macro aMacro*(u:untyped):untyped =
+  echo "in macro"
+  result = u

--- a/tests/generics/mpragma2.nim
+++ b/tests/generics/mpragma2.nim
@@ -1,0 +1,6 @@
+import mpragma1
+proc p*[T]() =
+  proc inner() {.aMacro.} =
+    discard
+  inner()
+  discard

--- a/tests/generics/tpragma.nim
+++ b/tests/generics/tpragma.nim
@@ -1,0 +1,10 @@
+discard """
+  nimout: '''
+in macro
+'''
+"""
+
+# issue #18649
+
+import mpragma2
+p[string]()


### PR DESCRIPTION
fixes #18649, refs #24183

Same as in #24183 for templates, we now process pragma nodes in generics so that macro symbols are captured and the pragma arguments are checked, but ignoring language pragma keywords.

A difference is that we cannot process call nodes as is, we have to process their children individually so that the early untyped macro/template instantiation in generics does not kick in.