### PR TITLE
Document about noinline calling convention and exportcpp pragma in Nim manual

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2241,6 +2241,11 @@ Nim supports these `calling conventions`:idx:\:
     only a hint for the compiler: it may completely ignore it, and
     it may inline procedures that are not marked as `inline`.
 
+`noinline`:idx:
+:   The backend compiler may inline procedures that are not marked as `inline`.
+    The noinline convention prevents it.
+    It might helps to reduce code size by adding it to large procedures.
+
 `fastcall`:idx:
 :   Fastcall means different things to different C compilers. One gets whatever
     the C `__fastcall` means.
@@ -8644,6 +8649,14 @@ is available and a literal dollar sign must be written as ``$$``.
 If the symbol should also be exported to a dynamic library, the `dynlib`
 pragma should be used in addition to the `exportc` pragma. See
 [Dynlib pragma for export].
+
+
+Exportcpp pragma
+----------------
+The `exportcpp` pragma works like `exportc` pragma but requires `cpp` backend.
+When compiled with `cpp` backend, `exportc` pragma adds `export "C"` to
+the declaration in generated code so that it can be called from both C and
+C++ code. `exportcpp` pragma doesn't add `export "C"`.
 
 
 Extern pragma

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2244,7 +2244,6 @@ Nim supports these `calling conventions`:idx:\:
 `noinline`:idx:
 :   The backend compiler may inline procedures that are not marked as `inline`.
     The noinline convention prevents it.
-    It might helps to reduce code size by adding it to large procedures.
 
 `fastcall`:idx:
 :   Fastcall means different things to different C compilers. One gets whatever
@@ -8653,9 +8652,9 @@ pragma should be used in addition to the `exportc` pragma. See
 
 Exportcpp pragma
 ----------------
-The `exportcpp` pragma works like `exportc` pragma but requires `cpp` backend.
-When compiled with `cpp` backend, `exportc` pragma adds `export "C"` to
-the declaration in generated code so that it can be called from both C and
+The `exportcpp` pragma works like the `exportc` pragma but it requires the `cpp` backend.
+When compiled with the `cpp` backend, the `exportc` pragma adds `export "C"` to
+the declaration in the generated code so that it can be called from both C and
 C++ code. `exportcpp` pragma doesn't add `export "C"`.
 
 


### PR DESCRIPTION
It seems exportcpp was implemented in v1.0 but there is no documentation about it excepts changelog.
`noinline` is used in many procedures in Nim code but there is also no documentation about it.