### PR TITLE
use cbuilder for int, set, const literals

### DIFF
--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -19,6 +19,14 @@ proc procPtrType(conv: TCallingConvention, rettype: Snippet, name: string): Snip
 proc cCast(typ, value: Snippet): Snippet =
   "((" & typ & ") " & value & ")"
 
+template addCast(builder: var Builder, typ: Snippet, valueBody: typed) =
+  ## adds a cast to `typ` with value built by `valueBody`
+  builder.add "(("
+  builder.add typ
+  builder.add ") "
+  valueBody
+  builder.add ")"
+
 proc cAddr(value: Snippet): Snippet =
   "&" & value
 

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -84,7 +84,7 @@ proc genLiteral(p: BProc, n: PNode, ty: PType; result: var Builder) =
               data.add("NIM_NIL")
             data.addField(closureInit, name = "ClE_0"):
               data.add("NIM_NIL")
-          p.module.s[cfsStrData].add(data)
+        p.module.s[cfsStrData].add(data)
       result.add tmpName
     elif k in {tyPointer, tyNil, tyProc}:
       result.add rope("NIM_NIL")


### PR DESCRIPTION
Most of this code was already structured in the `var Builder` manner. `intLiteral` etc could be used for all int literals in the future.