### PR TITLE
fixes #24258; compiler crash on `len` of `varargs[untyped]`

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1311,10 +1311,11 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
       put(g, tkCustomLit, n[0].strVal)
       gsub(g, n, 1)
     else:
-      gsub(g, n, 0)
+      for i in 0..<n.len-1:
+        gsub(g, n, i)
       put(g, tkDot, ".")
-      assert n.len == 2, $n.len
-      accentedName(g, n[1])
+      if n.len > 1:
+        accentedName(g, n[^1])
   of nkBind:
     putWithSpace(g, tkBind, "bind")
     gsub(g, n, 0)

--- a/tests/errmsgs/t24258.nim
+++ b/tests/errmsgs/t24258.nim
@@ -1,0 +1,10 @@
+discard """
+  cmd: "nim check $file"
+  errormsg: "illformed AST: [22]43.len"
+  joinable: false
+"""
+
+template encodeList*(args: varargs[untyped]): seq[byte] =
+  @[byte args.len]
+
+let x = encodeList([22], 43)


### PR DESCRIPTION
fixes #24258

It uses conditionals to guard against ill formed AST to produce better error messages, rather than crashing