### PR TITLE
Improve async stacktraces

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -299,11 +299,11 @@ proc format(entry: StackTraceEntry): string =
   result = spaces(2) & "$# $#\n" % [left, procname]
 
 proc isInternal(entry: StackTraceEntry): bool =
+  # support --excessiveStackTrace:off
   const internals = [
-    "/lib/pure/asyncdispatch.nim",
-    "/lib/pure/asyncfutures.nim",
-    "/lib/system/threadimpl.nim",  # XXX ?
-    "/patches/asyncfutures.nim"  # XXX remove
+    "asyncdispatch.nim",
+    "asyncfutures.nim",
+    "threadimpl.nim",  # XXX ?
   ]
   let (filename, procname) = getFilenameProcname(entry)
   for line in internals:
@@ -318,27 +318,24 @@ proc `$`*(stackTraceEntries: seq[StackTraceEntry]): string =
   else:
     let entries = stackTraceEntries
   var allEntries = newSeq[StackTraceEntry]()
-  var isRootCall = true
-  var i = 0
-  while i < entries.len:
-    isRootCall = true
-    while i < entries.len:
+  var currEntries = newSeq[StackTraceEntry]()
+  var i = entries.len-1
+  while i >= 0:
+    while i >= 0:
       if entries[i].line == reraisedFromBegin:
         break
       if entries[i].line > 0 and not isInternal(entries[i]):
-        if isRootCall:
-          isRootCall = false
-        else:
-          allEntries.add entries[i]
-      inc i
-    inc i
-  # add root call
-  for entry in entries:
-    if entry.line > 0 and not isInternal(entry):
-      allEntries.add entry
-      break
-  for j in countdown(allEntries.len-1, 0):
-    result.add format(allEntries[j])
+        # XXX n^2
+        # this removes recursive traces sadly
+        if entries[i] notin allEntries:
+          currEntries.add entries[i]
+      dec i
+    for j in countdown(currEntries.len-1, 0):
+      allEntries.add currEntries[j]
+    currEntries.setLen 0
+    dec i
+  for entry in allEntries:
+    result.add format(entry)
 
 proc injectStacktrace[T](future: Future[T]) =
   when not defined(release):

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -323,9 +323,9 @@ proc `$`*(stackTraceEntries: seq[StackTraceEntry]): string =
   var j = 0
   while i >= 0:
     if entries[i].line == reraisedFromBegin or i == 0:
-      j = i
+      j = i + int(i != 0)
       while j < L:
-        if entries[j].line == reraisedFromEnd:
+        if entries[j].line == reraisedFromBegin:
           break
         if entries[j].line >= 0 and not isInternal(entries[j]):
           # this skips recursive calls sadly

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -317,26 +317,23 @@ proc `$`*(stackTraceEntries: seq[StackTraceEntry]): string =
     let entries = addDebuggingInfo(stackTraceEntries)
   else:
     let entries = stackTraceEntries
-  var allEntries = newSeq[StackTraceEntry]()
-  var currEntries = newSeq[StackTraceEntry]()
   var seenEntries = initHashSet[StackTraceEntry]()
-  var i = entries.len-1
+  let L = entries.len-1
+  var i = L
+  var j = 0
   while i >= 0:
-    while i >= 0:
-      if entries[i].line == reraisedFromBegin:
-        break
-      if entries[i].line >= 0 and not isInternal(entries[i]):
-        # this skips recursive calls sadly
-        if entries[i] notin seenEntries:
-          currEntries.add entries[i]
-          seenEntries.incl entries[i]
-      dec i
-    for j in countdown(currEntries.len-1, 0):
-      allEntries.add currEntries[j]
-    currEntries.setLen 0
+    if entries[i].line == reraisedFromBegin or i == 0:
+      j = i
+      while j < L:
+        if entries[j].line == reraisedFromEnd:
+          break
+        if entries[j].line >= 0 and not isInternal(entries[j]):
+          # this skips recursive calls sadly
+          if entries[j] notin seenEntries:
+            result.add format(entries[j])
+            seenEntries.incl entries[j]
+        inc j
     dec i
-  for entry in allEntries:
-    result.add format(entry)
 
 proc injectStacktrace[T](future: Future[T]) =
   when not defined(release):

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -168,9 +168,9 @@ template await*[T](f: Future[T]): auto {.used.} =
   template yieldFuture {.redefine.} = yield FutureBase()
 
   when compiles(yieldFuture):
+    var internalTmpFuture: FutureBase = f
+    yield internalTmpFuture
     {.line: instantiationInfo(fullPaths = true).}:
-      var internalTmpFuture: FutureBase = f
-      yield internalTmpFuture
       (cast[typeof(f)](internalTmpFuture)).read()
   else:
     macro errorAsync(futureError: Future[T]) =

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -168,9 +168,10 @@ template await*[T](f: Future[T]): auto {.used.} =
   template yieldFuture {.redefine.} = yield FutureBase()
 
   when compiles(yieldFuture):
-    var internalTmpFuture: FutureBase = f
-    yield internalTmpFuture
-    (cast[typeof(f)](internalTmpFuture)).read()
+    {.line: instantiationInfo(fullPaths = true).}:
+      var internalTmpFuture: FutureBase = f
+      yield internalTmpFuture
+      (cast[typeof(f)](internalTmpFuture)).read()
   else:
     macro errorAsync(futureError: Future[T]) =
       error(

--- a/tests/async/tasync_traceback.nim
+++ b/tests/async/tasync_traceback.nim
@@ -76,12 +76,7 @@ Exception message: b failure
 bar failure
 Async traceback:
   tasync_traceback\.nim\(\d+?\) tasync_traceback
-  asyncdispatch\.nim\(\d+?\) waitFor
-  asyncdispatch\.nim\(\d+?\) poll
-    ## Processes asynchronous completion events
-  asyncdispatch\.nim\(\d+?\) runOnce
-  asyncdispatch\.nim\(\d+?\) processPendingCallbacks
-    ## Executes pending callbacks
+  tasync_traceback\.nim\(\d+?\) foo \(Async\)
   tasync_traceback\.nim\(\d+?\) bar \(Async\)
 Exception message: bar failure
 

--- a/tests/async/tasync_traceback2.nim
+++ b/tests/async/tasync_traceback2.nim
@@ -100,11 +100,11 @@ block:  # interleaved async work
     raise newException(ValueError, "the_error_msg")
 
   proc bar() {.async.} =
-    await sleepAsync(1)
+    #await sleepAsync(1)
     await baz()
 
   proc foo() {.async.} =
-    #await sleepAsync(1)
+    await sleepAsync(1)
     await bar()
 
   proc main {.async.} =

--- a/tests/async/tasync_traceback2.nim
+++ b/tests/async/tasync_traceback2.nim
@@ -1,0 +1,158 @@
+import std/asyncdispatch
+import std/re
+from std/strutils import dedent
+
+proc err() =
+  raise newException(ValueError, "the_error_msg")
+
+block:
+  proc recursion(i: int) {.async.} =
+    if i == 5:
+      err()
+    await sleepAsync(1)
+    await recursion(i+1)
+
+  proc main {.async.} =
+    await recursion(0)
+
+  try:
+    waitFor main()
+    doAssert false
+  except ValueError as err:
+    let expected = """
+      the_error_msg
+      Async traceback:
+        tasync_traceback2\.nim\(\d+\) tasync_traceback2
+        tasync_traceback2\.nim\(\d+\) main \(Async\)
+        tasync_traceback2\.nim\(\d+\) recursion \(Async\)
+        tasync_traceback2\.nim\(\d+\) recursion \(Async\)
+        tasync_traceback2\.nim\(\d+\) err
+      Exception message: the_error_msg
+      """.dedent
+    doAssert match(err.msg, re(expected)), err.getStackTrace & err.msg
+
+block:
+  proc baz() =
+    err()
+
+  proc bar() =
+    baz()
+
+  proc foo() {.async.} =
+    await sleepAsync(1)
+    bar()
+
+  proc main {.async.} =
+    await foo()
+
+  try:
+    waitFor main()
+    doAssert false
+  except ValueError as err:
+    let expected = """
+      the_error_msg
+      Async traceback:
+        tasync_traceback2\.nim\(\d+\) tasync_traceback2
+        tasync_traceback2\.nim\(\d+\) main \(Async\)
+        tasync_traceback2\.nim\(\d+\) foo \(Async\)
+        tasync_traceback2\.nim\(\d+\) bar
+        tasync_traceback2\.nim\(\d+\) baz
+        tasync_traceback2\.nim\(\d+\) err
+      Exception message: the_error_msg
+      """.dedent
+    doAssert match(err.msg, re(expected)), err.getStackTrace & err.msg
+
+block:  # async work
+  proc baz() {.async.} =
+    await sleepAsync(1)
+    raise newException(ValueError, "the_error_msg")
+
+  proc bar() {.async.} =
+    await sleepAsync(1)
+    await baz()
+
+  proc foo() {.async.} =
+    await sleepAsync(1)
+    await bar()
+
+  proc main {.async.} =
+    await foo()
+
+  try:
+    waitFor main()
+    doAssert false
+  except ValueError as err:
+    let expected = """
+      the_error_msg
+      Async traceback:
+        tasync_traceback2\.nim\(\d+\) tasync_traceback2
+        tasync_traceback2\.nim\(\d+\) main \(Async\)
+        tasync_traceback2\.nim\(\d+\) foo \(Async\)
+        tasync_traceback2\.nim\(\d+\) bar \(Async\)
+        tasync_traceback2\.nim\(\d+\) baz \(Async\)
+      Exception message: the_error_msg
+      """.dedent
+    doAssert match(err.msg, re(expected)), err.getStackTrace & err.msg
+
+block:  # interleaved async work
+  proc baz() {.async.} =
+    await sleepAsync(1)
+    raise newException(ValueError, "the_error_msg")
+
+  proc bar() {.async.} =
+    await sleepAsync(1)
+    await baz()
+
+  proc foo() {.async.} =
+    #await sleepAsync(1)
+    await bar()
+
+  proc main {.async.} =
+    await foo()
+
+  try:
+    waitFor main()
+    doAssert false
+  except ValueError as err:
+    let expected = """
+      the_error_msg
+      Async traceback:
+        tasync_traceback2\.nim\(\d+\) tasync_traceback2
+        tasync_traceback2\.nim\(\d+\) main \(Async\)
+        tasync_traceback2\.nim\(\d+\) foo \(Async\)
+        tasync_traceback2\.nim\(\d+\) bar \(Async\)
+        tasync_traceback2\.nim\(\d+\) baz \(Async\)
+      Exception message: the_error_msg
+      """.dedent
+    doAssert match(err.msg, re(expected)), err.getStackTrace & err.msg
+
+block:  # no async work
+  proc baz() {.async.} =
+    raise newException(ValueError, "the_error_msg")
+
+  proc bar() {.async.} =
+    await baz()
+
+  proc foo() {.async.} =
+    await bar()
+
+  proc main {.async.} =
+    await foo()
+
+  try:
+    waitFor main()
+    doAssert false
+  except ValueError as err:
+    let expected = """
+      the_error_msg
+      Async traceback:
+        tasync_traceback2\.nim\(\d+\) tasync_traceback2
+        tasync_traceback2\.nim\(\d+\) main \(Async\)
+        tasync_traceback2\.nim\(\d+\) foo \(Async\)
+        tasync_traceback2\.nim\(\d+\) bar \(Async\)
+        tasync_traceback2\.nim\(\d+\) baz \(Async\)
+      Exception message: the_error_msg
+      """.dedent
+    doAssert match(err.msg, re(expected)), err.getStackTrace & err.msg
+
+echo "ok"


### PR DESCRIPTION
This makes await point to the caller line instead of asyncmacro. It also reworks the "Async traceback:" section of the traceback. Follow up PR #21091 (issue #19931) so it works if there is asynchronous work done.