### PR TITLE
Fixes #3824, fixes #19154, and hopefully #24094. Re-applies #23787.

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -175,6 +175,7 @@ proc addHiddenParam(routine: PSym, param: PSym) =
   #echo "produced environment: ", param.id, " for ", routine.id
 
 proc getEnvParam*(routine: PSym): PSym =
+  if routine.ast.isNil: return nil
   let params = routine.ast[paramsPos]
   let hidden = lastSon(params)
   if hidden.kind == nkSym and hidden.sym.kind == skParam and hidden.sym.name.s == paramName:
@@ -419,6 +420,12 @@ proc addClosureParam(c: var DetectionPass; fn: PSym; info: TLineInfo) =
     localError(c.graph.config, fn.info, "internal error: inconsistent environment type")
   #echo "adding closure to ", fn.name.s
 
+proc iterEnvHasUpField(g: ModuleGraph, iter: PSym): bool =
+  let cp = getEnvParam(iter)
+  doAssert(cp != nil, "Env param not present in iter")
+  let upField = lookupInRecord(cp.typ.skipTypes({tyOwned, tyRef, tyPtr}).n, getIdent(g.cache, upName))
+  upField != nil
+
 proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
   case n.kind
   of nkSym:
@@ -437,7 +444,7 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
         let body = transformBody(c.graph, c.idgen, s, {useCache})
         detectCapturedVars(body, s, c)
     let ow = s.skipGenericOwner
-    let innerClosure = innerProc and s.typ.callConv == ccClosure and not s.isIterator
+    let innerClosure = innerProc and s.typ.callConv == ccClosure and (not s.isIterator or iterEnvHasUpField(c.graph, s))
     let interested = interestingVar(s)
     if ow == owner:
       if owner.isIterator:
@@ -642,16 +649,27 @@ proc finishClosureCreation(owner: PSym; d: var DetectionPass; c: LiftingPass;
     res.add newAsgnStmt(unowned, nilLit, info)
     createTypeBoundOpsLL(d.graph, unowned.typ, info, d.idgen, owner)
 
-proc closureCreationForIter(iter: PNode;
+proc getUpForIter(g: ModuleGraph; owner, iterOwner: PSym, expectedUpTyp: PType): PNode =
+  var p = getHiddenParam(g, owner)
+  var res = p.newSymNode
+  while res.typ.skipTypes({tyOwned, tyRef, tyPtr}) != expectedUpTyp:
+    let upField = lookupInRecord(p.typ.skipTypes({tyOwned, tyRef, tyPtr}).n, getIdent(g.cache, upName))
+    if upField == nil:
+      return nil
+    p = upField
+    res = rawIndirectAccess(res, upField, p.info)
+  res
+
+proc closureCreationForIter(owner: PSym, iter: PNode;
                             d: var DetectionPass; c: var LiftingPass): PNode =
   result = newNodeIT(nkStmtListExpr, iter.info, iter.sym.typ)
-  let owner = iter.sym.skipGenericOwner
-  var v = newSym(skVar, getIdent(d.graph.cache, envName), d.idgen, owner, iter.info)
+  let iterOwner = iter.sym.skipGenericOwner
+  var v = newSym(skVar, getIdent(d.graph.cache, envName), d.idgen, iterOwner, iter.info)
   incl(v.flags, sfShadowed)
   v.typ = asOwnedRef(d, getHiddenParam(d.graph, iter.sym).typ)
   var vnode: PNode
-  if owner.isIterator:
-    let it = getHiddenParam(d.graph, owner)
+  if iterOwner.isIterator:
+    let it = getHiddenParam(d.graph, iterOwner)
     addUniqueField(it.typ.skipTypes({tyOwned, tyRef, tyPtr}), v, d.graph.cache, d.idgen)
     vnode = indirectAccess(newSymNode(it), v, v.info)
   else:
@@ -660,12 +678,14 @@ proc closureCreationForIter(iter: PNode;
     addVar(vs, vnode)
     result.add(vs)
   result.add genCreateEnv(vnode)
-  createTypeBoundOpsLL(d.graph, vnode.typ, iter.info, d.idgen, owner)
+  createTypeBoundOpsLL(d.graph, vnode.typ, iter.info, d.idgen, iterOwner)
 
   let upField = lookupInRecord(v.typ.skipTypes({tyOwned, tyRef, tyPtr}).n, getIdent(d.graph.cache, upName))
   if upField != nil:
-    let u = setupEnvVar(owner, d, c, iter.info)
-    if u.typ.skipTypes({tyOwned, tyRef, tyPtr}) == upField.typ.skipTypes({tyOwned, tyRef, tyPtr}):
+    let expectedUpTyp = upField.typ.skipTypes({tyOwned, tyRef, tyPtr})
+    let u = if iterOwner == owner: setupEnvVar(iterOwner, d, c, iter.info)
+            else: getUpForIter(d.graph, owner, iterOwner, expectedUpTyp)
+    if u != nil and u.typ.skipTypes({tyOwned, tyRef, tyPtr}) == expectedUpTyp:
       result.add(newAsgnStmt(rawIndirectAccess(vnode, upField, iter.info),
                  u, iter.info))
     else:
@@ -699,7 +719,7 @@ proc symToClosure(n: PNode; owner: PSym; d: var DetectionPass;
     let available = getHiddenParam(d.graph, owner)
     result = makeClosure(d.graph, d.idgen, s, available.newSymNode, n.info)
   elif s.isIterator:
-    result = closureCreationForIter(n, d, c)
+    result = closureCreationForIter(owner, n, d, c)
   elif s.skipGenericOwner == owner:
     # direct dependency, so use the outer's env variable:
     result = makeClosure(d.graph, d.idgen, s, setupEnvVar(owner, d, c, n.info), n.info)

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -150,7 +150,7 @@ template isIterator*(owner: PSym): bool =
 
 proc createEnvObj(g: ModuleGraph; idgen: IdGenerator; owner: PSym; info: TLineInfo): PType =
   result = createObj(g, idgen, owner, info, final=false)
-  if owner.isIterator or not isDefined(g.config, "nimOptIters"):
+  if owner.isIterator:
     rawAddField(result, createStateField(g, owner, idgen))
 
 proc getClosureIterResult*(g: ModuleGraph; iter: PSym; idgen: IdGenerator): PSym =
@@ -228,13 +228,6 @@ proc makeClosure*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; env: PNode; inf
   if tfHasAsgn in result.typ.flags or optSeqDestructors in g.config.globalOptions:
     prc.flags.incl sfInjectDestructors
 
-proc interestingIterVar(s: PSym): bool {.inline.} =
-  # unused with -d:nimOptIters
-  # XXX optimization: Only lift the variable if it lives across
-  # yield/return boundaries! This can potentially speed up
-  # closure iterators quite a bit.
-  result = s.kind in {skResult, skVar, skLet, skTemp, skForVar} and sfGlobal notin s.flags
-
 template liftingHarmful(conf: ConfigRef; owner: PSym): bool =
   ## lambda lifting can be harmful for JS-like code generators.
   let isCompileTime = sfCompileTime in owner.flags or owner.kind == skMacro
@@ -280,16 +273,6 @@ proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PN
   result.add genCreateEnv(env)
   createTypeBoundOpsLL(g, env.typ, n.info, idgen, owner)
   result.add makeClosure(g, idgen, iter, env, n.info)
-
-proc freshVarForClosureIter*(g: ModuleGraph; s: PSym; idgen: IdGenerator; owner: PSym): PNode =
-  # unused with -d:nimOptIters
-  let envParam = getHiddenParam(g, owner)
-  let obj = envParam.typ.skipTypes({tyOwned, tyRef, tyPtr})
-  let field = addField(obj, s, g.cache, idgen)
-
-  var access = newSymNode(envParam)
-  assert obj.kind == tyObject
-  result = rawIndirectAccess(access, field, s.info)
 
 # ------------------ new stuff -------------------------------------------
 
@@ -339,7 +322,7 @@ proc getEnvTypeForOwner(c: var DetectionPass; owner: PSym;
   result = c.ownerToType.getOrDefault(owner.id)
   if result.isNil:
     let env = getEnvParam(owner)
-    if env.isNil or not owner.isIterator or not isDefined(c.graph.config, "nimOptIters"):
+    if env.isNil or not owner.isIterator:
       result = newType(tyRef, c.idgen, owner)
       let obj = createEnvObj(c.graph, c.idgen, owner, info)
       rawAddSon(result, obj)
@@ -460,17 +443,6 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
       if owner.isIterator:
         c.somethingToDo = true
         addClosureParam(c, owner, n.info)
-        if not isDefined(c.graph.config, "nimOptIters") and interestingIterVar(s):
-          if not c.capturedVars.contains(s.id):
-            if not c.inTypeOf: c.capturedVars.incl(s.id)
-            let obj = getHiddenParam(c.graph, owner).typ.skipTypes({tyOwned, tyRef, tyPtr})
-            #let obj = c.getEnvTypeForOwner(s.owner).skipTypes({tyOwned, tyRef, tyPtr})
-
-            if s.name.id == getIdent(c.graph.cache, ":state").id:
-              obj.n[0].sym.flags.incl sfNoInit
-              obj.n[0].sym.itemId = ItemId(module: s.itemId.module, item: -s.itemId.item)
-            else:
-              discard addField(obj, s, c.graph.cache, c.idgen)
     # direct or indirect dependency:
     elif innerClosure or interested:
       discard """
@@ -774,8 +746,6 @@ proc liftCapturedVars(n: PNode; owner: PSym; d: var DetectionPass;
     elif s.id in d.capturedVars:
       if s.owner != owner:
         result = accessViaEnvParam(d.graph, n, owner)
-      elif owner.isIterator and not isDefined(d.graph.config, "nimOptIters") and interestingIterVar(s):
-        result = accessViaEnvParam(d.graph, n, owner)
       else:
         result = accessViaEnvVar(n, owner, d, c)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit, nkComesFrom,
@@ -893,7 +863,7 @@ proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode; tooEarly: var bool;
     # ignore forward declaration:
     result = body
     tooEarly = true
-    if fn.isIterator and isDefined(g.config, "nimOptIters"):
+    if fn.isIterator:
       var d = initDetectionPass(g, fn, idgen)
       addClosureParam(d, fn, body.info)
   else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -98,10 +98,7 @@ proc newTemp(c: PTransf, typ: PType, info: TLineInfo): PNode =
   r.typ = typ #skipTypes(typ, {tyGenericInst, tyAlias, tySink})
   incl(r.flags, sfFromGeneric)
   let owner = getCurrOwner(c)
-  if owner.isIterator and not c.tooEarly and not isDefined(c.graph.config, "nimOptIters"):
-    result = freshVarForClosureIter(c.graph, r, c.idgen, owner)
-  else:
-    result = newSymNode(r)
+  result = newSymNode(r)
 
 proc transform(c: PTransf, n: PNode): PNode
 
@@ -177,13 +174,10 @@ proc transformSym(c: PTransf, n: PNode): PNode =
 
 proc freshVar(c: PTransf; v: PSym): PNode =
   let owner = getCurrOwner(c)
-  if owner.isIterator and not c.tooEarly and not isDefined(c.graph.config, "nimOptIters"):
-    result = freshVarForClosureIter(c.graph, v, c.idgen, owner)
-  else:
-    var newVar = copySym(v, c.idgen)
-    incl(newVar.flags, sfFromGeneric)
-    newVar.owner() = owner
-    result = newSymNode(newVar)
+  var newVar = copySym(v, c.idgen)
+  incl(newVar.flags, sfFromGeneric)
+  newVar.owner() = owner
+  result = newSymNode(newVar)
 
 proc transformVarSection(c: PTransf, v: PNode): PNode =
   result = newTransNode(v)

--- a/tests/destructor/tuse_ownedref_after_move.nim
+++ b/tests/destructor/tuse_ownedref_after_move.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: '''nim c --newruntime $file'''
-  errormsg: "'=copy' is not available for type <owned Button>; requires a copy because it's not the last read of ':envAlt.b1'; routine: main"
+  errormsg: "'=copy' is not available for type <owned Button>; requires a copy because it's not the last read of ':envAlt.b0'; routine: main"
   line: 48
 """
 

--- a/tests/iter/tnestedclosures.nim
+++ b/tests/iter/tnestedclosures.nim
@@ -1,0 +1,139 @@
+discard """
+  targets: "c"
+  output: '''
+Test 1:
+12
+Test 2:
+23
+23
+Test 3:
+34
+34
+Test 4:
+45
+45
+50
+50
+Test 5:
+45
+123
+47
+50
+Test 6:
+<hi>
+Test 7:
+0
+1
+2
+'''
+"""
+
+block: #24094
+  echo "Test 1:"
+  proc foo() =
+    let x = 12
+    iterator bar2(): int {.closure.} =
+      yield x
+    proc bar() =
+      let z = bar2
+      for y in z(): # just doing bar2() gives param not in env: x
+        echo y
+    bar()
+
+  foo()
+
+block: #24094
+  echo "Test 2:"
+  iterator foo(): int {.closure.} =
+    let x = 23
+    iterator bar2(): int {.closure.} =
+      yield x
+    proc bar() =
+      let z = bar2
+      for y in z():
+        echo y
+    bar()
+    yield x
+
+  for x in foo(): echo x
+
+block: #24094
+  echo "Test 3:"
+  iterator foo(): int {.closure.} =
+    let x = 34
+    proc bar() =
+      echo x
+    iterator bar2(): int {.closure.} =
+      bar()
+      yield x
+    for y in bar2():
+      yield y
+
+  for x in foo(): echo x
+
+block:
+  echo "Test 4:"
+  proc foo() =
+    var x = 45
+    iterator bar2(): int {.closure.} =
+      yield x
+      yield x + 3
+
+    let b1 = bar2
+    let b2 = bar2
+    echo b1()
+    echo b2()
+    x = 47
+    echo b1()
+    echo b2()
+  foo()
+
+block:
+  echo "Test 5:"
+  proc foo() =
+    var x = 45
+    iterator bar2(): int {.closure.} =
+      yield x
+      yield x + 3
+
+    proc bar() =
+      var y = 123
+      iterator bar3(): int {.closure.} =
+        yield x
+        yield y
+      let b3 = bar3
+      for z in b3():
+        echo z
+      x = 47
+      let b2 = bar2
+      for z in b2():
+        echo z
+    bar()
+  foo()
+
+block: #19154
+  echo "Test 6:"
+  proc test(s: string): proc(): iterator(): string =
+    iterator it(): string = yield s
+    proc f(): iterator(): string = it
+    return f
+
+  let it = test("hi")()
+  for s in it():
+    echo "<", s, ">"
+
+block: #3824
+  echo "Test 7:"
+  proc main =
+    iterator factory(): int {.closure.} =
+      iterator bar(): int {.closure.} =
+        yield 0
+        yield 1
+        yield 2
+
+      for x in bar(): yield x
+
+    for x in factory():
+      echo x
+
+  main()

--- a/tests/iter/tyieldintry.nim
+++ b/tests/iter/tyieldintry.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "; --experimental:strictdefs; -d:nimOptIters"
+  matrix: "; --experimental:strictdefs"
   targets: "c cpp"
 """
 
@@ -505,7 +505,7 @@ block: # void iterator
       discard
   var a = it
 
-if defined(nimOptIters): # Locals present in only 1 state should be on the stack
+block: # Locals present in only 1 state should be on the stack
   proc checkOnStack(a: pointer, shouldBeOnStack: bool) =
     # Quick and dirty way to check if a points to stack
     var dummy = 0


### PR DESCRIPTION
The first commit reverts the revert of #23787.
The second fixes lambdalifting in convolutedly nested closures/closureiters. This is considered to be the reason of #24094, though I can't tell for sure, as I was not able to reproduce #24094 for complicated but irrelevant reasons. Therefore I ask @jmgomez, @metagn or anyone who could reproduce it to try it again with this PR.

I would suggest this PR to not be squashed if possible, as the history is already messy enough.

Some theory behind the lambdalifting fix:
- A closureiter that captures anything outside its body will always have `:up` in its env. This property is now used as a trigger to lift any proc that captures such a closureiter.
- Instantiating a closureiter involves filling out its `:up`, which was previously done incorrectly. The fixed algorithm is to use "current" env if it is the owner of the iter declaration, or traverse through `:up`s of env param until the common ancestor is found.