### PR TITLE
check if unused import warning is enabled before adding import to stack

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -231,7 +231,7 @@ proc importForwarded(c: PContext, n: PNode, exceptSet: IntSet; fromMod: PSym; im
     for i in 0..n.safeLen-1:
       importForwarded(c, n[i], exceptSet, fromMod, importSet)
 
-proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden: bool): PSym =
+proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden, trackUnusedImport: bool): PSym =
   result = realModule
   template createModuleAliasImpl(ident): untyped =
     createModuleAlias(realModule, c.idgen, ident, n.info, c.config.options)
@@ -248,7 +248,7 @@ proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden: bool)
     result.options.incl optImportHidden
   let moduleIdent = if n.kind in {nkInfix, nkImportAs}: n[^1] else: n
   result.info = moduleIdent.info
-  if warnUnusedImportX in c.config.notes:
+  if trackUnusedImport:
     c.unusedImports.add((result, result.info))
   c.importModuleMap[result.id] = realModule.id
   c.importModuleLookup.mgetOrPut(result.name.id, @[]).addUnique realModule.id
@@ -290,10 +290,11 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
                 toFullPath(c.config, c.graph.importStack[i+1])
       c.recursiveDep = err
 
+    let trackUnusedImport = warnUnusedImportX in c.config.notes
     var realModule: PSym
     discard pushOptionEntry(c)
     realModule = c.graph.importModuleCallback(c.graph, c.module, f)
-    result = importModuleAs(c, n, realModule, transf.importHidden)
+    result = importModuleAs(c, n, realModule, transf.importHidden, trackUnusedImport)
     popOptionEntry(c)
 
     #echo "set back to ", L

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -248,7 +248,8 @@ proc importModuleAs(c: PContext; n: PNode, realModule: PSym, importHidden: bool)
     result.options.incl optImportHidden
   let moduleIdent = if n.kind in {nkInfix, nkImportAs}: n[^1] else: n
   result.info = moduleIdent.info
-  c.unusedImports.add((result, result.info))
+  if warnUnusedImportX in c.config.notes:
+    c.unusedImports.add((result, result.info))
   c.importModuleMap[result.id] = realModule.id
   c.importModuleLookup.mgetOrPut(result.name.id, @[]).addUnique realModule.id
 

--- a/tests/import/tpushunusedwarning.nim
+++ b/tests/import/tpushunusedwarning.nim
@@ -1,6 +1,13 @@
+discard """
+  action: compile
+  matrix: "--hints:off"
+  nimoutFull: true
+  nimout: '''
+'''
+"""
+
 # issue #24552
 
-{.warningAsError[UnusedImport]: on.}
 {.push warning[UnusedImport]: off.}
 import tables
 {.pop.}

--- a/tests/import/tpushunusedwarning.nim
+++ b/tests/import/tpushunusedwarning.nim
@@ -1,0 +1,9 @@
+# issue #24552
+
+{.warningAsError[UnusedImport]: on.}
+{.push warning[UnusedImport]: off.}
+import tables
+{.pop.}
+
+proc test*(a: float): float =
+  a


### PR DESCRIPTION
fixes #24552

Could also implement `{.used.}` for imports but this wouldn't be backwards compatible. The same problem as #24552 also exists for `{.hint[XDeclaredButNotUsed].}` but this isn't as much of a problem since `{.used.}`/`{.push used.}` exist.