### PR TITLE
fixes #24476; fold proc type `cast` if they are same types for backend

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -777,7 +777,8 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
     var a = getConstExpr(m, n[1], idgen, g)
     if a == nil: return
     if n.typ != nil and n.typ.kind in NilableTypes and
-        not (n.typ.kind == tyProc and a.typ.kind == tyProc):
+        (n.typ.kind != tyProc or a.typ.kind != tyProc or
+          sameBackendType(n.typ, a.typ)):
       # we allow compile-time 'cast' for pointer types:
       result = a
       result.typ() = n.typ


### PR DESCRIPTION
fixes #24476

The difference of proc types in `effects` or `gcsafe` affects compile-time only. So it should be safe to fold these casts if they are in fact same for the backends.