### PR TITLE
fixes #24434; C gen issue using nim-lang/opengl

### DIFF
--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -404,7 +404,7 @@ proc addVisibilityPrefix(builder: var Builder, visibility: DeclVisibility) =
   of Extern:
     builder.add("extern ")
   of ExternC:
-    builder.add("extern \"C\" ")
+    builder.add("NIM_EXTERNC ")
   of ImportLib:
     builder.add("N_LIB_IMPORT ")
   of ExportLib:


### PR DESCRIPTION
fixes #24434

In https://github.com/nim-lang/Nim/pull/24432

```nim
let ex = "NIM_EXTERNC N_NIMCALL(void, nimLoadProcs$1)(void) {$2}$N$N" %
        [(i.ord - '0'.ord).rope, extract(el)]
```

```nim
procs.addDeclWithVisibility(ExternC):
   procs.addProcHeader(ccNimCall, "nimLoadProcs" & $(i.ord - '0'.ord), "void", cProcParams())
```

extern "C" makes a function-name in C++ have C linkage; it should be effaced with C compiler