### PR TITLE
cbuilder: second half of cgen

### DIFF
--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -42,6 +42,12 @@ proc addLineEndDedent*(builder: var Builder, s: string) =
   builder.addDedent(s)
   builder.addNewline()
 
+proc addLineComment*(builder: var Builder, comment: string) =
+  # probably no-op on nifc
+  builder.add("// ")
+  builder.add(comment)
+  builder.addNewline()
+
 proc addIntValue*(builder: var Builder, val: int) =
   builder.buf.addInt(val)
 

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -468,6 +468,18 @@ proc addUnnamedParam(builder: var Builder, params: var ProcParamBuilder, typ: Sn
     params.needsComma = true
   builder.add(typ)
 
+proc addProcTypedParam(builder: var Builder, paramBuilder: var ProcParamBuilder, callConv: TCallingConvention, name: string, rettype, params: Snippet) =
+  if paramBuilder.needsComma:
+    builder.add(", ")
+  else:
+    paramBuilder.needsComma = true
+  builder.add(CallingConvToStr[callConv])
+  builder.add("_PTR(")
+  builder.add(rettype)
+  builder.add(", ")
+  builder.add(name)
+  builder.add(params)
+
 proc addVarargsParam(builder: var Builder, params: var ProcParamBuilder) =
   # does not exist in NIFC, needs to be proc pragma
   if params.needsComma:

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -478,6 +478,7 @@ proc addProcTypedParam(builder: var Builder, paramBuilder: var ProcParamBuilder,
   builder.add(rettype)
   builder.add(", ")
   builder.add(name)
+  builder.add(")")
   builder.add(params)
 
 proc addVarargsParam(builder: var Builder, params: var ProcParamBuilder) =

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -14,6 +14,9 @@ proc ptrConstType(t: Snippet): Snippet =
 proc ptrType(t: Snippet): Snippet =
   t & "*"
 
+proc cppRefType(t: Snippet): Snippet =
+  t & "&"
+
 const
   CallingConvToStr: array[TCallingConvention, string] = ["N_NIMCALL",
     "N_STDCALL", "N_CDECL", "N_SAFECALL",
@@ -31,6 +34,23 @@ proc procPtrTypeUnnamedNimCall(rettype, params: Snippet): Snippet =
 
 proc procPtrTypeUnnamed(callConv: TCallingConvention, rettype, params: Snippet): Snippet =
   CallingConvToStr[callConv] & "_PTR(" & rettype & ", )" & params
+
+proc procPtrType(callConv: TCallingConvention, rettype, name, params: Snippet): Snippet =
+  CallingConvToStr[callConv] & "_PTR(" & rettype & ", " & name & ")" & params
+
+type CppCaptureKind = enum None, ByReference, ByCopy
+
+template addCppLambda(builder: var Builder, captures: CppCaptureKind, params: Snippet, body: typed) =
+  builder.add("[")
+  case captures
+  of None: discard
+  of ByReference: builder.add("&")
+  of ByCopy: builder.add("=")
+  builder.add("] ")
+  builder.add(params)
+  builder.addLineEndIndent("{")
+  body
+  builder.addLineEndDedent("}")
 
 proc cCast(typ, value: Snippet): Snippet =
   "((" & typ & ") " & value & ")"

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -48,7 +48,7 @@ template addCppLambda(builder: var Builder, captures: CppCaptureKind, params: Sn
   of ByCopy: builder.add("=")
   builder.add("] ")
   builder.add(params)
-  builder.addLineEndIndent("{")
+  builder.addLineEndIndent(" {")
   body
   builder.addLineEndDedent("}")
 

--- a/compiler/cbuilderexprs.nim
+++ b/compiler/cbuilderexprs.nim
@@ -35,9 +35,6 @@ proc procPtrTypeUnnamedNimCall(rettype, params: Snippet): Snippet =
 proc procPtrTypeUnnamed(callConv: TCallingConvention, rettype, params: Snippet): Snippet =
   CallingConvToStr[callConv] & "_PTR(" & rettype & ", )" & params
 
-proc procPtrType(callConv: TCallingConvention, rettype, name, params: Snippet): Snippet =
-  CallingConvToStr[callConv] & "_PTR(" & rettype & ", " & name & ")" & params
-
 type CppCaptureKind = enum None, ByReference, ByCopy
 
 template addCppLambda(builder: var Builder, captures: CppCaptureKind, params: Snippet, body: typed) =

--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -59,9 +59,6 @@ proc generateThreadVarsSize(m: BModule) =
                        sfCompileToCpp in m.module.flags: ExternC
                   else: None
     m.s[cfsProcs].addDeclWithVisibility(externc):
-      m.s[cfsProcs].addProcHeaderWithParams(ccNoConvention, "NimThreadVarsSize", "NI"):
-        var params: ProcParamBuilder
-        m.s[cfsProcs].addProcParams(params):
-          discard
+      m.s[cfsProcs].addProcHeader("NimThreadVarsSize", "NI", cProcParams())
       m.s[cfsProcs].finishProcHeaderWithBody():
         m.s[cfsProcs].addReturn(cCast("NI", cSizeof("NimThreadVars")))

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2186,7 +2186,7 @@ proc genInitCode(m: BModule) =
       m.s[cfsInitProc].addProcHeaderWithParams(ccNimCall, getHcrInitName(m), "void"):
         var hcrInitParams: ProcParamBuilder
         m.s[cfsInitProc].addProcParams(hcrInitParams):
-          m.s[cfsInitProc].addUnnamedParam(hcrInitParams, "void*")
+          m.s[cfsInitProc].addParam(hcrInitParams, "handle", "void*")
           m.s[cfsInitProc].addProcTypedParam(hcrInitParams, ccNimCall, "getProcAddr", "void*", cProcParams(
             (name: "", typ: "void*"),
             (name: "", typ: ptrType("char"))))

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1952,11 +1952,6 @@ proc registerModuleToMain(g: BModuleList; m: BModule) =
       g.mainModProcs.addDeclWithVisibility(ExportLib):
         g.mainModProcs.addProcHeader(ccNimCall, datInit, "void", cProcParams())
         g.mainModProcs.finishProcHeaderAsProto()
-      g.mainModProcs.addDeclWithVisibility(ExportLib):
-        g.mainModProcs.addProcHeader(ccNimCall, m.getHcrInitName, "void", cProcParams(
-          (name: "", typ: "void*"),
-          (name: "", typ: ptrType("char"))))
-        g.mainModProcs.finishProcHeaderAsProto()
       g.mainModProcs.addf("N_LIB_EXPORT N_NIMCALL(void, $1)(void*, N_NIMCALL_PTR(void*, getProcAddr)(void*, char*));$N", [m.getHcrInitName])
       g.mainModProcs.addDeclWithVisibility(ExportLib):
         g.mainModProcs.addProcHeader(ccNimCall, "HcrCreateTypeInfos", "void", cProcParams())

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1985,7 +1985,7 @@ proc registerModuleToMain(g: BModuleList; m: BModule) =
       let osModulePath = ($systemModulePath).replace("stdlib_system", "stdlib_os").rope
       g.mainDatInit.addCallStmt("hcrAddModule", osModulePath)
       g.mainDatInit.addVar(name = "cmd_count", typ = ptrType("int"))
-      g.mainDatInit.addVar(name = "cmd_line", typ = ptrType(ptrType("char")))
+      g.mainDatInit.addVar(name = "cmd_line", typ = ptrType(ptrType(ptrType("char"))))
       g.mainDatInit.addCallStmt("hcrRegisterGlobal",
         osModulePath,
         "\"cmdCount\"",

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -115,7 +115,7 @@ type
                         # computing alive data on our own.
 
   BModuleList* = ref object of RootObj
-    mainModProcs*, mainModInit*, otherModsInit*, mainDatInit*: Rope
+    mainModProcs*, mainModInit*, otherModsInit*, mainDatInit*: Builder
     mapping*: Rope             # the generated mapping file (if requested)
     modules*: seq[BModule]     # list of all compiled modules
     modulesClosed*: seq[BModule] # list of the same compiled modules, but in the order they were closed

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -628,7 +628,7 @@ template withValue*[A, B](t: var Table[A, B], key: A, value, body: untyped) =
     assert t[1].uid == 1314
 
   mixin rawGet
-  var hc: Hash
+  var hc: Hash = default(Hash)
   var index = rawGet(t, key, hc)
   let hasKey = index >= 0
   if hasKey:


### PR DESCRIPTION
Follows up #24423, needed more refactoring than I expected, sorry for ugly diff.

With this pretty much all of the raw C code generating parts of the codegen are abstracted into the cbuilder API (to my knowledge at least). The current design of NIFC does not implement everything the codegen generates, such things have mostly not been adapted, they are the following along with how I'm guessing they could be implemented:

* C++ specific codegen: Maybe a dialect of NIFC for generating C++?
* `codegenDecl` pragma: Could be passed as a pragma to NIFC
* C macros, currently only used for line info IIRC i.e. `nimln_(123)`: Just inline them when generating NIFC
* Other C defines & `#line`: Maybe as NIFC directives or line infos?
  * There is also [this `#ifndef`](https://github.com/nim-lang/Nim/blob/21420d8b0976dc034feb90ab2878ae0dd63121ae/compiler/cgen.nim#L2249) when generating headers but NIFC shouldn't need it
* `alignof`/`offsetof`: Is in `cbuilder` but not implemented in NIFC, should be easy Edit: Done https://github.com/nim-lang/nif/pull/120

For now we can disable C++ and the `codegenDecl` pragma when generating NIFC but since cbuilder is mostly designed to generate NIFC as a flag when booting the compiler, this hinders the ability to run the CI against NIFC. Maybe we could also make cbuilder able to generate both C and NIFC at runtime, this would be a large refactor but wouldn't be too difficult.

Other missing abstractions before being able to generate NIFC are:

* Primitive types and symbols i.e. `int`, `void*`, `NI`, `NIM_NULL` are currently still constant string literals, `NU8`, `NU16` etc are also sometimes generated like `"NU" & $bits`.
* NIFC identifiers, i.e. adding `.c` to imported symbols and properly mangling generated ones. Not sure how difficult this is going to be.