### PR TITLE
fixes #24359; VM problem: dest register is not set with const-bound proc

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1006,9 +1006,9 @@ proc evalAtCompileTime(c: PContext, n: PNode): PNode =
       n.typ.flags.incl tfUnresolved
 
   # optimization pass: not necessary for correctness of the semantic pass
-  if callee.kind == skConst or
+  if (callee.kind == skConst or
      {sfNoSideEffect, sfCompileTime} * callee.flags != {} and
-     {sfForward, sfImportc} * callee.flags == {} and n.typ != nil:
+     {sfForward, sfImportc} * callee.flags == {}) and n.typ != nil:
 
     if callee.kind != skConst and
        sfCompileTime notin callee.flags and

--- a/tests/vm/tconstprocassignments.nim
+++ b/tests/vm/tconstprocassignments.nim
@@ -16,3 +16,18 @@ const G = proc ():int =
   y()
 
 echo G()
+
+
+block: # bug #24359
+  block:
+    proc h(_: bool) = discard
+    const m = h
+    static: m(true)  # works
+    m(true)          # does not work
+
+block:
+  block:
+    proc h(_: bool): int = result = 1
+    const m = h
+    static: doAssert m(true) == 1 # works
+    doAssert m(true) == 1          # does not work


### PR DESCRIPTION
fixes #24359

follow up https://github.com/nim-lang/Nim/pull/11076

It should not try to evaluate the const proc if the proc doesn't have a return value.
