### PR TITLE
Allow specifiying path to use for stdin error messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -71,4 +71,4 @@ errors.
 
 ## Tool changes
 
-
+- Added `--stdinfile` flag to name of the file used when running program from stdin (defaults to `stdinfile.nim`)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -937,10 +937,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.errorMax = if value == 0: high(int) else: value
   of "stdinfile":
     expectArg(conf, switch, arg, pass, info)
-    conf.stdinFile = if
-              os.isAbsolute(arg): AbsoluteFile(arg)
-             else:
-              AbsoluteFile(getCurrentDir() / arg)
+    conf.stdinFile = if os.isAbsolute(arg): AbsoluteFile(arg)
+                     else: AbsoluteFile(getCurrentDir() / arg)
   of "verbosity":
     expectArg(conf, switch, arg, pass, info)
     let verbosity = parseInt(arg)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -459,7 +459,7 @@ template handleStdinOrCmdInput =
     conf.outDir = getNimcacheDir(conf)
 
 proc handleStdinInput*(conf: ConfigRef) =
-  conf.projectName = "stdinfile"
+  conf.projectName = conf.stdinFile.string
   conf.projectIsStdin = true
   handleStdinOrCmdInput()
 
@@ -935,6 +935,12 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     var value: int = 0
     discard parseSaturatedNatural(arg, value)
     conf.errorMax = if value == 0: high(int) else: value
+  of "stdinfile":
+    expectArg(conf, switch, arg, pass, info)
+    conf.stdinFile = if
+              os.isAbsolute(arg): AbsoluteFile(arg)
+             else:
+              AbsoluteFile(getCurrentDir() / arg)
   of "verbosity":
     expectArg(conf, switch, arg, pass, info)
     let verbosity = parseInt(arg)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -404,6 +404,7 @@ type
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
     projectIsStdin*: bool # whether we're compiling from stdin
+    stdinFile*: AbsoluteFile # Filename to use in messages for stdin
     lastMsgWasDot*: set[StdOrrKind] # the last compiler message was a single '.'
     projectMainIdx*: FileIndex # the canonical path id of the main module
     projectMainIdx2*: FileIndex # consider merging with projectMainIdx
@@ -580,6 +581,7 @@ proc newConfigRef*(): ConfigRef =
     projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
     projectFull: AbsoluteFile"", # projectPath/projectName
     projectIsStdin: false, # whether we're compiling from stdin
+    stdinFile: AbsoluteFile"stdinfile"
     projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
     command: "", # the main command (e.g. cc, check, scan, etc)
     commandArgs: @[], # any arguments after the main command

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -581,7 +581,7 @@ proc newConfigRef*(): ConfigRef =
     projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
     projectFull: AbsoluteFile"", # projectPath/projectName
     projectIsStdin: false, # whether we're compiling from stdin
-    stdinFile: AbsoluteFile"stdinfile"
+    stdinFile: AbsoluteFile"stdinfile",
     projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
     command: "", # the main command (e.g. cc, check, scan, etc)
     commandArgs: @[], # any arguments after the main command

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -234,7 +234,8 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
     result = moduleFromRodFile(graph, fileIdx, cachedModules)
     let path = toFullPath(graph.config, fileIdx)
     let filename = AbsoluteFile path
-    if not graph.config.projectIsStdin: # it could be a stdinfile
+    # it could be a stdinfile/cmdfile
+    if fileExists(filename) and not graph.config.projectIsStdin:
       graph.cachedFiles[path] = $secureHashFile(path)
     if result == nil:
       result = newModule(graph, fileIdx)

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -234,7 +234,7 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
     result = moduleFromRodFile(graph, fileIdx, cachedModules)
     let path = toFullPath(graph.config, fileIdx)
     let filename = AbsoluteFile path
-    if fileExists(filename): # it could be a stdinfile
+    if not graph.config.projectIsStdin: # it could be a stdinfile
       graph.cachedFiles[path] = $secureHashFile(path)
     if result == nil:
       result = newModule(graph, fileIdx)

--- a/tests/tools/tloadstdin.nim
+++ b/tests/tools/tloadstdin.nim
@@ -1,6 +1,8 @@
 discard """
   action: "compile"
   cmd: "cat $file | $nim check --stdinfile:$file -"
+  # Don't believe cat and pipes works on windows
+  disabled: "win"
 """
 
 import std/[assertions, paths]

--- a/tests/tools/tloadstdin.nim
+++ b/tests/tools/tloadstdin.nim
@@ -3,10 +3,12 @@ discard """
   cmd: "cat $file | $nim check --stdinfile:$file -"
 """
 
-import std/assertions
+import std/[assertions, paths]
 
 # Test the nimscript config is loaded
 assert defined(nimscriptConfigLoaded)
+
+assert currentSourcePath() == $(getCurrentDir()/Path"tloadstdin.nim")
 
 {.warning: "Hello".}  #[tt.Warning
          ^ Hello]#

--- a/tests/tools/tloadstdin.nim
+++ b/tests/tools/tloadstdin.nim
@@ -1,6 +1,6 @@
 discard """
   action: "compile"
-  cmd: "cat $file | nim check --stdinfile:$file -"
+  cmd: "cat $file | $nim check --stdinfile:$file -"
 """
 
 import std/assertions

--- a/tests/tools/tloadstdin.nim
+++ b/tests/tools/tloadstdin.nim
@@ -1,0 +1,12 @@
+discard """
+  action: "compile"
+  cmd: "cat $file | nim check --stdinfile:$file -"
+"""
+
+import std/assertions
+
+# Test the nimscript config is loaded
+assert defined(nimscriptConfigLoaded)
+
+{.warning: "Hello".}  #[tt.Warning
+         ^ Hello]#

--- a/tests/tools/tloadstdin.nims
+++ b/tests/tools/tloadstdin.nims
@@ -1,0 +1,1 @@
+--d:nimscriptConfigLoaded


### PR DESCRIPTION
Implements #24569

Adds `--stdinfile` flag for specifying the file to use in place of `stdinfile.nim` in error messages. Will enable easier integration of tooling with nim check