### PR TITLE
cbuilder: implement designated initializers, finish default value braces

### DIFF
--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -68,7 +68,7 @@ type
     siOrderedStruct ## struct constructor, but without named fields on C
     siNamedStruct ## struct constructor, with named fields i.e. C99 designated initializer
     siArray ## array constructor
-    siWrapper ## wrapper for a single field, generates it verbatim
+    siWrapper ## wrapper for a single field, generates it verbatim, now unused
 
   StructInitializer = object
     ## context for building struct initializers, i.e. `{ field1, field2 }`
@@ -77,9 +77,7 @@ type
     needsComma: bool
 
 proc initStructInitializer(builder: var Builder, kind: StructInitializerKind): StructInitializer =
-  ## starts building a struct initializer, `orderCompliant = true` means
-  ## built fields must be ordered correctly
-  assert kind != siNamedStruct, "named struct constructors unimplemented"
+  ## starts building a struct initializer, i.e. braced initializer list
   result = StructInitializer(kind: kind, needsComma: false)
   if kind != siWrapper:
     builder.add("{")
@@ -100,7 +98,11 @@ template addField(builder: var Builder, constr: var StructInitializer, name: str
     assert name.len != 0, "name has to be given for struct initializer field"
     valueBody
   of siNamedStruct:
-    assert false, "named struct constructors unimplemented"
+    assert name.len != 0, "name has to be given for struct initializer field"
+    builder.add(".")
+    builder.add(name)
+    builder.add(" = ")
+    valueBody
 
 proc finishStructInitializer(builder: var Builder, constr: StructInitializer) =
   ## finishes building a struct initializer

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -68,7 +68,7 @@ type
     siOrderedStruct ## struct constructor, but without named fields on C
     siNamedStruct ## struct constructor, with named fields i.e. C99 designated initializer
     siArray ## array constructor
-    siWrapper ## wrapper for a single field, generates it verbatim, now unused
+    siWrapper ## wrapper for a single field, generates it verbatim
 
   StructInitializer = object
     ## context for building struct initializers, i.e. `{ field1, field2 }`

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3306,7 +3306,11 @@ proc getNullValueAux(p: BProc; t: PType; obj, constOrNil: PNode,
         var branchInit: StructInitializer
         result.addStructInitializer(branchInit, kind = siNamedStruct):
           result.addField(branchInit, name = fieldName):
-            getNullValueAux(p, t, b, constOrNil, result, branchInit, isConst, info)
+            # we need to generate the default value of the single sym,
+            # to do this create a dummy wrapper initializer and recurse
+            var branchFieldInit: StructInitializer
+            result.addStructInitializer(branchFieldInit, kind = siWrapper):
+              getNullValueAux(p, t, b, constOrNil, result, branchFieldInit, isConst, info)
     else:
       # no fields, don't initialize
       return


### PR DESCRIPTION
follows up #24259

This is the remaining missing use of `StructInitializer` in `getDefaultValue` after #24259 and #24302. The only remaining direct C code in getDefaultValue is [this line](https://github.com/nim-lang/Nim/blob/922f7dfd712130bb68a16336085c0320afceb273/compiler/ccgexprs.nim#L3525) which creates a global array variable, which isn't implemented yet. Next steps would be all remaining variable and `typedef` declarations, then hopefully we can move on to general statements and expressions.