### PR TITLE
Error msg for managed memory in passCopyToSink

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -485,8 +485,9 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
         ("cannot move '$1', passing '$1' to a sink parameter introduces an implicit copy") % $n)
   else:
     if c.graph.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
-      localError(c.graph.config, n.info, errInternal,
-                 "type contains managed memory: '$1' for '$2' " % [$nTyp, $n] )
+      if containsManagedMemory(nTyp):
+        localError(c.graph.config, n.info, errInternal,
+                   "type contains managed memory: '$1' for '$2' " % [$nTyp, $n] )
     if nTyp.skipTypes(abstractInst).kind in {tyOpenArray, tyVarargs}:
       localError(c.graph.config, n.info, "cannot create an implicit openArray copy to be passed to a sink parameter")
     result.add newTree(nkAsgn, tmp, p(n, c, s, normal))

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -486,7 +486,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
   else:
     if c.graph.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
       localError(c.graph.config, n.info, errInternal,
-              "type contains managed memory: '$1' for '$2' " % [$nTyp, $n] )
+                 "type contains managed memory: '$1' for '$2' " % [$nTyp, $n] )
     if nTyp.skipTypes(abstractInst).kind in {tyOpenArray, tyVarargs}:
       localError(c.graph.config, n.info, "cannot create an implicit openArray copy to be passed to a sink parameter")
     result.add newTree(nkAsgn, tmp, p(n, c, s, normal))

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -485,7 +485,8 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
         ("cannot move '$1', passing '$1' to a sink parameter introduces an implicit copy") % $n)
   else:
     if c.graph.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
-      assert(not containsManagedMemory(nTyp))
+      localError(c.graph.config, n.info, errInternal,
+              "type contains managed memory: '$1' for '$2' " % [$nTyp, $n] )
     if nTyp.skipTypes(abstractInst).kind in {tyOpenArray, tyVarargs}:
       localError(c.graph.config, n.info, "cannot create an implicit openArray copy to be passed to a sink parameter")
     result.add newTree(nkAsgn, tmp, p(n, c, s, normal))


### PR DESCRIPTION
Adds an error message for this situation. It's possibly due to a compiler bug but it's easy to workaround in user code by adding a destructor once you know what's causing the issue. 

What triggers this is a type that has a cursor in it. This error only shows up with Nim binaries built by Nimble which seem to have asserts enabled.

```nim
type WeakRef*[T] {.acyclic.} = object
  ## type alias descring a weak ref that *must* be cleaned up
  ## when it's actual object is set to be destroyed
  pt* {.cursor.}: T
```

I suspect the `cursor` bit combined with `sink` causes this error.

However, I can work around with this:

```nim
proc `=destroy`*[T](obj: WeakRef[T]) =
  discard
```
