### PR TITLE
Fix exitnow signature, mark as .noreturn

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -503,7 +503,7 @@ proc pthread_spin_unlock*(a1: ptr Pthread_spinlock): cint {.
 proc pthread_testcancel*() {.importc, header: "<pthread.h>".}
 
 
-proc exitnow*(code: int) {.importc: "_exit", header: "<unistd.h>".}
+proc exitnow*(code: cint) {.importc: "_exit", header: "<unistd.h>", noreturn.}
 proc access*(a1: cstring, a2: cint): cint {.importc, header: "<unistd.h>".}
 proc alarm*(a1: cint): cint {.importc, header: "<unistd.h>".}
 proc chdir*(a1: cstring): cint {.importc, header: "<unistd.h>".}


### PR DESCRIPTION
Like quit, this function never returns.

Also, "code" was marked as "int", even though POSIX _exit takes a C int.