### PR TITLE
bundle nif

### DIFF
--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -2,6 +2,10 @@
 
 hint[XDeclaredButNotUsed]:off
 
+# config needed for nif to import the compiler:
+define:nifCompilerInPath
+path:".."
+
 define:booting
 define:nimcore
 define:nimPreviewSlimSystem

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -2,9 +2,10 @@
 
 hint[XDeclaredButNotUsed]:off
 
-# config needed for nif to import the compiler:
-define:nifCompilerInPath
+# allow dependencies to import the compiler via `import compiler / ...`:
 path:".."
+# nif uses `--path:$nim` by default, make it use the current compiler instead:
+define:nifCompilerInPath
 
 define:booting
 define:nimcore

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -28,6 +28,8 @@ import
   commands, options, msgs, extccomp, main, idents, lineinfos, cmdlinehelper,
   pathutils, modulegraphs
 
+import ../dist/nif/src/[nifler/nifler, xelim/xelim, nifgram/nifgram, gear2/gear2]
+
 from std/browsers import openDefaultBrowser
 from nodejs import findNodeJs
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -28,7 +28,9 @@ import
   commands, options, msgs, extccomp, main, idents, lineinfos, cmdlinehelper,
   pathutils, modulegraphs
 
-import ../dist/nif/src/[nifler/nifler, xelim/xelim, nifgram/nifgram, gear2/gear2]
+when defined(testNifImports):
+  # temporary until nif is actually used in the compiler
+  import ../dist/nif/src/[nifler/nifler, xelim/xelim, nifgram/nifgram, gear2/gear2]
 
 from std/browsers import openDefaultBrowser
 from nodejs import findNodeJs

--- a/koch.nim
+++ b/koch.nim
@@ -15,6 +15,7 @@ const
   AtlasStableCommit = "5faec3e9a33afe99a7d22377dd1b45a5391f5504"
   ChecksumsStableCommit = "bd9bf4eaea124bf8d01e08f92ac1b14c6879d8d3"
   SatStableCommit = "faf1617f44d7632ee9601ebc13887644925dcc01"
+  NifStableCommit = "HEAD"
 
   # examples of possible values for fusion: #head, #ea82b54, 1.2.3
   FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
@@ -78,6 +79,7 @@ Possible Commands:
   nimble                   builds the Nimble tool
   atlas                    builds the Atlas tool
   checksums                installs the checksums dependency
+  nif                      installs the nif dependency
   fusion                   installs fusion via Nimble
 
 Boot options:
@@ -210,7 +212,15 @@ proc bundleChecksums(latest: bool) =
   let commit = if latest: "HEAD" else: ChecksumsStableCommit
   cloneDependency(distDir, "https://github.com/nim-lang/checksums.git", commit, allowBundled = true)
 
+proc bundleNif(latest: bool) =
+  when false:
+    let commit = if latest: "HEAD" else: NifStableCommit
+    cloneDependency(distDir, "https://github.com/nim-lang/nif.git", commit, allowBundled = true)
+  else:
+    cloneDependency(distDir, "https://github.com/metagn/nif.git", "slimsystem", allowBundled = true)
+
 proc zip(latest: bool; args: string) =
+  bundleNif(latest)
   bundleChecksums(latest)
   bundleNimbleExe(latest, args)
   bundleAtlasExe(latest, args)
@@ -265,6 +275,7 @@ proc testTools(args: string = "") =
   nimCompileFold("Compile testament", "testament/testament.nim", options = "-d:release " & args)
 
 proc nsis(latest: bool; args: string) =
+  bundleNif(latest)
   bundleChecksums(latest)
   bundleNimbleExe(latest, args)
   bundleAtlasExe(latest, args)
@@ -345,6 +356,7 @@ proc boot(args: string, skipIntegrityCheck: bool) =
   let smartNimcache = (if "release" in args or "danger" in args: "nimcache/r_" else: "nimcache/d_") &
                       hostOS & "_" & hostCPU
 
+  bundleNif(false)
   bundleChecksums(false)
 
   let usingLibFFI = "nimHasLibFFI" in args
@@ -508,6 +520,7 @@ proc temp(args: string) =
       result[1].add " " & quoteShell(args[i])
       inc i
 
+  bundleNif(false)
   bundleChecksums(false)
 
   let d = getAppDir()
@@ -764,6 +777,8 @@ when isMainModule:
         bundleAtlasExe(latest, op.cmdLineRest)
       of "checksums":
         bundleChecksums(latest)
+      of "nif":
+        bundleNif(latest)
       of "pushcsource":
         quit "use this instead: https://github.com/nim-lang/csources_v1/blob/master/push_c_code.nim"
       of "valgrind": valgrind(op.cmdLineRest)

--- a/koch.nim
+++ b/koch.nim
@@ -15,7 +15,7 @@ const
   AtlasStableCommit = "5faec3e9a33afe99a7d22377dd1b45a5391f5504"
   ChecksumsStableCommit = "bd9bf4eaea124bf8d01e08f92ac1b14c6879d8d3"
   SatStableCommit = "faf1617f44d7632ee9601ebc13887644925dcc01"
-  NifStableCommit = "HEAD"
+  NifStableCommit = "5a1570de3d9c0f246ba903c6780e5c0ecb6ddbfc"
 
   # examples of possible values for fusion: #head, #ea82b54, 1.2.3
   FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
@@ -213,11 +213,8 @@ proc bundleChecksums(latest: bool) =
   cloneDependency(distDir, "https://github.com/nim-lang/checksums.git", commit, allowBundled = true)
 
 proc bundleNif(latest: bool) =
-  when false:
-    let commit = if latest: "HEAD" else: NifStableCommit
-    cloneDependency(distDir, "https://github.com/nim-lang/nif.git", commit, allowBundled = true)
-  else:
-    cloneDependency(distDir, "https://github.com/metagn/nif.git", "slimsystem", allowBundled = true)
+  let commit = if latest: "HEAD" else: NifStableCommit
+  cloneDependency(distDir, "https://github.com/nim-lang/nif.git", commit, allowBundled = true)
 
 proc zip(latest: bool; args: string) =
   bundleNif(latest)

--- a/koch.nim
+++ b/koch.nim
@@ -596,7 +596,8 @@ proc runCI(cmd: string) =
   # boot without -d:nimHasLibFFI to make sure this still works
   # `--lib:lib` is needed for bootstrap on openbsd, for reasons described in
   # https://github.com/nim-lang/Nim/pull/14291 (`getAppFilename` bugsfor older nim on openbsd).
-  kochExecFold("Boot Nim ORC", "boot -d:release -d:nimStrictMode --lib:lib")
+  kochExecFold("Boot Nim ORC", "boot -d:release -d:nimStrictMode --lib:lib -d:testNifImports")
+    # remove -d:testNifImports when nif is actually used
 
   when false: # debugging: when you need to run only 1 test in CI, use something like this:
     execFold("debugging test", "nim r tests/stdlib/tosproc.nim")

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -164,6 +164,9 @@ when defined(nimHasEnsureMove):
         doAssert y == "Hello"
       foo()
     discard "implemented in injectdestructors"
+else:
+  template ensureMove*[T](x: T): T =
+    x
 
 type
   range*[T]{.magic: "Range".}         ## Generic type to construct range types.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -166,6 +166,7 @@ when defined(nimHasEnsureMove):
     discard "implemented in injectdestructors"
 else:
   template ensureMove*[T](x: T): T =
+    # no-op for bootstrapping
     x
 
 type


### PR DESCRIPTION
The nif repo (https://github.com/nim-lang/nif) is now installed as a dependency for the Nim compiler. At the moment the important tools (nifler, xelim, nifgram, gear2) are imported to test that this dependency installation works, but only with the define `-d:testNifImports`, which the test suite enables for now. This is temporary until NIF is actually used in the compiler.

For nif to be able to import the compiler, the original plan was to generate a config file as described in https://github.com/nim-lang/nif/pull/96 but config files in parent folders aren't checked for imports. Instead the compiler generally defines `--path:".."` so that dependencies can import it like `import compiler / ...`. nif also defines `--path:$nim` to work with any version of the compiler, but `$nim` isn't set to the compiler path when compiling the compiler, so this is disabled via `-d:nifCompilerInPath`.

In the future we can maybe just move the mutually dependent parts of NIF to the compiler codebase (gear2 & nifler for now), it might be painful to have to update both codebases for each change.

Also, for nif to compile for the bootstrapping version of the compiler (csources_v2), `system.ensureMove` is declared as a no-op for compiler versions that don't have it.