### PR TITLE
include new concepts in typeclasses, makes containsGenericType work

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -279,7 +279,7 @@ const
   GcTypeKinds* = {tyRef, tySequence, tyString}
 
   tyTypeClasses* = {tyBuiltInTypeClass, tyCompositeTypeClass,
-                    tyUserTypeClass, tyUserTypeClassInst,
+                    tyUserTypeClass, tyUserTypeClassInst, tyConcept,
                     tyAnd, tyOr, tyNot, tyAnything}
 
   tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -209,9 +209,6 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
       result = typeAllowedAux(marker, t.skipModifier, kind, c, flags+{taHeap})
     else:
       result = t
-  of tyConcept:
-    if kind != skParam: result = t
-    else: result = nil
 
 proc typeAllowed*(t: PType, kind: TSymKind; c: PContext; flags: TTypeAllowedFlags = {}): PType =
   # returns 'nil' on success and otherwise the part of the type that is

--- a/tests/concepts/tuninstantiated.nim
+++ b/tests/concepts/tuninstantiated.nim
@@ -1,0 +1,17 @@
+block: # issue #24450
+  type
+    B = object
+      b: int
+    A = object
+      x: int
+    AConcept = concept
+      proc implementation(s: var Self, p1: B)
+
+  proc implementation(r: var A, p1: B)=
+    discard
+
+  proc accept(r: var AConcept)=
+    discard
+
+  var a = A()
+  a.accept()


### PR DESCRIPTION
fixes #24450

The new concepts were previously not included in [containsGenericType][1] which prevents them from being instantiated. Here they are included by being added to `tyTypeClasses` though this doesn't have to be done, they can also be added manually to `containsGenericTypeIter`, but this might be too specific. 

[1]: https://github.com/nim-lang/Nim/blob/a2031ec6cfe9475fb38ebc204ebcf8c2b6d02dce/compiler/types.nim#L1507-L1517