### PR TITLE
don't track `result` initialization if it is marked `noinit`

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1665,7 +1665,8 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
   if not isEmptyType(s.typ.returnType) and
      (s.typ.returnType.requiresInit or s.typ.returnType.skipTypes(abstractInst).kind == tyVar or
        noStrictDefs notin c.config.legacyFeatures) and
-     s.kind in {skProc, skFunc, skConverter, skMethod} and s.magic == mNone:
+     s.kind in {skProc, skFunc, skConverter, skMethod} and s.magic == mNone and
+     sfNoInit notin s.flags:
     var res = s.ast[resultPos].sym # get result symbol
     if res.id notin t.init and breaksBlock(body) != bsNoReturn:
       if tfRequiresInit in s.typ.returnType.flags:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1644,6 +1644,9 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
      s.kind in {skProc, skFunc, skConverter, skMethod}:
     var res = s.ast[resultPos].sym # get result symbol
     t.scopes[res.id] = t.currentBlock
+    if sfNoInit in s.flags:
+      # marks result "noinit"
+      incl res.flags, sfNoInit
 
   track(t, body)
 

--- a/lib/pure/volatile.nim
+++ b/lib/pure/volatile.nim
@@ -19,7 +19,6 @@ proc volatileLoad*[T](src: ptr T): T {.inline, noinit.} =
     when defined(js):
       result = src[]
     else:
-      result = default(T)
       {.emit: [result, " = (*(", typeof(src[]), " volatile*)", src, ");"].}
 
 proc volatileStore*[T](dest: ptr T, val: T) {.inline.} =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2965,12 +2965,14 @@ when notJSnotNims and not defined(nimSeqsV2):
       assert y == "abcgh"
     discard
 
-proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [], noinit, nodestroy.} =
+proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [].} =
   ## Creates a new array filled with `y`.
+  result = zeroDefault(array[size, T])
   for i in 0..size-1:
     result[i] = y
 
-proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [], noinit, nodestroy.} =
+proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [].} =
   ## Creates a new array filled with `default(T)`.
+  result = zeroDefault(array[size, T])
   for i in 0..size-1:
     result[i] = default(T)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2965,12 +2965,12 @@ when notJSnotNims and not defined(nimSeqsV2):
       assert y == "abcgh"
     discard
 
-proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [], noinit.} =
+proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [], noinit, nodestroy.} =
   ## Creates a new array filled with `y`.
   for i in 0..size-1:
     result[i] = y
 
-proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [], noinit.} =
+proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [], noinit, nodestroy.} =
   ## Creates a new array filled with `default(T)`.
   for i in 0..size-1:
     result[i] = default(T)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2965,14 +2965,12 @@ when notJSnotNims and not defined(nimSeqsV2):
       assert y == "abcgh"
     discard
 
-proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [].} =
+proc arrayWith*[T](y: T, size: static int): array[size, T] {.raises: [], noinit.} =
   ## Creates a new array filled with `y`.
-  result = zeroDefault(array[size, T])
   for i in 0..size-1:
     result[i] = y
 
-proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [].} =
+proc arrayWithDefault*[T](size: static int): array[size, T] {.raises: [], noinit.} =
   ## Creates a new array filled with `default(T)`.
-  result = zeroDefault(array[size, T])
   for i in 0..size-1:
     result[i] = default(T)


### PR DESCRIPTION
We don't track `noinit` for variables introduced in https://github.com/nim-lang/Nim/pull/10566. It should be applied to `result` if the function is marked `noinit`