### PR TITLE
fixes #18081; fixes #18079; fixes #18080;  nested ref/deref'd types

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1541,8 +1541,8 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
         box.add Thing(s1: "121") # pass by sink can mutate Thing.
     ]#
     if handleConstExpr(p, e, d): return
-  var t = e[0].typ.skipTypes(abstractInstOwned+{tyTypedesc})
-  let isRef = t.kind == tyRef
+  var t = e.typ.skipTypes(abstractInstOwned)
+  let isRef = e[0].typ.skipTypes(abstractInstOwned+{tyTypedesc}).kind == tyRef
 
   # check if we need to construct the object in a temporary
   var useTemp =

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1542,7 +1542,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
     ]#
     if handleConstExpr(p, e, d): return
   var t = e.typ.skipTypes(abstractInstOwned)
-  let isRef = e[0].typ.skipTypes(abstractInstOwned+{tyTypeDesc}).kind == tyRef
+  let isRef = t.kind == tyRef
 
   # check if we need to construct the object in a temporary
   var useTemp =
@@ -3074,16 +3074,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkObjConstr: genObjConstr(p, n, d)
   of nkCast: genCast(p, n, d)
   of nkHiddenStdConv, nkHiddenSubConv, nkConv: genConv(p, n, d)
-  of nkHiddenAddr:
-    if n[0].kind == nkDerefExpr:
-      # addr ( deref ( x )) --> x
-      var x = n[0][0]
-      if n.typ.skipTypes(abstractVar).kind != tyOpenArray:
-        x.typ() = n.typ
-      expr(p, x, d)
-      return
-    genAddr(p, n, d)
-  of nkAddr: genAddr(p, n, d)
+  of nkAddr, nkHiddenAddr: genAddr(p, n, d)
   of nkBracketExpr: genBracketExpr(p, n, d)
   of nkDerefExpr, nkHiddenDeref: genDeref(p, n, d)
   of nkDotExpr: genRecordField(p, n, d)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1541,7 +1541,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
         box.add Thing(s1: "121") # pass by sink can mutate Thing.
     ]#
     if handleConstExpr(p, e, d): return
-  var t = e[0].typ.skipTypes(abstractInstOwned)
+  var t = e[0].typ.skipTypes(abstractInstOwned+{tyTypedesc})
   let isRef = t.kind == tyRef
 
   # check if we need to construct the object in a temporary

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1541,7 +1541,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
         box.add Thing(s1: "121") # pass by sink can mutate Thing.
     ]#
     if handleConstExpr(p, e, d): return
-  var t = e.typ.skipTypes(abstractInstOwned)
+  var t = e[0].typ.skipTypes(abstractInstOwned)
   let isRef = t.kind == tyRef
 
   # check if we need to construct the object in a temporary

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1542,7 +1542,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
     ]#
     if handleConstExpr(p, e, d): return
   var t = e.typ.skipTypes(abstractInstOwned)
-  let isRef = e[0].typ.skipTypes(abstractInstOwned+{tyTypedesc}).kind == tyRef
+  let isRef = e[0].typ.skipTypes(abstractInstOwned+{tyTypeDesc}).kind == tyRef
 
   # check if we need to construct the object in a temporary
   var useTemp =

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1585,15 +1585,8 @@ proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
         else: internalError(p.config, n[0].info, "expr(nkBracketExpr, " & $kindOfIndexedExpr & ')')
     of nkObjDownConv:
       gen(p, n[0], r)
-    of nkHiddenDeref:
+    of nkHiddenDeref, nkDerefExpr:
       gen(p, n[0], r)
-    of nkDerefExpr:
-      var x = n[0]
-      if n.kind == nkHiddenAddr:
-        x = n[0][0]
-        if n.typ.skipTypes(abstractVar).kind != tyOpenArray:
-          x.typ() = n.typ
-      gen(p, x, r)
     of nkHiddenAddr:
       gen(p, n[0], r)
     of nkConv:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -94,7 +94,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  if x.kind in {nkHiddenDeref}:
+  if x.kind == nkHiddenDeref:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -94,7 +94,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  if x.kind in {nkHiddenDeref, nkDerefExpr}:
+  if x.kind in {nkHiddenDeref}:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -94,7 +94,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
-  if x.kind == nkHiddenDeref:
+  if x.kind in {nkHiddenDeref, nkDerefExpr}:
     checkSonsLen(x, 1, c.g.config)
     result = x[0]
   else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -507,7 +507,8 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
         ) and not (n[0][0].kind == nkSym and n[0][0].sym.kind == skParam and
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
-          n[0][0].typ.skipTypes(abstractVar).kind == tyString)
+          n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
+          not (n.typ.kind == tyVar and n[0][0].typ.kind == tyRef)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -508,7 +508,8 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
           n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
-          not (isAddr and n.typ.kind == tyVar and n[0][0].typ.kind == tyRef)
+          not (isAddr and n.typ.kind == tyVar and n[0][0].typ.kind == tyRef and
+              n[0][0].kind == nkObjConstr)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -507,7 +507,8 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
         ) and not (n[0][0].kind == nkSym and n[0][0].sym.kind == skParam and
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
-          n[0][0].typ.skipTypes(abstractVar).kind == tyString)
+          n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
+          not (n.typ.kind == tyVar and n[0][0].typ.skipTypes(abstractVar).kind == tyRef)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x
@@ -1069,9 +1070,7 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
   of nkBreakStmt: result = transformBreak(c, n)
   of nkCallKinds:
     result = transformCall(c, n)
-  of nkHiddenAddr:
-    result = transformAddrDeref(c, n, {nkHiddenDeref}, isAddr = true)
-  of nkAddr:
+  of nkAddr, nkHiddenAddr:
     result = transformAddrDeref(c, n, {nkDerefExpr, nkHiddenDeref}, isAddr = true)
   of nkDerefExpr:
     result = transformAddrDeref(c, n, {nkAddr, nkHiddenAddr})

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -508,7 +508,7 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
           n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
-          not (n.typ.kind == tyVar and n[0][0].typ.kind == tyRef)
+          not (isAddr and n.typ.kind == tyVar and n[0][0].typ.kind == tyRef)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -507,8 +507,7 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
         ) and not (n[0][0].kind == nkSym and n[0][0].sym.kind == skParam and
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
-          n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
-          not (n.typ.kind == tyVar and n[0][0].typ.skipTypes(abstractVar).kind == tyRef)
+          n[0][0].typ.skipTypes(abstractVar).kind == tyString)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x

--- a/tests/ccgbugs/t13062.nim
+++ b/tests/ccgbugs/t13062.nim
@@ -56,3 +56,14 @@ block:
 
     proc baz(state: var Bar) = discard
     baz((ref Bar)(x: (new Foo)[])[])
+
+  block: # bug #18080
+    type
+      Foo = object
+        discard
+
+      Bar = object
+        x: Foo
+
+    proc baz(state: var Bar) = discard
+    baz((ref Bar)(x: Foo())[])

--- a/tests/ccgbugs/t13062.nim
+++ b/tests/ccgbugs/t13062.nim
@@ -31,3 +31,28 @@ elif defined(gcRefc):
   doAssert x.repr == "[p = nil]"
 else: # fixme # bug #20081
   doAssert x.repr == "Pledge(p: nil)"
+
+block:
+  block: # bug #18081
+    type
+      Foo = object
+        discard
+
+      Bar = object
+        x: Foo
+
+    proc baz(state: var Bar) =
+      state.x = Foo()
+
+    baz((ref Bar)(x: (new Foo)[])[])
+
+  block: # bug #18079
+    type
+      Foo = object
+        discard
+
+      Bar = object
+        x: Foo
+
+    proc baz(state: var Bar) = discard
+    baz((ref Bar)(x: (new Foo)[])[])


### PR DESCRIPTION
fixes #18081;
fixes https://github.com/nim-lang/Nim/issues/18080
fixes #18079

reverts https://github.com/nim-lang/Nim/pull/20738

It is probably more reasonable to use the type node from `nkObjConstr` since it is barely changed unlike the external type, which is susceptible to code transformation e.g. `addr(deref objconstr)`. 