### PR TITLE
install older version of nimcuda for arraymancer

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -35,7 +35,7 @@ proc pkg(name: string; cmd = "nimble test"; url = "", useHead = true, allowFailu
 
 pkg "alea"
 pkg "argparse"
-pkg "arraymancer", "nim c tests/tests_cpu.nim"
+pkg "arraymancer", "nimble install -y; nimble uninstall -i -y nimcuda; nimble install nimcuda@0.2.1; nim c tests/tests_cpu.nim"
 pkg "ast_pattern_matching", "nim c -r tests/test1.nim"
 pkg "asyncftpclient", "nimble compileExample"
 pkg "asyncthreadpool", "nimble test --mm:refc"


### PR DESCRIPTION
Attempt to fix CI failure, refs https://github.com/nim-lang/Nim/pull/24495#issuecomment-2511299112, alternative is to use a commit version like https://github.com/SciNim/nimcuda/commit/bc65375ff52980ca2faec058bea40c2306ab6081