### PR TITLE
don't cascade vmgen errors in nim check without error outputs

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1543,7 +1543,9 @@ proc setSlot(c: PCtx; v: PSym) =
     v.position = getFreeRegister(c, if v.kind == skLet: slotFixedLet else: slotFixedVar, start = 1)
 
 template cannotEval(c: PCtx; n: PNode) =
-  if c.config.cmd == cmdCheck:
+  if c.config.cmd == cmdCheck and c.config.m.errorOutputs != {}:
+    # nim check command with no error outputs doesn't need to cascade here,
+    # includes `tryConstExpr` case which should not continue generating code
     localError(c.config, n.info, "cannot evaluate at compile time: " & 
     n.renderTree)
     c.cannotEval = true


### PR DESCRIPTION
refs #23625, refs #24289

Encountered in #24360 but could not reproduce minimally: overloading on static parameters can work with the normal compile commands but crash `nim check`. Static overloading relies on `tryConstExpr` which recovers from things like `globalError` and fails softly, in this case this can happen when a variable etc. is not available to evaluate in the VM. But with `nim check`, the compiler does not throw an exception in this case, and instead tries to keep generating the entire expression in the VM, which can cause crashes.

To fix this, when the compiler has no error outputs even on `nim check`, we raise a global error so that the VM code generation stops early. This fixes both `tryConstExpr` and speeds up `nim check`, because no error outputs means we don't need cascading errors.