### PR TITLE
make linter use lineinfo to check originating package

### DIFF
--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -93,6 +93,7 @@ proc nep1CheckDefImpl(conf: ConfigRef; info: TLineInfo; s: PSym; k: TSymKind) =
     lintReport(conf, info, beau, s.name.s)
 
 template styleCheckDef*(ctx: PContext; info: TLineInfo; sym: PSym; k: TSymKind) =
+  bind getModule # workaround bug with csources_v2 version of compiler
   ## Check symbol definitions adhere to NEP1 style rules.
   if optStyleCheck in ctx.config.options and # ignore if styleChecks are off
      {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # check only if hint/error is enabled
@@ -135,6 +136,7 @@ proc styleCheckUseImpl(conf: ConfigRef; info: TLineInfo; s: PSym) =
     lintReport(conf, info, newName, badName, "".dup(addDeclaredLoc(conf, s)))
 
 template styleCheckUse*(ctx: PContext; info: TLineInfo; sym: PSym) =
+  bind getModule # workaround bug with csources_v2 version of compiler
   ## Check symbol uses match their definition's style.
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
@@ -152,6 +154,7 @@ proc checkPragmaUseImpl(conf: ConfigRef; info: TLineInfo; w: TSpecialWord; pragm
 template checkPragmaUse*(ctx: PContext; info: TLineInfo; w: TSpecialWord; pragmaName: string, sym: PSym) =
   ## Check builtin pragma uses match their definition's style.
   ## Note: This only applies to builtin pragmas, not user pragmas.
+  bind getModule # workaround bug with csources_v2 version of compiler
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
      ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)): # ignore foreign packages

--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -12,7 +12,7 @@
 import std/strutils
 from std/sugar import dup
 
-import options, ast, msgs, idents, lineinfos, wordrecg, astmsgs, semdata, packages
+import options, ast, msgs, idents, lineinfos, wordrecg, astmsgs, semdata, packages, modulegraphs
 export packages
 
 const
@@ -97,7 +97,7 @@ template styleCheckDef*(ctx: PContext; info: TLineInfo; sym: PSym; k: TSymKind) 
   if optStyleCheck in ctx.config.options and # ignore if styleChecks are off
      {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # check only if hint/error is enabled
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     ctx.config.belongsToProjectPackage(sym) and # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)) and # ignore foreign packages
      optStyleUsages notin ctx.config.globalOptions and # ignore if requested to only check name usage
      sym.kind != skResult and # ignore `result`
      sym.kind != skTemp and # ignore temporary variables created by the compiler
@@ -138,7 +138,7 @@ template styleCheckUse*(ctx: PContext; info: TLineInfo; sym: PSym) =
   ## Check symbol uses match their definition's style.
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     ctx.config.belongsToProjectPackage(sym) and # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)) and # ignore foreign packages
      sym.kind != skTemp and # ignore temporary variables created by the compiler
      sym.name.s[0] in Letters and # ignore operators TODO: what about unicode symbols???
      sfAnon notin sym.flags: # ignore temporary variables created by the compiler
@@ -154,5 +154,5 @@ template checkPragmaUse*(ctx: PContext; info: TLineInfo; w: TSpecialWord; pragma
   ## Note: This only applies to builtin pragmas, not user pragmas.
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     (sym != nil and ctx.config.belongsToProjectPackage(sym)): # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)): # ignore foreign packages
     checkPragmaUseImpl(ctx.config, info, w, pragmaName)

--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -93,12 +93,11 @@ proc nep1CheckDefImpl(conf: ConfigRef; info: TLineInfo; s: PSym; k: TSymKind) =
     lintReport(conf, info, beau, s.name.s)
 
 template styleCheckDef*(ctx: PContext; info: TLineInfo; sym: PSym; k: TSymKind) =
-  bind getModule # workaround bug with csources_v2 version of compiler
   ## Check symbol definitions adhere to NEP1 style rules.
   if optStyleCheck in ctx.config.options and # ignore if styleChecks are off
      {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # check only if hint/error is enabled
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)) and # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(getModule(ctx.graph, info.fileIndex)) and # ignore foreign packages
      optStyleUsages notin ctx.config.globalOptions and # ignore if requested to only check name usage
      sym.kind != skResult and # ignore `result`
      sym.kind != skTemp and # ignore temporary variables created by the compiler
@@ -136,11 +135,10 @@ proc styleCheckUseImpl(conf: ConfigRef; info: TLineInfo; s: PSym) =
     lintReport(conf, info, newName, badName, "".dup(addDeclaredLoc(conf, s)))
 
 template styleCheckUse*(ctx: PContext; info: TLineInfo; sym: PSym) =
-  bind getModule # workaround bug with csources_v2 version of compiler
   ## Check symbol uses match their definition's style.
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)) and # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(getModule(ctx.graph, info.fileIndex)) and # ignore foreign packages
      sym.kind != skTemp and # ignore temporary variables created by the compiler
      sym.name.s[0] in Letters and # ignore operators TODO: what about unicode symbols???
      sfAnon notin sym.flags: # ignore temporary variables created by the compiler
@@ -154,8 +152,7 @@ proc checkPragmaUseImpl(conf: ConfigRef; info: TLineInfo; w: TSpecialWord; pragm
 template checkPragmaUse*(ctx: PContext; info: TLineInfo; w: TSpecialWord; pragmaName: string, sym: PSym) =
   ## Check builtin pragma uses match their definition's style.
   ## Note: This only applies to builtin pragmas, not user pragmas.
-  bind getModule # workaround bug with csources_v2 version of compiler
   if {optStyleHint, optStyleError} * ctx.config.globalOptions != {} and # ignore if styleChecks are off
      hintName in ctx.config.notes and # ignore if name checks are not requested
-     ctx.config.belongsToProjectPackageMaybeNil(ctx.graph.getModule(info.fileIndex)): # ignore foreign packages
+     ctx.config.belongsToProjectPackageMaybeNil(getModule(ctx.graph, info.fileIndex)): # ignore foreign packages
     checkPragmaUseImpl(ctx.config, info, w, pragmaName)

--- a/compiler/packages.nim
+++ b/compiler/packages.nim
@@ -51,3 +51,11 @@ func belongsToProjectPackage*(conf: ConfigRef, sym: PSym): bool =
   ## See Also:
   ## * `modulegraphs.belongsToStdlib`
   conf.mainPackageId == sym.getPackageId
+
+func belongsToProjectPackageMaybeNil*(conf: ConfigRef, sym: PSym): bool =
+  ## Return whether the symbol belongs to the project's package.
+  ## Returns `false` if `sym` is nil.
+  ##
+  ## See Also:
+  ## * `modulegraphs.belongsToStdlib`
+  sym != nil and conf.mainPackageId == sym.getPackageId

--- a/tests/stdlib/tdeques.nim
+++ b/tests/stdlib/tdeques.nim
@@ -224,7 +224,7 @@ proc main() =
 
     block:
       var a, b = initDeque[int]()
-      for i in countDown(100, 1):
+      for i in countdown(100, 1):
         a.addFirst(i)
       for i in 1..100:
         b.addLast(i)

--- a/tests/stylecheck/tforeign_package.nim
+++ b/tests/stylecheck/tforeign_package.nim
@@ -13,4 +13,13 @@ import foreign_package/foreign_package
 #     - user pragma usage violations
 #   - definition violations in foreign packages are ignored
 #   - usage violations in foreign packages are ignored
-genericProc[int]()
+generic_proc[int]()
+# issue #24269, stdlib:
+proc c(_: openArray[int]) = discard
+static:
+  doAssert compiles(generic_proc[int]())
+  doAssert not compiles(genericProc[int]())
+  doAssert not (compiles do:
+    proc c(_: openarray[int]) = discard)
+  doAssert (compiles do:
+    proc d(_: openArray[int]) = discard)


### PR DESCRIPTION
fixes #24269, refs #20095

Instead of checking the package of the *used sym* to determine whether a stylecheck should trigger, we check the package of the lineinfo instead. Before #20095 this checked for the current compilation context module instead which caused issues with generic procs, but the lineinfo should more closely match the AST.

I figured this might cause issues with includes etc but the foreign package test specifically tests for an include and passes, so maybe the package determining logic accounts for this already. This still might not be the correct logic, I'm not too familiar with the package handling in the compiler.

Package PRs, both merged:

- json_rpc: https://github.com/status-im/nim-json-rpc/pull/226
- json_serialization: https://github.com/status-im/nim-json-serialization/pull/99