### PR TITLE
Make 'field is not accessible' and 'field initialized twice' errors point to the field inside the obj construction

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -79,7 +79,7 @@ proc semConstrField(c: PContext, flags: TExprFlags,
     if nfSkipFieldChecking in assignment[1].flags:
       discard
     elif not fieldVisible(c, field):
-      localError(c.config, initExpr.info,
+      localError(c.config, assignment[0].info,
         "the field '$1' is not accessible." % [field.name.s])
       return
 

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -521,7 +521,7 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType 
       for j in 1..<i:
         let prevId = considerQuotedIdent(c, result[j][0])
         if prevId.id == id.id:
-          localError(c.config, field.info, errFieldInitTwice % id.s)
+          localError(c.config, field[0].info, errFieldInitTwice % id.s)
           hasError = true
           break
       # 2) No such field exists in the constructed type

--- a/tests/objects/mobjconstr_msgs.nim
+++ b/tests/objects/mobjconstr_msgs.nim
@@ -1,0 +1,3 @@
+type
+  PrivateField* = object
+    priv: string

--- a/tests/objects/tobjconstr_msgs.nim
+++ b/tests/objects/tobjconstr_msgs.nim
@@ -1,8 +1,23 @@
+discard """
+  cmd: "nim check $file"
+"""
+
 import mobjconstr_msgs
 
 
-block: # Private field has correct line info
+block:
   discard PrivateField(
     priv: "test" #[tt.Error
     ^ the field 'priv' is not accessible]#
+  )
+
+
+block:
+  type
+    Foo = object
+      field: string
+  discard Foo(
+    field: "test",
+    field: "test" #[tt.Error
+    ^ field initialized twice: 'field']#
   )

--- a/tests/objects/tobjconstr_msgs.nim
+++ b/tests/objects/tobjconstr_msgs.nim
@@ -1,7 +1,8 @@
 import mobjconstr_msgs
 
 
-discard PrivateField(
-  priv: "test" #[tt.Error
-  ^ the field 'priv' is not accessible]#
-)
+block: # Private field has correct line info
+  discard PrivateField(
+    priv: "test" #[tt.Error
+    ^ the field 'priv' is not accessible]#
+  )

--- a/tests/objects/tobjconstr_msgs.nim
+++ b/tests/objects/tobjconstr_msgs.nim
@@ -1,0 +1,7 @@
+import mobjconstr_msgs
+
+
+discard PrivateField(
+  priv: "test" #[tt.Error
+  ^ the field 'priv' is not accessible]#
+)


### PR DESCRIPTION
Fixes two line infos to make the error's clearer inside editors

- 'field is not accessible' would point to the whole object construction instead of just the field inside the construction
- 'field initialized twice' would point to the colon instead of the field
 