### PR TITLE
make getType node for generic inst have skipped type

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -135,8 +135,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     if inst:
       if allowRecursion:
         result = mapTypeToAstR(t.skipModifier, info)
-        # keep original type info for getType calls on the output node:
-        result.typ() = t
+        # result.typ can be tyGenericBody, give it a proper type:
+        result.typ() = t.skipModifier
       else:
         result = newNodeX(nkBracketExpr)
         #result.add mapTypeToAst(t.last, info)
@@ -145,8 +145,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
           result.add mapTypeToAst(a, info)
     else:
       result = mapTypeToAstX(cache, t.skipModifier, info, idgen, inst, allowRecursion)
-      # keep original type info for getType calls on the output node:
-      result.typ() = t
+      # result.typ can be tyGenericBody, give it a proper type:
+      result.typ() = t.skipModifier
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.typeBodyImpl, info)


### PR DESCRIPTION
fixes #24503 (verified locally), refs #22655

This still fixes #22639, the issue before was that `result.typ` would be `tyGenericBody` by virtue of `tyObject` etc calling `atomicType(t.sym)` and thus losing type information. I think this is the real incorrect behavior and will open another PR disabling it but it might break stuff. Edit: Done in #24510