### PR TITLE
cbuilder: add switch stmt, use for ccgreset and ccgtrav

### DIFF
--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -29,6 +29,9 @@ proc procPtrTypeUnnamed(rettype, params: Snippet): Snippet =
 proc procPtrTypeUnnamedNimCall(rettype, params: Snippet): Snippet =
   rettype & "(N_RAW_NIMCALL*)" & params
 
+proc procPtrTypeUnnamed(callConv: TCallingConvention, rettype, params: Snippet): Snippet =
+  CallingConvToStr[callConv] & "_PTR(" & rettype & ", )" & params
+
 proc cCast(typ, value: Snippet): Snippet =
   "((" & typ & ") " & value & ")"
 

--- a/compiler/cbuilderstmts.nim
+++ b/compiler/cbuilderstmts.nim
@@ -119,6 +119,61 @@ template addForRangeInclusive(builder: var Builder, i, start, bound: Snippet, bo
   body
   builder.add("}\n")
 
+template addSwitchStmt(builder: var Builder, val: Snippet, body: typed) =
+  builder.add("switch (")
+  builder.add(val)
+  builder.add(") {\n")
+  body
+  builder.add("}\n")
+
+template addSingleSwitchCase(builder: var Builder, val: Snippet, body: typed) =
+  builder.add("case ")
+  builder.add(val)
+  builder.add(":\n")
+  body
+
+type
+  SwitchCaseState = enum
+    None, Of, Else, Finished
+  SwitchCaseBuilder = object
+    state: SwitchCaseState
+
+proc addCase(builder: var Builder, info: var SwitchCaseBuilder, val: Snippet) =
+  if info.state != Of:
+    assert info.state == None
+    info.state = Of
+  builder.add("case ")
+  builder.add(val)
+  builder.add(":\n")
+
+proc addCaseRange(builder: var Builder, info: var SwitchCaseBuilder, first, last: Snippet) =
+  if info.state != Of:
+    assert info.state == None
+    info.state = Of
+  builder.add("case ")
+  builder.add(first)
+  builder.add(" ... ")
+  builder.add(last)
+  builder.add(":\n")
+
+proc addCaseElse(builder: var Builder, info: var SwitchCaseBuilder) =
+  assert info.state == None
+  info.state = Else
+  builder.add("default:\n")
+
+template addSwitchCase(builder: var Builder, info: out SwitchCaseBuilder, caseBody, body: typed) =
+  info = SwitchCaseBuilder(state: None)
+  caseBody
+  info.state = Finished
+  body
+
+template addSwitchElse(builder: var Builder, body: typed) =
+  builder.add("default:\n")
+  body
+
+proc addBreak(builder: var Builder) =
+  builder.add("break;\n")
+
 template addScope(builder: var Builder, body: typed) =
   builder.add("{")
   body

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -959,7 +959,7 @@ proc ifSwitchSplitPoint(p: BProc, n: PNode): int =
       if branch.kind == nkOfBranch and branchHasTooBigRange(branch):
         result = i
 
-proc genCaseRange(p: BProc, branch: PNode) =
+proc genCaseRange(p: BProc, branch: PNode, info: var SwitchCaseBuilder) =
   for j in 0..<branch.len-1:
     if branch[j].kind == nkRange:
       if hasSwitchRange in CC[p.config.cCompiler].props:
@@ -967,18 +967,18 @@ proc genCaseRange(p: BProc, branch: PNode) =
         var litB = newBuilder("")
         genLiteral(p, branch[j][0], litA)
         genLiteral(p, branch[j][1], litB)
-        lineF(p, cpsStmts, "case $1 ... $2:$n", [extract(litA), extract(litB)])
+        p.s(cpsStmts).addCaseRange(info, extract(litA), extract(litB))
       else:
         var v = copyNode(branch[j][0])
         while v.intVal <= branch[j][1].intVal:
           var litA = newBuilder("")
           genLiteral(p, v, litA)
-          lineF(p, cpsStmts, "case $1:$n", [extract(litA)])
+          p.s(cpsStmts).addCase(info, extract(litA))
           inc(v.intVal)
     else:
       var litA = newBuilder("")
       genLiteral(p, branch[j], litA)
-      lineF(p, cpsStmts, "case $1:$n", [extract(litA)])
+      p.s(cpsStmts).addCase(info, extract(litA))
 
 proc genOrdinalCase(p: BProc, n: PNode, d: var TLoc) =
   # analyse 'case' statement:
@@ -993,26 +993,31 @@ proc genOrdinalCase(p: BProc, n: PNode, d: var TLoc) =
 
   # generate switch part (might be empty):
   if splitPoint+1 < n.len:
-    lineF(p, cpsStmts, "switch ($1) {$n", [rdCharLoc(a)])
-    var hasDefault = false
-    for i in splitPoint+1..<n.len:
-      # bug #4230: avoid false sharing between branches:
-      if d.k == locTemp and isEmptyType(n.typ): d.k = locNone
-      var branch = n[i]
-      if branch.kind == nkOfBranch:
-        genCaseRange(p, branch)
-      else:
-        # else part of case statement:
-        lineF(p, cpsStmts, "default:$n", [])
-        hasDefault = true
-      exprBlock(p, branch.lastSon, d)
-      lineF(p, cpsStmts, "break;$n", [])
-    if not hasDefault:
-      if hasBuiltinUnreachable in CC[p.config.cCompiler].props:
-        lineF(p, cpsStmts, "default: __builtin_unreachable();$n", [])
-      elif hasAssume in CC[p.config.cCompiler].props:
-        lineF(p, cpsStmts, "default: __assume(0);$n", [])
-    lineF(p, cpsStmts, "}$n", [])
+    let rca = rdCharLoc(a)
+    p.s(cpsStmts).addSwitchStmt(rca):
+      var hasDefault = false
+      for i in splitPoint+1..<n.len:
+        # bug #4230: avoid false sharing between branches:
+        if d.k == locTemp and isEmptyType(n.typ): d.k = locNone
+        var branch = n[i]
+        var caseBuilder: SwitchCaseBuilder
+        p.s(cpsStmts).addSwitchCase(caseBuilder):
+          if branch.kind == nkOfBranch:
+            genCaseRange(p, branch, caseBuilder)
+          else:
+            # else part of case statement:
+            hasDefault = true
+            p.s(cpsStmts).addCaseElse(caseBuilder)
+        do:
+          exprBlock(p, branch.lastSon, d)
+          p.s(cpsStmts).addBreak()
+      if not hasDefault:
+        if hasBuiltinUnreachable in CC[p.config.cCompiler].props:
+          p.s(cpsStmts).addSwitchElse():
+            p.s(cpsStmts).addCallStmt("__builtin_unreachable")
+        elif hasAssume in CC[p.config.cCompiler].props:
+          p.s(cpsStmts).addSwitchElse():
+            p.s(cpsStmts).addCallStmt("__assume", cIntValue(0))
   if lend != "": fixLabel(p, lend)
 
 proc genCase(p: BProc, t: PNode, d: var TLoc) =


### PR DESCRIPTION
Not all uses of switch statements are implemented, `genCaseGeneric` and `genIfForCaseUntil` still exist. The main purpose is to finish `ccgreset` and `ccgtrav`.