### PR TITLE
add ambiguous identifier message to generic instantiations

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1671,6 +1671,11 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       var err = "cannot instantiate "
       err.addTypeHeader(c.config, t)
       err.add "\ngot: <$1>\nbut expected: <$2>" % [describeArgs(c, n), describeArgs(c, t.n, 0)]
+      if m.firstMismatch.kind == kTypeMismatch and m.firstMismatch.arg < n.len:
+        let nArg = n[m.firstMismatch.arg]
+        if nArg.kind in nkSymChoices:
+          err.add "\n"
+          err.add ambiguousIdentifierMsg(nArg)
       localError(c.config, n.info, errGenerated, err)
       return newOrPrevType(tyError, prev, c)
 

--- a/tests/errmsgs/tambtypegeneric.nim
+++ b/tests/errmsgs/tambtypegeneric.nim
@@ -1,0 +1,11 @@
+import "."/[mambtype1, mambtype2]
+type H[K] = object
+proc b(_: int) =  # slightly different, still not useful, error message if `b` generic
+  proc r(): H[Y] = discard #[tt.Error
+             ^ cannot instantiate H [type declared in tambtypegeneric.nim(2, 6)]
+got: <typedesc[Y] | typedesc[Y]>
+but expected: <K>
+ambiguous identifier: 'Y' -- use one of the following:
+  mambtype1.Y: Y
+  mambtype2.Y: Y]#
+b(0)


### PR DESCRIPTION
fixes #24644

Another option is to include the symbol names and owners in the type listing as in #24645 but this is a bit verbose.