### PR TITLE
don't try to transform objconstr/cast type nodes

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -459,8 +459,7 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   var t = semTypeNode(c, n[0], nil)
   result = newNodeIT(nkObjConstr, n.info, t)
-  result.add newNodeIT(nkType, n[0].info, t)
-  for i in 1..<n.len:
+  for i in 0..<n.len:
     result.add n[i]
 
   if t == nil:

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -459,7 +459,8 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   var t = semTypeNode(c, n[0], nil)
   result = newNodeIT(nkObjConstr, n.info, t)
-  for i in 0..<n.len:
+  result.add newNodeIT(nkType, n[0].info, t)
+  for i in 1..<n.len:
     result.add n[i]
 
   if t == nil:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -106,6 +106,13 @@ proc transformSons(c: PTransf, n: PNode, noConstFold = false): PNode =
   for i in 0..<n.len:
     result[i] = transform(c, n[i], noConstFold)
 
+proc transformSonsAfterType(c: PTransf, n: PNode, noConstFold = false): PNode =
+  result = newTransNode(n)
+  assert n.len != 0
+  result[0] = n[0]
+  for i in 1..<n.len:
+    result[i] = transform(c, n[i], noConstFold)
+
 proc newAsgnStmt(c: PTransf, kind: TNodeKind, le: PNode, ri: PNode; isFirstWrite: bool): PNode =
   result = newTransNode(kind, ri.info, 2)
   result[0] = le
@@ -1102,6 +1109,9 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
       result = transformAddrDeref(c, n, {nkAddr, nkHiddenAddr})
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     result = transformConv(c, n)
+  of nkObjConstr, nkCast:
+    # don't try to transform type node
+    result = transformSonsAfterType(c, n)
   of nkDiscardStmt:
     result = n
     if n[0].kind != nkEmpty:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -109,7 +109,7 @@ proc transformSons(c: PTransf, n: PNode, noConstFold = false): PNode =
 proc transformSonsAfterType(c: PTransf, n: PNode, noConstFold = false): PNode =
   result = newTransNode(n)
   assert n.len != 0
-  result[0] = n[0]
+  result[0] = copyTree(n[0])
   for i in 1..<n.len:
     result[i] = transform(c, n[i], noConstFold)
 

--- a/tests/template/tgenericobjconstr.nim
+++ b/tests/template/tgenericobjconstr.nim
@@ -1,3 +1,7 @@
+discard """
+  matrix: "--skipParentCfg"
+"""
+
 # issue #24631
 
 type
@@ -6,3 +10,6 @@ type
 
 template y(): V[false] = V[false](l: 0)
 discard y()
+
+template z(): V[false] = cast[V[false]](V[false](l: 0))
+discard z()

--- a/tests/template/tgenericobjconstr.nim
+++ b/tests/template/tgenericobjconstr.nim
@@ -1,0 +1,8 @@
+# issue #24631
+
+type
+  V[d: static bool] = object
+    l: int
+
+template y(): V[false] = V[false](l: 0)
+discard y()


### PR DESCRIPTION
fixes #24631

[Object constructors](https://github.com/nim-lang/Nim/blob/793baf34ff72cb8c5485ce209af086e27f656853/compiler/semobjconstr.nim#L462), [casts](https://github.com/nim-lang/Nim/blob/793baf34ff72cb8c5485ce209af086e27f656853/compiler/semexprs.nim#L494) and [type conversions](https://github.com/nim-lang/Nim/blob/793baf34ff72cb8c5485ce209af086e27f656853/compiler/semexprs.nim#L419) copy their type nodes verbatim instead of producing semchecked type nodes. This causes a crash in transf when an untyped expression in the type node has `nil` type. To deal with this, don't try to transform the type node in these expressions at all. I couldn't reproduce the problem with type conversion nodes though so those are unchanged in transf.