### PR TITLE
poc: match block/macro pragma args from tail end with `flexibleOptionalParams`

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2764,18 +2764,31 @@ template isVarargsUntyped(x): untyped =
 template isVarargsTyped(x): untyped =
   x.kind == tyVarargs and x[0].kind == tyTyped
 
-proc findFirstArgBlock(m: var TCandidate, n: PNode): int =
+proc findFirstTailArg(m: var TCandidate, n: PNode): int =
   # see https://github.com/nim-lang/RFCs/issues/405
   result = int.high
-  for a2 in countdown(n.len-1, 0):
-    # checking `nfBlockArg in n[a2].flags` wouldn't work inside templates
-    if n[a2].kind != nkStmtList: break
-    let formalLast = m.callee.n[m.callee.n.len - (n.len - a2)]
+  var arg = n.len - 1
+  template checkArg() =
+    # get last i'th arg of m.callee.n
+    let formalLast = m.callee.n[m.callee.len - (n.len - arg)]
     # parameter has to occupy space (no default value, not void or varargs)
     if formalLast.kind == nkSym and formalLast.sym.ast == nil and
         formalLast.sym.typ.kind notin {tyVoid, tyVarargs}:
-      result = a2
-    else: break
+      result = arg
+    else:
+      return
+  if n[arg].kind in routineDefs + {nkVarSection, nkLetSection, nkConstSection, nkTypeDef}:
+    # definition that supports macro pragma, consider tail arg
+    # proc types and non-`do` lambdas excluded
+    checkArg()
+    dec arg
+  const postExprBlocks = {nkStmtList,
+    nkOfBranch, nkElifBranch, nkElse,
+    nkExceptBranch, nkFinally, nkDo}
+  while arg >= 0 and n[arg].kind in postExprBlocks:
+    # parameter has to occupy space (no default value, not void or varargs)
+    checkArg()
+    dec arg
 
 proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var IntSet) =
 
@@ -2817,7 +2830,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
     formalLen = m.callee.n.len
     formal = if formalLen > 1: m.callee.n[1].sym else: nil # current routine parameter
     container: PNode = nil # constructed container
-  let firstArgBlock = findFirstArgBlock(m, n)
+  let firstTailArg = findFirstTailArg(m, n)
   while a < n.len:
     c.openShadowScope
 
@@ -2919,7 +2932,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if m.callee.n[f].kind != nkSym:
           internalError(c.config, n[a].info, "matches")
           noMatch()
-        if flexibleOptionalParams in c.features and a >= firstArgBlock:
+        if flexibleOptionalParams in c.features and a >= firstTailArg:
           # this is a post-expr block, matched to the tail of the routine params
           let prevPos = f
           f = max(f, m.callee.n.len - (n.len - a))

--- a/config/config.nims
+++ b/config/config.nims
@@ -22,3 +22,4 @@ when defined(nimStrictMode):
 
 switch("define", "nimVersion:" & NimVersion) # deadcode
 switch("experimental", "strictDefs")
+switch("experimental", "flexibleOptionalParams")

--- a/tests/template/moverloadedblockparam.nim
+++ b/tests/template/moverloadedblockparam.nim
@@ -1,0 +1,3 @@
+template fun2*(a: bool, body: untyped): untyped = discard
+template fun2*(a: int, body: untyped): untyped = discard
+template fun2*(body: untyped): untyped = discard

--- a/tests/template/toverloadedblockparam.nim
+++ b/tests/template/toverloadedblockparam.nim
@@ -1,0 +1,90 @@
+{.experimental: "flexibleOptionalParams".}
+
+block: # adapted tests from PR #18618 for RFC 402, covers issue #19556
+  template fails(body: untyped) =
+    doAssert not compiles(body)
+    static: doAssert not compiles(body)
+  block: # test basic template overload with untyped
+    template t1(x: int, body: untyped) =
+      block:
+        var v {.inject.} = x
+        body
+
+    template t1(body: untyped) = t1(1, body)
+
+    var outputs: seq[string]
+    t1: outputs.add($v)
+    t1(2): outputs.add($v)
+    t1: outputs.add("hello" & $v)
+    fails: t1("hello", 10)
+    fails: t1()
+    fails: t1(1,2,3)
+    doAssert outputs == @["1", "2", "hello1"]
+
+  block: # test template with varargs combine untyped
+    template t1(x: int, vs: varargs[string], body: untyped) =
+      block:
+        var v {.inject.} = x + vs.len
+        body
+
+    template t1(body: untyped) = t1(1, "hello", body)
+
+    var outputs: seq[string]
+    t1: outputs.add($v)
+    t1(2, "hello", "hello 2"): outputs.add($v)
+    fails:
+      t1(2, 3): discard v
+    fails:
+      t1("hello", "world"): discard v
+    doAssert outputs == @["2", "4"]
+
+  block: # test template with named parameter combine untyped
+    template t1(x: int, y = 4, body: untyped) =
+      block:
+        var v {.inject.} = x + y
+        body
+
+    template t1(body: untyped) = t1(1, 3, body)
+
+    t1: discard v
+    t1(x = 1, 3): discard v
+    t1(2): discard v
+
+  block: # multiple overloads, covers issue #14827
+    template fun(a: bool, body: untyped): untyped = discard
+    template fun(a: int, body: untyped): untyped = discard
+    template fun(body: untyped): untyped = discard
+    fun(true): nonexistant # ok
+    fun(1): nonexistant # ok
+    fun: nonexistant # Error: undeclared identifier: 'nonexistant'
+    template varargsUntypedRedirection(x: varargs[untyped]) =
+      fun(x)
+    varargsUntypedRedirection(true): nonexistant
+    varargsUntypedRedirection(1): nonexistant
+    varargsUntypedRedirection: nonexistant
+
+when false: # issue #20274, pragma macros
+  macro a(path: string, fn: untyped): untyped =
+    result = fn
+  macro a(fn: untyped): untyped =
+    result = fn
+  proc b() {.a: "abc".} = discard
+  proc c() {.a.} = discard
+
+import moverloadedblockparam
+
+block:
+  fun2(true): nonexistant # ok
+  fun2(1): nonexistant # ok
+  fun2: nonexistant # Error: undeclared identifier: 'nonexistant'
+
+block:
+  template fun2(body: untyped): int = 123
+  fun2(true): nonexistant # ok
+  fun2(1): nonexistant # ok
+  discard (fun2 do: nonexistant) # Error: undeclared identifier: 'nonexistant'
+  template fun2(a: bool, body: untyped): untyped = discard
+  template fun2(a: int, body: untyped): untyped = discard
+  fun2(true): nonexistant # ok
+  fun2(1): nonexistant # ok
+  discard (fun2 do: nonexistant)

--- a/tests/template/toverloadedblockparam.nim
+++ b/tests/template/toverloadedblockparam.nim
@@ -50,7 +50,7 @@ block: # adapted tests from PR #18618 for RFC 402, covers issue #19556
     t1(x = 1, 3): discard v
     t1(2): discard v
 
-  block: # multiple overloads, covers issue #14827
+  block: # multiple overloads, block version of issue #14827
     template fun(a: bool, body: untyped): untyped = discard
     template fun(a: int, body: untyped): untyped = discard
     template fun(body: untyped): untyped = discard
@@ -63,7 +63,7 @@ block: # adapted tests from PR #18618 for RFC 402, covers issue #19556
     varargsUntypedRedirection(1): nonexistant
     varargsUntypedRedirection: nonexistant
 
-when false: # issue #20274, pragma macros
+block: # issue #20274, pragma macros
   macro a(path: string, fn: untyped): untyped =
     result = fn
   macro a(fn: untyped): untyped =


### PR DESCRIPTION
Not referencing any issues, just wanted to see if this works

Generalizes the logic from #18631 to all post expr blocks and definitions that support macro pragmas, which considers them "tail args", i.e. matched to the *end* of the overload params rather than the start, as long as the argument at that position has to be provided (no varargs, void, or params with default values).

Then it's checked that every argument before them is provided or doesn't need to be provided (i.e. varargs, default value) and the match fails if they aren't. This prevents post expr blocks and macro pragmas from needlessly getting typechecked when enough arguments aren't given for their overload. Restricting to post expr blocks and macro pragmas here is because they have a `void` type at syntax level, so it's not important that they get typechecked early

This solves the issues referenced in #21673 but only for post-expr blocks and macro pragmas.