### PR TITLE
generate destructor in nodestroy proc for explicit destructor call

### DIFF
--- a/tests/arc/tnodestroyexplicithook.nim
+++ b/tests/arc/tnodestroyexplicithook.nim
@@ -1,0 +1,24 @@
+discard """
+  ccodecheck: "'Result[(i - 0)] = eqdup'"
+"""
+
+# issue #24626
+
+proc arrayWith2[T](y: T, size: static int): array[size, T] {.noinit, nodestroy, raises: [].} =
+  ## Creates a new array filled with `y`.
+  for i in 0..size-1:
+    when defined(nimHasDup):
+      result[i] = `=dup`(y)
+    else:
+      wasMoved(result[i])
+      `=copy`(result[i], y)
+
+proc useArray(x: seq[int]) =
+  var a = arrayWith2(x, 2)
+
+proc main =
+  let x = newSeq[int](100)
+  for i in 0..5:
+    useArray(x)
+
+main()


### PR DESCRIPTION
fixes #24626

`createTypeboundOps` in sempass2 is called when generating destructors for types including for explicit destructor calls, however it blocks destructors from getting generated in a `nodestroy` proc. This causes issues when a destructor is explicitly called in a `nodestroy`  proc. To fix this, allow destructors to get generated only for explicit destructor calls in nodestroy procs.