### PR TITLE
implements `quirky` for functions

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1322,7 +1322,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         sym.flags.incl sfNeverRaises
       of wQuirky:
         sym.flags.incl sfNeverRaises
-        if sym.kind in {skProc, skMethod, skConverter}:
+        if sym.kind in {skProc, skMethod, skConverter, skFunc, skIterator}:
           sym.options.incl optQuirky
       of wSystemRaisesDefect:
         sym.flags.incl sfSystemRaisesDefect

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1318,8 +1318,12 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         pragmaProposition(c, it)
       of wEnsures:
         pragmaEnsures(c, it)
-      of wEnforceNoRaises, wQuirky:
+      of wEnforceNoRaises:
         sym.flags.incl sfNeverRaises
+      of wQuirky:
+        sym.flags.incl sfNeverRaises
+        if sym.kind in {skProc, skMethod, skConverter}:
+          sym.options.incl optQuirky
       of wSystemRaisesDefect:
         sym.flags.incl sfSystemRaisesDefect
       of wVirtual:

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -190,7 +190,7 @@ proc nimRawDispose(p: pointer, alignment: int) {.compilerRtl.} =
 template `=dispose`*[T](x: owned(ref T)) = nimRawDispose(cast[pointer](x), T.alignOf)
 #proc dispose*(x: pointer) = nimRawDispose(x)
 
-proc nimDestroyAndDispose(p: pointer) {.compilerRtl, raises: [].} =
+proc nimDestroyAndDispose(p: pointer) {.compilerRtl, quirky, raises: [].} =
   let rti = cast[ptr PNimTypeV2](p)
   if rti.destructor != nil:
     cast[DestructorProc](rti.destructor)(p)

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -87,6 +87,9 @@ else:
   template count(x: Cell): untyped =
     x.rc shr rcShift
 
+when not defined(nimHasQuirky):
+  {.pragma: quirky.}
+
 proc nimNewObj(size, alignment: int): pointer {.compilerRtl.} =
   let hdrSize = align(sizeof(RefHeader), alignment)
   let s = size + hdrSize

--- a/tests/arc/tvalgrind.nim
+++ b/tests/arc/tvalgrind.nim
@@ -1,0 +1,16 @@
+discard """
+  cmd: "nim c --mm:orc -d:useMalloc $file"
+  valgrind: "true"
+"""
+
+import std/streams
+
+
+proc foo() =
+  var name = newStringStream("2r2")
+  raise newException(ValueError, "sh")
+
+try:
+  foo()
+except:
+ discard


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/24686

With this PR

```nim
import std/streams


proc foo() =
  var name = newStringStream("2r2")
  raise newException(ValueError, "sh")

try:
  foo()
except:
 discard

echo 123
```
this example no longer leaks