### PR TITLE
fixes #24536; fixes nightlies regression caused by nimble update

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -159,7 +159,7 @@ proc bundleNimbleExe(latest: bool, args: string) =
   let commit = if latest: "HEAD" else: NimbleStableCommit
   cloneDependency(distDir, "https://github.com/nim-lang/nimble.git",
                   commit = commit, allowBundled = true)
-  updateSubmodules(distDir / "nimble")
+  updateSubmodules(distDir / "nimble", allowBundled = true)
   nimCompile("dist/nimble/src/nimble.nim",
              options = "-d:release --noNimblePath " & args)
 

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -43,10 +43,15 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
   else:
     quit "FAILURE: " & destdir & " already exists but is not a git repo"
 
-proc updateSubmodules*(dir: string) =
-  let oldDir = getCurrentDir()
-  setCurrentDir(dir)
-  try:
-    exec "git submodule update --init"
-  finally:
-    setCurrentDir(oldDir)
+proc updateSubmodules*(dir: string, allowBundled = false) =
+  if isGitRepo(dir):
+    let oldDir = getCurrentDir()
+    setCurrentDir(dir)
+    try:
+      exec "git submodule update --init"
+    finally:
+      setCurrentDir(oldDir)
+  elif allowBundled:
+    discard "this dependency was bundled with Nim, don't do anything"
+  else:
+    quit "FAILURE: " & dir & " already exists but is not a git repo"


### PR DESCRIPTION
follow up #24537

Because `nimble` is a bundled repo so it is bundled in the tarballs

i.e. https://github.com/nim-lang/nightlies/blob/82421fd7053bf58dea69e9a259e6f2618c2be2e5/.github/workflows/nightlies.yml#L264 has bundled `dist/nimble`, but it only copies the data without `.git`. So in this PR, we ignore bundled nimble repo.