### PR TITLE
Fixes for typedthreads data race issues

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -353,7 +353,11 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "genscript": result = contains(conf.globalOptions, optGenScript)
   of "gencdeps": result = contains(conf.globalOptions, optGenCDeps)
   of "threads": result = contains(conf.globalOptions, optThreads)
-  of "tlsemulation": result = contains(conf.globalOptions, optTlsEmulation)
+  of "tlsemulation": 
+    when defined(cpp): 
+      result = contains(conf.globalOptions, optTlsEmulation)
+    else:
+      result = false
   of "implicitstatic": result = contains(conf.options, optImplicitStatic)
   of "patterns", "trmacros":
     if switch.normalize == "patterns": deprecatedAlias(switch, "trmacros")
@@ -806,9 +810,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else: processOnOffSwitchG(conf, {optThreads}, arg, pass, info)
     #if optThreads in conf.globalOptions: conf.setNote(warnGcUnsafe)
   of "tlsemulation":
-    processOnOffSwitchG(conf, {optTlsEmulation}, arg, pass, info)
-    if optTlsEmulation in conf.globalOptions:
-      conf.legacyFeatures.incl emitGenerics
+    when defined(cpp):
+      processOnOffSwitchG(conf, {optTlsEmulation}, arg, pass, info)
+      if optTlsEmulation in conf.globalOptions:
+        conf.legacyFeatures.incl emitGenerics
   of "implicitstatic":
     processOnOffSwitch(conf, {optImplicitStatic}, arg, pass, info)
   of "patterns", "trmacros":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -581,7 +581,8 @@ proc processMemoryManagementOption(switch, arg: string, pass: TCmdLinePass,
       unregisterArcOrc(conf)
       conf.selectedGC = gcBoehm
       defineSymbol(conf.symbols, "boehmgc")
-      incl conf.globalOptions, optTlsEmulation # Boehm GC doesn't scan the real TLS
+      when defined(cpp):
+        incl conf.globalOptions, optTlsEmulation # Boehm GC doesn't scan the real TLS
     of "refc":
       unregisterArcOrc(conf)
       defineSymbol(conf.symbols, "gcrefc")

--- a/lib/std/private/threadtypes.nim
+++ b/lib/std/private/threadtypes.nim
@@ -1,4 +1,5 @@
 include system/inclrtl
+import std/atomics
 
 const hasSharedHeap* = defined(boehmgc) or defined(gogc) # don't share heaps; every thread has its own
 
@@ -163,13 +164,13 @@ const hasAllocStack* = defined(zephyr) # maybe freertos too?
 
 type
   Thread*[TArg] = object
-    core*: PGcThread
+    core*: Atomic[PGcThread]
     sys*: SysThread
     when TArg is void:
-      dataFn*: proc () {.nimcall, gcsafe.}
+      dataFn*: Atomic[proc () {.nimcall, gcsafe.}]
     else:
-      dataFn*: proc (m: TArg) {.nimcall, gcsafe.}
-      data*: TArg
+      dataFn*: Atomic[proc (m: TArg) {.nimcall, gcsafe.}]
+      data*: Atomic[TArg]
     when hasAllocStack:
       rawStack*: pointer
 

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -270,7 +270,10 @@ else:
 
     when TArg isnot void: t.data.store param
     t.dataFn.store tp
-    when hasSharedHeap: t.core.stackSize = ThreadStackSize
+    when hasSharedHeap: 
+      var stackSize: PGcThread = t.core.load()
+      stacksize.stackSize = ThreadStackSize
+      t.core.store stacksize
     var a {.noinit.}: Pthread_attr
     doAssert pthread_attr_init(a) == 0
     when hasAllocStack:

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -149,9 +149,12 @@ else:
     nimThreadProcWrapperBody(closure)
 {.pop.}
 
-proc running*[TArg](t: var Thread[TArg]): bool {.inline.} =
+proc running*[TArg](t: Thread[TArg]): bool {.inline.} =
   ## Returns true if `t` is running.
-  result = t.dataFn.load() != nil
+  when not defined(cpp):
+    result = t.dataFn.load(moAcquireRelease) != nil
+  else:
+    result = t.dataFn != nil
 
 proc handle*[TArg](t: Thread[TArg]): SysThread {.inline.} =
   ## Returns the thread handle of `t`.
@@ -202,11 +205,20 @@ when false:
     else:
       discard pthread_cancel(t.sys)
     when declared(registerThread): unregisterThread(addr(t))
-    t.dataFn.store nil
+    when not defined(cpp):
+      t.dataFn.store(nil, moAcquireRelease)
+    else:
+      t.dataFn = nil
     ## if thread `t` already exited, `t.core` will be `null`.
-    if not isNil(t.core):
-      deallocThreadStorage(t.core)
-      t.core = nil
+    when not defined(cpp):
+      var coreTmp = t.core.load(moAcquireRelease)
+      if not isNil(coreTmp):
+        deallocThreadStorage(coreTmp)
+        t.core.store(nil, moAcquireRelease)
+    else:
+      if not isNil(t.core):
+        deallocThreadStorage(t.core)
+        t.core = nil
 
 when hostOS == "windows":
   proc createThread*[TArg](t: var Thread[TArg],
@@ -217,11 +229,30 @@ when hostOS == "windows":
     ## Entry point is the proc `tp`.
     ## `param` is passed to `tp`. `TArg` can be `void` if you
     ## don't need to pass any data to the thread.
-    t.core.store cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    when not defined(cpp):
+      t.core.store(cast[PGcThread](allocThreadStorage(sizeof(GcThread))), moAcquireRelease)
+    else:
+      t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    
+    when TArg isnot void:
+      when not defined(cpp):
+        t.data.store(param, moAcquireRelease)
+      else:
+        t.data = param
 
-    when TArg isnot void: t.data.store param
-    t.dataFn.store tp
-    when hasSharedHeap: t.core.stackSize = ThreadStackSize
+    when not defined(cpp):
+      t.dataFn.store(tp, moAcquireRelease)
+    else:
+      t.dataFn = tp
+    
+    when hasSharedHeap:
+      when not defined(cpp):
+        var core = cast[PGcThread](t.core.load(moAcquireRelease))
+        core.stackSize = ThreadStackSize
+        t.core.store(core, moAcquireRelease)
+      else:
+        t.core.stackSize = ThreadStackSize
+
     var dummyThreadId: int32 = 0'i32
     t.sys = createThread(nil, ThreadStackSize, threadProcWrapper[TArg],
                          addr(t), 0'i32, dummyThreadId)
@@ -242,11 +273,30 @@ elif defined(genode):
   proc createThread*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
-    t.core.store cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    when not defined(cpp):
+      t.core.store(cast[PGcThread](allocThreadStorage(sizeof(GcThread))), moAcquireRelease)
+    else:
+      t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
-    when TArg isnot void: t.data.store param
-    t.dataFn.store tp
-    when hasSharedHeap: t.stackSize = ThreadStackSize
+    when TArg isnot void:
+      when not defined(cpp):
+        t.data.store(param, moAcquireRelease)
+      else:
+        t.data = param
+
+    when not defined(cpp):
+      t.dataFn.store(tp, moAcquireRelease)
+    else:
+      t.dataFn = tp
+
+    when hasSharedHeap:
+      when not defined(cpp):
+        var core = cast[PGcThread](t.core.load(moAcquireRelease))
+        core.stackSize = ThreadStackSize
+        t.core.store(core, moAcquireRelease)
+      else:
+        t.core.stackSize = ThreadStackSize
+    
     t.sys.initThread(
       runtimeEnv,
       ThreadStackSize.culonglong,
@@ -266,14 +316,30 @@ else:
     ## Entry point is the proc `tp`. `param` is passed to `tp`.
     ## `TArg` can be `void` if you
     ## don't need to pass any data to the thread.
-    t.core.store cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    when not defined(cpp):
+      t.core.store(cast[PGcThread](allocThreadStorage(sizeof(GcThread))), moAcquireRelease)
+    else:
+      t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
-    when TArg isnot void: t.data.store param
-    t.dataFn.store tp
-    when hasSharedHeap: 
-      var stackSize: PGcThread = t.core.load()
-      stacksize.stackSize = ThreadStackSize
-      t.core.store stacksize
+    when TArg isnot void:
+      when not defined(cpp):
+        t.data.store(param, moAcquireRelease)       
+      else:
+        t.data = param
+
+    when not defined(cpp):
+      t.dataFn.store(tp, moAcquireRelease)
+    else:
+      t.dataFn = tp
+
+    when hasSharedHeap:
+      when not defined(cpp):
+        var core = cast[PGcThread](t.core.load(moAcquireRelease))
+        core.stackSize = ThreadStackSize
+        t.core.store(core, moAcquireRelease)
+      else:
+        t.core.stackSize = ThreadStackSize
+
     var a {.noinit.}: Pthread_attr
     doAssert pthread_attr_init(a) == 0
     when hasAllocStack:
@@ -288,9 +354,14 @@ else:
     when not defined(ios):
       # This fails on iOS
       doAssert(setstacksizeResult == 0)
-    if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
-      raise newException(ResourceExhaustedError, "cannot create thread")
-    doAssert pthread_attr_destroy(a) == 0
+    when not defined(cpp):
+      if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
+        raise newException(ResourceExhaustedError, "cannot create thread")
+      doAssert pthread_attr_destroy(a) == 0
+    else:
+      if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
+        raise newException(ResourceExhaustedError, "cannot create thread")
+      doAssert pthread_attr_destroy(a) == 0
 
   proc pinToCpu*[Arg](t: var Thread[Arg]; cpu: Natural) =
     ## Pins a thread to a `CPU`:idx:.

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -149,7 +149,7 @@ else:
     nimThreadProcWrapperBody(closure)
 {.pop.}
 
-proc running*[TArg](t: Thread[TArg]): bool {.inline.} =
+proc running*[TArg](t: var Thread[TArg]): bool {.inline.} =
   ## Returns true if `t` is running.
   when not defined(cpp):
     result = t.dataFn.load(moAcquireRelease) != nil

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -354,14 +354,9 @@ else:
     when not defined(ios):
       # This fails on iOS
       doAssert(setstacksizeResult == 0)
-    when not defined(cpp):
-      if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
-        raise newException(ResourceExhaustedError, "cannot create thread")
-      doAssert pthread_attr_destroy(a) == 0
-    else:
-      if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
-        raise newException(ResourceExhaustedError, "cannot create thread")
-      doAssert pthread_attr_destroy(a) == 0
+    if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
+      raise newException(ResourceExhaustedError, "cannot create thread")
+    doAssert pthread_attr_destroy(a) == 0
 
   proc pinToCpu*[Arg](t: var Thread[Arg]; cpu: Natural) =
     ## Pins a thread to a `CPU`:idx:.

--- a/lib/std/typedthreads.nim
+++ b/lib/std/typedthreads.nim
@@ -217,7 +217,7 @@ when hostOS == "windows":
     ## Entry point is the proc `tp`.
     ## `param` is passed to `tp`. `TArg` can be `void` if you
     ## don't need to pass any data to the thread.
-    t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    t.core.store cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
     when TArg isnot void: t.data.store param
     t.dataFn.store tp
@@ -242,7 +242,7 @@ elif defined(genode):
   proc createThread*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
-    t.core = cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
+    t.core.store cast[PGcThread](allocThreadStorage(sizeof(GcThread)))
 
     when TArg isnot void: t.data.store param
     t.dataFn.store tp

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -56,7 +56,7 @@ when defined(boehmgc):
       when TArg is void:
         dataFn()
       else:
-        dataFn(thrd.data)
+        dataFn(thrd.data.load())
     except:
       threadTrouble()
     finally:
@@ -102,7 +102,7 @@ template nimThreadProcWrapperBody*(closure: untyped): untyped =
   var thr = cast[Atomic[ptr Thread[TArg]]](closure)
   var thrd = thr.load()
   var core = thrd.core
-  when declared(globalsSlot): threadVarSetValue(globalsSlot, thrd.core)
+  when declared(globalsSlot): threadVarSetValue(globalsSlot, core.load())
   threadProcWrapStackFrame(thrd)
   # Since an unhandled exception terminates the whole process (!), there is
   # no need for a ``try finally`` here, nor would it be correct: The current


### PR DESCRIPTION
fixes #24591

Modifications have been tested with examples in the open issue 24591. All seem to work except one with Thread[Socket] because of ref SocketImpl. Needs testing in Linux and Windows, probably better with some existing software that uses typedthreads to make sure I have not broken it.