### PR TITLE
disable weird type inference for object constructors

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -465,11 +465,14 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType 
   if t == nil:
     return localErrorNode(c, result, "object constructor needs an object type")
 
-  if t.skipTypes({tyGenericInst,
-      tyAlias, tySink, tyOwned, tyRef}).kind != tyObject and
-      expectedType != nil and expectedType.skipTypes({tyGenericInst,
-      tyAlias, tySink, tyOwned, tyRef}).kind == tyObject:
-    t = expectedType
+  when false:
+    # attempted type inference for generic object types,
+    # doesn't work since n[0] isn't set and seems underspecified
+    if t.skipTypes({tyGenericInst,
+        tyAlias, tySink, tyOwned, tyRef}).kind != tyObject and
+        expectedType != nil and expectedType.skipTypes({tyGenericInst,
+        tyAlias, tySink, tyOwned, tyRef}).kind == tyObject:
+      t = expectedType
 
   t = skipTypes(t, {tyGenericInst, tyAlias, tySink, tyOwned})
   if t.kind == tyRef:

--- a/tests/errmsgs/tuninstobjconstr.nim
+++ b/tests/errmsgs/tuninstobjconstr.nim
@@ -1,0 +1,11 @@
+# issue #24372
+
+type
+  Foo[T] = object
+    x: string
+    
+proc initFoo(): Foo[string] =
+  Foo(x: "hello") #[tt.Error
+     ^ cannot instantiate: 'Foo[T]'; the object's generic parameters cannot be inferred and must be explicitly given]#
+
+discard initFoo()


### PR DESCRIPTION
closes #24372, refs #20091

This was added in #20091 for some reason but doesn't actually work and only makes error messages more obscure. So for now, it's disabled.

Can also be backported to 2.0 if necessary.