### PR TITLE
give bare generic sym node from getType of object/distinct an instantiated type

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -161,8 +161,9 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
-        # keep original type, t.sym can have type tyGenericBody:
-        result.typ() = t
+        if tfFromGeneric in t.flags and t.sym.typ.kind == tyGenericBody:
+          # keep original type, t.sym can have type tyGenericBody:
+          result.typ() = t
   of tyGenericParam, tyForward:
     result = atomicType(t.sym)
   of tyObject:
@@ -193,8 +194,9 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
         result.add copyTree(t.n)
       else:
         result = atomicType(t.sym)
-        # keep original type, t.sym can have type tyGenericBody:
-        result.typ() = t
+        if tfFromGeneric in t.flags and t.sym.typ.kind == tyGenericBody:
+          # keep original type, t.sym can have type tyGenericBody:
+          result.typ() = t
   of tyEnum:
     result = newNodeIT(nkEnumTy, if t.n.isNil: info else: t.n.info, t)
     result.add newNodeI(nkEmpty, info)  # pragma node, currently always empty for enum

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -135,8 +135,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     if inst:
       if allowRecursion:
         result = mapTypeToAstR(t.skipModifier, info)
-        # keep original type info for getType calls on the output node:
-        result.typ() = t
+        # result.typ can be tyGenericBody, give it a proper type:
+        result.typ() = t.skipModifier
       else:
         result = newNodeX(nkBracketExpr)
         #result.add mapTypeToAst(t.last, info)
@@ -145,8 +145,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
           result.add mapTypeToAst(a, info)
     else:
       result = mapTypeToAstX(cache, t.skipModifier, info, idgen, inst, allowRecursion)
-      # keep original type info for getType calls on the output node:
-      result.typ() = t
+      # result.typ can be tyGenericBody, give it a proper type:
+      result.typ() = t.skipModifier
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.typeBodyImpl, info)

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -135,8 +135,6 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     if inst:
       if allowRecursion:
         result = mapTypeToAstR(t.skipModifier, info)
-        # result.typ can be tyGenericBody, give it a proper type:
-        result.typ() = t.skipModifier
       else:
         result = newNodeX(nkBracketExpr)
         #result.add mapTypeToAst(t.last, info)
@@ -145,8 +143,6 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
           result.add mapTypeToAst(a, info)
     else:
       result = mapTypeToAstX(cache, t.skipModifier, info, idgen, inst, allowRecursion)
-      # result.typ can be tyGenericBody, give it a proper type:
-      result.typ() = t.skipModifier
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.typeBodyImpl, info)
@@ -161,7 +157,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result = newNodeX(nkDistinctTy)
       result.add mapTypeToAst(t.skipModifier, info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
@@ -185,7 +181,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       else:
         result.add newNodeI(nkEmpty, info)
     else:
-      if allowRecursion or t.sym == nil:
+      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
         result = newNodeIT(nkObjectTy, if t.n.isNil: info else: t.n.info, t)
         result.add newNodeI(nkEmpty, info)
         if t.baseClass == nil:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -157,10 +157,12 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result = newNodeX(nkDistinctTy)
       result.add mapTypeToAst(t.skipModifier, info)
     else:
-      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
+      if allowRecursion or t.sym == nil:
         result = mapTypeToBracket("distinct", mDistinct, t, info)
       else:
         result = atomicType(t.sym)
+        # keep original type, t.sym can have type tyGenericBody:
+        result.typ() = t
   of tyGenericParam, tyForward:
     result = atomicType(t.sym)
   of tyObject:
@@ -181,7 +183,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       else:
         result.add newNodeI(nkEmpty, info)
     else:
-      if allowRecursion or t.sym == nil or tfFromGeneric in t.flags:
+      if allowRecursion or t.sym == nil:
         result = newNodeIT(nkObjectTy, if t.n.isNil: info else: t.n.info, t)
         result.add newNodeI(nkEmpty, info)
         if t.baseClass == nil:
@@ -191,6 +193,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
         result.add copyTree(t.n)
       else:
         result = atomicType(t.sym)
+        # keep original type, t.sym can have type tyGenericBody:
+        result.typ() = t
   of tyEnum:
     result = newNodeIT(nkEnumTy, if t.n.isNil: info else: t.n.info, t)
     result.add newNodeI(nkEmpty, info)  # pragma node, currently always empty for enum


### PR DESCRIPTION
fixes #24503, refs #22655, alternative to #24509 and #24510

Instead of producing a different node as in #24510, we keep the produced node the same, but give it the actual type rather than the `tyGenericBody` type of the symbol. This is possibly less intrusive but still not correct as the symbol has a different type than the symbol node.