### PR TITLE
fix getType on object/distinct types giving bare generic sym 

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -135,8 +135,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     if inst:
       if allowRecursion:
         result = mapTypeToAstR(t.skipModifier, info)
-        # keep original type info for getType calls on the output node:
-        result.typ() = t
+        # result.typ can be tyGenericBody, give it a proper type:
+        result.typ() = t.skipModifier
       else:
         result = newNodeX(nkBracketExpr)
         #result.add mapTypeToAst(t.last, info)
@@ -145,8 +145,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
           result.add mapTypeToAst(a, info)
     else:
       result = mapTypeToAstX(cache, t.skipModifier, info, idgen, inst, allowRecursion)
-      # keep original type info for getType calls on the output node:
-      result.typ() = t
+      # result.typ can be tyGenericBody, give it a proper type:
+      result.typ() = t.skipModifier
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.typeBodyImpl, info)

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -135,8 +135,6 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     if inst:
       if allowRecursion:
         result = mapTypeToAstR(t.skipModifier, info)
-        # result.typ can be tyGenericBody, give it a proper type:
-        result.typ() = t.skipModifier
       else:
         result = newNodeX(nkBracketExpr)
         #result.add mapTypeToAst(t.last, info)
@@ -145,8 +143,6 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
           result.add mapTypeToAst(a, info)
     else:
       result = mapTypeToAstX(cache, t.skipModifier, info, idgen, inst, allowRecursion)
-      # result.typ can be tyGenericBody, give it a proper type:
-      result.typ() = t.skipModifier
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.typeBodyImpl, info)
@@ -161,7 +157,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result = newNodeX(nkDistinctTy)
       result.add mapTypeToAst(t.skipModifier, info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
@@ -185,7 +181,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       else:
         result.add newNodeI(nkEmpty, info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = newNodeIT(nkObjectTy, if t.n.isNil: info else: t.n.info, t)
         result.add newNodeI(nkEmpty, info)
         if t.baseClass == nil:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -157,7 +157,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result = newNodeX(nkDistinctTy)
       result.add mapTypeToAst(t.skipModifier, info)
     else:
-      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
+      if allowRecursion or t.sym == nil or
+          (tfFromGeneric in t.flags and t.sym.typ.kind == tyGenericBody):
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
@@ -181,7 +182,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       else:
         result.add newNodeI(nkEmpty, info)
     else:
-      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
+      if allowRecursion or t.sym == nil or
+          (tfFromGeneric in t.flags and t.sym.typ.kind == tyGenericBody):
         result = newNodeIT(nkObjectTy, if t.n.isNil: info else: t.n.info, t)
         result.add newNodeI(nkEmpty, info)
         if t.baseClass == nil:


### PR DESCRIPTION
fixes #24503, refs #22655, alternative to #24509

This removes the need for the fix in #22655 entirely, since `getType` no longer gives nodes with invalid `tyGenericBody` types for types that are actually instantiated. But it significantly changes the output of `getType`, and likely not in a great way. Maybe an `inst=true` version of `t.typeInst` would be better, but this also changes the output, and `t.typeInst` was only fixed recently for types without generic fields in #24425 (also the dereferenced types of generic `ref object`s still give the `ref object` type as the `typeInst`).

There is also [this line](https://github.com/nim-lang/Nim/blob/2e9e7f13ee7dda0ecf4010c6edc77d9e495c1633/compiler/vmdeps.nim#L94) that has a similar issue, but it doesn't seem to be encountered, likely because skipped `tyGenericInst` types aren't very common when using `getTypeInst`.

Alternatively we could still produce a sym node but just set its type to the current type, i.e. `result = atomicType(t.sym); result.typ = t`. Edit: Done in #24511 just to test