### PR TITLE
fixes #24641; `quote do` captures no variables without backticks

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2447,9 +2447,9 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
         dummyTemplate[paramsPos].add newTreeI(nkIdentDefs, n.info, ids[i], newNodeIT(nkType, n.info, typ), c.graph.emptyNode)
       else:
         dummyTemplate[paramsPos].add newTreeI(nkIdentDefs, n.info, ids[i], getSysSym(c.graph, n.info, "typed").newSymNode, c.graph.emptyNode)
-  # don't allow templates to capture variables in macors without backticks
+  # don't allow templates to capture syms without backticks
   let oldScope = c.currentScope
-  c.currentScope = c.topLevelScope
+  c.currentScope = PScope(parent: nil, symbols: initStrTable(), depthLevel: 0)
   var tmpl = semTemplateDef(c, dummyTemplate)
   c.currentScope = oldScope
   quotes[0] = tmpl[namePos]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2453,14 +2453,14 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
   if c.p.owner != nil and c.p.owner.kind in routineKinds:
     # skips the current routine scopes
     block exitLabel:
-      while c.currentScope != nil:
-        c.currentScope = c.currentScope.parent
+      while c.currentScope != c.topLevelScope:
         block continueLabel:
           for s in items(c.currentScope.symbols):
             if s.owner != c.p.owner:
               break exitLabel
             else:
               break continueLabel
+        c.currentScope = c.currentScope.parent
   var tmpl = semTemplateDef(c, dummyTemplate)
   c.currentScope = oldScope
   quotes[0] = tmpl[namePos]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2447,7 +2447,11 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
         dummyTemplate[paramsPos].add newTreeI(nkIdentDefs, n.info, ids[i], newNodeIT(nkType, n.info, typ), c.graph.emptyNode)
       else:
         dummyTemplate[paramsPos].add newTreeI(nkIdentDefs, n.info, ids[i], getSysSym(c.graph, n.info, "typed").newSymNode, c.graph.emptyNode)
+  # don't allow templates to capture variables in macors without backticks
+  let oldScope = c.currentScope
+  c.currentScope = c.topLevelScope
   var tmpl = semTemplateDef(c, dummyTemplate)
+  c.currentScope = oldScope
   quotes[0] = tmpl[namePos]
   # This adds a call to newIdentNode("result") as the first argument to the template call
   let identNodeSym = getCompilerProc(c.graph, "newIdentNode")

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2450,7 +2450,7 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
   # don't allow templates to capture syms without backticks
   let oldScope = c.currentScope
   # c.currentScope = PScope(parent: nil, symbols: initStrTable(), depthLevel: 0)
-  if c.p.owner.kind in routineKinds:
+  if c.p.owner != nil and c.p.owner.kind in routineKinds:
     # skips the current routine scopes
     block exitLabel:
       while c.currentScope != nil:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2449,7 +2449,10 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
         dummyTemplate[paramsPos].add newTreeI(nkIdentDefs, n.info, ids[i], getSysSym(c.graph, n.info, "typed").newSymNode, c.graph.emptyNode)
   # don't allow templates to capture syms without backticks
   let oldScope = c.currentScope
-  c.currentScope = PScope(parent: nil, symbols: initStrTable(), depthLevel: 0)
+  # c.currentScope = PScope(parent: nil, symbols: initStrTable(), depthLevel: 0)
+  # TODO: allows toplevel syms to be captured for backwards compatibility
+  # perhaps `{.dirty.}` can be used for `dummyTemplate`
+  c.currentScope = c.topLevelScope
   var tmpl = semTemplateDef(c, dummyTemplate)
   c.currentScope = oldScope
   quotes[0] = tmpl[namePos]

--- a/tests/lexer/tcustom_numeric_literals.nim
+++ b/tests/lexer/tcustom_numeric_literals.nim
@@ -163,9 +163,9 @@ template main =
     doAssert fn3() == "[[-12]]"
 
     block: # bug 9 from https://github.com/nim-lang/Nim/pull/17020#issuecomment-803193947
+      func wrap1(a: string): string = "{" & a & "}"
+      func `'wrap3`(a: string): string = "{" & a & "}"
       macro metawrap(): untyped =
-        func wrap1(a: string): string = "{" & a & "}"
-        func `'wrap3`(a: string): string = "{" & a & "}"
         result = quote do:
           let a1 {.inject.} = wrap1"-128"
           let a2 {.inject.} = -128'wrap3

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -332,7 +332,7 @@ block:
   macro main =
     let x = 12
     result = quote do:
-      `hello`(12, type(x))
+      `hello`(12, type(`x`))
 
   main()
 


### PR DESCRIPTION
fixes #24641

ref https://github.com/nim-lang/Nim/pull/17426


TODO:
- [x] revert https://github.com/nim-lang/Nim/pull/7343 

This PR solves problems in https://github.com/nim-lang/RFCs/issues/122

```nim
import macros

macro genPrintX(): untyped =
  let x = "mystring"
  result = quote do:
    echo x # Error: internal error: environment misses: x

proc main(): void =
  let x = 123
  genPrintX()

main()
```
The quoted ast won't capture local variables from macros anymore. It solves #7323 which is a special case of capturing `result`. Then we can revert https://github.com/nim-lang/Nim/pull/7343 that did some hack on `result`. 