### PR TITLE
include sym name and owner in sigmatch symchoice error message

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -432,9 +432,16 @@ proc cmpCandidates*(a, b: TCandidate, isFormal=true): int =
 
 proc argTypeToString(arg: PNode; prefer: TPreferedDesc): string =
   if arg.kind in nkSymChoices:
-    result = typeToString(arg[0].typ, prefer)
-    for i in 1..<arg.len:
-      result.add(" | ")
+    result = ""
+    for i in 0..<arg.len:
+      if i != 0:
+        result.add(" | ")
+      let s = arg[i].sym
+      if s.owner != nil:
+        result.add(s.owner.name.s)
+        result.add(".")
+      result.add(s.name.s)
+      result.add(": ")
       result.add typeToString(arg[i].typ, prefer)
   elif arg.typ == nil:
     result = "void"

--- a/tests/enum/tpure_enums_conflict.nim
+++ b/tests/enum/tpure_enums_conflict.nim
@@ -18,7 +18,7 @@ when true:
   echo amb #[tt.Error
   ^ type mismatch
 Expression: echo amb
-  [1] amb: MyEnum | OtherEnum
+  [1] amb: MyEnum.amb: MyEnum | OtherEnum.amb: OtherEnum
 
 Expected one of (first mismatch at [position]):
 [1] proc echo(x: varargs[typed, `$$`])

--- a/tests/enum/tpure_enums_conflict_legacy.nim
+++ b/tests/enum/tpure_enums_conflict_legacy.nim
@@ -12,7 +12,7 @@ when true:
   echo valueA # MyEnum.valueA
   echo MyEnum.amb # OK.
   echo amb #[tt.Error
-  ^ type mismatch: got <MyEnum | OtherEnum>
+  ^ type mismatch: got <MyEnum.amb: MyEnum | OtherEnum.amb: OtherEnum>
 but expected one of:
 proc echo(x: varargs[typed, `$$`])
   first type mismatch at position: 1

--- a/tests/errmsgs/t5167_4.nim
+++ b/tests/errmsgs/t5167_4.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "type mismatch: got <proc [*missing parameters*](x: int) | proc (x: string){.gcsafe.}>"
+errormsg: "type mismatch: got <t5167_4.foo: proc [*missing parameters*](x: int) | t5167_4.foo: proc (x: string){.gcsafe.}>"
 line: 19
 """
 

--- a/tests/errmsgs/tambparam.nim
+++ b/tests/errmsgs/tambparam.nim
@@ -7,7 +7,7 @@ import mambparam2, mambparam3
 echo test #[tt.Error
 ^ type mismatch
 Expression: echo test
-  [1] test: string | string
+  [1] test: mambparam1.test: string | mambparam3.test: string
 
 Expected one of (first mismatch at [position]):
 [1] proc echo(x: varargs[typed, `$$`])

--- a/tests/errmsgs/tambparam_legacy.nim
+++ b/tests/errmsgs/tambparam_legacy.nim
@@ -1,7 +1,7 @@
 import mambparam2, mambparam3
 
 echo test #[tt.Error
-^ type mismatch: got <string | string>
+^ type mismatch: got <mambparam1.test: string | mambparam3.test: string>
 but expected one of:
 proc echo(x: varargs[typed, `$$`])
   first type mismatch at position: 1

--- a/tests/errmsgs/tambtypegeneric.nim
+++ b/tests/errmsgs/tambtypegeneric.nim
@@ -1,0 +1,8 @@
+import "."/[mambtype1, mambtype2]
+type H[K] = object
+proc b(_: int) =  # slightly different, still not useful, error message if `b` generic
+  proc r(): H[Y] = discard #[tt.Error
+             ^ cannot instantiate H [type declared in tambtypegeneric.nim(2, 6)]
+got: <mambtype1.Y: typedesc[Y] | mambtype2.Y: typedesc[Y]>
+but expected: <K>]#
+b(0)

--- a/tests/lookups/tnicerrorforsymchoice.nim
+++ b/tests/lookups/tnicerrorforsymchoice.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <proc (s: TScgi: ScgiState or AsyncScgiState) | proc (client: AsyncSocket, headers: StringTableRef, input: string){.noSideEffect, gcsafe.}>"
+  errormsg: "type mismatch: got <tnicerrorforsymchoice.handleSCGIRequest: proc (s: TScgi: ScgiState or AsyncScgiState) | tnicerrorforsymchoice.handleSCGIRequest: proc (client: AsyncSocket, headers: StringTableRef, input: string){.noSideEffect, gcsafe.}>"
   line: 23
 """
 


### PR DESCRIPTION
refs #24644

Instead of listing the type of symchoices as `Foo | Bar` where `Foo`/`Bar` are the types of each sym, we also include the name of the sym itself as well as the owner if it exists.

This is a bit verbose, so another option would be to add an ambiguous identifier message after the "cannot instantiate" message as done for [overload errors](https://github.com/nim-lang/Nim/blob/1f9cac1f5cdeb242e70bf1e058a87213bbee64fb/compiler/semcall.nim#L358). PRing this instead.