### PR TITLE
Add seek and tell

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -772,11 +772,17 @@ proc setFilePos*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet) {.benign
   if c_fseek(f, pos, cint(relativeTo)) != 0:
     raiseEIO("cannot set file position")
 
+proc seek*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet): bool {.benign, sideEffect.} =
+  c_fseek(f, pos, cint(relativeTo)) != 0
+
 proc getFilePos*(f: File): int64 {.benign.} =
   ## Retrieves the current position of the file pointer that is used to
   ## read from the file `f`. The file's first byte has the index zero.
   result = c_ftell(f)
   if result < 0: raiseEIO("cannot retrieve file position")
+
+proc tell*(f: File): int64 {.benign.} =
+  c_ftell(f)
 
 proc getFileSize*(f: File): int64 {.tags: [ReadIOEffect], benign.} =
   ## Retrieves the file size (in bytes) of `f`.

--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -174,6 +174,7 @@ proc checkErr(f: File) =
     # shouldn't happen
     quit(1)
 
+
 {.push stackTrace: off, profiler: off.}
 proc readBuffer*(f: File, buffer: pointer, len: Natural): int {.
   tags: [ReadIOEffect], benign.} =
@@ -766,13 +767,13 @@ proc open*(filename: string,
   if not open(result, filename, mode, bufSize):
     raise newException(IOError, "cannot open: " & filename)
 
-proc setFilePos*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet) {.benign, sideEffect.} =
+proc setFilePos*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet) {.raises: [], benign, sideEffect.} =
   ## Sets the position of the file pointer that is used for read/write
   ## operations. The file's first byte has the index zero.
   if c_fseek(f, pos, cint(relativeTo)) != 0:
     raiseEIO("cannot set file position")
 
-proc seek*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet): bool {.benign, sideEffect.} =
+proc seek*(f: File, pos: int64, relativeTo: FileSeekPos = fspSet): bool {.raises: [], benign, sideEffect.} =
   c_fseek(f, pos, cint(relativeTo)) != 0
 
 proc getFilePos*(f: File): int64 {.benign.} =


### PR DESCRIPTION
I think it would be nice to have these procs exposed to access `c_fseek` and `c_ftell` as defined in `syncio` without raising exceptions. It complements some of the other `proc`s in the module for some use cases. I know exception dodging isn't a particularly good reason for extra procs, but I figured I would try anyway.