### PR TITLE
fix standalone explicit generic procs with unresolved arguments

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1816,7 +1816,9 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags, afterOverloading = f
         # type parameters: partial generic specialization
         n[0] = semSymGenericInstantiation(c, n[0], s)
         result = maybeInstantiateGeneric(c, n, s, doError = afterOverloading)
-        if result != nil:
+        if result != nil and
+            # leave untyped generic expression alone:
+            (result.typ == nil or result.typ.kind != tyFromExpr):
           # check newly created sym/symchoice
           result = semExpr(c, result, flags)
       of skMacro, skTemplate:

--- a/tests/proc/texplicitgenerics.nim
+++ b/tests/proc/texplicitgenerics.nim
@@ -53,3 +53,11 @@ block: # issue #21346
   b1(false)     # Error: cannot instantiate K; got: <T> but expected: <T>
   b2(false)     # Builds, on its own
   b3(false)
+
+block: # explicit generic with unresolved generic param, https://forum.nim-lang.org/t/12579
+  var s: seq[string] = @[]
+  proc MyMedian[T](A: var openArray[T],myCmp : proc(x,y:T):int {.nimcall.} = cmp[T]) : T =
+    if myCmp(A[0], A[1]) == 0: s.add("1")
+  var x = [1, 1]
+  discard MyMedian(x) # emits "1\n"
+  doAssert s == @["1"]


### PR DESCRIPTION
fixes issue described in https://forum.nim-lang.org/t/12579

In #24065 explicit generic parameter matching was made to fail matches on arguments with unresolved types in generic contexts (the sigmatch diff, following #24010), similar to what is done for regular calls since #22029. However unlike regular calls, a failed match in a generic context for a standalone explicit generic instantiation did not convert the expression into one with `tyFromExpr` type, which means it would error immediately given any unresolved parameter. This is now done to fix the issue.

For explicit generic instantiations on single non-overloaded symbols, a successful match is still instantiated. For multiple overloads (i.e. symchoice), if any of the overloads fail the match, the entire expression is considered untyped and any instantiations are not used, so as to not void overloads that would match later. This means even symchoices without unresolved arguments aren't instantiated, which may be too restrictive, but it could also be too lenient and we might need to make symchoice instantiations always untyped. The behavior for symchoice is not sound anyway given it causes #9997 so this is something to consider for a redesign.

Diff follows #24276.

