### PR TITLE
prohibits redefining field variables in a 'fields' loop

### DIFF
--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -29,10 +29,10 @@ proc instFieldLoopBody(c: var TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     result = n
     let ident = considerQuotedIdent(c.c, n)
     if c.replaceByFieldName:
-      if c.leftPartOfDefinition:
-        localError(c.c.config, n.info,
-                  "redefine field variable '$1' in a 'fields' loop" % [ident.s])
       if ident.id == considerQuotedIdent(c.c, forLoop[0]).id:
+        if c.leftPartOfDefinition:
+          localError(c.c.config, n.info,
+                  "redefine field variable '$1' in a 'fields' loop" % [ident.s])
         let fieldName = if c.tupleType.isNil: c.field.name.s
                         elif c.tupleType.n.isNil: "Field" & $c.tupleIndex
                         else: c.tupleType.n[c.tupleIndex].sym.name.s

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -17,8 +17,9 @@ type
     field: PSym
     replaceByFieldName: bool
     c: PContext
+    leftPartOfAssign: bool
 
-proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
+proc instFieldLoopBody(c: var TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
   if c.field != nil and isEmptyType(c.field.typ):
     result = newNode(nkEmpty)
     return
@@ -29,6 +30,9 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     let ident = considerQuotedIdent(c.c, n)
     if c.replaceByFieldName:
       if ident.id == considerQuotedIdent(c.c, forLoop[0]).id:
+        if c.leftPartOfAssign:
+          localError(c.c.config, n.info,
+                    "field variable '$1' is not allowed to use as a lvalue in a 'fields' loop" % [ident.s])
         let fieldName = if c.tupleType.isNil: c.field.name.s
                         elif c.tupleType.n.isNil: "Field" & $c.tupleIndex
                         else: c.tupleType.n[c.tupleIndex].sym.name.s
@@ -37,6 +41,9 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     # other fields:
     for i in ord(c.replaceByFieldName)..<forLoop.len-2:
       if ident.id == considerQuotedIdent(c.c, forLoop[i]).id:
+        if c.leftPartOfAssign:
+          localError(c.c.config, n.info,
+                    "field variable '$1' is not allowed to use as a lvalue in a 'fields' loop" % [ident.s])
         var call = forLoop[^2]
         var tupl = call[i+1-ord(c.replaceByFieldName)]
         if c.field.isNil:
@@ -48,6 +55,14 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
           result.add(tupl)
           result.add(newSymNode(c.field, n.info))
         break
+  of nkIdentDefs, nkVarTuple, nkConstDef,
+      nkAsgn, nkFastAsgn, nkSinkAsgn:
+    result = shallowCopy(n)
+    c.leftPartOfAssign = true
+    result[0] = instFieldLoopBody(c, n[0], forLoop)
+    c.leftPartOfAssign = false
+    for i in 1..<n.len:
+      result[i] = instFieldLoopBody(c, n[i], forLoop)
   else:
     if n.kind == nkContinueStmt:
       localError(c.c.config, n.info,

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -30,9 +30,6 @@ proc instFieldLoopBody(c: var TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     let ident = considerQuotedIdent(c.c, n)
     if c.replaceByFieldName:
       if ident.id == considerQuotedIdent(c.c, forLoop[0]).id:
-        if c.leftPartOfAssign:
-          localError(c.c.config, n.info,
-                    "field variable '$1' is not allowed to be used as a lvalue in a 'fields' loop" % [ident.s])
         let fieldName = if c.tupleType.isNil: c.field.name.s
                         elif c.tupleType.n.isNil: "Field" & $c.tupleIndex
                         else: c.tupleType.n[c.tupleIndex].sym.name.s

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -32,7 +32,7 @@ proc instFieldLoopBody(c: var TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
       if ident.id == considerQuotedIdent(c.c, forLoop[0]).id:
         if c.leftPartOfAssign:
           localError(c.c.config, n.info,
-                    "field variable '$1' is not allowed to use as a lvalue in a 'fields' loop" % [ident.s])
+                    "field variable '$1' is not allowed to be used as a lvalue in a 'fields' loop" % [ident.s])
         let fieldName = if c.tupleType.isNil: c.field.name.s
                         elif c.tupleType.n.isNil: "Field" & $c.tupleIndex
                         else: c.tupleType.n[c.tupleIndex].sym.name.s
@@ -43,7 +43,7 @@ proc instFieldLoopBody(c: var TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
       if ident.id == considerQuotedIdent(c.c, forLoop[i]).id:
         if c.leftPartOfAssign:
           localError(c.c.config, n.info,
-                    "field variable '$1' is not allowed to use as a lvalue in a 'fields' loop" % [ident.s])
+                    "field variable '$1' is not allowed to be used as a lvalue in a 'fields' loop" % [ident.s])
         var call = forLoop[^2]
         var tupl = call[i+1-ord(c.replaceByFieldName)]
         if c.field.isNil:


### PR DESCRIPTION
ref #24339

```nim
const r = (0, 0)
for x in r.fields:
  let x = 0
  echo x
```

Field replacing is disabled for lvaues in a 'fields' loop