### PR TITLE
fixes bugs on the Nim manual

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -5186,22 +5186,22 @@ caught by reference. Example:
   proc fn() =
     let a = initRuntimeError("foo")
     doAssert $a.what == "foo"
-    var b: cstring
+    var b = ""
     try: raise initRuntimeError("foo2")
     except CStdException as e:
       doAssert e is CStdException
-      b = e.what()
-    doAssert $b == "foo2"
+      b = $e.what()
+    doAssert b == "foo2"
 
     try: raise initStdException()
     except CStdException: discard
 
     try: raise initRuntimeError("foo3")
     except CRuntimeError as e:
-      b = e.what()
+      b = $e.what()
     except CStdException:
       doAssert false
-    doAssert $b == "foo3"
+    doAssert b == "foo3"
 
   fn()
   ```

--- a/tests/cpp/tmanual_exception.nim
+++ b/tests/cpp/tmanual_exception.nim
@@ -1,6 +1,4 @@
 discard """
-  # doesn't work on macos 13 seemingly due to libc++ linking issue https://stackoverflow.com/a/77375947
-  disabled: osx
   targets: cpp
 """
 
@@ -18,21 +16,21 @@ proc initStdException(): CStdException {.importcpp: "std::exception()", construc
 proc fn() =
   let a = initRuntimeError("foo")
   doAssert $a.what == "foo"
-  var b: cstring
+  var b = ""
   try: raise initRuntimeError("foo2")
   except CStdException as e:
     doAssert e is CStdException
-    b = e.what()
-  doAssert $b == "foo2"
+    b = $e.what()
+  doAssert b == "foo2"
 
   try: raise initStdException()
   except CStdException: discard
 
   try: raise initRuntimeError("foo3")
   except CRuntimeError as e:
-    b = e.what()
+    b = $e.what()
   except CStdException:
     doAssert false
-  doAssert $b == "foo3"
+  doAssert b == "foo3"
 
 fn()


### PR DESCRIPTION
ref https://en.cppreference.com/w/cpp/error/exception/what

> Pointer to a null-terminated string with explanatory information. The pointer is guaranteed to be valid at least until the exception object from which it is obtained is destroyed, or until a non-const member function on the exception object is called.

The pointer is only valid before `CStdException as e` is destroyed


Old examples are broken on macOS arm64

```
/Users/blue/Desktop/nimony/test4.nim(38) test4
/Users/blue/Desktop/nimony/test4.nim(26) fn
/Users/blue/.choosenim/toolchains/nim-#devel/lib/std/assertions.nim(41) failedAssertImpl
/Users/blue/.choosenim/toolchains/nim-#devel/lib/std/assertions.nim(36) raiseAssert
/Users/blue/.choosenim/toolchains/nim-#devel/lib/system/fatal.nim(53) sysFatal
Error: unhandled exception: /Users/blue/Desktop/nimony/test4.nim(26, 3) `$b == "foo2"`  [AssertionDefect]
```