### PR TITLE
fix doc format: testament.md

### DIFF
--- a/doc/testament.md
+++ b/doc/testament.md
@@ -30,11 +30,13 @@ a working NodeJS on `PATH`.
 Commands
 ========
 
+==========================  ==========================
 p|pat|pattern <glob>        run all the tests matching the given pattern
 all                         run all tests inside of category folders
 c|cat|category <category>   run all the tests of a certain category
 r|run <test>                run single test file
 html                        generate testresults.html from the database
+==========================  ==========================
 
 
 Options

--- a/doc/testament.md
+++ b/doc/testament.md
@@ -40,18 +40,18 @@ html                        generate testresults.html from the database
 Options
 =======
 
---print                   print results to the console
---verbose                 print commands (compiling and running tests)
---simulate                see what tests would be run but don't run them (for debugging)
---failing                 only show failing/ignored tests
---targets:"c cpp js objc" run tests for specified targets (default: c)
---nim:path                use a particular nim executable (default: $PATH/nim)
---directory:dir           Change to directory dir before reading the tests or doing anything else.
---colors:on|off           Turn messages coloring on|off.
---backendLogging:on|off   Disable or enable backend logging. By default turned on.
---megatest:on|off         Enable or disable megatest. Default is on.
---valgrind:on|off         Enable or disable valgrind support. Default is on.
---skipFrom:file           Read tests to skip from `file` - one test per line, # comments ignored
+--print                    print results to the console
+--verbose                  print commands (compiling and running tests)
+--simulate                 see what tests would be run but don't run them (for debugging)
+--failing                  only show failing/ignored tests
+--targets:"c cpp js objc"  run tests for specified targets (default: c)
+--nim:path                 use a particular nim executable (default: $PATH/nim)
+--directory:dir            Change to directory dir before reading the tests or doing anything else.
+--colors:on|off            Turn messages coloring on|off.
+--backendLogging:on|off    Disable or enable backend logging. By default turned on.
+--megatest:on|off          Enable or disable megatest. Default is on.
+--valgrind:on|off          Enable or disable valgrind support. Default is on.
+--skipFrom:file            Read tests to skip from `file` - one test per line, # comments ignored
 
 
 Running a single test


### PR DESCRIPTION

- **doc(format): testament: fix `Commands` not regarded as table**
![image](https://github.com/user-attachments/assets/85238dd5-e199-41ca-a8cb-05849415097a)

- **doc(format): testament: row `--target` not splited as columns**
![image](https://github.com/user-attachments/assets/230ec693-c459-4fee-bc57-f3ab6c34a9b6)

