### PR TITLE
remove inserted derefs for ref object fields when transforming to dot call

### DIFF
--- a/tests/objects/trefobjfieldoverload.nim
+++ b/tests/objects/trefobjfieldoverload.nim
@@ -1,5 +1,6 @@
-type MyType = ref object
-  a: int
+block: # issue #24492
+  type MyType = ref object
+    a: int
 
-proc a(val: MyType, i: int) = discard
-MyType().a(100)
+  proc a(val: MyType, i: int) = discard
+  MyType().a(100)

--- a/tests/objects/trefobjfieldoverload.nim
+++ b/tests/objects/trefobjfieldoverload.nim
@@ -1,0 +1,5 @@
+type MyType = ref object
+  a: int
+
+proc a(val: MyType, i: int) = discard
+MyType().a(100)


### PR DESCRIPTION
fixes #24492

Kind of a goofy way of doing this, but we count how many derefs were used for the first parameter before calling `builtinFieldAccess`, then count after, and if there are more now than before, we remove the added derefs. I thought maybe getting rid of #18298 would simplify it but maybe this would still be the best way.

For better encapsulation we could make `dotTransformation` take an `nOrig` param instead but this would be less efficient since it would need a copy, though `semAsgn` already makes one.