### PR TITLE
Fix quoted idents in ctags

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -830,7 +830,7 @@ proc getName(n: PNode): string =
   of nkAccQuoted:
     result = "`"
     for i in 0..<n.len: result.add(getName(n[i]))
-    result = "`"
+    result.add('`')
   of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
     result = getName(n[0])
   else:

--- a/tests/tools/tctags.nim
+++ b/tests/tools/tctags.nim
@@ -1,0 +1,16 @@
+discard """
+  cmd: '''nim ctags --stdout $file'''
+  nimout: '''
+Foo
+hello
+`$$`
+'''
+  action: "compile"
+"""
+
+type
+  Foo = object
+
+proc hello() = discard
+
+proc `$`(x: Foo): string = "foo"


### PR DESCRIPTION
Running `ctags` on files with quoted symbols (e.g. `$`) would list \` instead of the full ident. Issue was the result getting reassigned at the end to a \` instead of appending