### PR TITLE
fixes nightlies failures

### DIFF
--- a/compiler/cbuilderbase.nim
+++ b/compiler/cbuilderbase.nim
@@ -151,10 +151,10 @@ const
   CPointer* = "void*"
   CConstPointer* = "NIM_CONST void*"
 
-proc cIntType*(bits: int): Snippet =
+proc cIntType*(bits: BiggestInt): Snippet =
   "NI" & $bits
 
-proc cUintType*(bits: int): Snippet =
+proc cUintType*(bits: BiggestInt): Snippet =
   "NU" & $bits
 
 type


### PR DESCRIPTION
https://github.com/nim-lang/nightlies/actions/runs/11904588983/job/33173656837#step:12:91

```
/home/runner/work/nightlies/nightlies/nim/compiler/ccgexprs.nim(706, 23) Error: type mismatch
Expression: cIntType(getSize(p.module.g.config, t) * 8)
  [1] getSize(p.module.g.config, t) * 8: int64

Expected one of (first mismatch at [position]):
[1] proc cIntType(bits: int): Snippet
```