### PR TITLE
new-style concepts adjusments

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -585,14 +585,6 @@ proc hash*(x: ItemId): Hash =
   result = !$h
 
 
-var ctrlc* = 0
-proc prepC*(ic=true): string=
-  result = newString(ctrlc)
-  for i in 0..<result.len:
-    result[i] = ' '
-  if ic:
-    ctrlc += 1
-
 type
   PNode* = ref TNode
   TNodeSeq* = seq[PNode]

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -585,6 +585,14 @@ proc hash*(x: ItemId): Hash =
   result = !$h
 
 
+var ctrlc* = 0
+proc prepC*(ic=true): string=
+  result = newString(ctrlc)
+  for i in 0..<result.len:
+    result[i] = ' '
+  if ic:
+    ctrlc += 1
+
 type
   PNode* = ref TNode
   TNodeSeq* = seq[PNode]

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -135,7 +135,7 @@ proc bindParam(c: PContext, m: var MatchCon; key, v: PType): bool {. discardable
   let old = existingBinding(m, key)
   if old != key:
     # check previously bound value
-    if matchType(c, old, value, m) == false:
+    if not matchType(c, old, value, m):
       return false
   elif key.hasElementType and key.elementType.kind != tyNone:
     # check constaint
@@ -159,7 +159,7 @@ proc acceptsAllTypes(t: PType): bool=
   elif t.kind == tyGenericParam:
     if tfImplicitTypeParam in t.flags:
       result = true
-    if not(t.hasElementType) or t.elementType.kind == tyNone:
+    if not t.hasElementType or t.elementType.kind == tyNone:
       result = true
 
 proc procDefSignature(s: PSym): PNode {. deprecated .} = 

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -162,14 +162,6 @@ proc acceptsAllTypes(t: PType): bool=
     if not(t.hasElementType) or t.elementType.kind == tyNone:
       result = true
 
-iterator travStmts(n: PNode): PNode {. closure .} =
-  if n.kind in {nkStmtList, nkStmtListExpr}:
-    for i in 0..<n.len:
-      for sn in travStmts(n[i]):
-        yield sn
-  else:
-    yield n
-
 proc procDefSignature(s: PSym): PNode {. deprecated .} = 
   var nc = s.ast.copyNode()
   for i in 0 .. 5:

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -73,6 +73,7 @@ type
   MatchFlags* = enum
     mfDontBind  # Do not bind generic parameters
     mfCheckGeneric  # formal <- formal comparison as opposed to formal <- operand
+    mfConceptToConcept # remove this
   
   MatchCon = object ## Context we pass around during concept matching.
     bindings: LayeredIdTable
@@ -459,7 +460,8 @@ proc matchType(c: PContext; f, a: PType; m: var MatchCon): bool =
     ctrlc -= 1
 
 proc checkConstraint(c: PContext; f, a: PType; m: var MatchCon): bool =
-  assert mfCheckGeneric notin m.flags
+  # TODO: remove assertion and mfConceptToConcept flag
+  assert mfConceptToConcept in m.flags or mfCheckGeneric notin m.flags
   result = matchType(c, f, a, m) or matchType(c, a, f, m)
 
 proc matchReturnType(c: PContext; f, a: PType; m: var MatchCon): bool =
@@ -628,6 +630,7 @@ proc conceptMatch*(c: PContext; concpt, arg: PType; bindings: var LayeredIdTable
   # bindParam(c, m, concpt.n[0].typ, arg)
   if arg.isConcept:
     # TODO: This pre-check needs to be beefed up - generic parameters and such
+    m.flags.incl mfConceptToConcept
     result = conceptsMatch(c, concpt.reduceToBase, arg.reduceToBase, m) >= mkSubset
   elif arg.acceptsAllTypes:
     # XXX: I think this is wrong, or at least partially wrong. Can still test ambiguous types

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -206,13 +206,14 @@ proc matchConceptToImpl(c: PContext, f, potentialImpl: PType; m: var MatchCon): 
   m.concpt = concpt
   
   var invocation: PType = nil
-  if f.kind == tyGenericInvocation:
+  if f.kind in {tyGenericInvocation, tyGenericInst}:
     invocation = f
   inc m.depthCount
   result = processConcept(c, concpt, invocation, oldBindings, m)
   dec m.depthCount
   m.potentialImplementation = oldPotentialImplementation
   m.concpt = oldConcept
+  m.bindings = oldBindings
 
 proc cmpConceptDefs(c: PContext, fn, an: PNode, m: var MatchCon): bool=
   if fn.kind != an.kind:
@@ -283,7 +284,7 @@ proc matchType(c: PContext; fo, ao: PType; m: var MatchCon): bool =
       # if f is a subset of a then any match to a will also match f. Not the other way around
       return conceptsMatch(c, a.reduceToBase, f.reduceToBase, m) >= mkSubset
     else:
-      return matchConceptToImpl(c, f.reduceToBase, a, m)
+      return matchConceptToImpl(c, f, a, m)
   
   result = false
 
@@ -359,6 +360,7 @@ proc matchType(c: PContext; fo, ao: PType; m: var MatchCon): bool =
       result = matchType(c, scomp, a, m)
   of tyGenericParam:
     if a.acceptsAllTypes:
+      discard bindParam(c, m, f, a)
       result = f.acceptsAllTypes
     else:
       result = bindParam(c, m, f, a)

--- a/compiler/layeredtable.nim
+++ b/compiler/layeredtable.nim
@@ -1,4 +1,4 @@
-import std/[tables, assertions]
+import std/[tables]
 import ast
 
 type

--- a/compiler/layeredtable.nim
+++ b/compiler/layeredtable.nim
@@ -1,4 +1,4 @@
-import std/tables
+import std/[tables, assertions]
 import ast
 
 type
@@ -52,6 +52,15 @@ proc setToPreviousLayer*(pt: var LayeredIdTable) {.inline.} =
       # workaround refc
       let tmp = pt.nextLayer[]
       pt = tmp
+
+iterator pairs*(pt: LayeredIdTable): (ItemId, PType) =
+  var tm = pt
+  while true:
+    for (k, v) in pairs(tm.topLayer):
+      yield (k, v)
+    if tm.nextLayer == nil:
+      break
+    tm.setToPreviousLayer
 
 proc lookup(typeMap: ref LayeredIdTableObj, key: ItemId): PType =
   result = nil

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -47,11 +47,6 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
   result = @[]
   var symx = initOverloadIter(o, c, headSymbol)
   while symx != nil:
-    when defined(debugTypeRel):
-      if `??`(c.config, headSymbol.info, "nimscraps.nim") or true:
-        echo "==========================================="
-        echo "symx: ", renderTree(symx.ast)
-        echo "==========================================="
     if symx.kind in filter:
       result.add((symx, o.lastOverloadScope))
     elif symx.kind == skGenericParam:
@@ -149,13 +144,6 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
   while true:
     determineType(c, sym)
     z = initCandidate(c, sym, initialBinding, scope, diagnosticsFlag)
-    when defined(debugTypeRel):
-      if `??`(c.config, n.info, "nimscraps.nim") or true:
-        echo "==========================================="
-        echo "BEST: ", $best.callee, "' at ", best.c.config $ best.calleeSym.info
-        echo "-------------------------------------------"
-        echo "Compare: ", $z.callee, "' at ", z.c.config $ z.calleeSym.info
-        echo "==========================================="
     # this is kinda backwards as without a check here the described
     # problems in recalc would not happen, but instead it 100%
     # does check forever in some cases
@@ -225,9 +213,6 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
     sym = syms[nextSymIndex].s
     scope = syms[nextSymIndex].scope
     inc(nextSymIndex)
-  when defined(debugTypeRel):
-    echo "BEST: ", renderTree(best.calleeSym.ast)
-    echo "==== END: pickBestCandidate ====="
 
 
 proc effectProblem(f, a: PType; result: var string; c: PContext) =

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -47,6 +47,11 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
   result = @[]
   var symx = initOverloadIter(o, c, headSymbol)
   while symx != nil:
+    when defined(debugTypeRel):
+      if `??`(c.config, headSymbol.info, "nimscraps.nim") or true:
+        echo "==========================================="
+        echo "symx: ", renderTree(symx.ast)
+        echo "==========================================="
     if symx.kind in filter:
       result.add((symx, o.lastOverloadScope))
     elif symx.kind == skGenericParam:
@@ -144,7 +149,13 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
   while true:
     determineType(c, sym)
     z = initCandidate(c, sym, initialBinding, scope, diagnosticsFlag)
-
+    when defined(debugTypeRel):
+      if `??`(c.config, n.info, "nimscraps.nim") or true:
+        echo "==========================================="
+        echo "BEST: ", $best.callee, "' at ", best.c.config $ best.calleeSym.info
+        echo "-------------------------------------------"
+        echo "Compare: ", $z.callee, "' at ", z.c.config $ z.calleeSym.info
+        echo "==========================================="
     # this is kinda backwards as without a check here the described
     # problems in recalc would not happen, but instead it 100%
     # does check forever in some cases
@@ -214,6 +225,9 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
     sym = syms[nextSymIndex].s
     scope = syms[nextSymIndex].scope
     inc(nextSymIndex)
+  when defined(debugTypeRel):
+    echo "BEST: ", renderTree(best.calleeSym.ast)
+    echo "==== END: pickBestCandidate ====="
 
 
 proc effectProblem(f, a: PType; result: var string; c: PContext) =

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -195,7 +195,7 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
       # 1) new symbols are discovered but the loop ends before we recalc
       # 2) new symbols are discovered and resemmed forever
       # not 100% sure if these are possible though as they would rely
-      #  on somehow introducing a new overload during overload resolution
+      # on somehow introducing a new overload during overload resolution
 
       # Symbol table has been modified. Restart and pre-calculate all syms
       # before any further candidate init and compare. SLOW, but rare case.

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2195,8 +2195,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       of "sink": result = semAnyRef(c, n, tySink, prev)
       of "owned": result = semAnyRef(c, n, tyOwned, prev)
       else: result = semGeneric(c, n, s, prev)
-    else:
-      result = semGeneric(c, n, s, prev)
+    else: result = semGeneric(c, n, s, prev)
   of nkDotExpr:
     let typeExpr = semExpr(c, n)
     if typeExpr.typ.isNil:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1289,12 +1289,14 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
         paramType[i] = lifted
         result = paramType
         result.last.shouldHaveMeta
-
-    let liftBody = recurse(paramType.skipModifier, true)
-    if liftBody != nil:
-      result = liftBody
-      result.flags.incl tfHasMeta
-      #result.shouldHaveMeta
+    if paramType.isConcept:
+      return addImplicitGeneric(c, paramType, paramTypId, info, genericParams, paramName)
+    else:
+      let liftBody = recurse(paramType.skipModifier, true)
+      if liftBody != nil:
+        result = liftBody
+        result.flags.incl tfHasMeta
+        #result.shouldHaveMeta
 
   of tyGenericInvocation:
     result = nil
@@ -1308,7 +1310,6 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       # this may happen for proc type appearing in a type section
       # before one of its param types
       return
-
     if body.last.kind == tyUserTypeClass:
       let expanded = instGenericContainer(c, info, paramType,
                                           allowMetaTypes = true)
@@ -2194,7 +2195,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       of "sink": result = semAnyRef(c, n, tySink, prev)
       of "owned": result = semAnyRef(c, n, tyOwned, prev)
       else: result = semGeneric(c, n, s, prev)
-    else: result = semGeneric(c, n, s, prev)
+    else:
+      result = semGeneric(c, n, s, prev)
   of nkDotExpr:
     let typeExpr = semExpr(c, n)
     if typeExpr.typ.isNil:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -608,10 +608,13 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType, isInstValue = false): 
   result = t
   if t == nil: return
 
+  var et = t
+  if t.isConcept:
+    et = t.reduceToBase
   const lookupMetas = {tyStatic, tyGenericParam, tyConcept} + tyTypeClasses - {tyAnything}
-  if t.kind in lookupMetas or
-      (t.kind == tyAnything and tfRetType notin t.flags):
-    let lookup = cl.typeMap.lookup(t)
+  if et.kind in lookupMetas or
+      (et.kind == tyAnything and tfRetType notin et.flags):
+    let lookup = cl.typeMap.lookup(et)
     if lookup != nil: return lookup
 
   case t.kind

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -311,6 +311,9 @@ proc checkGeneric(a, b: TCandidate): int =
   result = winner
 
 proc sumGeneric(t: PType): int =
+  # count the "genericness" so that Foo[Foo[T]] has the value 3
+  # and Foo[T] has the value 2 so that we know Foo[Foo[T]] is more
+  # specific than Foo[T].
   result = 0
   var t = t
   while true:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -310,9 +310,7 @@ proc checkGeneric(a, b: TCandidate): int =
       winner = -1
   result = winner
 
-proc sumGeneric(t: PType): int 
-
-proc sumGenericM(t: PType): int =
+proc sumGeneric(t: PType): int =
   result = 0
   var t = t
   while true:
@@ -368,16 +366,7 @@ proc sumGenericM(t: PType): int =
         result += t.reduceToBase.conceptBody.len
       break
 
-proc sumGeneric(t: PType): int =
-  when defined(debugTypeRel):
-    let prep = prepC()
-  result = sumGenericM(t)
-  when defined(debugTypeRel):
-    echo prep,"------> sumGeneric: ", t, ": ", t.kind, " -> ", result
-    ctrlc -= 1
-
-proc complexDisambiguation(a, b: PType): int
-proc complexDisambiguationM(a, b: PType): int =
+proc complexDisambiguation(a, b: PType): int =
   # 'a' matches better if *every* argument matches better or equal than 'b'.
   var winner = 0
   for ai, bi in underspecifiedPairs(a, b, 1):
@@ -400,13 +389,6 @@ proc complexDisambiguationM(a, b: PType): int =
     for i in 1..<a.len: x += ai.sumGeneric
     for i in 1..<b.len: y += bi.sumGeneric
     result = x - y
-proc complexDisambiguation(a, b: PType): int =
-  when defined(debugTypeRel):
-    let prep = prepC()
-  result = complexDisambiguationM(a, b)
-  when defined(debugTypeRel):
-    echo prep,"------> complexDisambiguation"
-    ctrlc -= 1
 
 proc writeMatches*(c: TCandidate) =
   echo "Candidate '", c.calleeSym.name.s, "' at ", c.c.config $ c.calleeSym.info
@@ -427,12 +409,6 @@ proc cmpInheritancePenalty(a, b: int): int =
   eb - ea
 
 proc cmpCandidates*(a, b: TCandidate, isFormal=true): int =
-  when defined(debugTypeRel):
-    echo " ---S--- "
-    writeMatches(a)
-    echo " ------ "
-    writeMatches(b)
-    echo " ---E--- "
   result = a.exactMatches - b.exactMatches
   if result != 0: return
   result = a.genericMatches - b.genericMatches
@@ -1186,7 +1162,7 @@ when false:
 template skipOwned(a) =
   if a.kind == tyOwned: a = a.skipTypes({tyOwned, tyGenericInst})
 
-proc typeRelM(c: var TCandidate, f, aOrig: PType,
+proc typeRel(c: var TCandidate, f, aOrig: PType,
              flags: TTypeRelFlags = {}): TTypeRelation =
   # typeRel can be used to establish various relationships between types:
   #
@@ -2153,20 +2129,6 @@ proc typeRelM(c: var TCandidate, f, aOrig: PType,
     if a.kind == tyNone: result = isEqual
   else:
     internalError c.c.graph.config, " unknown type kind " & $f.kind
-
-proc typeRel(c: var TCandidate, f, aOrig: PType,
-             flags: TTypeRelFlags = {}): TTypeRelation =
-  when defined(debugTypeRel):
-    let prep = prepC()
-    if aOrig == nil:
-      echo prep, "TYPEREL(", ctrlc ,"): ", f, "  <>  ", f.kind, "  <fits?-  nil"
-    else:
-      echo prep, "TYPEREL(", ctrlc ,"): ", f.kind, "(", f, ") <- ",aOrig.kind, "(", aOrig, ")"
-  var ret =  typeRelM(c, f,aOrig,flags=flags)
-  when defined(debugTypeRel):
-    echo prep, "TYPEREL(", ctrlc ,"): ","RETURNED: ", ret
-    ctrlc -= 1
-  return ret
 
 when false:
   var nowDebug = false

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1509,7 +1509,8 @@ proc getSize*(conf: ConfigRef; typ: PType): BiggestInt =
 proc isConcept*(t: PType): bool=
   case t.kind
   of tyConcept: true
-  of tyCompositeTypeClass: t.hasElementType and t.elementType.kind == tyConcept
+  of tyCompositeTypeClass:
+    t.hasElementType and isConcept(t.elementType)
   of tyGenericBody:
     return t.typeBodyImpl.kind == tyConcept
   of tyGenericInvocation, tyGenericInst:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1512,7 +1512,7 @@ proc isConcept*(t: PType): bool=
   of tyCompositeTypeClass:
     t.hasElementType and isConcept(t.elementType)
   of tyGenericBody:
-    return t.typeBodyImpl.kind == tyConcept
+    t.typeBodyImpl.kind == tyConcept
   of tyGenericInvocation, tyGenericInst:
     if t.baseClass.kind == tyGenericBody:
       t.baseClass.typeBodyImpl.kind == tyConcept

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1506,6 +1506,19 @@ proc getSize*(conf: ConfigRef; typ: PType): BiggestInt =
   computeSizeAlign(conf, typ)
   result = typ.size
 
+proc isConcept*(t: PType): bool=
+  case t.kind
+  of tyConcept: true
+  of tyCompositeTypeClass: t.hasElementType and t.elementType.kind == tyConcept
+  of tyGenericBody:
+    return t.typeBodyImpl.kind == tyConcept
+  of tyGenericInvocation, tyGenericInst:
+    if t.baseClass.kind == tyGenericBody:
+      t.baseClass.typeBodyImpl.kind == tyConcept
+    else:
+      t.baseClass.kind == tyConcept
+  else: false
+
 proc containsGenericTypeIter(t: PType, closure: RootRef): bool =
   case t.kind
   of tyStatic:
@@ -1516,6 +1529,8 @@ proc containsGenericTypeIter(t: PType, closure: RootRef): bool =
     return false
   of GenericTypes + tyTypeClasses + {tyFromExpr}:
     return true
+  of tyGenericInst:
+    return t.isConcept
   else:
     return false
 
@@ -2044,6 +2059,7 @@ proc genericRoot*(t: PType): PType =
 
 proc reduceToBase*(f: PType): PType =
   #[
+    Not recursion safe
     Returns the lowest order (most general) type that that is compatible with the input.
     E.g.
     A[T] = ptr object ... A -> ptr object
@@ -2068,7 +2084,7 @@ proc reduceToBase*(f: PType): PType =
     result = reduceToBase(f.typeBodyImpl)
   of tyUserTypeClass:
     if f.isResolvedUserTypeClass:
-      result = f.base  # ?? idk if this is right
+      result = f.base
     else:
       result = f.skipModifier
   of tyStatic, tyOwned, tyVar, tyLent, tySink:

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2941,6 +2941,9 @@ type
     proc `[]`(x: Self; at: I): T
     proc `[]=`(x: var Self; at: I; newVal: T)
     proc len(x: Self): I
+  Index = concept
+    proc inc(x: var Self)
+    proc `<`(a, b: Self): bool
 proc sort*[I: Index; T: Comparable](x: var Indexable[I, T])
 ```
 

--- a/tests/concepts/conceptv2negative/tmarrget.nim
+++ b/tests/concepts/conceptv2negative/tmarrget.nim
@@ -1,0 +1,12 @@
+discard """
+action: "reject"
+"""
+
+# stop mArrGet magic from giving everything `[]`
+type
+  C[T] = concept
+    proc `[]`(b: Self, i: int): T
+  A = object
+  
+proc p(a: C): int = assert false
+discard p(A())

--- a/tests/concepts/conceptv2negative/tmissingbind.nim
+++ b/tests/concepts/conceptv2negative/tmissingbind.nim
@@ -1,0 +1,26 @@
+discard """
+action: "reject"
+"""
+
+#[
+  ArrayImpl is not Sizeable
+]#
+
+type
+  Sizeable = concept
+    proc size(s: Self): int
+  Buffer = concept
+    proc w(s: Self, data: Sizeable)
+  Serializable = concept
+    proc something(s: Self)
+    proc w(b: Buffer, s: Self)
+  BufferImpl = object
+  ArrayImpl = object
+
+proc something(s: ArrayImpl)= discard
+#proc size(s: ArrayImpl): int= discard
+proc w(x: BufferImpl, d: Sizeable)= discard
+
+proc spring(s: Buffer, data: Serializable)= discard
+
+spring(BufferImpl(), ArrayImpl())

--- a/tests/concepts/tconceptsv2.nim
+++ b/tests/concepts/tconceptsv2.nim
@@ -5,7 +5,13 @@ B[system.int]
 A[system.string]
 A[array[0..0, int]]
 A[seq[int]]
-char
+100
+a
+b
+c
+a
+b
+c
 '''
 """
 import conceptsv2_helper
@@ -104,7 +110,7 @@ block: # simple recursion
     WritableImpl = object
 
   proc launch(a: var Buffer, b: Writable)= discard
-  proc put(x: var BufferImpl, i: object)= discard
+  proc put[T](x: var BufferImpl, i: T)= discard
   proc second(x: BufferImpl)= discard
   proc put(x: var Buffer, y: WritableImpl)= discard
 
@@ -122,7 +128,7 @@ block: # more complex recursion
     WritableImpl = object
 
   proc launch(a: var Buffer, b: Writable)= discard
-  proc put(x: var Buffer, i: object)= discard
+  proc put[T](x: var Buffer, i: T)= discard
   proc put(x: var BufferImpl, i: object)= discard
   proc second(x: BufferImpl)= discard
   proc put(x: var Buffer, y: WritableImpl)= discard
@@ -130,37 +136,282 @@ block: # more complex recursion
   var a = BufferImpl[5]()
   launch(a, WritableImpl())
 
-block:  # capture p1[T]
+block: # co-dependent concepts
   type
-    A[T] = object
-    C = concept
-      proc p1(x: Self, i: int): float
+    Writable = concept
+      proc w(b: var Buffer; s: Self): int
+    Buffer = concept
+      proc w(s: var Self; data: Writable): int
+    SizedWritable = concept
+      proc size(x: Self): int
+      proc w(b: var Buffer, x: Self): int
+    BufferImpl = object
+    
+  proc w(x: var BufferImpl, d: int): int = return 100
+  proc size(d: int): int = sizeof(int)
 
-  proc p1[T](a: A[T], idx: int): T = default(T)
-  proc p(a: C): int = discard
-  proc p[T](a: T):int = assert false
+  proc p(b: var Buffer, data: SizedWritable): int =
+    b.w(data)
 
-  discard p(A[float]())
+  var b = BufferImpl()
+  echo p(b, 5)
 
-block:  # mArrGet binding
+block: # indirect concept matching
+  type
+    Sizeable = concept
+      proc size(s: Self): int
+    Buffer = concept
+      proc w(s: Self, data: Sizeable)
+    Serializable = concept
+      proc something(s: Self)
+      proc w(b: Buffer, s: Self)
+    BufferImpl = object
+    ArrayImpl = object
+
+  proc something(s: ArrayImpl)= discard
+  proc size(s: ArrayImpl): int= discard
+
+  proc w(x: BufferImpl, d: Sizeable)= discard
+
+  proc spring(s: Buffer, data: Serializable)=discard
+
+  spring(BufferImpl(), ArrayImpl())
+
+block: # instantiate even when generic params are the same
   type
     ArrayLike[T] = concept
       proc len(x: Self): int
       proc `[]`(b: Self, i: int): T
+  proc p[T](x: ArrayLike[T])=
+    for k in x:
+      echo k
+  # For this test to work the second call's instantiation has to be incompatible with the first on the back end
+  p(['a','b','c'])
+  p("abc")
 
-  proc p[T](a: ArrayLike[T]): int= discard
-  discard p([1,2])
+block: # reject improper generic variables in candidates
+  type
+    ArrayLike[T] = concept
+      proc len(x: Self): int
+      proc g(b: Self, i: int): T
+    FreakString = concept
+      proc len(x: Self): int
+      proc characterSize(s: Self): int 
+    A = object
+
+  proc g[T, H](s: T, i: H): H = default(T)
+  proc len(s: A): int = discard
+  proc characterSize(s: A): int = discard
+  
+  proc p(symbol: ArrayLike[char]): int = assert false
+  proc p(symbol: FreakString): int=discard
+  
+  discard p(A())
+
+block: # typerel disambiguation by concept subset
+  type
+    ArrayLike[T] = concept
+      proc len(x: Self): int
+      proc characterSize(s: Self): int
+    FreakString = concept
+      proc len(x: Self): int
+      proc characterSize(s: Self): int
+      proc tieBreaker(s: Self, j: int): float
+    A = object
+
+  proc len(s: A): int = discard
+  proc characterSize(s: A): int = discard
+  proc tieBreaker(s: A, h: int):float = 0.0
+  
+  proc p(symbol: ArrayLike[char]): int = assert false
+  proc p(symbol: FreakString): int=discard
+  
+  discard p(A())
+
+block:  # tie break via sumGeneric
+  type
+    C1 = concept
+      proc p1(x: Self, b: int)
+      proc p2(x: Self, b: float)
+      proc p3(x: Self, b: string)
+    C2 = concept
+      proc b1(x: Self, b: int)
+      proc b2(x: Self, b: float)
+    A = object
+  
+  proc p1(x: A, b: int)=discard
+  proc p2(x: A, b: float)=discard
+  proc p3(x: A, b: string)=discard
+  
+  proc b1(x: A, b: int)=discard
+  proc b2(x: A, b: float)=discard
+  
+  proc p(symbol: C1): int = discard
+  proc p(symbol: C2): int = assert false
+  
+  discard p(A())
+
+block: # not type
+  type
+    C1 = concept
+      proc p(s: Self, a: int)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: not float)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # not type parameterized
+  type
+    C1[T: not int] = concept
+      proc p(s: Self, a: T)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: float)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # typedesc
+  type
+    C1 = concept
+      proc p(s: Self, a: typedesc[SomeInteger])
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: typedesc)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+
+block: # or
+  type
+    C1 = concept
+      proc p(s: Self, a: int | float)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: int | float | string)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # or mixed generic param
+  type
+    C1 = concept
+      proc p(s: Self, a: int | float)
+    C1Impl = object
+    
+  proc p[T: string | float](x: C1Impl, a: int | T) = discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # or parameterized
+  type
+    C1[T: int | float | string] = concept
+      proc p(s: Self, a: T)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: int | float)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # unconstrained param
+  type
+    A = object
+    C1[T] = concept
+      proc p(s: Self, a: T)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: A)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # unconstrained param sanity check
+  type
+    A = object
+    C1[T: auto] = concept
+      proc p(s: Self, a: T)
+    C1Impl = object
+    
+  proc p(x: C1Impl, a: A)= discard
+  proc spring(x: C1)= discard
+
+  spring(C1Impl())
+
+block: # exact nested concept binding
+  #[
+    prove ArrayImpl is serializable (spring)
+      prove Buffer is Buffer (w)
+      prove ArrayImpl is ArrayLike (w)
+        prove ArrayImpl is ArrayImpl (len)
+  ]#
+  type
+    Sizeable = concept
+      proc size(s: Self): int
+    Buffer = concept
+      proc w(s: Self, data: Sizeable)
+    Serializable = concept
+      proc w(b: Buffer, s: Self)
+    ArrayLike = concept
+      proc len(s: Self): int
+    ArrayImpl = object
+
+  proc len(s: ArrayImpl): int = discard
+  proc w(x: Buffer, d: ArrayLike)=discard
+
+  proc spring(data: Serializable)=discard
+  spring(ArrayImpl())
 
 block:
   type
-    A[T] = object
-    ArrayLike[T] = concept
-      proc len(x: Self): int
-      proc `[]`(b: Self, i: int): T
-      proc tell(s: Self, x: A[int])
-  
-  proc tell(x: string, h: A[int])= discard
+    StaticallySized = concept
+      proc staticSize(x: typedesc[Self]): int
+      proc dynamicSize(x: Self): int
+    DynamicallySized = concept
+      proc dynamicSize(x: Self): int
 
-  proc spring[T](w: ArrayLike[T])= echo T
-  
-  spring("hi")
+  proc dynamicSize(a: SomeInteger): int = 5
+  proc read[T: DynamicallySized](a: var T): int = 1
+  proc read[T: SomeInteger](a: var T): int = 2
+
+  var a: uint16
+  assert read(a) == 2
+
+block:
+  type
+    A[X, Y] = object
+      x: X
+      y: Y
+    C1 = concept
+      proc p(z: var Self)
+    C2 = concept
+      proc g(x: var Self, y: int)
+    C3 = C1 and C2
+    C4 = concept
+      proc h(x: Self): C3
+
+  proc p[X, Y](z: var A[int, float]) = discard
+  proc g[X, Y](z: var A[X, Y], y: int) = discard
+  proc h[X, Y](z: var A[X, Y]): A[X, Y] = discard
+
+  proc spring(x: C4) = discard
+  var d = A[int, float]()
+  d.spring()
+
+block:
+  type
+    A[X, Y] = object
+      x: X
+      y: Y
+    B = object
+    C1 = concept
+      proc p(z: var Self, d: A[int, float])
+
+  proc p[X: int; Y: float](x: var B, y: A[X, Y]) = discard
+  proc spring(x: var C1) = discard
+  var d = B()
+  d.spring()

--- a/tests/concepts/tconceptsv2.nim
+++ b/tests/concepts/tconceptsv2.nim
@@ -415,3 +415,20 @@ block:
   proc spring(x: var C1) = discard
   var d = B()
   d.spring()
+
+block:
+  type
+    A = object
+    C1 = concept
+      proc p(s: Self; x: auto)
+    C2[T: int] = concept
+      proc p(s: Self; x: T)
+    Impl = object
+
+  proc p(n: Impl; i: int) = discard
+
+  proc spring(x: C1): int = 1
+  proc spring(x: C2): int = 2
+
+  assert spring(Impl()) == 2
+

--- a/tests/concepts/tconceptsv2.nim
+++ b/tests/concepts/tconceptsv2.nim
@@ -343,12 +343,6 @@ block: # unconstrained param sanity check
   spring(C1Impl())
 
 block: # exact nested concept binding
-  #[
-    prove ArrayImpl is serializable (spring)
-      prove Buffer is Buffer (w)
-      prove ArrayImpl is ArrayLike (w)
-        prove ArrayImpl is ArrayImpl (len)
-  ]#
   type
     Sizeable = concept
       proc size(s: Self): int

--- a/tests/concepts/tconceptsv2.nim
+++ b/tests/concepts/tconceptsv2.nim
@@ -12,6 +12,8 @@ c
 a
 b
 c
+1
+2
 '''
 """
 import conceptsv2_helper
@@ -426,3 +428,30 @@ block:
 
   assert spring(Impl()) == 2
 
+# this code fails inside a block for some reason
+type Indexable[T] = concept
+  proc `[]`(t: Self, i: int): T
+  proc len(t: Self): int
+
+iterator items[T](t: Indexable[T]): T =
+  for i in 0 ..< t.len:
+    yield t[i]
+
+type Enumerable[T] = concept
+  iterator items(t: Self): T
+
+proc echoAll[T](t: Enumerable[T]) =
+  for item in t:
+    echo item
+
+type DummyIndexable[T] = distinct seq[T]
+
+proc `[]`[T](t: DummyIndexable[T], i: int): T =
+  seq[T](t)[i]
+
+proc len[T](t: DummyIndexable[T]): int =
+  seq[T](t).len
+
+
+let dummyIndexable = DummyIndexable(@[1, 2])
+echoAll(dummyIndexable)


### PR DESCRIPTION
Yet another one of these. Multiple changes piled up in this one. I've only minimally cleaned it for now (debug code is still here etc). Just want to start putting this up so I might get feedback. I know this is a lot and you all are busy with bigger things. As per my last PR, this might just contain changes that are not ready.

### concept instantiation uniqueness
It has already been said that concepts like `ArrayLike[int]` is not unique for each matching type of that concept. Likewise the compiler needs to instantiate a new proc for each unique *bound* type not each unique invocation of `ArrayLike`

### generic parameter bindings
Couple of things here. The code in sigmatch has to give it's bindings to the code in concepts, else the information is lost in that step. The code that prepares the generic variables bound in concepts was also changed slightly. Net effect is that it works better.
I did choose to use the `LayedIdTable` instead of the `seq`s in `concepts.nim`. This was mostly to avoid confusing myself. It also avoids some unnecessary movings around. I wouldn't doubt this is slightly less performant, but not much in the grand scheme of things and I would prefer to keep things as easy to understand as possible for as long as possible because this stuff can get confusing.

### various fixes in the matching logic
Certain forms of modifiers like `var` and generic types like `tyGenericInst` and `tyGenericInvocation` have logic adjustments based on my testing and usage

### signature matching method adjustment
This is the weird one, like my last PR. I thought a lot about the feedback from my last attempt and this is what I came up with. Perhaps unfortunately I am preoccupied with a slight grey area. consider the follwing:
```nim
type
  C1 = concept
    proc p[T](s: Self; x: T)
  C2[T] = concept
    proc p(s: Self; x: T)
```
It would be temping to say that these are the same, but I don't think they are. `C2` makes each invocation distinct, and this has important implications in the type system. eg `C2[int]` is not the same type as `C2[string]` and this means that signatures are meant to accept a type that only matches `p` for a single type per unique binding. For `C1` all are the same and the binding `p` accepts multiple types. There are multiple variations of this type classes, `tyAnything` and the like.

The make things more complicated, an implementation might match:
```nim
type
  A = object
  C3 = concept
    proc p(s: Self; x:  A)
```
if the implementation defines:
```nim
proc p(x: Impl; y: object)
```

while a concept that fits `C2` may be satisfied by something like:
```nim
proc p(x: Impl; y: int)
proc spring[T](x: C2[T])
```
it just depends. None of this is really a problem, it just seems to provoke some more logic in `concepts.nim` that makes all of this (appear to?) work. The logic checks for both kinds of matches with a couple of caveats. The fist is that some unbind-able arrangements may be matched during overload resolution. I don't think this is avoidable and I actually think this is a good way to get a failed compilation. So, first note imo is that failing during binding is preferred to forcing the programming to write annoying stub procs and putting insane gymnastics in the compiler. Second thing is: I think this logic is way to accepting for some parts of overload resolutions. Particularly in `checkGeneric` when disambiguation is happening. Things get hard to understand for me here. ~~I made it so the implicit bindings to not count during disambiguation~~. I still need to test this more, but the thought is that it would help curb excessive ambiguity errors.

Again, I'm sorry for this being so many changes. It's probably inconvenient.