### PR TITLE
templates/macros use no expected types when return types are specified

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -494,7 +494,7 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
       if retType.kind == tyVoid:
         result = semStmt(c, result, flags)
       else:
-        result = semExpr(c, result, flags, retType)
+        result = semExpr(c, result, flags)
         result = fitNode(c, retType, result, result.info)
       #globalError(s.info, errInvalidParamKindX, typeToString(s.typ.returnType))
   dec(c.config.evalTemplateCounter)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -494,7 +494,7 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
       if retType.kind == tyVoid:
         result = semStmt(c, result, flags)
       else:
-        result = semExpr(c, result, flags, expectedType)
+        result = semExpr(c, result, flags, retType)
         result = fitNode(c, retType, result, result.info)
       #globalError(s.info, errInvalidParamKindX, typeToString(s.typ.returnType))
   dec(c.config.evalTemplateCounter)

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -331,3 +331,29 @@ block: # issue #24164, related regression
   template bar(x: untyped = nil) =
     foo(x)
   bar()
+
+block: # bug #24296
+  # Either changing the template to `proc`/`func` or using `$""`, not a string
+  # literal alone, allows any version of Nim 2.x to compile this.
+  template g(): string = ""
+
+  # Alternatively: don't retrieve the string through g(), but directly, also
+  # allows compilation across Nim 2.x versions.
+  const d: cstring = ""
+  const f: cstring = $""
+  const b = cstring g()
+  const m = cstring ""
+  const p = cstring $""
+
+  # But this does not compile across Nim 2.x/devel.
+  const c: cstring = g()
+  let d: cstring = g()
+
+block: # bug #24295
+  template g(_: int): string = ""
+  const c: cstring = 0.g()
+
+block: # bug #24295
+  template g(_: int): cstring = ""
+  let c: string = 0.g()
+

--- a/tests/types/ttopdowninference.nim
+++ b/tests/types/ttopdowninference.nim
@@ -347,13 +347,9 @@ block: # bug #24296
 
   # But this does not compile across Nim 2.x/devel.
   const c: cstring = g()
-  let d: cstring = g()
+  let e: cstring = g()
 
 block: # bug #24295
   template g(_: int): string = ""
   const c: cstring = 0.g()
-
-block: # bug #24295
-  template g(_: int): cstring = ""
-  let c: string = 0.g()
 


### PR DESCRIPTION
fixes #24296 
fixes #24295

Templates use `expectedType` for type inference. It's justified that when templates don't have an actual return type, i.e., `untyped` etc. 

When the return type of templates is specified, we should not infer the type

```nim
template g(): string = ""

let c: cstring = g()
```
In this example, it is not reasonable to annotate the templates expression with the `cstring` type before the `fitNode` check with its specified return type. 