### PR TITLE
Fix check for Nintendo Switch target

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -255,7 +255,7 @@ when supportedSystem:
       for ext in extensions:
         var x = addFileExt(x, ext)
         if fileExists(x):
-          when defined(posix): #not (defined(windows) or defined(nintendoswitch)):
+          when defined(posix) and not defined(nintendoswitch):
             while followSymlinks: # doubles as if here
               if x.symlinkExists:
                 var r = newString(maxSymlinkLen)


### PR DESCRIPTION
This should fix ringabouts comment here: https://github.com/nim-lang/Nim/pull/24639#issuecomment-2615107496

I wasn't aware that `nintendoswitch` and `posix` would be active at the same time, so I falsely inverted a check.