### PR TITLE
better errors for standalone explicit generic instantiations

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -200,6 +200,9 @@ proc matchGenericParams*(m: var TCandidate, binding: PNode, callee: PSym) =
     elif tfImplicitTypeParam in paramSym.typ.flags:
       # not a mismatch, but can't create sym
       m.state = csEmpty
+      m.firstMismatch.kind = kMissingGenericParam
+      m.firstMismatch.arg = i + 1
+      m.firstMismatch.formal = paramSym
       return
     else:
       m.state = csNoMatch

--- a/tests/generics/tpointerprocs.nim
+++ b/tests/generics/tpointerprocs.nim
@@ -2,10 +2,17 @@ discard """
 cmd: "nim check $options --hints:off $file"
 action: "reject"
 nimout:'''
-tpointerprocs.nim(15, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
-tpointerprocs.nim(27, 11) Error: cannot instantiate: 'foo[int]'; got 1 typeof(s) but expected 2
-tpointerprocs.nim(27, 14) Error: expression 'foo[int]' has no type (or is ambiguous)
-tpointerprocs.nim(28, 11) Error: expression 'bar' has no type (or is ambiguous)
+tpointerprocs.nim(22, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
+tpointerprocs.nim(34, 14) Error: type mismatch: got <int>
+but expected one of:
+proc foo(x: int | float; y: int or string): float
+  first type mismatch at position: 2 in generic parameters
+  missing generic parameter: y:type
+
+expression: foo[int]
+tpointerprocs.nim(34, 14) Error: cannot instantiate: 'foo[int]'
+tpointerprocs.nim(34, 14) Error: expression 'foo[int]' has no type (or is ambiguous)
+tpointerprocs.nim(35, 11) Error: expression 'bar' has no type (or is ambiguous)
 '''
 """
 

--- a/tests/overload/tambiguousexplicitgeneric.nim
+++ b/tests/overload/tambiguousexplicitgeneric.nim
@@ -1,0 +1,6 @@
+# related to issue #8064
+
+import tables
+
+let x = values[int] #[tt.Error
+        ^ ambiguous identifier: 'values' -- use one of the following:]#

--- a/tests/overload/texplicitgenericdiscard.nim
+++ b/tests/overload/texplicitgenericdiscard.nim
@@ -1,0 +1,7 @@
+# issue #8064
+
+import tables
+
+values[int] #[tt.Error
+^ ambiguous identifier: 'values' -- use one of the following:]#
+# this happens before discard check, so no discard error


### PR DESCRIPTION
refs #8064, refs #24010

Error messages for standalone explicit generic instantiations are revamped. Failing standalone explicit generic instantiations now only error after overloading has finished and resolved to the default `[]` magic (this means `[]` can now be overloaded for procs but this isn't necessarily intentional, in #24010 it was documented that it isn't possible). The error messages for failed instantiations are also no longer a simple `cannot instantiate: foo` message, instead they now give the same type mismatch error message as overloads with mismatching explicit generic parameters.

This is now possible due to the changes in #24010 that delegate all explicit generic proc instantiations to overload resolution. Old code that worked around this is now removed. `maybeInstantiateGeneric` could maybe also be removed in favor of just `explicitGenericSym`, the `result == n` case is due to `explicitGenericInstError` which is only for niche cases.

Also, to cause "ambiguous identifier" error messages when the explicit instantiation is a symchoice and the expression context doesn't allow symchoices, we semcheck the sym/symchoice created by `explicitGenericSym` with the given expression flags.

#8064 isn't entirely fixed because the error message is still misleading for the original case which does `values[1]`, as a consequence of #12664.