### PR TITLE
cbuilder: ccgexprs sweep part 1, basic if stmts

### DIFF
--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -27,6 +27,50 @@ import std/formatfloat
 proc addFloatValue(builder: var Builder, val: float) =
   builder.addFloat(val)
 
-proc cFloatValue(val: float): Snippet =
-  result = ""
-  result.addFloat(val)
+template cFloatValue(val: float): Snippet = $val
+
+proc int64Literal(i: BiggestInt; result: var Builder) =
+  if i > low(int64):
+    result.add "IL64($1)" % [rope(i)]
+  else:
+    result.add "(IL64(-9223372036854775807) - IL64(1))"
+
+proc uint64Literal(i: uint64; result: var Builder) =
+  result.add rope($i & "ULL")
+
+proc intLiteral(i: BiggestInt; result: var Builder) =
+  if i > low(int32) and i <= high(int32):
+    result.addIntValue(i)
+  elif i == low(int32):
+    # Nim has the same bug for the same reasons :-)
+    result.add "(-2147483647 -1)"
+  elif i > low(int64):
+    result.add "IL64($1)" % [rope(i)]
+  else:
+    result.add "(IL64(-9223372036854775807) - IL64(1))"
+
+proc intLiteral(i: Int128; result: var Builder) =
+  intLiteral(toInt64(i), result)
+
+proc cInt64Literal(i: BiggestInt): Snippet =
+  if i > low(int64):
+    result = "IL64($1)" % [rope(i)]
+  else:
+    result = "(IL64(-9223372036854775807) - IL64(1))"
+
+proc cUint64Literal(i: uint64): Snippet =
+  result = $i & "ULL"
+
+proc cIntLiteral(i: BiggestInt): Snippet =
+  if i > low(int32) and i <= high(int32):
+    result = rope(i)
+  elif i == low(int32):
+    # Nim has the same bug for the same reasons :-)
+    result = "(-2147483647 -1)"
+  elif i > low(int64):
+    result = "IL64($1)" % [rope(i)]
+  else:
+    result = "(IL64(-9223372036854775807) - IL64(1))"
+
+proc cIntLiteral(i: Int128): Snippet =
+  result = cIntLiteral(toInt64(i))

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -33,6 +33,11 @@ proc wrapPar(value: Snippet): Snippet =
   # used for expression group, no-op on sexp
   "(" & value & ")"
 
+proc removeSinglePar(value: Snippet): Snippet =
+  # removes a single paren layer expected to exist, to silence Wparentheses-equality
+  assert value[0] == '(' and value[^1] == ')'
+  value[1..^2]
+
 template addCast(builder: var Builder, typ: Snippet, valueBody: typed) =
   ## adds a cast to `typ` with value built by `valueBody`
   builder.add "(("

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -87,15 +87,25 @@ template addCall(builder: var Builder, call: out CallBuilder, callee: Snippet, b
   body
   finishCallBuilder(builder, call)
 
-proc addNullaryCall(builder: var Builder, callee: Snippet) =
-  builder.add(callee)
-  builder.add("()")
-
-proc addUnaryCall(builder: var Builder, callee: Snippet, arg: Snippet) =
+proc addCall(builder: var Builder, callee: Snippet, args: varargs[Snippet]) =
   builder.add(callee)
   builder.add("(")
-  builder.add(arg)
+  if args.len != 0:
+    builder.add(args[0])
+    for i in 1 ..< args.len:
+      builder.add(", ")
+      builder.add(args[i])
   builder.add(")")
+
+proc cCall(callee: Snippet, args: varargs[Snippet]): Snippet =
+  result = callee
+  result.add("(")
+  if args.len != 0:
+    result.add(args[0])
+    for i in 1 ..< args.len:
+      result.add(", ")
+      result.add(args[i])
+  result.add(")")
 
 proc addSizeof(builder: var Builder, val: Snippet) =
   builder.add("sizeof(")

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -2,7 +2,14 @@
 # XXX add stuff like NI, NIM_NIL as constants
 
 proc constType(t: Snippet): Snippet =
+  # needs manipulation of `t` in nifc
   "NIM_CONST " & t
+
+proc constPtrType(t: Snippet): Snippet =
+  t & "* NIM_CONST"
+
+proc ptrConstType(t: Snippet): Snippet =
+  "NIM_CONST " & t & "*"
 
 proc ptrType(t: Snippet): Snippet =
   t & "*"

--- a/compiler/cbuilderstmts.nim
+++ b/compiler/cbuilderstmts.nim
@@ -1,31 +1,56 @@
-template addAssignment(builder: var Builder, lhs: Snippet, valueBody: typed) =
+template addAssignmentWithValue(builder: var Builder, lhs: Snippet, valueBody: typed) =
   builder.add(lhs)
   builder.add(" = ")
   valueBody
   builder.add(";\n")
 
-template addFieldAssignment(builder: var Builder, lhs: Snippet, name: string, valueBody: typed) =
+template addFieldAssignmentWithValue(builder: var Builder, lhs: Snippet, name: string, valueBody: typed) =
   builder.add(lhs)
   builder.add("." & name & " = ")
   valueBody
   builder.add(";\n")
 
-template addDerefFieldAssignment(builder: var Builder, lhs: Snippet, name: string, valueBody: typed) =
+template addAssignment(builder: var Builder, lhs, rhs: Snippet) =
+  builder.addAssignmentWithValue(lhs):
+    builder.add(rhs)
+
+template addFieldAssignment(builder: var Builder, lhs: Snippet, name: string, rhs: Snippet) =
+  builder.addFieldAssignmentWithValue(lhs, name):
+    builder.add(rhs)
+
+template addMutualFieldAssignment(builder: var Builder, lhs, rhs: Snippet, name: string) =
+  builder.addFieldAssignmentWithValue(lhs, name):
+    builder.add(rhs)
+    builder.add("." & name)
+
+template addAssignment(builder: var Builder, lhs: Snippet, rhs: int | int64 | uint64 | Int128) =
+  builder.addAssignmentWithValue(lhs):
+    builder.addIntValue(rhs)
+
+template addFieldAssignment(builder: var Builder, lhs: Snippet, name: string, rhs: int | int64 | uint64 | Int128) =
+  builder.addFieldAssignmentWithValue(lhs, name):
+    builder.addIntValue(rhs)
+
+template addDerefFieldAssignment(builder: var Builder, lhs: Snippet, name: string, rhs: Snippet) =
   builder.add(lhs)
   builder.add("->" & name & " = ")
-  valueBody
+  builder.add(rhs)
   builder.add(";\n")
 
-template addSubscriptAssignment(builder: var Builder, lhs: Snippet, index: Snippet, valueBody: typed) =
+template addSubscriptAssignment(builder: var Builder, lhs: Snippet, index: Snippet, rhs: Snippet) =
   builder.add(lhs)
   builder.add("[" & index & "] = ")
-  valueBody
+  builder.add(rhs)
   builder.add(";\n")
 
 template addStmt(builder: var Builder, stmtBody: typed) =
   ## makes an expression built by `stmtBody` into a statement
   stmtBody
   builder.add(";\n")
+
+proc addCallStmt(builder: var Builder, callee: Snippet, args: varargs[Snippet]) =
+  builder.addStmt():
+    builder.addCall(callee, args)
 
 # XXX blocks need indent tracker in `Builder` object
 

--- a/compiler/cbuilderstmts.nim
+++ b/compiler/cbuilderstmts.nim
@@ -26,3 +26,44 @@ template addStmt(builder: var Builder, stmtBody: typed) =
   ## makes an expression built by `stmtBody` into a statement
   stmtBody
   builder.add(";\n")
+
+# XXX blocks need indent tracker in `Builder` object
+
+template addSingleIfStmt(builder: var Builder, cond: Snippet, body: typed) =
+  builder.add("if (")
+  builder.add(cond)
+  builder.add(") {\n")
+  body
+  builder.add("}\n")
+
+template addSingleIfStmtWithCond(builder: var Builder, condBody: typed, body: typed) =
+  builder.add("if (")
+  condBody
+  builder.add(") {\n")
+  body
+  builder.add("}\n")
+
+type IfStmt = object
+  needsElse: bool
+
+template addIfStmt(builder: var Builder, stmt: out IfStmt, body: typed) =
+  stmt = IfStmt(needsElse: false)
+  body
+  builder.add("\n")
+
+template addElifBranch(builder: var Builder, stmt: var IfStmt, cond: Snippet, body: typed) =
+  if stmt.needsElse:
+    builder.add(" else ")
+  else:
+    stmt.needsElse = true
+  builder.add("if (")
+  builder.add(cond)
+  builder.add(") {\n")
+  body
+  builder.add("}")
+
+template addElseBranch(builder: var Builder, stmt: var IfStmt, body: typed) =
+  assert stmt.needsElse
+  builder.add(" else {\n")
+  body
+  builder.add("}")

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -187,7 +187,7 @@ proc genRefAssign(p: BProc, dest, src: TLoc) =
     let rs = rdLoc(src)
     var asgnCall: CallBuilder
     p.s(cpsStmts).addStmt():
-      p.s(cpsStmts).addCall(asgnCall, cgsymValue(p.module, fnName)):
+      p.s(cpsStmts).addCall(asgnCall, fnName):
         p.s(cpsStmts).addArgument(asgnCall):
           p.s(cpsStmts).addCast("void**"):
             p.s(cpsStmts).add(rad)
@@ -830,7 +830,7 @@ proc binaryArithOverflow(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
       if e[2].kind in {nkIntLit..nkInt64Lit}:
         needsOverflowCheck = e[2].intVal == -1
       if canBeZero:
-        p.s(cpsStmts).addSingleIfStmt(cOp(Equal, rdLoc(b), cIntValue(0))):
+        p.s(cpsStmts).addSingleIfStmt(removeSinglePar(cOp(Equal, rdLoc(b), cIntValue(0)))):
           p.s(cpsStmts).addStmt():
             p.s(cpsStmts).addNullaryCall(cgsymValue(p.module, "raiseDivByZero"))
           raiseInstr(p, p.s(cpsStmts))
@@ -851,7 +851,7 @@ proc unaryArithOverflow(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
   let ra = rdLoc(a)
   if optOverflowCheck in p.options:
     let first = cIntLiteral(firstOrd(p.config, t))
-    p.s(cpsStmts).addSingleIfStmt(cOp(Equal, ra, first)):
+    p.s(cpsStmts).addSingleIfStmt(removeSinglePar(cOp(Equal, ra, first))):
       p.s(cpsStmts).addStmt():
         p.s(cpsStmts).addNullaryCall(cgsymValue(p.module, "raiseOverflow"))
       raiseInstr(p, p.s(cpsStmts))

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -576,7 +576,7 @@ proc binaryStmtAddr(p: BProc, e: PNode, d: var TLoc, cpname: string) =
   var b = initLocExpr(p, e[2])
   let bra = byRefLoc(p, a)
   let rb = rdLoc(b)
-  p.s(cpsStmts).addCallStmt(cgsymValue(p.module, cpname), bra, rb):
+  p.s(cpsStmts).addCallStmt(cgsymValue(p.module, cpname), bra, rb)
 
 template unaryStmt(p: BProc, e: PNode, d: var TLoc, frmt: string) =
   if d.k != locNone: internalError(p.config, e.info, "unaryStmt")

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -187,7 +187,7 @@ proc genRefAssign(p: BProc, dest, src: TLoc) =
     let rs = rdLoc(src)
     var asgnCall: CallBuilder
     p.s(cpsStmts).addStmt():
-      p.s(cpsStmts).addCall(asgnCall, cgsymValue(p.module, "asgnRef")):
+      p.s(cpsStmts).addCall(asgnCall, cgsymValue(p.module, fnName)):
         p.s(cpsStmts).addArgument(asgnCall):
           p.s(cpsStmts).addCast("void**"):
             p.s(cpsStmts).add(rad)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -400,20 +400,20 @@ template mapTypeChooser(a: TLoc): TSymKind = mapTypeChooser(a.lode)
 
 proc addAddrLoc(conf: ConfigRef; a: TLoc; result: var Rope) =
   if lfIndirect notin a.flags and mapType(conf, a.t, mapTypeChooser(a) == skParam) != ctArray:
-    result.add "(&" & a.snippet & ")"
+    result.add wrapPar(cAddr(a.snippet))
   else:
     result.add a.snippet
 
 proc addrLoc(conf: ConfigRef; a: TLoc): Rope =
   if lfIndirect notin a.flags and mapType(conf, a.t, mapTypeChooser(a) == skParam) != ctArray:
-    result = cAddr(a.snippet)
+    result = wrapPar(cAddr(a.snippet))
   else:
     result = a.snippet
 
 proc byRefLoc(p: BProc; a: TLoc): Rope =
   if lfIndirect notin a.flags and mapType(p.config, a.t, mapTypeChooser(a) == skParam) != ctArray and not
       p.module.compileToCpp:
-    result = cAddr(a.snippet)
+    result = wrapPar(cAddr(a.snippet))
   else:
     result = a.snippet
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -337,31 +337,44 @@ proc getTempName(m: BModule): Rope =
   result = m.tmpBase & rope(m.labels)
   inc m.labels
 
+include cbuilderbase
+include cbuilderexprs
+include cbuilderdecls
+include cbuilderstmts
+
 proc rdLoc(a: TLoc): Rope =
   # 'read' location (deref if indirect)
   if lfIndirect in a.flags:
-    result = "(*" & a.snippet & ")"
+    result = cDeref(a.snippet)
   else:
     result = a.snippet
 
 proc addRdLoc(a: TLoc; result: var Rope) =
   if lfIndirect in a.flags:
-    result.add "(*" & a.snippet & ")"
+    result.add cDeref(a.snippet)
   else:
     result.add a.snippet
 
 proc lenField(p: BProc): Rope {.inline.} =
   result = rope(if p.module.compileToCpp: "len" else: "Sup.len")
 
+proc lenField(p: BProc, val: Rope): Rope {.inline.} =
+  if p.module.compileToCpp:
+    result = derefField(val, "len")
+  else:
+    result = dotField(derefField(val, "Sup"), "len")
+  result = rope(if p.module.compileToCpp: "len" else: "Sup.len")
+
 proc lenExpr(p: BProc; a: TLoc): Rope =
   if optSeqDestructors in p.config.globalOptions:
-    result = rdLoc(a) & ".len"
+    result = dotField(rdLoc(a), "len")
   else:
-    result = "($1 ? $1->$2 : 0)" % [rdLoc(a), lenField(p)]
+    let ra = rdLoc(a)
+    result = cIfExpr(ra, lenField(p, ra), cIntValue(0))
 
 proc dataFieldAccessor(p: BProc, sym: Rope): Rope =
   if optSeqDestructors in p.config.globalOptions:
-    result = "(" & sym & ").p"
+    result = dotField(wrapPar(sym), "p")
   else:
     result = sym
 
@@ -371,12 +384,11 @@ proc dataField(p: BProc): Rope =
   else:
     result = rope"->data"
 
+proc dataField(p: BProc, val: Rope): Rope {.inline.} =
+  result = derefField(dataFieldAccessor(p, val), "data")
+
 proc genProcPrototype(m: BModule, sym: PSym)
 
-include cbuilderbase
-include cbuilderexprs
-include cbuilderdecls
-include cbuilderstmts
 include ccgliterals
 include ccgtypes
 
@@ -395,14 +407,14 @@ proc addAddrLoc(conf: ConfigRef; a: TLoc; result: var Rope) =
 
 proc addrLoc(conf: ConfigRef; a: TLoc): Rope =
   if lfIndirect notin a.flags and mapType(conf, a.t, mapTypeChooser(a) == skParam) != ctArray:
-    result = "(&" & a.snippet & ")"
+    result = cAddr(a.snippet)
   else:
     result = a.snippet
 
 proc byRefLoc(p: BProc; a: TLoc): Rope =
   if lfIndirect notin a.flags and mapType(p.config, a.t, mapTypeChooser(a) == skParam) != ctArray and not
       p.module.compileToCpp:
-    result = "(&" & a.snippet & ")"
+    result = cAddr(a.snippet)
   else:
     result = a.snippet
 
@@ -410,7 +422,7 @@ proc rdCharLoc(a: TLoc): Rope =
   # read a location that may need a char-cast:
   result = rdLoc(a)
   if skipTypes(a.t, abstractRange).kind == tyChar:
-    result = "((NU8)($1))" % [result]
+    result = cCast("NU8", result)
 
 type
   TAssignmentFlag = enum
@@ -756,7 +768,6 @@ proc genStmts(p: BProc, t: PNode)
 proc expr(p: BProc, n: PNode, d: var TLoc)
 
 proc putLocIntoDest(p: BProc, d: var TLoc, s: TLoc)
-proc intLiteral(i: BiggestInt; result: var Rope)
 proc genLiteral(p: BProc, n: PNode; result: var Rope)
 proc genOtherArg(p: BProc; ri: PNode; i: int; typ: PType; result: var Rope; argsCounter: var int)
 proc raiseExit(p: BProc)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -363,7 +363,6 @@ proc lenField(p: BProc, val: Rope): Rope {.inline.} =
     result = derefField(val, "len")
   else:
     result = dotField(derefField(val, "Sup"), "len")
-  result = rope(if p.module.compileToCpp: "len" else: "Sup.len")
 
 proc lenExpr(p: BProc; a: TLoc): Rope =
   if optSeqDestructors in p.config.globalOptions:


### PR DESCRIPTION
Most of what ccgexprs uses is now ported to cbuilder, so this PR makes around ~25% of ccgexprs use it, along with adding `if` stmts (no `while`/`switch` and `for` which is only used as `for (tmp = a; tmp < b; tmp++)`). The `if` builder does not add indents for blocks since we can't make `Builder` an object yet rather than an alias to `string`, this will likely be one of the last refactors.

Somewhat unrelated but `ccgtypes` is not ready yet because proc signatures are not implemented.