### PR TITLE
use cbuilder for typedefs, add array typedef

### DIFF
--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -89,6 +89,17 @@ template addTypedef(builder: var Builder, name: string, typeBody: typed) =
   builder.add(name)
   builder.add(";\n")
 
+template addArrayTypedef(builder: var Builder, name: string, len: int, typeBody: typed) =
+  ## adds an array typedef declaration to the builder with name `name`,
+  ## length `len`, and element type as built in `typeBody`
+  builder.add("typedef ")
+  typeBody
+  builder.add(" ")
+  builder.add(name)
+  builder.add("[")
+  builder.addInt(len)
+  builder.add("];\n")
+
 type
   StructInitializerKind = enum
     siOrderedStruct ## struct constructor, but without named fields on C

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -1,4 +1,5 @@
 # XXX make complex ones like bitOr use builder instead
+# XXX add stuff like NI, NIM_NIL as constants
 
 proc ptrType(t: Snippet): Snippet =
   t & "*"


### PR DESCRIPTION
The only remaining explicit use of `typedef` in the codegen (from my search) is in `addForwardStructFormat` which from what I understand won't do anything in NIFC.