### PR TITLE
fixes #24378; supportsCopyMem can fail from macro context with tuples

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1645,7 +1645,7 @@ proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
   if mask != {} and propagateHasAsgn:
     let o2 = owner.skipTypes({tyGenericInst, tyAlias, tySink})
     if o2.kind in {tyTuple, tyObject, tyArray,
-                   tySequence, tySet, tyDistinct}:
+                   tySequence, tyString, tySet, tyDistinct}:
       o2.flags.incl mask
       owner.flags.incl mask
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -500,7 +500,7 @@ proc semAnonTuple(c: PContext, n: PNode, prev: PType): PType =
   result = newOrPrevType(tyTuple, prev, c)
   for it in n:
     let t = semTypeNode(c, it, nil)
-    addSonSkipIntLitChecked(c, result, t.skipTypes({tyAlias}), it, c.idgen)
+    addSonSkipIntLitChecked(c, result, t, it, c.idgen)
 
 proc firstRange(config: ConfigRef, t: PType): PNode =
   if t.skipModifier().kind in tyFloat..tyFloat64:
@@ -543,7 +543,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
           fSym.sym.ast = a[^1]
           fSym.sym.ast.flags.incl nfSkipFieldChecking
         result.n.add fSym
-        addSonSkipIntLit(result, typ.skipTypes({tyAlias}), c.idgen)
+        addSonSkipIntLit(result, typ, c.idgen)
       styleCheckDef(c, a[j].info, field)
       onDef(field.info, field)
   if result.n.len == 0: result.n = nil

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -500,7 +500,7 @@ proc semAnonTuple(c: PContext, n: PNode, prev: PType): PType =
   result = newOrPrevType(tyTuple, prev, c)
   for it in n:
     let t = semTypeNode(c, it, nil)
-    addSonSkipIntLitChecked(c, result, t, it, c.idgen)
+    addSonSkipIntLitChecked(c, result, t.skipTypes({tyAlias}), it, c.idgen)
 
 proc firstRange(config: ConfigRef, t: PType): PNode =
   if t.skipModifier().kind in tyFloat..tyFloat64:
@@ -543,7 +543,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
           fSym.sym.ast = a[^1]
           fSym.sym.ast.flags.incl nfSkipFieldChecking
         result.n.add fSym
-        addSonSkipIntLit(result, typ, c.idgen)
+        addSonSkipIntLit(result, typ.skipTypes({tyAlias}), c.idgen)
       styleCheckDef(c, a[j].info, field)
       onDef(field.info, field)
   if result.n.len == 0: result.n = nil

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -1,3 +1,7 @@
+discard """
+  joinable: false
+"""
+
 import typetraits
 import macros
 
@@ -411,7 +415,7 @@ block: # bug #24378
       doAssert not supportsCopyMem((int, Win))
       doAssert not supportsCopyMem(tuple[a: int, b: Win])
 
-      type WIn2[T] = typeof(`body`)
+      type Win2[T] = typeof(`body`)
       doAssert not supportsCopyMem((int, Win2[int]))
       doAssert not supportsCopyMem(tuple[a: int, b: Win2[int]])
   forked:

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -402,3 +402,26 @@ when true: # Odd bug where alias can seep inside of `distinctBase`
   proc `$`*[T: AdtChild](adtChild: T): string = ""
 
   check 10 is int
+
+
+block: # bug #24378
+  macro forked(body: typed): untyped = # typed or untyped does not matter
+    result = quote do:
+      type Win = typeof(`body`)
+      doAssert not supportsCopyMem((int, Win))
+      doAssert not supportsCopyMem(tuple[a: int, b: Win])
+
+      type WIn2[T] = typeof(`body`)
+      doAssert not supportsCopyMem((int, Win2[int]))
+      doAssert not supportsCopyMem(tuple[a: int, b: Win2[int]])
+  forked:
+    "foobar"
+
+
+  type Win111 = typeof("foobar")
+  doAssert not supportsCopyMem((int, Win111))
+  doAssert not supportsCopyMem(tuple[a: int, b: Win111])
+
+  type Win222[T] = typeof("foobar")
+  doAssert not supportsCopyMem((int, Win222[int]))
+  doAssert not supportsCopyMem(tuple[a: int, b: Win222[int]])


### PR DESCRIPTION
fixes #24378

```nim
type Win = typeof(`body`)
doAssert not supportsCopyMem((int, Win))
```

`semAfterMacroCall` doesn't skip the children aliases types in the tuple typedesc construction while the normal program seem to skip the aliases types somewhere

`(int, Win)` is kept as `(int, alias string)` instead of expected `(int, string)`