### PR TITLE
do not match generic invocations to their base body types

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1745,23 +1745,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     elif x.kind == tyGenericInst and concpt.kind == tyConcept:
       result = if concepts.conceptMatch(c.c, concpt, x, c.bindings, f): isGeneric
                else: isNone
-    elif x.kind == tyGenericBody:
-      # pretend we are matching against invocation type
-      let base = x[0]
-      if base == f[0]:
-        for i in 1..<f.len:
-          if i >= base.len-1: return
-          # least specific type that the parameter satisfies:
-          let constraint =
-            if base[i].genericParamHasConstraints:
-              base[i].genericConstraint
-            else:
-              # same as in liftParamType
-              newTypeS(tyAnything, c.c)
-          # match against constraint
-          let tr = typeRel(c, f[i], constraint, {trDontBind})
-          if tr <= isSubtype: return
-        result = isGeneric
+    elif x.kind == tyGenericBody and f[0] == x:
+      # not specific enough
+      result = isNone
     else:
       let genericBody = f[0]
       var askip = skippedNone

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1745,6 +1745,23 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     elif x.kind == tyGenericInst and concpt.kind == tyConcept:
       result = if concepts.conceptMatch(c.c, concpt, x, c.bindings, f): isGeneric
                else: isNone
+    elif x.kind == tyGenericBody:
+      # pretend we are matching against invocation type
+      let base = x[0]
+      if base == f[0]:
+        for i in 1..<f.len:
+          if i >= base.len-1: return
+          # least specific type that the parameter satisfies:
+          let constraint =
+            if base[i].genericParamHasConstraints:
+              base[i].genericConstraint
+            else:
+              # same as in liftParamType
+              newTypeS(tyAnything, c.c)
+          # match against constraint
+          let tr = typeRel(c, f[i], constraint, {trDontBind})
+          if tr <= isSubtype: return
+        result = isGeneric
     else:
       let genericBody = f[0]
       var askip = skippedNone

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -35,7 +35,9 @@ proc pkg(name: string; cmd = "nimble test -l"; url = "", useHead = true, allowFa
 
 pkg "alea"
 pkg "argparse"
-pkg "arraymancer", "nimble install -y; nimble uninstall -i -y nimcuda; nimble install nimcuda@0.2.1; nim c tests/tests_cpu.nim"
+pkg "arraymancer", "nimble install -y; nimble uninstall -i -y nimcuda; nimble install nimcuda@0.2.1; nim c tests/tests_cpu.nim",
+  # remove when https://github.com/mratsim/Arraymancer/pull/674 is merged
+  url = "https://github.com/metagn/Arraymancer"
 pkg "ast_pattern_matching", "nim c -r tests/test1.nim"
 pkg "asyncftpclient", "nimble compileExample"
 pkg "asyncthreadpool", "nimble test --mm:refc"

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -741,7 +741,8 @@ block t1684:
 block t5632:
   type Option[T] = object
 
-  proc point[A](v: A, t: typedesc[Option[A]]): Option[A] =
+  # original issue test uses Option[A] instead
+  proc point[A](v: A, t: typedesc[Option]): Option[A] =
     discard
 
   discard point(1, Option)

--- a/tests/overload/tgenericbodymatch.nim
+++ b/tests/overload/tgenericbodymatch.nim
@@ -1,0 +1,13 @@
+# issue #24688
+
+type
+  R[T, E] = object
+  A = object
+  B = object
+
+# Remove this overload to make it work
+func err[T](_: type R[T, void]): R[T, void] = discard
+
+func err(_: type R): R[A, B] = discard
+
+discard R.err()


### PR DESCRIPTION
fixes #24688, refs #5632

This would make sense if generic body types as the type of expressions are purely symbolic and never valid for an actual generic expression, which should produce some invocation type instead (liftParamType produces a generic invocation with args as `tyAnything` or the param constraints). Not sure if there is a valid counter case to this.

#5632 is a counter case which no longer works, but it doesn't really seem like a valid case, unless we still want to support it.

PR to arraymancer: https://github.com/mratsim/Arraymancer/pull/674, doesn't mean I'm sure this is correct though