### PR TITLE
fixes #24677; rename macro variables in nimbase.h to avoid conflicts

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1024,7 +1024,7 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
       else:
         result = cppNameAsRope & "<"
         for needsComma, a in tt.genericInstParams:
-          if needsComma: result.add(" _NIM_MACRO_COMMA ")
+          if needsComma: result.add(" NIM_MACRO_COMMA ")
           addResultType(a)
         result.add("> ")
       # always call for sideeffects:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1024,7 +1024,7 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
       else:
         result = cppNameAsRope & "<"
         for needsComma, a in tt.genericInstParams:
-          if needsComma: result.add(" NIM_MACRO_COMMA ")
+          if needsComma: result.add(" _NIM_MACRO_COMMA ")
           addResultType(a)
         result.add("> ")
       # always call for sideeffects:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1024,7 +1024,7 @@ proc getTypeDescAux(m: BModule; origTyp: PType, check: var IntSet; kind: TypeDes
       else:
         result = cppNameAsRope & "<"
         for needsComma, a in tt.genericInstParams:
-          if needsComma: result.add(" COMMA ")
+          if needsComma: result.add(" NIM_MACRO_COMMA ")
           addResultType(a)
         result.add("> ")
       # always call for sideeffects:

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -261,7 +261,7 @@ __EMSCRIPTEN__
 
 /* ----------------------------------------------------------------------- */
 
-#define COMMA ,
+#define NIM_MACRO_COMMA ,
 
 #include <limits.h>
 #include <stddef.h>

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -261,7 +261,7 @@ __EMSCRIPTEN__
 
 /* ----------------------------------------------------------------------- */
 
-#define NIM_MACRO_COMMA ,
+#define _NIM_MACRO_COMMA ,
 
 #include <limits.h>
 #include <stddef.h>

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -261,7 +261,7 @@ __EMSCRIPTEN__
 
 /* ----------------------------------------------------------------------- */
 
-#define _NIM_MACRO_COMMA ,
+#define NIM_MACRO_COMMA ,
 
 #include <limits.h>
 #include <stddef.h>

--- a/tests/ccgbugs/tccgissues.nim
+++ b/tests/ccgbugs/tccgissues.nim
@@ -55,3 +55,10 @@ block:
       attr: MyBaseObj[string]
 
   var myObj: MyObj
+
+
+proc main =
+  let COMMA = 1
+  doAssert COMMA == 1
+
+main()


### PR DESCRIPTION
fixes #24677;

ref https://github.com/nim-lang/Nim/pull/4094

COMMA is too common a name to reduce the possible of conflicts. We can choose either to add the name to the mangle lists or simply prefix it with name-related names