### PR TITLE
fix nil node in sym ast of exported ref objects [backport:2.2]

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1698,12 +1698,14 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
         obj.ast[0] = a[0].shallowCopy
         if a[0][0].kind == nkPostfix:
           obj.ast[0][0] = a[0][0].shallowCopy
+          obj.ast[0][0][0] = a[0][0][0] # ident "*"
           obj.ast[0][0][1] = symNode
         else:
           obj.ast[0][0] = symNode
         obj.ast[0][1] = a[0][1]
       of nkPostfix:
         obj.ast[0] = a[0].shallowCopy
+        obj.ast[0][0] = a[0][0] # ident "*"
         obj.ast[0][1] = symNode
       else: assert(false)
       obj.ast[1] = a[1]

--- a/tests/pragmas/tpostfixcustompragma.nim
+++ b/tests/pragmas/tpostfixcustompragma.nim
@@ -1,0 +1,24 @@
+# issue #24526
+
+import std/macros
+
+template prag {.pragma.}
+
+type
+  Foo1* = ref object of RootObj
+    name*: string
+  Foo2* {.used.} = ref object of RootObj
+    name*: string
+  Foo3* {.prag.} = ref object of RootObj
+    name*: string
+  Foo4* {.used, prag.} = ref object of RootObj
+    name*: string
+
+# needs to have `typedesc` type
+proc foo(T: typedesc): bool =
+  T.hasCustomPragma(prag)
+
+doAssert not foo(typeof(Foo1()[]))
+doAssert not foo(typeof(Foo2()[]))
+doAssert foo(typeof(Foo3()[]))
+doAssert foo(typeof(Foo4()[]))


### PR DESCRIPTION
fixes #24526, follows up #23101

The `shallowCopy` calls do not keep the original node's children, they just make a new seq with the same length, so the `Ident "*"` node from the original postfix nodes was not carried over, making it `nil` and causing the segfault.