### PR TITLE
fixes #18896; fixes #20886; importc types alias doesn't work with distinct

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -340,7 +340,12 @@ proc getSimpleTypeDesc(m: BModule; typ: PType): Rope =
   of tyNil: result = typeNameOrLiteral(m, typ, "void*")
   of tyInt..tyUInt64:
     result = typeNameOrLiteral(m, typ, NumericalTypeToStr[typ.kind])
-  of tyDistinct, tyRange, tyOrdinal: result = getSimpleTypeDesc(m, typ.skipModifier)
+  of tyRange, tyOrdinal: result = getSimpleTypeDesc(m, typ.skipModifier)
+  of tyDistinct:
+    result = getSimpleTypeDesc(m, typ.skipModifier)
+    if isImportedType(typ) and result != "":
+      useHeader(m, typ.sym)
+      result = typ.sym.loc.snippet
   of tyStatic:
     if typ.n != nil: result = getSimpleTypeDesc(m, skipModifier typ)
     else:
@@ -861,7 +866,8 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
   if t != origTyp and origTyp.sym != nil: useHeader(m, origTyp.sym)
   let sig = hashType(origTyp, m.config)
 
-  result = getTypePre(m, t, sig)
+  # tyDistinct matters if it is an importc type
+  result = getTypePre(m, origTyp.skipTypes(irrelevantForBackend-{tyOwned, tyDistinct}), sig)
   defer: # defer is the simplest in this case
     if isImportedType(t) and not m.typeABICache.containsOrIncl(sig):
       addAbiCheck(m, t, result)

--- a/tests/ccgbugs/timportc_distinct.nim
+++ b/tests/ccgbugs/timportc_distinct.nim
@@ -1,0 +1,13 @@
+discard """
+  ccodecheck: "time_t"
+  joinable: false
+"""
+
+type
+  Time* {.importc: "time_t", header: "<time.h>".} = distinct clong
+
+proc foo =
+  var s: Time = default(Time)
+  discard s
+
+foo()


### PR DESCRIPTION
fixes #18896
fixes #20886

```nim
type
  PFile {.importc: "FILE*", header: "<stdio.h>".} = distinct pointer
    # import C's FILE* type; Nim will treat it as a new pointer type
```
This is an excerpt from the Nim manual. In the old Nim versions, it produces a void pointer type instead of the `FILE*` type that should have been generated. Because these C types tend to be opaque and adapt to changes on different platforms. It might affect the portability of Nim on various OS, i.e. `csource_v2` cannot build on the apline platform because of `Time` relies on Nim types instead of the `time_t` type.

ref https://github.com/nim-lang/Nim/pull/18851