### PR TITLE
"interface" concepts or something... I guess

### DIFF
--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -233,7 +233,6 @@ proc matchImplicitDef(c: PContext; fn, an: PNode; aConpt: PNode, m: var MatchCon
     if aType.reduceToBase.isSelf:
       # Self in `an` is always legal here
       continue
-    echo aType
     
     if fType.reduceToBase.isSelf:
       if fType.kind in {tyVar, tySink, tyLent, tyOwned} and aType.kind == fType.kind:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -608,10 +608,13 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType, isInstValue = false): 
   result = t
   if t == nil: return
 
+  var et = t
+  if t.isConcept:
+    et = t.reduceToBase
   const lookupMetas = {tyStatic, tyGenericParam, tyConcept} + tyTypeClasses - {tyAnything}
-  if t.kind in lookupMetas or
-      (t.kind == tyAnything and tfRetType notin t.flags):
-    let lookup = cl.typeMap.lookup(t)
+  if et.kind in lookupMetas or
+      (et.kind == tyAnything and tfRetType notin et.flags):
+    let lookup = cl.typeMap.lookup(et)
     if lookup != nil: return lookup
 
   case t.kind

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -595,45 +595,6 @@ proc handleFloatRange(f, a: PType): TTypeRelation =
       else: result = isIntConv
     else: result = isNone
 
-proc reduceToBase(f: PType): PType =
-  #[
-    Returns the lowest order (most general) type that that is compatible with the input.
-    E.g.
-    A[T] = ptr object ... A -> ptr object
-    A[N: static[int]] = array[N, int] ... A -> array
-  ]#
-  case f.kind:
-  of tyGenericParam:
-    if f.len <= 0 or f.skipModifier == nil:
-      result = f
-    else:
-      result = reduceToBase(f.skipModifier)
-  of tyGenericInvocation:
-    result = reduceToBase(f.baseClass)
-  of tyCompositeTypeClass, tyAlias:
-    if not f.hasElementType or f.elementType == nil:
-      result = f
-    else:
-      result = reduceToBase(f.elementType)
-  of tyGenericInst:
-    result = reduceToBase(f.skipModifier)
-  of tyGenericBody:
-    result = reduceToBase(f.typeBodyImpl)
-  of tyUserTypeClass:
-    if f.isResolvedUserTypeClass:
-      result = f.base  # ?? idk if this is right
-    else:
-      result = f.skipModifier
-  of tyStatic, tyOwned, tyVar, tyLent, tySink:
-    result = reduceToBase(f.base)
-  of tyInferred:
-    # This is not true "After a candidate type is selected"
-    result = reduceToBase(f.base)
-  of tyRange:
-    result = f.elementType
-  else:
-    result = f
-
 proc genericParamPut(c: var TCandidate; last, fGenericOrigin: PType) =
   if fGenericOrigin != nil and last.kind == tyGenericInst and
      last.kidsLen-1 == fGenericOrigin.kidsLen:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -363,6 +363,8 @@ proc sumGeneric(t: PType): int =
         result += sumGeneric(a)
       break
     else:
+      if t.isConcept:
+        result += t.reduceToBase.conceptBody.len
       break
 
 proc complexDisambiguation(a, b: PType): int =

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -102,6 +102,9 @@ const
   # typedescX is used if we're sure tyTypeDesc should be included (or skipped)
   typedescPtrs* = abstractPtrs + {tyTypeDesc}
   typedescInst* = abstractInst + {tyTypeDesc, tyOwned, tyUserTypeClass}
+  
+  # incorrect definition of `[]` and `[]=` for these types in
+  arrPutGetMagicApplies* = {tyArray, tyOpenArray, tyString, tySequence, tyCstring, tyTuple}
 
 proc invalidGenericInst*(f: PType): bool =
   result = f.kind == tyGenericInst and skipModifier(f) == nil
@@ -2077,3 +2080,11 @@ proc reduceToBase*(f: PType): PType =
     result = f.elementType
   else:
     result = f
+
+proc isConcept*(t: PType): bool=
+  if t.kind == tyConcept:
+    true
+  elif t.kind in {tyGenericInst, tyCompositeTypeClass, tyGenericInvocation}:
+    t.reduceToBase.kind == tyConcept
+  else:
+    false

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -2038,3 +2038,42 @@ proc genericRoot*(t: PType): PType =
       result = t.sym.typ
     else:
       result = nil
+
+proc reduceToBase*(f: PType): PType =
+  #[
+    Returns the lowest order (most general) type that that is compatible with the input.
+    E.g.
+    A[T] = ptr object ... A -> ptr object
+    A[N: static[int]] = array[N, int] ... A -> array
+  ]#
+  case f.kind:
+  of tyGenericParam:
+    if f.len <= 0 or f.skipModifier == nil:
+      result = f
+    else:
+      result = reduceToBase(f.skipModifier)
+  of tyGenericInvocation:
+    result = reduceToBase(f.baseClass)
+  of tyCompositeTypeClass, tyAlias:
+    if not f.hasElementType or f.elementType == nil:
+      result = f
+    else:
+      result = reduceToBase(f.elementType)
+  of tyGenericInst:
+    result = reduceToBase(f.skipModifier)
+  of tyGenericBody:
+    result = reduceToBase(f.typeBodyImpl)
+  of tyUserTypeClass:
+    if f.isResolvedUserTypeClass:
+      result = f.base
+    else:
+      result = f.skipModifier
+  of tyStatic, tyOwned, tyVar, tyLent, tySink:
+    result = reduceToBase(f.base)
+  of tyInferred:
+    # This is not true "After a candidate type is selected"
+    result = reduceToBase(f.base)
+  of tyRange:
+    result = f.elementType
+  else:
+    result = f

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -48,6 +48,7 @@ type
     ##
     ## The coercion `type(x)` can be used to obtain the type of the given
     ## expression `x`.
+  TypeEach[T] = object
 
 type
   TypeOfMode* = enum ## Possible modes of `typeof`.
@@ -75,6 +76,8 @@ proc typeof*(x: untyped; mode = typeOfIter): typedesc {.
       # this would give: Error: attempting to call routine: 'myFoo2'
       # since `typeOfProc` expects a typed expression and `myFoo2()` can
       # only be used in a `for` context.
+
+template each*(a: untyped): untyped = TypeEach[a]
 
 proc `or`*(a, b: typedesc): typedesc {.magic: "TypeTrait", noSideEffect.}
   ## Constructs an `or` meta class.

--- a/tests/concepts/conceptv2negative/tauto.nim
+++ b/tests/concepts/conceptv2negative/tauto.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+  action: "reject"
 """
 type
   A = object

--- a/tests/concepts/conceptv2negative/tauto.nim
+++ b/tests/concepts/conceptv2negative/tauto.nim
@@ -1,0 +1,14 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  A = object
+  C1 = concept
+    proc p(s: Self, a: auto)
+  C1Impl = object
+  
+proc p(x: C1Impl, a: A)= discard
+proc spring(x: C1)= discard
+
+spring(C1Impl())

--- a/tests/concepts/conceptv2negative/tgenobj.nim
+++ b/tests/concepts/conceptv2negative/tgenobj.nim
@@ -1,0 +1,14 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  A[T] = object
+  C1 = concept
+    proc p(s: Self, a: A)
+  C1Impl = object
+  
+proc p(x: C1Impl, a: A[int])= discard
+proc spring(x: C1)= discard
+
+spring(C1Impl())

--- a/tests/concepts/conceptv2negative/tgenobj.nim
+++ b/tests/concepts/conceptv2negative/tgenobj.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   A[T] = object

--- a/tests/concepts/conceptv2negative/tmarrget.nim
+++ b/tests/concepts/conceptv2negative/tmarrget.nim
@@ -1,0 +1,12 @@
+discard """
+action: "reject"
+"""
+
+# stop mArrGet magic from giving everything `[]`
+type
+  C[T] = concept
+    proc `[]`(b: Self, i: int): T
+  A = object
+  
+proc p(a: C): int = assert false
+discard p(A())

--- a/tests/concepts/conceptv2negative/tnoimplicitbindingcontainer.nim
+++ b/tests/concepts/conceptv2negative/tnoimplicitbindingcontainer.nim
@@ -1,0 +1,19 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  Sizeable = concept
+    proc size(s: Self): int
+  Buffer = concept
+    proc w(s: Self, data: Sizeable)
+  Serializable[T: Buffer] = concept
+    proc w(b: T, s: Self)
+  ArrayLike = concept
+    proc size(s: Self): int
+  ArrayImpl = object
+
+proc size(x: ArrayImpl): int= discard
+
+proc spring(data: Serializable)= discard
+spring(ArrayImpl())

--- a/tests/concepts/conceptv2negative/tnoimplicitbindingcontainer.nim
+++ b/tests/concepts/conceptv2negative/tnoimplicitbindingcontainer.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   Sizeable = concept

--- a/tests/concepts/conceptv2negative/tnoimplicitbindingeach.nim
+++ b/tests/concepts/conceptv2negative/tnoimplicitbindingeach.nim
@@ -1,0 +1,19 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  Sizeable = concept
+    proc size(s: Self): int
+  Buffer = concept
+    proc w(s: Self, data: Sizeable)
+  Serializable = concept
+    proc w(b: each Buffer, s: Self)
+  ArrayLike = concept
+    proc size(s: Self): int
+  ArrayImpl = object
+
+proc size(x: ArrayImpl): int= discard
+
+proc spring(data: Serializable)= discard
+spring(ArrayImpl())

--- a/tests/concepts/conceptv2negative/tnoimplicitbindingeach.nim
+++ b/tests/concepts/conceptv2negative/tnoimplicitbindingeach.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   Sizeable = concept

--- a/tests/concepts/conceptv2negative/tnottype.nim
+++ b/tests/concepts/conceptv2negative/tnottype.nim
@@ -1,0 +1,17 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  Sizeable = concept
+    proc size(s: Self): int
+  Buffer = concept
+    proc w(s: Self, data: Sizeable)
+  Serializable = concept
+    proc w(b: each Buffer, s: Self)
+  ArrayImpl = object
+
+proc size(x: ArrayImpl): int= discard
+
+proc spring(data: Serializable)= discard
+spring(ArrayImpl())

--- a/tests/concepts/conceptv2negative/tnottype.nim
+++ b/tests/concepts/conceptv2negative/tnottype.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   Sizeable = concept

--- a/tests/concepts/conceptv2negative/tor.nim
+++ b/tests/concepts/conceptv2negative/tor.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   C1 = concept

--- a/tests/concepts/conceptv2negative/tor.nim
+++ b/tests/concepts/conceptv2negative/tor.nim
@@ -1,0 +1,13 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  C1 = concept
+    proc p(s: Self, a: int | float | string)
+  C1Impl = object
+  
+proc p(x: C1Impl, a: int | float)= discard
+proc spring(x: C1)= discard
+
+spring(C1Impl())

--- a/tests/concepts/conceptv2negative/ttypedesc.nim
+++ b/tests/concepts/conceptv2negative/ttypedesc.nim
@@ -1,6 +1,5 @@
 discard """
-  outputsub: "type mismatch"
-  exitcode: "1"
+action: "reject"
 """
 type
   C1 = concept

--- a/tests/concepts/conceptv2negative/ttypedesc.nim
+++ b/tests/concepts/conceptv2negative/ttypedesc.nim
@@ -1,0 +1,13 @@
+discard """
+  outputsub: "type mismatch"
+  exitcode: "1"
+"""
+type
+  C1 = concept
+    proc p(s: Self, a: typedesc)
+  C1Impl = object
+  
+proc p(x: C1Impl, a: typedesc[SomeInteger])= discard
+proc spring(x: C1)= discard
+
+spring(C1Impl())


### PR DESCRIPTION
This is going to be hard to explain. I've been trying to figure out how more complex examples of concepts should be implemented and that lead me to trying out a bunch of things that didn't work well. In the end, to me, it seems like a small conceptual adjustment should be made to make these work.

This PR is not fully implemented. I'm drafting it for visibility and because completing it is going to require a lot more work and I want to make sure I'm not wasting my time.

Consider the following two concepts:
```nim
type
  C1 = concept
    proc p(s: Self, a: string | int)
  C2[T: string | int] = concept
    proc p(s: Self, a: T)
```
Currently, they accept the same set of implementations (as well as the `each` form but I'm going to ignore that from now on since `each` is supposed to be the same as generic parameter on the concept minus the obvious small differences). If you think about what `proc p(s: Self, a: string | int)` could mean on the atomic concept it could mean one of the following:
1.) an implementation of `C1` has to match `p` , `a` being either `string` or `int` parameter
2.) all implementations of `C1` must match `p` and `p` (or overloads of `p`) must accept `string | int`

This question becomes especially relevant when dealing with concepts that reference other concepts in their body, but I'll get to that later. Again currently, concepts generally use 1 as their rule regardless. I'm going to try and make a case that 2 is better. First, 1 is already covered by `C2` so there is no reason to choose one or the other in the first place. Second, it makes the expectations of `C1` odd because there is no way to operate on `C1` and know for sure what the implementation looks like which is a property I think is useful. It is also better for `C2` to have this behavior exclusively because instantiations of `C2` will have additional information about an implementation bound to it's generic parameters. Last, it makes resolving complex dependencies between concepts computationally expensive and confusing.

The below example is very contrived, but for now this is the example I'm going with:
```nim
type
  Writable = concept
    proc w(b: var Buffer; s: Self): int
  Buffer* = concept
    proc w(s: var Self; data: Writable): int
  SizedWritable* = concept
    proc size(x: Self): int
    proc w(b: var Buffer, x: Self): int
  BufferImpl = object

proc w(x: var BufferImpl, d: int): int = return 100
proc size(d: int): int = sizeof(int)

proc p(b: var Buffer, data: SizedWritable): int =
  b.w(data)

var b = BufferImpl()
echo p(b, 5)
```

`Writable` and `Buffer` are coupled to one another and `SizedWritable` is coupled to `Buffer`. Situations like this, some simpler, some more complex have been giving me grief with the current concept implementation. Either from recursion errors, abysmal performance or needing to `auto` excessively to get it to compile. Again, I know they are not finished yet, I'm just saying: I tried to get the old behaviors to handle this stuff and I couldn't figure it out.

Another problem with situations like this in implementations like 1 (above) is that only one example `proc` needs to match for the concept to call the binding valid. This is not really a problem when there is a single concept and one potential implementation, but if there are more, or a concept is being evaluated inside a concept the compiler needs to ask, for example, "is X a SizedWritable." If it proves this by observing a `proc` that implements `w` on a particular implementation of `Buffer` that is disjoint from references of `Buffer` (even within the same concept) it starts to become confusing what the compiler is even trying to prove and why.

It seems to me, like there are valid reasons to express "All implementations must handle some form X" as well as "An implementation must handle some form of X." I think that using container types (or `each` - pretty much the same thing) and generic parameters are the answer to the latter and something like this PR can answer the former.

There are more examples in the test cases. I will be adding more as I try and work through this. That is, unless I am made aware that I am being dumb :P

The reason I didn't make an RFC first is mostly because I need to understand what's going on and I'm only going to get there from messing around with the compiler. I will make an RFC is that is the guidance. Also, new-style concepts being new, have several things that still need to be implemented and a lot of the implementation falls into grey areas so I'm not exactly sure if any of this is even controversial. On that note of things that need to be done here is a short list of things that are not done yet / are incorrect in this PR. This is here just so that they are not confusing:

- `each` is hacked into the compiler in a very lazy way. I'm unfamiliar with how to do this right for now and I didn't want that blocking me
- generic parameters in the `proc` bodies inside concept bodies vs the generic parameters of the concept itself are not handled correctly
- generic parameters of the concepts need some special cases
- there are incorrect things that I haven't fixed yet (like concept subset comparison in the wrong place). I'll get to those through testing
- there are comments and potentially dead code that I'll clean up once I get around to it. I'm trying not to forget what to do later.