### PR TITLE
bugfix memory leak in parseJson() on invalid json-string

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1047,7 +1047,12 @@ else:
     ## field but kept as raw numbers via `JString`.
     ## If `rawFloats` is true, floating point literals will not be converted to a `JFloat`
     ## field but kept as raw numbers via `JString`.
-    result = parseJson(newStringStream(buffer), "input", rawIntegers, rawFloats)
+    var stream: StringStream
+    try:
+      stream = newStringStream(buffer)
+      result = parseJson(stream, "input", rawIntegers, rawFloats)
+    finally:
+      stream.close
 
   proc parseFile*(filename: string): JsonNode =
     ## Parses `file` into a `JsonNode`.

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -919,10 +919,10 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
         discard getTok(p)
       eat(p, tkCurlyRi)
       result = obj
+      obj = nil
     except JsonParsingError:
       if obj != nil:
-        # Ensure proper cleanup of the object if parsing fails
-        GC_unref(obj)
+        obj = nil
       raise
   of tkBracketLe:
     if depth > DepthLimit:
@@ -937,9 +937,10 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
         discard getTok(p)
       eat(p, tkBracketRi)
       result = arr
+      arr = nil
     except JsonParsingError:
       if arr != nil:
-        GC_unref(arr)
+        arr = nil
       raise
   of tkError, tkCurlyRi, tkBracketRi, tkColon, tkComma, tkEof:
     raiseParseErr(p, "{")

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1047,12 +1047,14 @@ else:
     ## field but kept as raw numbers via `JString`.
     ## If `rawFloats` is true, floating point literals will not be converted to a `JFloat`
     ## field but kept as raw numbers via `JString`.
-    var stream: StringStream
+    var stream: StringStream = nil
     try:
       stream = newStringStream(buffer)
       result = parseJson(stream, "input", rawIntegers, rawFloats)
     finally:
-      stream.close
+      if stream != nil:
+        stream.close()
+        stream = nil  # Clear the reference
 
   proc parseFile*(filename: string): JsonNode =
     ## Parses `file` into a `JsonNode`.


### PR DESCRIPTION
⚠️ Original PR was only for closing the stream in parseJson, but during testing the solution I encountered memory leaks in the parsing when the input string included non-compliant JSON.


### PR Summary  
This PR ensures that the stream created within the `parseJson*()` result variable is properly closed and that the object created during parsing JSON is freed in case of a bad input string.

1. Previously, `newStringStream()` was used inline within the `result =` assignment with an implicite `.close()`, but this change refactors it into a `try-finally` block to guarantee cleanup.
2. The `raiseParseErr` within the parser did not remove the newObject created.


### Reproduction
The second part of the of the PR - the parsing memory leak can be replicated with the code and commands in the post below.


### Changes
1. Streaming change is within line 1065-1072
2. Parsing change is within line 906-943


### Stream bug

This here is the valgrind output from a larger code base where the parsing bug is fixed, but the streaming part is not fixed.

```sh
$ nim c -d:dev --m:orc -d:useMalloc --debugger:native main
$ valgrind --leak-check=full --log-file=valgrind_details4.txt --track-origins=yes --num-callers=20 ./main
```
**Output:**
```sh
==787== 10,240 bytes in 80 blocks are definitely lost in loss record 485 of 494
==787==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==787==    by 0x2564C9: system::alloc0Impl(range09223372036854775807) (malloc.nim:11)
==787==    by 0x2564D7: system::allocShared0Impl(range09223372036854775807) (malloc.nim:37)
==787==    by 0x257FD8: system::alignedAlloc0(range09223372036854775807, range09223372036854775807) (memalloc.nim:351)
==787==    by 0x257B70: nimNewObj (arc.nim:96)
==787==    by 0x29F761: streams::newStringStream(sink<string>) (streams.nim:1304)
==787==    by 0x2A7F6F: json::parseJson(string, bool, bool) (json.nim:1050)
==787==    by 0x5A9218: api_tasks::apiTasksGet(string, string, string, string, seq<string>, string, string, bool, string, seq<string>, bool, bool, bool, string, string) (system.nim:940)
==787==    by 0x7DF381: routes_api::colonanonymous__resourcesZroutesZapi95generalZroutes95api_u18865_(ptr<mummy::RequestObj>) (routes_api_tasks.nim:39)
==787==    by 0x337FAC: toHandler::colonanonymous_(ptr<mummy::RequestObj>) (routers.nim:271)
```

### Parsing bug

_(see second post below)_
