### PR TITLE
fixes #24623; fixes #23692; size pragma only allowed for imported types and enum types

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1793,7 +1793,7 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         if pragmas[i].kind == nkExprColonExpr and
             pragmas[i][0].kind == nkIdent and
             whichKeyword(pragmas[i][0].ident) == wSize:
-          if s.typ.kind != tyEnum and sfImportC notin s.flags:
+          if s.typ.kind != tyEnum and sfImportc notin s.flags:
             # EventType* {.size: sizeof(uint32).} = enum
             # AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
             localError(c.config, pragmas[i].info, "size pragma only allowed for enum types and imported types")

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1796,7 +1796,7 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
           if s.typ.kind != tyEnum and sfImportC notin s.flags:
             # EventType* {.size: sizeof(uint32).} = enum
             # AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
-            localError(c.config, pragmas[i].info, "size pragma only allowed for imported objects and enums")
+            localError(c.config, pragmas[i].info, "size pragma only allowed for enum types and imported types")
 
     if a[1].kind == nkEmpty:
       var x = a[2]

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1787,6 +1787,17 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
     # check the style here after the pragmas have been processed:
     styleCheckDef(c, s)
     # compute the type's size and check for illegal recursions:
+    if a[0].kind == nkPragmaExpr:
+      let pragmas = a[0][1]
+      for i in 0 ..< pragmas.len:
+        if pragmas[i].kind == nkExprColonExpr and
+            pragmas[i][0].kind == nkIdent and
+            whichKeyword(pragmas[i][0].ident) == wSize:
+          if s.typ.kind notin {tyObject, tyEnum}:
+            # EventType* {.size: sizeof(uint32).} = enum
+            # AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
+            localError(c.config, pragmas[i].info, "size pragma only allowed for objects and enums")
+
     if a[1].kind == nkEmpty:
       var x = a[2]
       if x.kind in nkCallKinds and nfSem in x.flags:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1793,10 +1793,10 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         if pragmas[i].kind == nkExprColonExpr and
             pragmas[i][0].kind == nkIdent and
             whichKeyword(pragmas[i][0].ident) == wSize:
-          if s.typ.kind notin {tyObject, tyEnum}:
+          if s.typ.kind != tyEnum and sfImportC notin s.flags:
             # EventType* {.size: sizeof(uint32).} = enum
             # AtomicFlag* {.importc: "atomic_flag", header: "<stdatomic.h>", size: 1.} = object
-            localError(c.config, pragmas[i].info, "size pragma only allowed for objects and enums")
+            localError(c.config, pragmas[i].info, "size pragma only allowed for imported objects and enums")
 
     if a[1].kind == nkEmpty:
       var x = a[2]


### PR DESCRIPTION
fixes #24623
fixes #23692

ref https://nim-lang.org/docs/manual.html#implementation-specific-pragmas-size-pragma

confines `size` pragma to `enums` and imported `objects` for now

The `typeDefLeftSidePass` carries out the check for pragmas, but the type is not complete yet. So the `size` pragma checking is postponed at the final pass.