### PR TITLE
disable all badssl tests indefinitely

### DIFF
--- a/tests/untestable/thttpclient_ssl_disabled.nim
+++ b/tests/untestable/thttpclient_ssl_disabled.nim
@@ -9,6 +9,7 @@
 ## nim r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:nimDisableCertificateValidation -d:ssl -p:. tests/untestable/thttpclient_ssl_disabled.nim
 
 from stdtest/testutils import enableRemoteNetworking
+# badssl tests disabled indefinitely
 when false and enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(openbsd)):
   import httpclient, net, unittest
 

--- a/tests/untestable/thttpclient_ssl_disabled.nim
+++ b/tests/untestable/thttpclient_ssl_disabled.nim
@@ -9,7 +9,7 @@
 ## nim r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:nimDisableCertificateValidation -d:ssl -p:. tests/untestable/thttpclient_ssl_disabled.nim
 
 from stdtest/testutils import enableRemoteNetworking
-when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(openbsd)):
+when false and enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(openbsd)):
   import httpclient, net, unittest
 
   const expired = "https://expired.badssl.com/"

--- a/tests/untestable/thttpclient_ssl_env_var.nim
+++ b/tests/untestable/thttpclient_ssl_env_var.nim
@@ -19,7 +19,6 @@ from net import newSocket, newContext, wrapSocket, connect, close, Port,
 from strutils import contains
 
 const
-  expired = "https://expired.badssl.com/"
   good = "https://google.com/"
 
 
@@ -56,12 +55,13 @@ suite "SSL certificate check":
       var ctx = newContext(verifyMode=CVerifyPeerUseEnvVars)
       ctx.wrapSocket(sock)
       checkpoint("Socket created")
-      try:
-        sock.connect("expired.badssl.com", 443.Port)
-        fail()
-      except:
-        sock.close
-        check getCurrentExceptionMsg().contains("certificate verify failed")
+      when false:
+        try:
+          sock.connect("expired.badssl.com", 443.Port)
+          fail()
+        except:
+          sock.close
+          check getCurrentExceptionMsg().contains("certificate verify failed")
 
     elif existsEnv("SSL_CERT_DIR"):
       var sock = newSocket()

--- a/tests/untestable/thttpclient_ssl_env_var.nim
+++ b/tests/untestable/thttpclient_ssl_env_var.nim
@@ -55,7 +55,7 @@ suite "SSL certificate check":
       var ctx = newContext(verifyMode=CVerifyPeerUseEnvVars)
       ctx.wrapSocket(sock)
       checkpoint("Socket created")
-      when false:
+      when false: # badssl tests disabled indefinitely
         try:
           sock.connect("expired.badssl.com", 443.Port)
           fail()

--- a/tests/untestable/thttpclient_ssl_remotenetwork.nim
+++ b/tests/untestable/thttpclient_ssl_remotenetwork.nim
@@ -33,6 +33,7 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
     CertTest = tuple[url:string, category:Category, desc: string]
 
   # badssl certs sometimes expire, set to false when that happens
+  # badssl now disabled indefinitely
   when false:
     const certificate_tests: array[0..54, CertTest] = [
       ("https://wrong.host.badssl.com/", bad, "wrong.host"),

--- a/tests/untestable/thttpclient_ssl_remotenetwork.nim
+++ b/tests/untestable/thttpclient_ssl_remotenetwork.nim
@@ -33,7 +33,7 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
     CertTest = tuple[url:string, category:Category, desc: string]
 
   # badssl certs sometimes expire, set to false when that happens
-  when true:
+  when false:
     const certificate_tests: array[0..54, CertTest] = [
       ("https://wrong.host.badssl.com/", bad, "wrong.host"),
       ("https://captive-portal.badssl.com/", bad, "captive-portal"),
@@ -197,7 +197,7 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
 
   type NetSocketTest = tuple[hostname: string, port: Port, category:Category, desc: string]
   # badssl certs sometimes expire, set to false when that happens
-  when true:
+  when false:
     const net_tests:array[0..3, NetSocketTest] = [
       ("imap.gmail.com", 993.Port, good, "IMAP"),
       ("wrong.host.badssl.com", 443.Port, bad, "wrong.host"),


### PR DESCRIPTION
Flaky not just due to recent ubuntu 24/GCC 14 upgrades, windows fails as well, assuming the issue is with badssl or it's just not worth testing here.