### PR TITLE
Minor `std/strscans` improvements

### DIFF
--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -324,7 +324,7 @@ macro scanf*(input: string; pattern: static[string]; results: varargs[typed]): b
   template at(s: string; i: int): char = (if i < s.len: s[i] else: '\0')
   template matchError() =
     error("type mismatch between pattern '$" & pattern[p] & "' (position: " & $p &
-      ") and " & $getTypeInst(results[i]) & " var '" & repr(results[i]) & "'")
+      ") and " & $getTypeInst(results[i]) & " var '" & repr(results[i]) & "'", results[i])
 
   var i = 0
   var p = 0

--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -490,7 +490,7 @@ macro scanTuple*(input: untyped; pattern: static[string]; matcherTypes: varargs[
   result = newStmtList()
   template addVar(typ: string) =
     let varIdent = ident("temp" & $arguments.len)
-    result.add(newNimNode(nnkVarSection).add(newIdentDefs(varIdent, ident(typ), newEmptyNode())))
+    result.add(newVarStmt(varIdent, newCall(ident"default", ident(typ))))
     arguments.add(varIdent)
   while p < pattern.len:
     if pattern[p] == '$':

--- a/tests/stdlib/t8925.nim
+++ b/tests/stdlib/t8925.nim
@@ -1,6 +1,6 @@
 discard """
   errormsg: "type mismatch between pattern '$$i' (position: 1) and HourRange var 'hour'"
-  file: "strscans.nim"
+  file: "t8925.nim"
 """
 
 import strscans

--- a/tests/stdlib/tstrscans_errs.nim
+++ b/tests/stdlib/tstrscans_errs.nim
@@ -1,0 +1,11 @@
+discard """
+  cmd: "nim check $file"
+"""
+
+import std/strscans
+
+
+block:
+  var strVar: string
+  discard "123".scanf("$i", strVar) #[tt.Error
+                            ^ type mismatch between pattern '$$i' (position: 1) and string var 'strVar']#


### PR DESCRIPTION
#### Removes UnInit warnings when using `scanTuple` 

e.g. this would emit a warning
```nim
import std/strscans

proc main() =
  let (ok, number) = "123".scanTuple()
```
![image](https://github.com/user-attachments/assets/68170ac6-402d-48b0-b8b6-69e71f4b70ae)

#### Error for wrong type now points to the passed in variable

```nim
import std/strscans

var str: string
discard "123".scanf("$i", str)
```

it gave this warning before
![image](https://github.com/user-attachments/assets/096e56d2-0eb5-4c67-9725-25caa97afebd)
now it returns
![image](https://github.com/user-attachments/assets/736a4292-2f56-4cf3-a27a-677045377171)

