### PR TITLE
install sfml 2 on osx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
       displayName: 'Install dependencies (i386 Linux)'
       condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
-    - bash: brew install boehmgc make sfml
+    - bash: brew install boehmgc make sfml@2
       displayName: 'Install dependencies (OSX)'
       condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
       # XXX can't find boehm on macos 13


### PR DESCRIPTION
Bindings are only implemented for sfml 2

If CI still doesn't pass, we can disable the test on OSX