### PR TITLE
fix type of reconstructed kind field node in field checking analysis [backport]

### DIFF
--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -114,7 +114,7 @@ proc neg(n: PNode; o: Operators): PNode =
     # `buildOf`, `buildElse` give the set a type but the RHS can
     # lose type information somehow, probably the int node generation
     # in this module
-    let t = n[1].typ.skipTypes(abstractInst).elementType
+    let t = n[2].typ.skipTypes(abstractInst)
     result = newNodeI(nkCall, n.info, 3)
     result[0] = n[0]
     result[2] = n[2]
@@ -1169,8 +1169,12 @@ proc buildProperFieldCheck(access, check: PNode; o: Operators): PNode =
   if check[1].kind == nkCurly:
     result = copyTree(check)
     if access.kind == nkDotExpr:
+      # change the access to the discriminator field access
       var a = copyTree(access)
+      # set field name to discriminator field name
       a[1] = check[2]
+      # set discriminator field type: important for `neg`
+      a.typ = check[2].typ
       result[2] = a
       # 'access.kind != nkDotExpr' can happen for object constructors
       # which we don't check yet

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -110,10 +110,6 @@ proc neg(n: PNode; o: Operators): PNode =
     result = swapArgs(n, o.opLt)
   of mInSet:
     if n[1].kind != nkCurly: return nil
-    # use type of set rather than type of potential element
-    # `buildOf`, `buildElse` give the set a type but the RHS can
-    # lose type information somehow, probably the int node generation
-    # in this module
     let t = n[2].typ.skipTypes(abstractInst)
     result = newNodeI(nkCall, n.info, 3)
     result[0] = n[0]

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -110,7 +110,11 @@ proc neg(n: PNode; o: Operators): PNode =
     result = swapArgs(n, o.opLt)
   of mInSet:
     if n[1].kind != nkCurly: return nil
-    let t = n[2].typ.skipTypes(abstractInst)
+    # use type of set rather than type of potential element
+    # `buildOf`, `buildElse` give the set a type but the RHS can
+    # lose type information somehow, probably the int node generation
+    # in this module
+    let t = n[1].typ.skipTypes(abstractInst).elementType
     result = newNodeI(nkCall, n.info, 3)
     result[0] = n[0]
     result[2] = n[2]

--- a/tests/objvariant/tcorrectcheckedfield.nim
+++ b/tests/objvariant/tcorrectcheckedfield.nim
@@ -1,0 +1,22 @@
+discard """
+  matrix: "; --warning[ProveField]:on --warningAsError[ProveField]:on; --experimental:strictCaseObjects"
+"""
+
+block: # issue #24021
+  type
+    FooKind = enum
+      a
+      b
+    BiggerEnum = enum b1, b2, b3, b4, b5, b6, b7, b8, b9, b10
+    Foo = object
+      case kind: FooKind
+      of a: discard
+      else:
+        z: BiggerEnum
+
+  proc p(foo: Foo, val: int) =
+    case foo.kind
+    of a:
+      discard
+    else:
+      discard foo.z


### PR DESCRIPTION
fixes #24021

The field checking for case object branches at some point generates a negated set `contains` check for the object discriminator. For enum types, this tries to generate a complement set and convert to a `contains` check in that instead. It obtains this type from the type of the element node in the `contains` check.

`buildProperFieldCheck` creates the element node by changing a field access expression like `foo.z` into `foo.kind`. In order to do this, it copies the node `foo.z` and sets the field name in the node to the symbol `kind`. But when copying the node, the type of the original `foo.z` is retained. This means that the complement is performed on the type of the accessed field rather than the type of the discriminator, which causes problems when the accessed field is also an enum.

To fix this, we properly set the type of the copied node to the type of the kind field. An alternative is just to make a new node instead.

A lot of text for a single line change, I know, but this part of the codebase could use more explanation.