### PR TITLE
 cbuilder: add array vars, use for openarray init 

### DIFF
--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -54,6 +54,32 @@ template addVarWithTypeAndInitializer(builder: var Builder, kind: VarKind = Loca
   initializerBody
   builder.add(";\n")
 
+proc addArrayVar(builder: var Builder, kind: VarKind = Local, name: string, elementType: Snippet, len: int, initializer: Snippet = "") =
+  ## adds an array variable declaration to the builder
+  builder.addVarHeader(kind)
+  builder.add(elementType)
+  builder.add(" ")
+  builder.add(name)
+  builder.add("[")
+  builder.addInt(len)
+  builder.add("]")
+  if initializer.len != 0:
+    builder.add(" = ")
+    builder.add(initializer)
+  builder.add(";\n")
+
+template addArrayVarWithInitializer(builder: var Builder, kind: VarKind = Local, name: string, elementType: Snippet, len: int, body: typed) =
+  ## adds an array variable declaration to the builder with the initializer built according to `body`
+  builder.addVarHeader(kind)
+  builder.add(elementType)
+  builder.add(" ")
+  builder.add(name)
+  builder.add("[")
+  builder.addInt(len)
+  builder.add("] = ")
+  initializerBody
+  builder.add(";\n")
+
 template addTypedef(builder: var Builder, name: string, typeBody: typed) =
   ## adds a typedef declaration to the builder with name `name` and type as
   ## built in `typeBody`

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -77,7 +77,7 @@ template addArrayVarWithInitializer(builder: var Builder, kind: VarKind = Local,
   builder.add("[")
   builder.addInt(len)
   builder.add("] = ")
-  initializerBody
+  body
   builder.add(";\n")
 
 template addTypedef(builder: var Builder, name: string, typeBody: typed) =


### PR DESCRIPTION
The remaining followup from #24259. A body for building the type doesn't seem necessary here since the types with array fields are generally atomic/already built from `getTypeDescAux`.