### PR TITLE
fixes #20908; Unknown warnings and hints now give a warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ rounding guarantees (via the
 
 - With `-d:nimPreviewCheckedClose`, the `close` function in the `std/syncio` module now raises an IO exception in case of an error.
 
+- Unknown warnings and hints now gives warnings `warnUnknownNotes` instead of
+errors.
+
 ## Standard library additions and changes
 
 [//]: # "Additions:"

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -203,13 +203,14 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
   else: invalidCmdLineOption(conf, pass, orig, info)
 
   let isSomeHint = state in {wHint, wHintAsError}
+  let isSomeWarning = state in {wWarning, wWarningAsError}
   template findNote(noteMin, noteMax, name) =
     # unfortunately, hintUser and warningUser clash, otherwise implementation would simplify a bit
     let x = findStr(noteMin, noteMax, id, errUnknown)
     if x != errUnknown: notes = {TNoteKind(x)}
     else:
-      if isSomeHint:
-        message(conf, info, hintUnknownHint, id)
+      if isSomeHint or isSomeWarning:
+        message(conf, info, warnUnknownNotes, "unknown $#: $#" % [name, id])
       else:
         localError(conf, info, "unknown $#: $#" % [name, id])
   case id.normalize

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -94,6 +94,7 @@ type
     warnImplicitDefaultValue = "ImplicitDefaultValue",
     warnIgnoredSymbolInjection = "IgnoredSymbolInjection",
     warnStdPrefix = "StdPrefix"
+    warnUnknownNotes = "UnknownNotes"
     warnUser = "User",
     warnGlobalVarConstructorTemporary = "GlobalVarConstructorTemporary",
     # hints
@@ -111,7 +112,6 @@ type
     hintUser = "User", hintUserRaw = "UserRaw", hintExtendedContext = "ExtendedContext",
     hintMsgOrigin = "MsgOrigin", # since 1.3.5
     hintDeclaredLoc = "DeclaredLoc", # since 1.5.1
-    hintUnknownHint = "UnknownHint"
 
 const
   MsgKindToStr*: array[TMsgKind, string] = [
@@ -200,6 +200,7 @@ const
     warnImplicitDefaultValue: "$1",
     warnIgnoredSymbolInjection: "$1",
     warnStdPrefix: "$1 needs the 'std' prefix",
+    warnUnknownNotes: "$1",
     warnUser: "$1",
     warnGlobalVarConstructorTemporary: "global variable '$1' initialization requires a temporary variable",
     hintSuccess: "operation successful: $#",
@@ -236,8 +237,7 @@ const
     hintUserRaw: "$1",
     hintExtendedContext: "$1",
     hintMsgOrigin: "$1",
-    hintDeclaredLoc: "$1",
-    hintUnknownHint: "unknown hint: $1"
+    hintDeclaredLoc: "$1"
   ]
 
 const


### PR DESCRIPTION
fixes #20908

This PR unifies the treatment of unknown warnings and hints, which now gives an `warnUnknownNotes` instead of an error. 