### PR TITLE
test using type node for object constr type

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -459,7 +459,8 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   var t = semTypeNode(c, n[0], nil)
   result = newNodeIT(nkObjConstr, n.info, t)
-  for i in 0..<n.len:
+  result.add newNodeIT(nkType, n[0].info, t)
+  for i in 1..<n.len:
     result.add n[i]
 
   if t == nil:

--- a/tests/template/tgenericobjconstr.nim
+++ b/tests/template/tgenericobjconstr.nim
@@ -1,0 +1,8 @@
+# issue #24631
+
+type
+  V[d: static bool] = object
+    l: int
+
+template y(): V[false] = V[false](l: 0)
+discard y()


### PR DESCRIPTION
fixes #24631

`semConv` has the [same problem](https://github.com/nim-lang/Nim/blob/793baf34ff72cb8c5485ce209af086e27f656853/compiler/semexprs.nim#L419)