### PR TITLE
Fix `tyArray` with 3 kids breaking concept

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1726,7 +1726,9 @@ proc checkForMetaFields(c: PContext; n: PNode; hasError: var bool) =
     elif parent != nil and parent != t:
       # TODO: openarray has the `tfGenericTypeParam` flag & generics
       # TODO: handle special cases (sink etc.) and views
-      if t.kind == tyNone:
+      if parent.kind in {tyRef, tyPtr} and t.kind == tyObject and parent[0] == t:
+        localError(c.config, n.info, errTIsNotAConcreteType % parent.typeToString)
+      elif t.kind == tyNone:
         localError(c.config, n.info, errTIsNotAConcreteType % parent.typeToString)
       else:
         localError(c.config, n.info, (errTIsNotAConcreteType % t.typeToString) & (" for '$1'" % parent.typeToString))

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1723,10 +1723,14 @@ proc checkForMetaFields(c: PContext; n: PNode; hasError: var bool) =
     if t.kind == tyBuiltInTypeClass and t.len == 1 and t.elementType.kind == tyProc:
       localError(c.config, n.info, ("'$1' is not a concrete type; " &
         "for a callback without parameters use 'proc()'") % t.typeToString)
-    elif t.kind == tyNone and parent != nil:
+    elif parent != nil and parent != t:
       # TODO: openarray has the `tfGenericTypeParam` flag & generics
       # TODO: handle special cases (sink etc.) and views
-      localError(c.config, n.info, errTIsNotAConcreteType % parent.typeToString)
+      if t.kind == tyNone:
+        localError(c.config, n.info, errTIsNotAConcreteType % parent.typeToString)
+      else:
+        localError(c.config, n.info, (errTIsNotAConcreteType % t.typeToString) & (" for '$1'" % parent.typeToString))
+      
     else:
       localError(c.config, n.info, errTIsNotAConcreteType % t.typeToString)
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -2051,9 +2051,9 @@ proc findUnspecifiedGenericsOrNil*(t: PType): PType=
        tyProc, tyGenericInvocation, tyGenericInst, tyAlias, tySink, tyOwned:
     let start = ord(t.kind in {tyGenericInvocation, tyGenericInst})
     for i in start..<t.len:
-      result = findUnspecifiedGenericsOrNil(t[i])
-      if result != nil:
-        break
+      let tmp = findUnspecifiedGenericsOrNil(t[i])
+      if tmp != nil:
+        result = tmp
   else:
     discard
   t.size = tmp

--- a/tests/concepts/tconceptsv2.nim
+++ b/tests/concepts/tconceptsv2.nim
@@ -1,0 +1,22 @@
+discard """
+action: "run"
+output: '''
+A[array[0..0, int]]
+A[seq[int]]
+'''
+"""
+type
+  SomethingLike[T] = concept
+    proc len(s: Self): int
+    proc `[]`(s: Self; index: int): T
+
+  A[T] = object
+    x: T
+
+proc initA*(x: SomethingLike): auto =
+  A[type x](x: x)
+
+var a: array[1, int]
+var s: seq[int]
+echo typeof(initA(a))
+echo typeof(initA(s))

--- a/tests/errmsgs/tmetaobjectfields.nim
+++ b/tests/errmsgs/tmetaobjectfields.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim check --hints:off $file"
   action: "reject"
   nimout: '''
-tmetaobjectfields.nim(26, 5) Error: 'array' is not a concrete type
+tmetaobjectfields.nim(26, 5) Error: 'T' is not a concrete type for 'array'
 tmetaobjectfields.nim(30, 5) Error: 'seq' is not a concrete type
 tmetaobjectfields.nim(34, 5) Error: 'set' is not a concrete type
 tmetaobjectfields.nim(37, 3) Error: 'sink' is not a concrete type

--- a/tests/errmsgs/tmetaobjectfields.nim
+++ b/tests/errmsgs/tmetaobjectfields.nim
@@ -1,19 +1,20 @@
 discard """
   cmd: "nim check --hints:off $file"
+  matrix: "--hints:off"
   action: "reject"
   nimout: '''
-tmetaobjectfields.nim(26, 5) Error: 'T' is not a concrete type for 'array'
-tmetaobjectfields.nim(30, 5) Error: 'seq' is not a concrete type
-tmetaobjectfields.nim(34, 5) Error: 'set' is not a concrete type
-tmetaobjectfields.nim(37, 3) Error: 'sink' is not a concrete type
-tmetaobjectfields.nim(39, 3) Error: 'lent' is not a concrete type
-tmetaobjectfields.nim(56, 16) Error: 'seq' is not a concrete type
-tmetaobjectfields.nim(60, 5) Error: 'ptr' is not a concrete type
-tmetaobjectfields.nim(61, 5) Error: 'ref' is not a concrete type
-tmetaobjectfields.nim(62, 5) Error: 'auto' is not a concrete type
-tmetaobjectfields.nim(63, 5) Error: 'UncheckedArray' is not a concrete type
-tmetaobjectfields.nim(68, 5) Error: 'object' is not a concrete type
-tmetaobjectfields.nim(72, 5) Error: 'Type3011:ObjectType' is not a concrete type
+tmetaobjectfields.nim(27, 5) Error: 'T' is not a concrete type for 'array'
+tmetaobjectfields.nim(31, 5) Error: 'seq' is not a concrete type
+tmetaobjectfields.nim(35, 5) Error: 'set' is not a concrete type
+tmetaobjectfields.nim(38, 3) Error: 'sink' is not a concrete type
+tmetaobjectfields.nim(40, 3) Error: 'lent' is not a concrete type
+tmetaobjectfields.nim(57, 16) Error: 'seq' is not a concrete type
+tmetaobjectfields.nim(61, 5) Error: 'ptr' is not a concrete type
+tmetaobjectfields.nim(62, 5) Error: 'ref' is not a concrete type
+tmetaobjectfields.nim(63, 5) Error: 'auto' is not a concrete type
+tmetaobjectfields.nim(64, 5) Error: 'UncheckedArray' is not a concrete type
+tmetaobjectfields.nim(69, 5) Error: 'object' is not a concrete type for 'ref object'
+tmetaobjectfields.nim(73, 5) Error: 'Type3011' is not a concrete type
 '''
 """
 

--- a/tests/generics/tmetafield.nim
+++ b/tests/generics/tmetafield.nim
@@ -1,10 +1,11 @@
 discard """
   cmd: "nim check $options $file"
+  matrix: "--hints:off"
   action: "reject"
   nimout: '''
-tmetafield.nim(26, 5) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
-tmetafield.nim(27, 5) Error: 'Foo' is not a concrete type
-tmetafield.nim(29, 5) Error: invalid type: 'proc' in this context: 'TBaseMed' for var
+tmetafield.nim(27, 5) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
+tmetafield.nim(28, 5) Error: 'Foo' is not a concrete type for 'seq[Foo]'
+tmetafield.nim(30, 5) Error: invalid type: 'proc' in this context: 'TBaseMed' for var
 '''
 """
 

--- a/tests/generics/twrong_generic_object.nim
+++ b/tests/generics/twrong_generic_object.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "'Node' is not a concrete type"
+  errormsg: "'Node:ObjectType' is not a concrete type for 'seq[Node]'"
   line: 11
 """
 # bug #2509


### PR DESCRIPTION
Some types have a tyNone when they have no right hand side of their type definition (like magics array and seq). In some places of the code this appears to have been used like a sentinel value. It seems better to handle this in a different way and not construct invalid objects of these types.