### PR TITLE
fixes #22153; UB calling allocCStringArray([""]) with --mm:refc

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2143,7 +2143,7 @@ when not defined(js) and declared(alloc0) and declared(dealloc):
     let x = cast[ptr UncheckedArray[string]](a)
     for i in 0 .. a.high:
       result[i] = cast[cstring](alloc0(x[i].len+1))
-      copyMem(result[i], addr(x[i][0]), x[i].len)
+      copyMem(result[i], x[i].cstring, x[i].len)
 
   proc deallocCStringArray*(a: cstringArray) =
     ## Frees a NULL terminated cstringArray.

--- a/tests/objects/t20972.nim
+++ b/tests/objects/t20972.nim
@@ -13,3 +13,11 @@ var info = ForkedEpochInfo(kind: true)
 doAssert info.kind
 info.kind = false
 doAssert not info.kind
+
+block: # bug #22153
+  discard allocCStringArray([""])
+  discard allocCStringArray(["1234"])
+
+  var s = "1245"
+  s.add "1"
+  discard allocCStringArray([s])


### PR DESCRIPTION
fixes #22153

It's a problem for refc because you cannot index a nil string: i.e. `[""]` is `{((NimStringDesc*) NIM_NIL)}` which cannot be indexed