### PR TITLE
fixes #24673; divmod errors for ranges

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -105,7 +105,7 @@ when not defined(js) and not defined(nimscript): # C
       when compileOption("overflowChecks"):
         if y == 0:
           raise new(DivByZeroDefect)
-        elif (x == T.low and y == -1.T):
+        elif (x == T.low and int64(y) == -1):
           raise new(OverflowDefect)
       let res = divmod_c(x, y)
       result[0] = res.quot

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -545,3 +545,8 @@ when not defined(js) and not defined(danger):
       doAssertRaises(OverflowDefect):
         discard sum(x)
 
+block: # bug #24673
+  let x: Natural = 5
+  let y: Natural = 3
+
+  doAssert divmod(x, y) == (Natural 1, Natural 2)


### PR DESCRIPTION
fixes #24673

The problem is that there is no way to distinguish `cint`, `cint`, etc ctypes with Nim types. So `when T is cint | clong | clonglong:` is true for types derived from `int`, `int32` and `int64`. In this PR, it fixes the branch to avoid erros for `Natural`