### PR TITLE
fix subtype match of generic object types

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1938,6 +1938,9 @@ proc isCharArrayPtr*(t: PType; allowPointerToChar: bool): bool =
   else:
     result = false
 
+proc isRefPtrObject*(t: PType): bool =
+  t.kind in {tyRef, tyPtr} and tfRefsAnonObj in t.flags
+
 proc nominalRoot*(t: PType): PType =
   ## the "name" type of a given instance of a nominal type,
   ## i.e. the type directly associated with the symbol where the root
@@ -1970,7 +1973,7 @@ proc nominalRoot*(t: PType): PType =
       result = result.skipModifier[0]
     let val = result.skipModifier
     if val.kind in {tyDistinct, tyEnum, tyObject} or
-        (val.kind in {tyRef, tyPtr} and tfRefsAnonObj in val.flags):
+        isRefPtrObject(val):
       # atomic nominal types, this generic body is attached to them
       discard
     else:
@@ -2000,3 +2003,20 @@ proc nominalRoot*(t: PType): PType =
     # skips all typeclasses
     # is this correct for `concept`?
     result = nil
+
+proc genericRoot*(t: PType): PType =
+  ## gets the root generic type (`tyGenericBody`) from `t`,
+  ## if `t` is a generic type or the body of a generic instantiation
+  case t.kind
+  of tyGenericBody:
+    result = t
+  of tyGenericInst, tyGenericInvocation:
+    result = t.genericHead
+  else:
+    if t.typeInst != nil:
+      result = t.typeInst.genericHead
+    elif t.sym != nil and t.sym.typ.kind == tyGenericBody:
+      # can happen if `t` is the last child (body) of the generic body
+      result = t.sym.typ
+    else:
+      result = nil

--- a/tests/objects/tgenericsubtype.nim
+++ b/tests/objects/tgenericsubtype.nim
@@ -1,0 +1,18 @@
+block: # has generic field
+  type
+    Foo[T] = object of RootObj
+      x: T
+    Bar = object of Foo[int]
+
+  proc foo(x: typedesc[Foo]) = discard
+
+  foo(Bar)
+
+block: # no generic field
+  type
+    Foo[T] = object of RootObj
+    Bar = object of Foo[int]
+
+  proc foo(x: typedesc[Foo]) = discard
+
+  foo(Bar)


### PR DESCRIPTION
split from #24425

Matching `tyGenericBody` performs a match on the last child of the generic body, in this case the uninstantied `tyObject` type. If the object contains no generic fields, this ends up being the same type as all instantiated ones, but if it does, a new type is created. This fails the `sameObjectTypes` check that subtype matching for object types uses. To fix this, also consider that the pattern type could be the generic uninstantiated object type of the matched type in subtype matching.