### PR TITLE
don't evaluate "cannot eval" errors with nim check

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -270,6 +270,7 @@ type
     templInstCounter*: ref int # gives every template instantiation a unique ID, needed here for getAst
     vmstateDiff*: seq[(PSym, PNode)] # we remember the "diff" to global state here (feature for IC)
     procToCodePos*: Table[int, int]
+    cannotEval*: bool
 
   PStackFrame* = ref TStackFrame
   TStackFrame* {.acyclic.} = object

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1545,6 +1545,7 @@ template cannotEval(c: PCtx; n: PNode) =
   if c.config.cmd == cmdCheck:
     localError(c.config, n.info, "cannot evaluate at compile time: " & 
     n.renderTree)
+    c.cannotEval = true
     return
   globalError(c.config, n.info, "cannot evaluate at compile time: " &
     n.renderTree)


### PR DESCRIPTION
fixes #24288, refs #23625

Since #23625 "cannot evaluate" errors during VM code generation are "soft" errors with `nim check`, i.e. the code generation isn't halted (except for the current proc which `return`s which can cause wrong codegen) and the expression is still attempted to be evaluated. Now, these errors signal to the VM that the current generated VM code cannot be evaluated, and so instead of evaluating, an error node is returned. This keeps the benefit of the "soft" errors without potentially crashing the compiler on improperly generated VM code. Although maybe the compiler might not be able to handle the generated error node in some cases.

This fixes the chame example in #24288 but this is not tested in CI. Presumably it or the compiler was doing something like `compiles()` on code that can't run in the VM.

I would accept nicer ways of tracking non-evaluability than `c.cannotEval = true` but I tried to keep it as harmless as possible.