### PR TITLE
warn about destructors with `setLenUninit` in docs

### DIFF
--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -203,6 +203,12 @@ func setLenUninit*[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
   ## Sets the length of seq `s` to `newlen`. `T` may be any sequence type.
   ## New slots will not be initialized.
   ##
+  ## .. warning:: Assigning to the uninitialized slots can generate
+  ##   destructor calls. If the slots have garbage data, they can still
+  ##   be interpreted as well-formed, potentially causing crashes.
+  ##   To prevent this, destructor injections should be disabled in the
+  ##   context, currently possible via the [nodestroy pragma](destructors.html#nodestroy-pragma).
+  ##
   ## If the current length is greater than the new length,
   ## `s` will be truncated.
   ##   ```nim


### PR DESCRIPTION
The compiler normally prevents destructor calls when assigning to `noinit` locations ([sink][], [variable init][]). But with `setLenUninit` the compiler can't track that the location is uninitialized, and so destructor calls are still generated. This can cause crashes since destructors may assume that the assigned location is well-formed. To deal with this, [grow][], [add][], [setLen][] all use `nodestroy` to prevent any destructor calls from being generated. So the docs for `setLenUninit` now warn about this issue, and suggest using `nodestroy`.

[grow]: https://github.com/nim-lang/Nim/blob/67442471ae4504bc074c8bb02308613fadc199f8/lib/system/seqs_v2.nim#L138
[add]: https://github.com/nim-lang/Nim/blob/67442471ae4504bc074c8bb02308613fadc199f8/lib/system/seqs_v2.nim#L150
[setLen]: https://github.com/nim-lang/Nim/blob/67442471ae4504bc074c8bb02308613fadc199f8/lib/system/seqs_v2.nim#L169
[sink]: https://github.com/nim-lang/Nim/blob/67442471ae4504bc074c8bb02308613fadc199f8/compiler/injectdestructors.nim#L280
[variable init]: https://github.com/nim-lang/Nim/blob/67442471ae4504bc074c8bb02308613fadc199f8/compiler/injectdestructors.nim#L964