### PR TITLE
Add inline assembler tests for i386, arm, arm64, riscv32 and riscv64

### DIFF
--- a/tests/compiler/tasm.nim
+++ b/tests/compiler/tasm.nim
@@ -1,16 +1,25 @@
-discard """
-disabled: "arm64"
-"""
-
 proc testAsm() =
   let src = 41
   var dst = 0
 
-  asm """
-    mov %1, %0\n\t
-    add $1, %0
-    : "=r" (`dst`)
-    : "r" (`src`)"""
+  when defined(i386) or defined(amd64):
+    asm """
+      mov %1, %0\n\t
+      add $1, %0
+      : "=r" (`dst`)
+      : "r" (`src`)"""
+  elif defined(arm) or defined(arm64):
+    asm """
+      mov %0, %1\n\t
+      add %0, %0, #1
+      : "=r" (`dst`)
+      : "r" (`src`)"""
+  elif defined(riscv32) or defined(riscv64):
+    asm """
+      addi %0, %1, 0\n\t
+      addi %0, %0, 1
+      : "=r" (`dst`)
+      : "r" (`src)"""
 
   doAssert dst == 42
 


### PR DESCRIPTION
This fixes one error in https://github.com/nim-lang/Nim/issues/24544 .
I tested this on Raspberry Pi Pico (arm) and Raspberry Pi 3(arm64).
It is not tested on i386, riscv32 and riscv64 CPU.