### PR TITLE
fix unix stdlib install location after #21328

### DIFF
--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -31,7 +31,7 @@ if [ $# -eq 1 ] ; then
     "/usr/bin")
       bindir=$1
       configdir="/etc/?proj"
-      libdir="/usr/lib/?proj"
+      libdir="/usr/lib/?proj/lib"
       docdir="/usr/share/?proj/doc"
       datadir="/usr/share/?proj/data"
       nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
@@ -39,7 +39,7 @@ if [ $# -eq 1 ] ; then
     "/usr/local/bin")
       bindir=$1
       configdir="/etc/?proj"
-      libdir="/usr/local/lib/?proj"
+      libdir="/usr/local/lib/?proj/lib"
       docdir="/usr/local/share/?proj/doc"
       datadir="/usr/local/share/?proj/data"
       nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"


### PR DESCRIPTION
closes #22369, closes #23197, closes #24385, refs #21328

According to #21328 the standard library on Unix should be installed in `/usr/lib/nim/lib`, however the installer was not updated for this change, hence the problem as described in https://github.com/nim-lang/Nim/issues/23197#issuecomment-2031386896. 

Have not tested if this fixes the problem but the comment heavily implies it does. The problem is also in 2.0 so it could be backported but I can't say for sure that it works and doesn't break anything.