### PR TITLE
use cbuilder for most braced initializers

### DIFF
--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -15,5 +15,11 @@ const
 proc procPtrType(conv: TCallingConvention, rettype: Snippet, name: string): Snippet =
   CallingConvToStr[conv] & "_PTR(" & rettype & ", " & name & ")"
 
+proc cCast(typ, value: Snippet): Snippet =
+  "((" & typ & ") " & value & ")"
+
+proc cAddr(value: Snippet): Snippet =
+  "&" & value
+
 proc bitOr(a, b: Snippet): Snippet =
   a & " | " & b

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3343,7 +3343,7 @@ proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
       else:
         result.add genTypeInfoV1(p.module, orig, obj.info)
   getNullValueAux(p, t, obj, constOrNil, result, init, isConst, info)
-  when false: # not sure why this was here, every call to this emits {}
+  when false: # referring to Sup field, hopefully not a problem
     # do not emit '{}' as that is not valid C:
     if oldcount == count: result = oldRes
 

--- a/compiler/ccgliterals.nim
+++ b/compiler/ccgliterals.nim
@@ -65,7 +65,7 @@ proc genStringLiteralDataOnlyV2(m: BModule, s: string; result: Rope; isConst: bo
       res.addArrayField(name = "data", elementType = "NIM_CHAR", len = s.len + 1)
   do:
     var structInit: StructInitializer
-    res.addStructInitializer(structInit, orderCompliant = true):
+    res.addStructInitializer(structInit, kind = siOrderedStruct):
       res.addField(structInit, name = "cap"):
         res.add(bitOr(rope(s.len), "NIM_STRLIT_FLAG"))
       res.addField(structInit, name = "data"):

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -279,7 +279,7 @@ proc genGotoVar(p: BProc; value: PNode) =
   else:
     lineF(p, cpsStmts, "goto NIMSTATE_$#;$n", [value.intVal.rope])
 
-proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType; result: var Rope)
+proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType; result: var Builder)
 
 proc potentialValueInit(p: BProc; v: PSym; value: PNode; result: var Rope) =
   if lfDynamicLib in v.loc.flags or sfThread in v.flags or p.hcrOn:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -716,6 +716,7 @@ proc genRecordFieldsAux(m: BModule; n: PNode,
       else: internalError(m.config, "genRecordFieldsAux(record case branch)")
     if unionBody.len != 0:
       result.addAnonUnion:
+        # XXX this has to be a named field for NIFC
         result.add(unionBody)
   of nkSym:
     let field = n.sym


### PR DESCRIPTION
`StructInitializer` is now used for most braced initializers in the C generation, mostly in `genBracedInit`, `getNullValueAux`, `getDefaultValue`. The exceptions are:

* the default case branch initializer for objects uses C99 designated initializers with field names, which are not implemented for `StructInitializer` yet (`siNamedStruct`)
* the uses in `ccgliterals` are untouched so all of ccgliterals can be done separately and in 1 go

There is one case where `genBracedInit` does not use cbuilder, which is the global literal variable for openarrays. The reason for this is simply that variables with C array type are not implemented, which I thought would be best to leave out of this PR.

For the simplicity of the implementation, code in `getNullValueAuxT` that reset the initializer back to its initial state if the `Sup` field did not have any fields itself, is now disabled. This was so the compiler does not generate `{}` for the Sup field, i.e. `{{}}`, but every call to `getNullValueAuxT` still generates `{}` if the struct doesn't have any fields, so I don't know if it really breaks anything. The case where the Sup field doesn't have any fields but the struct does also would have generated `{{}, field}`.

Worst case, we can implement either the "resetting" or just disable the generation of the `Sup` field if there are no fields total. But a better fix might be to always generate `{0}` if the struct has no fields, in line with the `char dummy` field that gets added for all objects with no fields. This doesn't seem necessary for now but might be for the NIFC output, in which case we can probably keep the logic contained inside cbuilder (if no fields generated for `siOrderedStruct`/`siNamedStruct`, we add a `0` for the `dummy` field). This would stipulate that all uses of struct initializers are exhaustive for every field in structs.