### PR TITLE
fixes strictdefs warnings for stdlibs [part two]

### DIFF
--- a/lib/core/macrocache.nim
+++ b/lib/core/macrocache.nim
@@ -44,6 +44,9 @@ runnableExamples:
     assert mcCounter.value == 3
 
 
+when defined(nimPreviewSlimSystem):
+  import std/assertions
+
 type
   CacheSeq* = distinct string
     ## Compile-time sequence of `NimNode`s.
@@ -207,7 +210,7 @@ proc hasKey*(t: CacheTable; key: string): bool =
       mcTable["foo"] = newEmptyNode()
       # Will now be true since we inserted a value
       assert mcTable.hasKey("foo")
-  quit "Implemented in vmops"
+  raiseAssert "Implemented in vmops"
 
 proc contains*(t: CacheTable; key: string): bool {.inline.} =
   ## Alias of [hasKey][hasKey(CacheTable, string)] for use with the `in` operator.

--- a/lib/core/macrocache.nim
+++ b/lib/core/macrocache.nim
@@ -207,7 +207,7 @@ proc hasKey*(t: CacheTable; key: string): bool =
       mcTable["foo"] = newEmptyNode()
       # Will now be true since we inserted a value
       assert mcTable.hasKey("foo")
-  discard "Implemented in vmops"
+  quit "Implemented in vmops"
 
 proc contains*(t: CacheTable; key: string): bool {.inline.} =
   ## Alias of [hasKey][hasKey(CacheTable, string)] for use with the `in` operator.

--- a/lib/core/macrocache.nim
+++ b/lib/core/macrocache.nim
@@ -210,7 +210,7 @@ proc hasKey*(t: CacheTable; key: string): bool =
       mcTable["foo"] = newEmptyNode()
       # Will now be true since we inserted a value
       assert mcTable.hasKey("foo")
-  raiseAssert "Implemented in vmops"
+  raiseAssert "implemented in the vmops"
 
 proc contains*(t: CacheTable; key: string): bool {.inline.} =
   ## Alias of [hasKey][hasKey(CacheTable, string)] for use with the `in` operator.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -365,7 +365,7 @@ proc symBodyHash*(s: NimNode): string {.noSideEffect.} =
   ## and owning module, but also implementation body. All procs/variables used in
   ## the implementation of this symbol are hashed recursively as well, including
   ## magics from system module.
-  discard
+  raiseAssert "implemented in the vmops"
 
 proc getTypeImpl*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
   ## Version of `getTypeImpl` which takes a `typedesc`.
@@ -1508,6 +1508,7 @@ proc expectIdent*(n: NimNode, name: string) {.since: (1,1).} =
 
 proc hasArgOfName*(params: NimNode; name: string): bool =
   ## Search `nnkFormalParams` for an argument.
+  result = false
   expectKind(params, nnkFormalParams)
   for i in 1..<params.len:
     for j in 0..<params[i].len-2:
@@ -1575,6 +1576,7 @@ proc extractTypeImpl(n: NimNode): NimNode =
   else: error("Invalid node to retrieve type implementation of: " & $n.kind)
 
 proc customPragmaNode(n: NimNode): NimNode =
+  result = nil
   expectKind(n, {nnkSym, nnkDotExpr, nnkBracketExpr, nnkTypeOfExpr, nnkType, nnkCheckedFieldExpr})
   let
     typ = n.getTypeInst()
@@ -1730,7 +1732,7 @@ macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
   for i in 0 ..< args.len:
     result.add args[i]
 
-proc getProjectPath*(): string = discard
+proc getProjectPath*(): string = raiseAssert "implemented in the vmops"
   ## Returns the path to the currently compiling project.
   ##
   ## This is not to be confused with `system.currentSourcePath <system.html#currentSourcePath.t>`_
@@ -1773,6 +1775,7 @@ proc getOffset*(arg: NimNode): int {.magic: "NSizeOf", noSideEffect.} =
 
 proc isExported*(n: NimNode): bool {.noSideEffect.} =
   ## Returns whether the symbol is exported or not.
+  raiseAssert "implemented in the vmops"
 
 proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
   ## returns a `nnkStmtList` containing the top-level doc comments and

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -24,7 +24,7 @@ type
 proc initRLock*(lock: var RLock) {.inline.} =
   ## Initializes the given lock.
   when defined(posix):
-    var a: SysLockAttr
+    var a: SysLockAttr = default(SysLockAttr)
     initSysLockAttr(a)
     setSysLockType(a, SysLockType_Reentrant)
     initSysLock(lock, a.addr)

--- a/lib/experimental/diff.nim
+++ b/lib/experimental/diff.nim
@@ -82,7 +82,7 @@ proc diffCodes(aText: string; h: var Table[string, int]): DiffData =
   ## `trimSpace` ignore leading and trailing space characters
   ## Returns a array of integers.
   var lastUsedCode = h.len
-  result.data = newSeq[int]()
+  result = DiffData(data: newSeq[int]())
   for s in aText.splitLines:
     if h.contains s:
       result.data.add h[s]
@@ -123,7 +123,7 @@ proc sms(dataA: var DiffData; lowerA, upperA: int; dataB: DiffData; lowerB, uppe
   ## `downVector` a vector for the (0,0) to (x,y) search. Passed as a parameter for speed reasons.
   ## `upVector` a vector for the (u,v) to (N,M) search. Passed as a parameter for speed reasons.
   ## Returns a MiddleSnakeData record containing x,y and u,v.
-
+  result = Smsrd()
   let max = dataA.len + dataB.len + 1
 
   let downK = lowerA - lowerB # the k-line to start the forward search
@@ -250,6 +250,7 @@ proc lcs(dataA: var DiffData; lowerA, upperA: int; dataB: var DiffData; lowerB, 
 proc createDiffs(dataA, dataB: DiffData): seq[Item] =
   ## Scan the tables of which lines are inserted and deleted,
   ## producing an edit script in forward order.
+  result = @[]
   var startA = 0
   var startB = 0
   var lineA = 0

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -146,6 +146,7 @@ proc respondError(req: Request, code: HttpCode): Future[void] =
   result = req.client.send(msg)
 
 proc parseProtocol(protocol: string): tuple[orig: string, major, minor: int] =
+  result = default(tuple[orig: string, major, minor: int])
   var i = protocol.skipIgnoreCase("HTTP/")
   if i != 5:
     raise newException(ValueError, "Invalid request protocol. Got: " &

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -189,7 +189,7 @@ proc encodeMime*(s: string, lineLen = 75.Positive, newLine = "\r\n",
   if e.len <= lineLen or newLine.len == 0:
     return e
   result = newString(e.len + newLine.len * ((e.len div lineLen) - int(e.len mod lineLen == 0)))
-  var i, j, k, b: int
+  var i, j, k, b: int = 0
   let nd = e.len - lineLen
   while j < nd:
     cpy(i + lineLen, e, j)
@@ -199,6 +199,7 @@ proc encodeMime*(s: string, lineLen = 75.Positive, newLine = "\r\n",
 
 proc initDecodeTable*(): array[256, char] =
   # computes a decode table at compile time
+  result = default(array[256, char])
   for i in 0 ..< 256:
     let ch = char(i)
     var code = invalidChar
@@ -221,6 +222,7 @@ proc decode*(s: string): string =
   runnableExamples:
     assert decode("SGVsbG8gV29ybGQ=") == "Hello World"
     assert decode("  SGVsbG8gV29ybGQ=") == "Hello World"
+  result = ""
   if s.len == 0: return
 
   proc decodeSize(size: int): int =

--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -83,6 +83,8 @@ proc getEncodedData(allowedMethods: set[RequestMethod]): string =
   else:
     if methodNone notin allowedMethods:
       cgiError("'REQUEST_METHOD' must be 'POST' or 'GET'")
+    else:
+      result = ""
 
 iterator decodeData*(data: string): tuple[key, value: string] =
   ## Reads and decodes CGI data and yields the (name, value) pairs the

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -535,5 +535,5 @@ proc toCritBitTree*(items: sink openArray[string]): CritBitTree[void] {.since: (
   ## Creates a new `CritBitTree` that contains the given `items`.
   runnableExamples:
     doAssert ["a", "b", "c"].toCritBitTree is CritBitTree[void]
-
+  result = default(CritBitTree[void])
   for item in items: result.incl item

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -91,8 +91,10 @@ proc extractRGB*(a: Color): tuple[r, g, b: range[0..255]] =
     echo typeof(extractRGB(a))
     echo extractRGB(b)
     echo typeof(extractRGB(b))
-
-  result = (a.int shr 16 and 0xff, a.int shr 8 and 0xff, a.int and 0xff)
+  result = default(tuple[r, g, b: range[0..255]])
+  result.r = a.int shr 16 and 0xff
+  result.g = a.int shr 8 and 0xff
+  result.b = a.int and 0xff
 
 proc intensity*(a: Color, f: float): Color =
   ## Returns `a` with intensity `f`. `f` should be a float from 0.0 (completely

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -92,9 +92,7 @@ proc extractRGB*(a: Color): tuple[r, g, b: range[0..255]] =
     echo extractRGB(b)
     echo typeof(extractRGB(b))
 
-  result.r = a.int shr 16 and 0xff
-  result.g = a.int shr 8 and 0xff
-  result.b = a.int and 0xff
+  result = (a.int shr 16 and 0xff, a.int shr 8 and 0xff, a.int and 0xff)
 
 proc intensity*(a: Color, f: float): Color =
   ## Returns `a` with intensity `f`. `f` should be a float from 0.0 (completely

--- a/lib/pure/concurrency/cpuload.nim
+++ b/lib/pure/concurrency/cpuload.nim
@@ -65,10 +65,10 @@ proc advice*(s: var ThreadPoolState): ThreadPoolAdvice =
     proc fscanf(c: File, frmt: cstring) {.varargs, importc,
       header: "<stdio.h>".}
 
-    var f: File
+    var f: File = default(File)
     if f.open("/proc/loadavg"):
       var b: float
-      var busy, total: int
+      var busy, total: int = 0
       fscanf(f,"%lf %lf %lf %ld/%ld",
             addr b, addr b, addr b, addr busy, addr total)
       f.close()

--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -155,6 +155,8 @@ proc selectWorker(w: ptr Worker; fn: WorkerProc; data: pointer): bool =
     signal(w.taskArrived)
     blockUntil(w.taskStarted)
     result = true
+  else:
+    result = false
 
 proc cleanFlowVars(w: ptr Worker) =
   let q = addr(w.q)
@@ -277,7 +279,7 @@ proc blockUntilAny*(flowVars: openArray[FlowVarBase]): int =
   ## to be able to wait on, -1 is returned.
   ##
   ## **Note:** This results in non-deterministic behaviour and should be avoided.
-  var ai: AwaitInfo
+  var ai: AwaitInfo = AwaitInfo()
   ai.cv.initSemaphore()
   var conflicts = 0
   result = -1

--- a/lib/pure/cstrutils.nim
+++ b/lib/pure/cstrutils.nim
@@ -39,6 +39,7 @@ func startsWith*(s, prefix: cstring): bool {.rtl, extern: "csuStartsWith".} =
     when defined(js):
       result = jsStartsWith(s, prefix)
     else:
+      result = false
       var i = 0
       while true:
         if prefix[i] == '\0': return true
@@ -60,6 +61,7 @@ func endsWith*(s, suffix: cstring): bool {.rtl, extern: "csuEndsWith".} =
     when defined(js):
       result = jsEndsWith(s, suffix)
     else:
+      result = false
       let slen = s.len
       var i = 0
       var j = slen - len(suffix)

--- a/lib/pure/dynlib.nim
+++ b/lib/pure/dynlib.nim
@@ -90,6 +90,7 @@ proc loadLibPattern*(pattern: string, globalSymbols = false): LibHandle =
   ## pragma does. Returns nil if the library could not be loaded.
   ##
   ## .. warning:: this proc uses the GC and so cannot be used to load the GC.
+  result = default(LibHandle)
   var candidates = newSeq[string]()
   libCandidates(pattern, candidates)
   for c in candidates:

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -464,7 +464,7 @@ else:
     var outLen = csize_t len(result)
     var src = cstring(s)
     var dst = cstring(result)
-    var iconvres: csize_t
+    var iconvres: csize_t = csize_t(0)
     while inLen > 0:
       iconvres = iconv(c, addr src, addr inLen, addr dst, addr outLen)
       if iconvres == high(csize_t):

--- a/lib/pure/endians.nim
+++ b/lib/pure/endians.nim
@@ -55,7 +55,7 @@ when useBuiltinSwap:
     ## We have to use `copyMem` here instead of a simple dereference because they
     ## may point to a unaligned address. A sufficiently smart compiler _should_
     ## be able to elide them when they're not necessary.
-    var tmp: T
+    var tmp: T = default(T)
     copyMem(addr tmp, inp, sizeof(T))
     tmp = op(tmp)
     copyMem(outp, addr tmp, sizeof(T))

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -74,6 +74,8 @@ proc delete[T](s: var seq[T], attr: T): bool =
     s[idx] = s[L-1]
     setLen(s, L-1)
     result = true
+  else:
+    result = false
 
 proc xmlCheckedTag*(argsList: NimNode, tag: string, optAttr = "", reqAttr = "",
     isLeaf = false): NimNode =

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -403,6 +403,7 @@ proc `$`*(data: MultipartData): string {.since: (1, 1).} =
   ## convert MultipartData to string so it's human readable when echo
   ## see https://github.com/nim-lang/Nim/issues/11863
   const sep = "-".repeat(30)
+  result = ""
   for pos, entry in data.content:
     result.add(sep & center($pos, 3) & sep)
     result.add("\nname=\"" & entry.name & "\"")
@@ -476,7 +477,7 @@ proc addFiles*(p: MultipartData, xs: openArray[tuple[name, file: string]],
   ##   data.addFiles({"uploaded_file": "public/test.html"})
   ##   ```
   for name, file in xs.items:
-    var contentType: string
+    var contentType: string = ""
     let (_, fName, ext) = splitFile(file)
     if ext.len > 0:
       contentType = mimeDb.getMimetype(ext[1..ext.high], "")
@@ -1039,7 +1040,7 @@ proc format(client: HttpClient | AsyncHttpClient,
 
   await client.readFileSizes(multipart)
 
-  var length: int64
+  var length: int64 = int64(0)
   for entry in multipart.content:
     result.add(format(entry, bound) & httpNewLine)
     if entry.isFile:
@@ -1082,7 +1083,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
 
   var newHeaders: HttpHeaders
 
-  var data: seq[string]
+  var data: seq[string] = @[]
   if multipart != nil and multipart.content.len > 0:
     # `format` modifies `client.headers`, see 
     # https://github.com/nim-lang/Nim/pull/18208#discussion_r647036979
@@ -1105,7 +1106,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   await client.socket.send(headerString)
 
   if data.len > 0:
-    var buffer: string
+    var buffer: string = ""
     for i, entry in multipart.content:
       buffer.add data[i]
       if not entry.isFile: continue

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -212,6 +212,7 @@ iterator pairs*(headers: HttpHeaders): tuple[key, value: string] =
 func contains*(values: HttpHeaderValues, value: string): bool =
   ## Determines if `value` is one of the values inside `values`. Comparison
   ## is performed without case sensitivity.
+  result = false
   for val in seq[string](values):
     if val.toLowerAscii == value.toLowerAscii: return true
 
@@ -230,6 +231,7 @@ func getOrDefault*(headers: HttpHeaders, key: string,
 func len*(headers: HttpHeaders): int {.inline.} = headers.table.len
 
 func parseList(line: string, list: var seq[string], start: int): int =
+  result = 0
   var i = 0
   var current = ""
   while start+i < line.len and line[start + i] notin {'\c', '\l'}:
@@ -244,7 +246,7 @@ func parseHeader*(line: string): tuple[key: string, value: seq[string]] =
   ##
   ## Used by `asynchttpserver` and `httpclient` internally and should not
   ## be used by you.
-  result.value = @[]
+  result = ("", @[])
   var i = 0
   i = line.parseUntil(result.key, ':')
   inc(i) # skip :

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -501,6 +501,7 @@ proc hash*(n: JsonNode): Hash {.noSideEffect.} =
     result = Hash(0)
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash =
+  result = default(Hash)
   for key, val in n:
     result = result xor (hash(key) !& hash(val))
   result = !$result
@@ -512,7 +513,7 @@ proc len*(n: JsonNode): int =
   case n.kind
   of JArray: result = n.elems.len
   of JObject: result = n.fields.len
-  else: discard
+  else: result = 0
 
 proc `[]`*(node: JsonNode, name: string): JsonNode {.inline.} =
   ## Gets a field from a `JObject`, which must not be nil.
@@ -610,6 +611,8 @@ proc getOrDefault*(node: JsonNode, key: string): JsonNode =
   ## value at `key` does not exist, returns nil
   if not isNil(node) and node.kind == JObject:
     result = node.fields.getOrDefault(key)
+  else:
+    result = nil
 
 proc `{}`*(node: JsonNode, key: string): JsonNode =
   ## Gets a field from a `node`. If `node` is nil or not an object or
@@ -937,7 +940,7 @@ iterator parseJsonFragments*(s: Stream, filename: string = ""; rawIntegers = fal
   ## field but kept as raw numbers via `JString`.
   ## If `rawFloats` is true, floating point literals will not be converted to a `JFloat`
   ## field but kept as raw numbers via `JString`.
-  var p: JsonParser
+  var p: JsonParser = default(JsonParser)
   p.open(s, filename)
   try:
     discard getTok(p) # read first token
@@ -955,7 +958,7 @@ proc parseJson*(s: Stream, filename: string = ""; rawIntegers = false, rawFloats
   ## field but kept as raw numbers via `JString`.
   ## If `rawFloats` is true, floating point literals will not be converted to a `JFloat`
   ## field but kept as raw numbers via `JString`.
-  var p: JsonParser
+  var p: JsonParser = default(JsonParser)
   p.open(s, filename)
   try:
     discard getTok(p) # read first token

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -539,6 +539,7 @@ when not defined(js):
   # ------
 
   proc countLogLines(logger: RollingFileLogger): int =
+    result = 0
     let fp = open(logger.baseName, fmRead)
     for line in fp.lines():
       result.inc()

--- a/lib/pure/marshal.nim
+++ b/lib/pure/marshal.nim
@@ -273,7 +273,7 @@ proc loadAny(p: var JsonParser, a: Any, t: var Table[BiggestInt, pointer]) =
   of akRange: loadAny(p, a.skipRange, t)
 
 proc loadAny(s: Stream, a: Any, t: var Table[BiggestInt, pointer]) =
-  var p: JsonParser
+  var p: JsonParser = default(JsonParser)
   open(p, s, "unknown file")
   next(p)
   loadAny(p, a, t)

--- a/lib/pure/md5.nim
+++ b/lib/pure/md5.nim
@@ -127,7 +127,7 @@ template memOrNot(withMem, withoutMem): untyped =
 
 proc transform(buffer: openArray[uint8], state: var MD5State) =
   var
-    myBlock: MD5Block
+    myBlock: MD5Block = default(MD5Block)
   encode(myBlock, buffer)
   var a = state[0]
   var b = state[1]
@@ -225,8 +225,8 @@ proc toMD5*(s: string): MD5Digest =
   ## * `$ proc <#$,MD5Digest>`_ for converting MD5Digest to string
   runnableExamples:
     assert $toMD5("abc") == "900150983cd24fb0d6963f7d28e17f72"
-
-  var c: MD5Context
+  result = default(MD5Digest)
+  var c: MD5Context = default(MD5Context)
   md5Init(c)
   md5Update(c, s.slice(0, s.len - 1))
   md5Final(c, result)
@@ -248,8 +248,8 @@ proc getMD5*(s: string): string =
     assert getMD5("abc") == "900150983cd24fb0d6963f7d28e17f72"
 
   var
-    c: MD5Context
-    d: MD5Digest
+    c: MD5Context = default(MD5Context)
+    d: MD5Digest = default(MD5Digest)
   md5Init(c)
   md5Update(c, s.slice(0, s.len - 1))
   md5Final(c, d)
@@ -319,7 +319,7 @@ proc md5Final*(c: var MD5Context, digest: var MD5Digest) =
   ## If you use the `toMD5 proc <#toMD5,string>`_, there's no need to call this
   ## function explicitly.
   var
-    Bits: MD5CBits
+    Bits: MD5CBits = default(MD5CBits)
     PadLen: int
   decode(Bits, c.count)
   var Index = int((c.count[0] shr 3) and 0x3F)

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1038,7 +1038,7 @@ func newMimetypes*(): MimeDB =
   ## Creates a new Mimetypes database. The database will contain the most
   ## common mimetypes.
   {.cast(noSideEffect).}:
-    result.mimes = mimes.toOrderedTable()
+    result = MimeDB(mimes: mimes.toOrderedTable())
 
 func getMimetype*(mimedb: MimeDB, ext: string, default = "text/plain"): string =
   ## Gets mimetype which corresponds to `ext`. Returns `default` if `ext`

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -143,6 +143,7 @@ else:
                  # avoid calling 'getTicks' too frequently
 
   proc requestedHook(): bool {.nimcall.} =
+    result = false
     if interval == 0: result = true
     elif gTicker == 0:
       gTicker = 500
@@ -174,7 +175,7 @@ proc writeProfile() {.noconv.} =
     system.profilerHook = nil
   const filename = "profile_results.txt"
   echo "writing " & filename & "..."
-  var f: File
+  var f: File = default(File)
   if open(f, filename, fmWrite):
     sort(profileData, cmpEntries)
     writeLine(f, "total executions of each stack trace:")

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -44,6 +44,7 @@ proc hexbyte*(hex: char): int {.inline.} =
 
 proc parseOid*(str: cstring): Oid =
   ## Parses an OID.
+  result = Oid()
   var bytes = cast[cstring](cast[pointer](cast[int](addr(result.time)) + 4))
   var i = 0
   while i < 12:
@@ -53,7 +54,7 @@ proc parseOid*(str: cstring): Oid =
 proc `$`*(oid: Oid): string =
   ## Converts an OID to a string.
   const hex = "0123456789abcdef"
-
+  result = ""
   result.setLen 24
 
   var o = oid
@@ -89,11 +90,12 @@ proc genOid*(): Oid =
     doAssert ($genOid()).len == 24
   runnableExamples("-r:off"):
     echo $genOid() # for example, "5fc7f546ddbbc84800006aaf"
+  result = Oid()
   genOid(result, incr, fuzz)
 
 proc generatedTime*(oid: Oid): Time =
   ## Returns the generated timestamp of the OID.
-  var tmp: int64
+  var tmp: int64 = int64(0)
   var dummy = oid.time
   bigEndian64(addr(tmp), addr(dummy))
   result = fromUnix(tmp)

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -13,6 +13,9 @@
 # Note: Only add new enum values at the end to ensure binary compatibility with
 # other Nim compiler versions!
 
+when defined(nimPreviewSlimSystem):
+  import std/assertions
+
 type
   SingleValueSetting* {.pure.} = enum ## \
                       ## settings resulting in a single string value
@@ -54,6 +57,7 @@ proc querySetting*(setting: SingleValueSetting): string {.
   ##
   runnableExamples:
     const nimcache = querySetting(SingleValueSetting.nimcacheDir)
+  raiseAssert "implemented in the vmops"
 
 proc querySettingSeq*(setting: MultipleValueSetting): seq[string] {.
   compileTime, noSideEffect.} =
@@ -64,3 +68,4 @@ proc querySettingSeq*(setting: MultipleValueSetting): seq[string] {.
   ## * `compileOption <system.html#compileOption,string,string>`_ for enum options
   runnableExamples:
     const nimblePaths = querySettingSeq(MultipleValueSetting.nimblePaths)
+  raiseAssert "implemented in the vmops"

--- a/lib/std/editdistance.nim
+++ b/lib/std/editdistance.nim
@@ -114,7 +114,7 @@ proc editDistance*(a, b: string): int {.noSideEffect.} =
   iCurrentA = iStart
   var
     char2pI = -1
-    char2pPrev: int
+    char2pPrev: int = 0
   for i in 1 .. (len1 - 1):
     iNextA = iCurrentA
     a.fastRuneAt(iNextA, runeA)

--- a/lib/std/effecttraits.nim
+++ b/lib/std/effecttraits.nim
@@ -16,11 +16,14 @@
 
 import std/macros
 
-proc getRaisesListImpl(n: NimNode): NimNode = discard "see compiler/vmops.nim"
-proc getTagsListImpl(n: NimNode): NimNode = discard "see compiler/vmops.nim"
-proc getForbidsListImpl(n: NimNode): NimNode = discard "see compiler/vmops.nim"
-proc isGcSafeImpl(n: NimNode): bool = discard "see compiler/vmops.nim"
-proc hasNoSideEffectsImpl(n: NimNode): bool = discard "see compiler/vmops.nim"
+when defined(nimPreviewSlimSystem):
+  import std/assertions
+
+proc getRaisesListImpl(n: NimNode): NimNode = raiseAssert "see compiler/vmops.nim"
+proc getTagsListImpl(n: NimNode): NimNode = raiseAssert "see compiler/vmops.nim"
+proc getForbidsListImpl(n: NimNode): NimNode = raiseAssert "see compiler/vmops.nim"
+proc isGcSafeImpl(n: NimNode): bool = raiseAssert "see compiler/vmops.nim"
+proc hasNoSideEffectsImpl(n: NimNode): bool = raiseAssert "see compiler/vmops.nim"
 
 proc getRaisesList*(fn: NimNode): NimNode =
   ## Extracts the `.raises` list of the func/proc/etc `fn`.

--- a/lib/std/envvars.nim
+++ b/lib/std/envvars.nim
@@ -11,6 +11,9 @@
 ## The `std/envvars` module implements environment variable handling.
 import std/oserrors
 
+when defined(nimPreviewSlimSystem):
+  import std/assertions
+
 type
   ReadEnvEffect* = object of ReadIOEffect   ## Effect that denotes a read
                                             ## from an environment variable.
@@ -200,7 +203,7 @@ when not defined(nimscript):
           let p = find(kv, '=')
           yield (substr(kv, 0, p-1), substr(kv, p+1))
 
-proc envPairsImplSeq(): seq[tuple[key, value: string]] = discard # vmops
+proc envPairsImplSeq(): seq[tuple[key, value: string]] = raiseAssert "implemented in the vmops" # vmops
 
 iterator envPairs*(): tuple[key, value: string] {.tags: [ReadEnvEffect].} =
   ## Iterate over all `environments variables`:idx:.

--- a/lib/std/monotimes.nim
+++ b/lib/std/monotimes.nim
@@ -98,7 +98,7 @@ proc getMonoTime*(): MonoTime {.tags: [TimeEffect].} =
     result = MonoTime(ticks: (ticks * 1_000_000_000).int64)
   elif defined(macosx):
     let ticks = mach_absolute_time()
-    var machAbsoluteTimeFreq: MachTimebaseInfoData
+    var machAbsoluteTimeFreq: MachTimebaseInfoData = default(MachTimebaseInfoData)
     mach_timebase_info(machAbsoluteTimeFreq)
     result = MonoTime(ticks: ticks * machAbsoluteTimeFreq.numer div
       machAbsoluteTimeFreq.denom)
@@ -106,15 +106,15 @@ proc getMonoTime*(): MonoTime {.tags: [TimeEffect].} =
     let ticks = k_ticks_to_ns_floor64(k_uptime_ticks())
     result = MonoTime(ticks: ticks)
   elif defined(posix):
-    var ts: Timespec
+    var ts: Timespec = default(Timespec)
     discard clock_gettime(CLOCK_MONOTONIC, ts)
     result = MonoTime(ticks: ts.tv_sec.int64 * 1_000_000_000 +
       ts.tv_nsec.int64)
   elif defined(windows):
-    var ticks: uint64
+    var ticks: uint64 = 0'u64
     QueryPerformanceCounter(ticks)
 
-    var freq: uint64
+    var freq: uint64 = 0'u64
     QueryPerformanceFrequency(freq)
     let queryPerformanceCounterFreq = 1_000_000_000'u64 div freq
     result = MonoTime(ticks: (ticks * queryPerformanceCounterFreq).int64)

--- a/lib/std/socketstreams.nim
+++ b/lib/std/socketstreams.nim
@@ -88,6 +88,7 @@ proc rsGetPosition(s: Stream): int =
   return s.pos
 
 proc rsPeekData(s: Stream, buffer: pointer, bufLen: int): int =
+  result = 0
   let s = ReadSocketStream(s)
   if bufLen > 0:
     let oldLen = s.buf.len

--- a/lib/std/staticos.nim
+++ b/lib/std/staticos.nim
@@ -1,13 +1,16 @@
 ## This module implements path handling like os module but works at only compile-time.
 ## This module works even when cross compiling to OS that is not supported by os module.
 
+when defined(nimPreviewSlimSystem):
+  import std/assertions
+
 proc staticFileExists*(filename: string): bool {.compileTime.} =
   ## Returns true if `filename` exists and is a regular file or symlink.
   ##
   ## Directories, device files, named pipes and sockets return false.
-  discard
+  raiseAssert "implemented in the vmops"
 
 proc staticDirExists*(dir: string): bool {.compileTime.} =
   ## Returns true if the directory `dir` exists. If `dir` is a file, false
   ## is returned. Follows symlinks.
-  discard
+  raiseAssert "implemented in the vmops"

--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -287,6 +287,7 @@ else:
         discard posix.close(fd)
 
 proc urandomInternalImpl(dest: var openArray[byte]): int {.inline.} =
+  result = 0
   when batchImplOS:
     batchImpl(result, dest, getRandomImpl)
   else:

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -156,6 +156,7 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
     assert readFile(path) == "foo"
     removeFile(path)
   # xxx why does above work without `cfile.flushFile` ?
+  result = default(tuple[cfile: File, path: string])
   let dir = getTempDirImpl(dir)
   for i in 0 ..< maxRetry:
     result.path = genTempPath(prefix, suffix, dir)

--- a/lib/std/varints.nim
+++ b/lib/std/varints.nim
@@ -107,10 +107,10 @@ proc writeVu64*(z: var openArray[byte], x: uint64): int =
   varintWrite32(toOpenArray(z, 5, 8), y)
   return 9
 
-proc sar(a, b: int64): int64 =
+proc sar(a, b: int64): int64 {.noinit.} =
   {.emit: [result, " = ", a, " >> ", b, ";"].}
 
-proc sal(a, b: int64): int64 =
+proc sal(a, b: int64): int64 {.noinit.} =
   {.emit: [result, " = ", a, " << ", b, ";"].}
 
 proc encodeZigzag*(x: int64): uint64 {.inline.} =

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -61,10 +61,11 @@ proc finalize(n: NimNode, lhs: NimNode, level: int): NimNode =
     result = quote: (var `lhs` = `n`)
 
 proc process(n: NimNode, lhs: NimNode, label: NimNode, level: int): NimNode =
+  result = nil
   var n = n.copyNimTree
   var it = n
   let addr2 = bindSym"addr"
-  var old: tuple[n: NimNode, index: int]
+  var old: tuple[n: NimNode, index: int] = (nil, 0)
   while true:
     if it.len == 0:
       result = finalize(n, lhs, level)

--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -405,6 +405,7 @@ proc recv*[TMsg](c: var Channel[TMsg]): TMsg =
   ##
   ## This blocks until a message has arrived!
   ## You may use `peek proc <#peek,Channel[TMsg]>`_ to avoid the blocking.
+  result = default(TMsg)
   var q = cast[PRawChannel](addr(c))
   acquireSys(q.lock)
   llRecv(q, addr(result), cast[PNimType](getTypeInfo(result)))
@@ -417,6 +418,7 @@ proc tryRecv*[TMsg](c: var Channel[TMsg]): tuple[dataAvailable: bool,
   ##
   ## If it fails, it returns `(false, default(msg))` otherwise it
   ## returns `(true, msg)`.
+  result = default(tuple[dataAvailable: bool, msg: TMsg])
   var q = cast[PRawChannel](addr(c))
   if q.mask != ChannelDeadMask:
     if tryAcquireSys(q.lock):

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -22,3 +22,6 @@ define:nimcore
 #define:noDocgen
 --path:"$nim"
 --threads:on
+--warningAserror:ProveInit
+--warningAserror:Uninit
+

--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -152,7 +152,7 @@ proc parseString(my: var SexpParser): TTokKind =
         inc(pos, 2)
       of 'u':
         inc(pos, 2)
-        var r: int
+        var r: int = 0
         if handleHexChar(my.buf[pos], r): inc(pos)
         if handleHexChar(my.buf[pos], r): inc(pos)
         if handleHexChar(my.buf[pos], r): inc(pos)
@@ -452,7 +452,7 @@ proc len*(n: SexpNode): int =
   ## Else it returns 0.
   case n.kind
   of SList: result = n.elems.len
-  else: discard
+  else: result = 0
 
 proc `[]`*(node: SexpNode, index: int): SexpNode =
   ## Gets the node at `index` in a List. Result is undefined if `index`
@@ -629,7 +629,7 @@ proc open*(my: var SexpParser, input: Stream) =
 
 proc parseSexp*(s: Stream): SexpNode =
   ## Parses from a buffer `s` into a `SexpNode`.
-  var p: SexpParser
+  var p: SexpParser = SexpParser()
   p.open(s)
   discard getTok(p) # read first token
   result = p.parseSexp()

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -37,8 +37,7 @@ proc exe*(f: string): string =
 proc findNimImpl*(): tuple[path: string, ok: bool] =
   if nimExe.len > 0: return (nimExe, true)
   let nim = "nim".exe
-  result.path = "bin" / nim
-  result.ok = true
+  result = ("bin" / nim, true)
   if fileExists(result.path): return
   for dir in split(getEnv("PATH"), PathSep):
     result.path = dir / nim
@@ -98,6 +97,7 @@ pkgs/atlas/doc/atlas.md
 """.splitWhitespace()
 
 proc getMd2html(): seq[string] =
+  result = @[]
   for a in walkDirRecFilter("doc"):
     let path = a.path
     if a.kind == pcFile and path.splitFile.ext == ".md" and path.lastPathPart notin
@@ -191,7 +191,8 @@ when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
 
 proc getDocList(): seq[string] =
   ##
-  var docIgnore: HashSet[string]
+  result = @[]
+  var docIgnore: HashSet[string] = initHashSet[string]()
   for a in withoutIndex: docIgnore.incl a
   for a in ignoredModules: docIgnore.incl a
 
@@ -327,7 +328,7 @@ proc nim2pdf(src: string, dst: string, nimArgs: string) =
 
 proc buildPdfDoc*(args: string, destPath: string) =
   let args = nimArgs & " " & args
-  var pdfList: seq[string]
+  var pdfList: seq[string] = @[]
   createDir(destPath)
   if os.execShellCmd("xelatex -version") != 0:
     doAssert false, "xelatex not found" # or, raise an exception


### PR DESCRIPTION
After some cleanups for stdlibs, then we should enable warningaserror for all tests