### PR TITLE
don't mark captured field sym in template as fully used

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -67,7 +67,12 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     # for instance 'nextTry' is both in tables.nim and astalgo.nim ...
     if not isField or sfGenSym notin s.flags:
       result = newSymNode(s, info)
-      markUsed(c, info, s)
+      if isField:
+        # possibly not final field sym
+        incl(s.flags, sfUsed)
+        markOwnerModuleAsUsed(c, s)
+      else:
+        markUsed(c, info, s)
       onUse(info, s)
     else:
       result = n

--- a/tests/template/tfielduse.nim
+++ b/tests/template/tfielduse.nim
@@ -1,0 +1,9 @@
+# issue #24657
+
+proc g() {.error.} = discard
+
+type T = object
+  g: int
+
+template B(): untyped = typeof(T.g)
+type _ = B()


### PR DESCRIPTION
fixes #24657