### PR TITLE
cbuilder: abstract over unmangled C identifiers

### DIFF
--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -157,6 +157,10 @@ proc cIntType*(bits: int): Snippet =
 proc cUintType*(bits: int): Snippet =
   "NU" & $bits
 
+proc cSymbol*(name: string): Snippet =
+  ## a symbol `name` imported from C, unmangled
+  name
+
 type
   IfBuilderState* = enum
     WaitingIf, WaitingElseIf, InBlock

--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -157,7 +157,7 @@ proc cIntType*(bits: int): Snippet =
 proc cUintType*(bits: int): Snippet =
   "NU" & $bits
 
-proc cSymbol*(name: string): Snippet =
+template cSymbol*(name: string): Snippet =
   ## a symbol `name` imported from C, unmangled
   name
 

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1393,7 +1393,7 @@ proc genEcho(p: BProc, n: PNode) =
     p.module.includeHeader("<base/log.h>")
     p.module.includeHeader("<util/string.h>")
     var a: TLoc
-    let logName = "Genode::log"
+    let logName = cSymbol("Genode::log")
     var logCall: CallBuilder
     p.s(cpsStmts).addStmt():
       p.s(cpsStmts).addCall(logCall, logName):
@@ -1404,7 +1404,7 @@ proc genEcho(p: BProc, n: PNode) =
           elif n.len != 0:
             a = initLocExpr(p, it)
             let ra = a.rdLoc
-            let fnName = "Genode::Cstring"
+            let fnName = cSymbol("Genode::Cstring")
             p.s(cpsStmts).addArgument(logCall):
               case detectStrVersion(p.module)
               of 2:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1097,10 +1097,10 @@ proc genOrdinalCase(p: BProc, n: PNode, d: var TLoc) =
       if not hasDefault:
         if hasBuiltinUnreachable in CC[p.config.cCompiler].props:
           p.s(cpsStmts).addSwitchElse():
-            p.s(cpsStmts).addCallStmt("__builtin_unreachable")
+            p.s(cpsStmts).addCallStmt(cSymbol("__builtin_unreachable"))
         elif hasAssume in CC[p.config.cCompiler].props:
           p.s(cpsStmts).addSwitchElse():
-            p.s(cpsStmts).addCallStmt("__assume", cIntValue(0))
+            p.s(cpsStmts).addCallStmt(cSymbol("__assume"), cIntValue(0))
   if lend != "": fixLabel(p, lend)
 
 proc genCase(p: BProc, t: PNode, d: var TLoc) =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1712,7 +1712,7 @@ proc genNimMainBody(m: BModule, preMainCode: Snippet) =
   genNimMainProc(m, preMainCode)
 
 proc genPosixCMain(m: BModule) =
-  m.s[cfsProcs].addProcHeader("main", CInt, cProcParams(
+  m.s[cfsProcs].addProcHeader(cSymbol("main"), CInt, cProcParams(
     (name: "argc", typ: CInt),
     (name: "args", typ: ptrType(ptrType(CChar))),
     (name: "env", typ: ptrType(ptrType(CChar)))))
@@ -1724,7 +1724,7 @@ proc genPosixCMain(m: BModule) =
   m.s[cfsProcs].addNewline()
 
 proc genStandaloneCMain(m: BModule) =
-  m.s[cfsProcs].addProcHeader("main", CInt, cProcParams())
+  m.s[cfsProcs].addProcHeader(cSymbol("main"), CInt, cProcParams())
   m.s[cfsProcs].finishProcHeaderWithBody():
     genMainProcs(m)
     m.s[cfsProcs].addReturn(cIntValue(0))
@@ -1734,10 +1734,10 @@ proc genWinNimMain(m: BModule, preMainCode: Snippet) =
   genNimMainBody(m, preMainCode)
 
 proc genWinCMain(m: BModule) =
-  m.s[cfsProcs].addProcHeader(ccStdCall, "WinMain", CInt, cProcParams(
-    (name: "hCurInstance", typ: "HINSTANCE"),
-    (name: "hPrevInstance", typ: "HINSTANCE"),
-    (name: "lpCmdLine", typ: "LPSTR"),
+  m.s[cfsProcs].addProcHeader(ccStdCall, cSymbol("WinMain"), CInt, cProcParams(
+    (name: "hCurInstance", typ: cSymbol("HINSTANCE")),
+    (name: "hPrevInstance", typ: cSymbol("HINSTANCE")),
+    (name: "lpCmdLine", typ: cSymbol("LPSTR")),
     (name: "nCmdShow", typ: CInt)))
   m.s[cfsProcs].finishProcHeaderWithBody():
     genMainProcsWithResult(m)
@@ -1750,12 +1750,12 @@ proc genWinNimDllMain(m: BModule, preMainCode: Snippet) =
 
 proc genWinCDllMain(m: BModule) =
   # used to use WINAPI macro, now ccStdCall:
-  m.s[cfsProcs].addProcHeader(ccStdCall, "DllMain", "BOOL", cProcParams(
-    (name: "hinstDLL", typ: "HINSTANCE"),
-    (name: "fwdreason", typ: "DWORD"),
-    (name: "lpvReserved", typ: "LPVOID")))
+  m.s[cfsProcs].addProcHeader(ccStdCall, cSymbol("DllMain"), cSymbol("BOOL"), cProcParams(
+    (name: "hinstDLL", typ: cSymbol("HINSTANCE")),
+    (name: "fwdreason", typ: cSymbol("DWORD")),
+    (name: "lpvReserved", typ: cSymbol("LPVOID"))))
   m.s[cfsProcs].finishProcHeaderWithBody():
-    m.s[cfsProcs].addSingleIfStmt(removeSinglePar(cOp(Equal, "fwdreason", "DLL_PROCESS_ATTACH"))):
+    m.s[cfsProcs].addSingleIfStmt(removeSinglePar(cOp(Equal, "fwdreason", cSymbol("DLL_PROCESS_ATTACH")))):
       genMainProcs(m)
     m.s[cfsProcs].addReturn(cIntValue(1))
   m.s[cfsProcs].addNewline()
@@ -1771,7 +1771,7 @@ proc genPosixCDllMain(m: BModule) =
   m.s[cfsProcs].addNewline()
 
 proc genGenodeNimMain(m: BModule, preMainCode: Snippet) =
-  let typName = "Genode::Env"
+  let typName = cSymbol("Genode::Env")
   m.s[cfsProcs].addDeclWithVisibility(Extern):
     m.s[cfsProcs].addVar(name = "nim_runtime_env", typ = ptrType(typName))
   m.s[cfsProcs].addDeclWithVisibility(ExternC):
@@ -1780,13 +1780,13 @@ proc genGenodeNimMain(m: BModule, preMainCode: Snippet) =
   genNimMainBody(m, preMainCode)
 
 proc genComponentConstruct(m: BModule) =
-  let fnName = "Libc::Component::construct"
-  let typName = "Libc::Env"
+  let fnName = cSymbol("Libc::Component::construct")
+  let typName = cSymbol("Libc::Env")
   m.s[cfsProcs].addProcHeader(fnName, CVoid, cProcParams((name: "env", typ: cppRefType(typName))))
   m.s[cfsProcs].finishProcHeaderWithBody():
     m.s[cfsProcs].addLineComment("Set Env used during runtime initialization")
     m.s[cfsProcs].addAssignment("nim_runtime_env", cAddr("env"))
-    let callFn = "Libc::with_libc"
+    let callFn = cSymbol("Libc::with_libc")
     var call: CallBuilder
     m.s[cfsProcs].addStmt():
       m.s[cfsProcs].addCall(call, callFn):


### PR DESCRIPTION
Does not include `importc` identifiers yet, just the constant identifiers used in the codegen, which turned out to be not that many. Not sure exactly where this would be called on importc symbols.

`compilerproc` symbols are also used verbatim in a lot of places, guessing this is not an issue for now.