### PR TITLE
Testing change to concept binding

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1784,6 +1784,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     elif x.kind == tyGenericInst and concpt.kind == tyConcept:
       result = if concepts.conceptMatch(c.c, concpt, x, c.bindings, f): isGeneric
                else: isNone
+    elif concpt.kind == tyUserTypeClass:
+      let inst = prepareMetatypeForSigmatch(c.c, c.bindings, c.call.info, f)
+      return typeRel(c, inst, a, flags)
     else:
       let genericBody = f[0]
       var askip = skippedNone
@@ -1900,8 +1903,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         if aOrig == f: return isEqual
         var matched = matchUserTypeClass(c, f, aOrig)
         if matched != nil:
-          bindConcreteTypeToUserTypeClass(matched, a)
-          if doBind: put(c, f, matched)
+          if doBind: put(c, f, a)
           result = isGeneric
         elif a.len > 0 and a.last == f:
           # Needed for checking `Y` == `Addable` in the following

--- a/tests/concepts/tconcepts_concrete.nim
+++ b/tests/concepts/tconcepts_concrete.nim
@@ -1,0 +1,28 @@
+discard """
+  output: '''string
+A[seq[int]]
+A[array[0..0, string]]
+'''
+"""
+
+type
+  SomethingLike[T] = concept x
+    x.len is int
+    x[int] is T
+  
+  A[T] = object
+    x: T
+
+proc p*[T](x: SomethingLike[T]) =
+  echo typeof(x)
+
+proc initA*[T; S: SomethingLike[T]](x: S): A[S] =
+  A[S](x: x)
+
+proc initA2[T](x: SomethingLike[T]): auto =
+  A[typeof x](x:x)
+
+p("testing")
+echo typeof(initA(newSeq[int]()))
+var ar: array[1, string]
+echo typeof(initA2(ar))

--- a/tests/concepts/tusertypeclasses.nim
+++ b/tests/concepts/tusertypeclasses.nim
@@ -3,8 +3,7 @@ discard """
   output: '''Sortable
 Sortable
 Container
-TObj
-int
+oof
 111 111
 (id: @[1, 2, 3], name: @["Vas", "Pas", "NafNaf"], age: @[10, 16, 18])
 '''
@@ -97,8 +96,7 @@ proc to(x: TObj, t: type string) = discard
 proc to(x: TObj, t: type JSonValue) = discard
 
 proc testFoo(x: TFoo) =
-  echo x.TypeName
-  echo x.MappedType.name
+  echo "oof"
 
 testFoo(TObj(x: 10))
 

--- a/tests/lent/t16898.nim
+++ b/tests/lent/t16898.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid type: 'lent QuadraticExt' in this context: 'proc (r: var QuadraticExt, a: lent QuadraticExt, b: lent QuadraticExt){.noSideEffect, gcsafe.}' for proc"
+  errormsg: "invalid type: 'lent Fp2[6, system.uint64]' in this context: 'proc (r: var Fp2[6, system.uint64], a: lent Fp2[6, system.uint64], b: lent Fp2[6, system.uint64]){.noSideEffect, gcsafe.}' for proc"
 """
 
 # bug #16898


### PR DESCRIPTION
This breaks the ability to reference constants defined in concept's body. In order for them to be accessible the type of an operand must get wrapped into the concepts type, as opposed to the generic construct (the concept type here) being formal and a concrete type bound to the operand. I am unaware of anything else that behaves like this and it doesn't seem to make sense to me. I don't think the compiler likes it very much either, but maybe that is a separate problem. Not sure about this one, but I want to run the CI and see what happens.