### PR TITLE
shallow fold prevention for `addr`, `nkHiddenAddr`

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -1077,7 +1077,10 @@ proc transform(c: PTransf, n: PNode): PNode =
   of nkCallKinds:
     result = transformCall(c, n)
   of nkHiddenAddr:
+    let oldInAddr = c.inAddr
+    c.inAddr = true
     result = transformAddrDeref(c, n, {nkHiddenDeref})
+    c.inAddr = oldInAddr
   of nkAddr:
     let oldInAddr = c.inAddr
     c.inAddr = true

--- a/tests/iter/tfoldedaddr.nim
+++ b/tests/iter/tfoldedaddr.nim
@@ -24,3 +24,9 @@ block: # issue #24305 with array
 
   for k in demo([17]):
     echo k
+
+block: # related regression
+  proc main =
+    let a = [0, 1, 2]
+    let x = addr a[low(a)]
+  main()

--- a/tests/iter/tfoldedaddr.nim
+++ b/tests/iter/tfoldedaddr.nim
@@ -1,0 +1,26 @@
+discard """
+  output: '''
+23
+23
+23
+23
+23
+23
+'''
+"""
+
+block: # issue #24305
+  iterator demo(a: openArray[int]): int =
+    for k in countUp(a[0], 19):
+      yield 23
+
+  for k in demo(@[17]):
+    echo k
+
+block: # issue #24305 with array
+  iterator demo(a: array[1, int]): int =
+    for k in countUp(a[0], 19):
+      yield 23
+
+  for k in demo([17]):
+    echo k


### PR DESCRIPTION
fixes #24305, refs #23807

Since #23014 `nkHiddenAddr` is produced to fast assign array elements in iterators. However the array access inside this `nkHiddenAddr` can get folded at compile time, generating invalid code. In #23807, compile time folding of regular `addr` expressions was changed to be prevented in `transf` but `nkHiddenAddr` was not updated alongside it.

The method for preventing folding in `addr` in #23807 was also faulty, it should only trigger on the immediate child node of the address rather than all nodes nested inside it. This caused a regression as outlined in [this comment](https://github.com/nim-lang/Nim/pull/24322#issuecomment-2419560182).

To fix both issues, `addr` and `nkHiddenAddr` now both shallowly prevent constant folding for their immediate children.