### PR TITLE
cbuilder: abstract over int and float generation

### DIFF
--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -5,7 +5,13 @@ type
 template newBuilder(s: string): Builder =
   s
 
-proc addIntValue(builder: var Builder, val: int | int64 | uint64) =
+proc addIntValue(builder: var Builder, val: int) =
+  builder.addInt(val)
+
+proc addIntValue(builder: var Builder, val: int64) =
+  builder.addInt(val)
+
+proc addIntValue(builder: var Builder, val: uint64) =
   builder.addInt(val)
 
 proc addIntValue(builder: var Builder, val: Int128) =
@@ -20,7 +26,15 @@ template addIntValue(builder: var Builder, val: static int64) =
 template addIntValue(builder: var Builder, val: static uint64) =
   builder.add(static($val))
 
-proc cIntValue(val: int | int64 | uint64): Snippet =
+proc cIntValue(val: int): Snippet =
+  result = ""
+  result.addInt(val)
+
+proc cIntValue(val: int64): Snippet =
+  result = ""
+  result.addInt(val)
+
+proc cIntValue(val: uint64): Snippet =
   result = ""
   result.addInt(val)
 

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -18,6 +18,10 @@ proc cIntValue(val: int | int64 | uint64): Snippet =
   result = ""
   result.addInt(val)
 
+proc cIntValue(val: Int128): Snippet =
+  result = ""
+  result.addInt128(val)
+
 template cIntValue(val: static int): Snippet =
   (static($val))
 

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -14,6 +14,12 @@ proc addIntValue(builder: var Builder, val: Int128) =
 template addIntValue(builder: var Builder, val: static int) =
   builder.add(static($val))
 
+template addIntValue(builder: var Builder, val: static int64) =
+  builder.add(static($val))
+
+template addIntValue(builder: var Builder, val: static uint64) =
+  builder.add(static($val))
+
 proc cIntValue(val: int | int64 | uint64): Snippet =
   result = ""
   result.addInt(val)
@@ -23,6 +29,12 @@ proc cIntValue(val: Int128): Snippet =
   result.addInt128(val)
 
 template cIntValue(val: static int): Snippet =
+  (static($val))
+
+template cIntValue(val: static int64): Snippet =
+  (static($val))
+
+template cIntValue(val: static uint64): Snippet =
   (static($val))
 
 import std/formatfloat

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -4,3 +4,31 @@ type
 
 template newBuilder(s: string): Builder =
   s
+
+proc addIntValue(builder: var Builder, val: int | int64 | uint64) =
+  builder.addInt(val)
+
+template addIntValue(builder: var Builder, val: static int) =
+  builder.add(static($val))
+
+proc cIntValue(val: int | int64 | uint64): Snippet =
+  result = ""
+  result.addInt(val)
+
+template cIntValue(val: static int): Snippet =
+  (static($val))
+
+import std/formatfloat
+
+proc addFloatValue(builder: var Builder, val: float) =
+  builder.addFloat(val)
+
+template addFloatValue(builder: var Builder, val: static float) =
+  builder.add(static($val))
+
+proc cFloatValue(val: float): Snippet =
+  result = ""
+  result.addFloat(val)
+
+template cFloatValue(val: static float): Snippet =
+  (static($val))

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -17,51 +17,16 @@ proc addIntValue(builder: var Builder, val: uint64) =
 proc addIntValue(builder: var Builder, val: Int128) =
   builder.addInt128(val)
 
-template addIntValue(builder: var Builder, val: static int) =
-  builder.add(static($val))
-
-template addIntValue(builder: var Builder, val: static int64) =
-  builder.add(static($val))
-
-template addIntValue(builder: var Builder, val: static uint64) =
-  builder.add(static($val))
-
-proc cIntValue(val: int): Snippet =
-  result = ""
-  result.addInt(val)
-
-proc cIntValue(val: int64): Snippet =
-  result = ""
-  result.addInt(val)
-
-proc cIntValue(val: uint64): Snippet =
-  result = ""
-  result.addInt(val)
-
-proc cIntValue(val: Int128): Snippet =
-  result = ""
-  result.addInt128(val)
-
-template cIntValue(val: static int): Snippet =
-  (static($val))
-
-template cIntValue(val: static int64): Snippet =
-  (static($val))
-
-template cIntValue(val: static uint64): Snippet =
-  (static($val))
+template cIntValue(val: int): Snippet = $val
+template cIntValue(val: int64): Snippet = $val
+template cIntValue(val: uint64): Snippet = $val
+template cIntValue(val: Int128): Snippet = $val
 
 import std/formatfloat
 
 proc addFloatValue(builder: var Builder, val: float) =
   builder.addFloat(val)
 
-template addFloatValue(builder: var Builder, val: static float) =
-  builder.add(static($val))
-
 proc cFloatValue(val: float): Snippet =
   result = ""
   result.addFloat(val)
-
-template cFloatValue(val: static float): Snippet =
-  (static($val))

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -8,6 +8,9 @@ template newBuilder(s: string): Builder =
 proc addIntValue(builder: var Builder, val: int | int64 | uint64) =
   builder.addInt(val)
 
+proc addIntValue(builder: var Builder, val: Int128) =
+  builder.addInt128(val)
+
 template addIntValue(builder: var Builder, val: static int) =
   builder.add(static($val))
 

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -61,7 +61,7 @@ proc addArrayVar(builder: var Builder, kind: VarKind = Local, name: string, elem
   builder.add(" ")
   builder.add(name)
   builder.add("[")
-  builder.addInt(len)
+  builder.addIntValue(len)
   builder.add("]")
   if initializer.len != 0:
     builder.add(" = ")
@@ -75,7 +75,7 @@ template addArrayVarWithInitializer(builder: var Builder, kind: VarKind = Local,
   builder.add(" ")
   builder.add(name)
   builder.add("[")
-  builder.addInt(len)
+  builder.addIntValue(len)
   builder.add("] = ")
   body
   builder.add(";\n")
@@ -97,7 +97,7 @@ template addArrayTypedef(builder: var Builder, name: string, len: BiggestInt, ty
   builder.add(" ")
   builder.add(name)
   builder.add("[")
-  builder.addInt(len)
+  builder.addIntValue(len)
   builder.add("];\n")
 
 type
@@ -173,7 +173,7 @@ proc addArrayField(obj: var Builder; name, elementType: Snippet; len: int; initi
   obj.add(" ")
   obj.add(name)
   obj.add("[")
-  obj.addInt(len)
+  obj.addIntValue(len)
   obj.add("]")
   if initializer.len != 0:
     obj.add(initializer)
@@ -184,7 +184,7 @@ proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bo
   obj.add('\t')
   if field.alignment > 0:
     obj.add("NIM_ALIGN(")
-    obj.addInt(field.alignment)
+    obj.addIntValue(field.alignment)
     obj.add(") ")
   obj.add(typ)
   if sfNoalias in field.flags:
@@ -195,7 +195,7 @@ proc addField(obj: var Builder; field: PSym; name, typ: Snippet; isFlexArray: bo
     obj.add("[SEQ_DECL_SIZE]")
   if field.bitsize != 0:
     obj.add(":")
-    obj.addInt(field.bitsize)
+    obj.addIntValue(field.bitsize)
   if initializer.len != 0:
     obj.add(initializer)
   obj.add(";\n")

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3536,7 +3536,7 @@ proc genConstSeqV2(p: BProc, n: PNode, t: PType; isConst: bool; result: var Buil
   var resultInit: StructInitializer
   result.addStructInitializer(resultInit, kind = siOrderedStruct):
     result.addField(resultInit, name = "len"):
-      result.add(rope(n.len))
+      result.addIntValue(n.len)
     result.addField(resultInit, name = "p"):
       result.add cCast(typ = ptrType(getSeqPayloadType(p.module, t)), value = cAddr(payload))
 
@@ -3610,7 +3610,7 @@ proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType; resul
         result.addField(openArrInit, name = "Field0"):
           result.add(cCast(typ = ptrType(ctype), value = cAddr(payload)))
         result.addField(openArrInit, name = "Field1"):
-          result.add(rope arrLen)
+          result.addIntValue(arrLen)
 
     of tyObject:
       genConstObjConstr(p, n, isConst, result)

--- a/compiler/ccgliterals.nim
+++ b/compiler/ccgliterals.nim
@@ -48,7 +48,7 @@ proc genStringLiteralDataOnlyV1(m: BModule, s: string; result: var Rope) =
         var seqInit: StructInitializer
         res.addStructInitializer(seqInit, kind = siOrderedStruct):
           res.addField(seqInit, name = "len"):
-            res.add(rope(s.len))
+            res.addIntValue(s.len)
           res.addField(seqInit, name = "reserved"):
             res.add(cCast("NI", bitOr(cCast("NU", rope(s.len)), "NIM_STRLIT_FLAG")))
       res.addField(strInit, name = "data"):
@@ -109,7 +109,7 @@ proc genStringLiteralV2(m: BModule; n: PNode; isConst: bool; result: var Rope) =
     var strInit: StructInitializer
     res.addStructInitializer(strInit, kind = siOrderedStruct):
       res.addField(strInit, name = "len"):
-        res.add(rope(n.strVal.len))
+        res.addIntValue(n.strVal.len)
       res.addField(strInit, name = "p"):
         res.add(cCast(ptrType("NimStrPayload"), cAddr(litName)))
   m.s[cfsStrData].add(res)
@@ -128,7 +128,7 @@ proc genStringLiteralV2Const(m: BModule; n: PNode; isConst: bool; result: var Ro
   var strInit: StructInitializer
   result.addStructInitializer(strInit, kind = siOrderedStruct):
     result.addField(strInit, name = "len"):
-      result.add(rope(n.strVal.len))
+      result.addIntValue(n.strVal.len)
     result.addField(strInit, name = "p"):
       result.add(cCast(ptrType("NimStrPayload"), cAddr(pureLit)))
 

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1265,7 +1265,7 @@ proc genProcHeader(m: BModule; prc: PSym; result: var Rope; asPtr: bool = false)
 
 proc genTypeInfoV1(m: BModule; t: PType; info: TLineInfo): Rope
 proc getNimNode(m: BModule): Rope =
-  result = subscript(m.typeNodesName, rope(m.typeNodes))
+  result = subscript(m.typeNodesName, cIntValue(m.typeNodes))
   inc(m.typeNodes)
 
 proc tiNameForHcr(m: BModule; name: Rope): Rope =
@@ -1366,7 +1366,7 @@ proc genObjectFields(m: BModule; typ, origType: PType, n: PNode, expr: Rope;
       genTNimNodeArray(m, tmp, rope(n.len))
       for i in 0..<n.len:
         var tmp2 = getNimNode(m)
-        m.s[cfsTypeInit3].addSubscriptAssignment(tmp, rope(i)):
+        m.s[cfsTypeInit3].addSubscriptAssignment(tmp, cIntValue(i)):
           m.s[cfsTypeInit3].add(cAddr(tmp2))
         genObjectFields(m, typ, origType, n[i], tmp2, info)
       m.s[cfsTypeInit3].addFieldAssignment(expr, "len"):
@@ -1410,14 +1410,14 @@ proc genObjectFields(m: BModule; typ, origType: PType, n: PNode, expr: Rope;
             var x = toInt(getOrdValue(b[j][0]))
             var y = toInt(getOrdValue(b[j][1]))
             while x <= y:
-              m.s[cfsTypeInit3].addSubscriptAssignment(tmp, rope(x)):
+              m.s[cfsTypeInit3].addSubscriptAssignment(tmp, cIntValue(x)):
                 m.s[cfsTypeInit3].add(cAddr(tmp2))
               inc(x)
           else:
-            m.s[cfsTypeInit3].addSubscriptAssignment(tmp, rope(getOrdValue(b[j]))):
+            m.s[cfsTypeInit3].addSubscriptAssignment(tmp, cIntValue(getOrdValue(b[j]))):
               m.s[cfsTypeInit3].add(cAddr(tmp2))
       of nkElse:
-        m.s[cfsTypeInit3].addSubscriptAssignment(tmp, rope(L)):
+        m.s[cfsTypeInit3].addSubscriptAssignment(tmp, cIntValue(L)):
           m.s[cfsTypeInit3].add(cAddr(tmp2))
       else: internalError(m.config, n.info, "genObjectFields(nkRecCase)")
   of nkSym:
@@ -1459,7 +1459,7 @@ proc genTupleInfo(m: BModule; typ, origType: PType, name: Rope; info: TLineInfo)
     genTNimNodeArray(m, tmp, rope(typ.kidsLen))
     for i, a in typ.ikids:
       var tmp2 = getNimNode(m)
-      m.s[cfsTypeInit3].addSubscriptAssignment(tmp, rope(i)):
+      m.s[cfsTypeInit3].addSubscriptAssignment(tmp, cIntValue(i)):
         m.s[cfsTypeInit3].add(cAddr(tmp2))
       m.s[cfsTypeInit3].addf("$1.kind = 1;$n" &
           "$1.offset = offsetof($2, Field$3);$n" &

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1370,14 +1370,14 @@ proc genObjectFields(m: BModule; typ, origType: PType, n: PNode, expr: Rope;
           m.s[cfsTypeInit3].add(cAddr(tmp2))
         genObjectFields(m, typ, origType, n[i], tmp2, info)
       m.s[cfsTypeInit3].addFieldAssignment(expr, "len"):
-        m.s[cfsTypeInit3].add(rope(n.len))
+        m.s[cfsTypeInit3].addIntValue(n.len)
       m.s[cfsTypeInit3].addFieldAssignment(expr, "kind"):
         m.s[cfsTypeInit3].addIntValue(2)
       m.s[cfsTypeInit3].addFieldAssignment(expr, "sons"):
         m.s[cfsTypeInit3].add(cAddr(subscript(tmp, cIntValue(0))))
     else:
       m.s[cfsTypeInit3].addFieldAssignment(expr, "len"):
-        m.s[cfsTypeInit3].add(rope(n.len))
+        m.s[cfsTypeInit3].addIntValue(n.len)
       m.s[cfsTypeInit3].addFieldAssignment(expr, "kind"):
         m.s[cfsTypeInit3].addIntValue(2)
   of nkRecCase:
@@ -1467,14 +1467,14 @@ proc genTupleInfo(m: BModule; typ, origType: PType, name: Rope; info: TLineInfo)
           "$1.name = \"Field$3\";$n",
            [tmp2, getTypeDesc(m, origType, dkVar), rope(i), genTypeInfoV1(m, a, info)])
     m.s[cfsTypeInit3].addFieldAssignment(expr, "len"):
-      m.s[cfsTypeInit3].add(rope(typ.kidsLen))
+      m.s[cfsTypeInit3].addIntValue(typ.kidsLen)
     m.s[cfsTypeInit3].addFieldAssignment(expr, "kind"):
       m.s[cfsTypeInit3].addIntValue(2)
     m.s[cfsTypeInit3].addFieldAssignment(expr, "sons"):
       m.s[cfsTypeInit3].add(cAddr(subscript(tmp, cIntValue(0))))
   else:
     m.s[cfsTypeInit3].addFieldAssignment(expr, "len"):
-      m.s[cfsTypeInit3].add(rope(typ.kidsLen))
+      m.s[cfsTypeInit3].addIntValue(typ.kidsLen)
     m.s[cfsTypeInit3].addFieldAssignment(expr, "kind"):
       m.s[cfsTypeInit3].addIntValue(2)
   m.s[cfsTypeInit3].addFieldAssignment(tiNameForHcr(m, name), "node"):
@@ -1506,7 +1506,7 @@ proc genEnumInfo(m: BModule; typ: PType, name: Rope; info: TLineInfo) =
           enumNames.add(makeCString(field.ast.strVal))
       if field.position != i or tfEnumHasHoles in typ.flags:
         specialCases.addFieldAssignment(elemNode, "offset"):
-          specialCases.add(rope(field.position))
+          specialCases.addIntValue(field.position)
         hasHoles = true
   var enumArray = getTempName(m)
   var counter = getTempName(m)
@@ -1524,7 +1524,7 @@ proc genEnumInfo(m: BModule; typ: PType, name: Rope; info: TLineInfo) =
   m.s[cfsTypeInit3].add(specialCases)
   let n = getNimNode(m)
   m.s[cfsTypeInit3].addFieldAssignment(n, "len"):
-    m.s[cfsTypeInit3].add(rope(typ.n.len))
+    m.s[cfsTypeInit3].addIntValue(typ.n.len)
   m.s[cfsTypeInit3].addFieldAssignment(n, "kind"):
     m.s[cfsTypeInit3].addIntValue(0)
   m.s[cfsTypeInit3].addFieldAssignment(n, "sons"):
@@ -1540,7 +1540,7 @@ proc genSetInfo(m: BModule; typ: PType, name: Rope; info: TLineInfo) =
   genTypeInfoAux(m, typ, typ, name, info)
   var tmp = getNimNode(m)
   m.s[cfsTypeInit3].addFieldAssignment(tmp, "len"):
-    m.s[cfsTypeInit3].add(rope(firstOrd(m.config, typ)))
+    m.s[cfsTypeInit3].addIntValue(firstOrd(m.config, typ))
   m.s[cfsTypeInit3].addFieldAssignment(tmp, "kind"):
     m.s[cfsTypeInit3].addIntValue(0)
   m.s[cfsTypeInit3].addFieldAssignment(tiNameForHcr(m, name), "node"):
@@ -1746,7 +1746,7 @@ proc genTypeInfoV2OldImpl(m: BModule; t, origType: PType, name: Rope; info: TLin
         len = objDepth + 1,
         initializer = objDisplay)
     typeEntry.addFieldAssignment(name, "display"):
-      typeEntry.add(rope(objDisplayStore))
+      typeEntry.add(objDisplayStore)
 
   let dispatchMethods = toSeq(getMethodsPerType(m.g.graph, t))
   if dispatchMethods.len > 0:


### PR DESCRIPTION
Different from `intLiteral`, we add procs that just try to generate integer values, assuming they're not an edge case like `<= low(int32)` or `> high(int32)`.