### PR TITLE
fixes #24630; static openArray backed by seq cannot be passed to another function

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2040,7 +2040,7 @@ proc genArrayConstr(c: PCtx, n: PNode, dest: var TDest) =
   c.gABx(n, opcLdNull, dest, c.genType(n.typ))
 
   let intType = getSysType(c.graph, n.info, tyInt)
-  let seqType = n.typ.skipTypes(abstractVar-{tyTypeDesc})
+  let seqType = n.typ.skipTypes(abstractVar+{tyStatic}-{tyTypeDesc})
   if seqType.kind == tySequence:
     var tmp = c.getTemp(intType)
     c.gABx(n, opcLdImmInt, tmp, n.len)

--- a/tests/vm/topenarrays.nim
+++ b/tests/vm/topenarrays.nim
@@ -87,3 +87,12 @@ block: # bug #22095
     z = fn()
 
   doAssert z.limbs[0] == 10
+
+block: # bug #24630
+  func f(a: static openArray[int]): int =
+    12
+
+  func g(a: static openArray[int]) =
+    const b = f(a)
+
+  g(@[1,2,3])


### PR DESCRIPTION
fixes #24630