### PR TITLE
fixes devel version number

### DIFF
--- a/lib/system/compilation.nim
+++ b/lib/system/compilation.nim
@@ -6,7 +6,7 @@ const
     ##   ```
     # see also std/private/since
 
-  NimMinor* {.intdefine.}: int = 2
+  NimMinor* {.intdefine.}: int = 3
     ## is the minor number of Nim's version.
     ## Odd for devel, even for releases.
 


### PR DESCRIPTION
As said in the documentation, `NimMinor` is supposed to be odd and should be greater than the stable channel