### PR TITLE
fix wrong error for iterators with no body and pragma macro

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2648,7 +2648,7 @@ proc semIterator(c: PContext, n: PNode): PNode =
     incl(s.typ.flags, tfCapturesEnv)
   else:
     s.typ.callConv = ccInline
-  if n[bodyPos].kind == nkEmpty and s.magic == mNone and c.inConceptDecl == 0:
+  if result[bodyPos].kind == nkEmpty and s.magic == mNone and c.inConceptDecl == 0:
     localError(c.config, n.info, errImplOfXexpected % s.name.s)
   if optOwnedRefs in c.config.globalOptions and result.typ != nil:
     result.typ() = makeVarType(c, result.typ, tyOwned)

--- a/tests/pragmas/titeratormacro.nim
+++ b/tests/pragmas/titeratormacro.nim
@@ -1,0 +1,17 @@
+# issue #16413
+
+import std/macros
+
+macro identity(x: untyped) =
+  result = x.copy()
+  result[6] = quote do:
+    yield 1
+  discard result.toStrLit
+
+iterator demo(): int {.identity.}
+iterator demo2(): int {.identity.} = discard # but this works as expected
+
+var s: seq[int] = @[]
+for e in demo():
+  s.add(e)
+doAssert s == @[1]


### PR DESCRIPTION
fixes #16413

`semIterator` checks if the original iterator passed to it has no body, but it should check the processed node created by `semProcAux`.