### PR TITLE
fixes #24705; encode `static parameters` into function names for debugging

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -57,11 +57,15 @@ proc mangleField(m: BModule; name: PIdent): string =
 
 proc mangleProc(m: BModule; s: PSym; makeUnique: bool): string =
   result = "_Z"  # Common prefix in Itanium ABI
-  result.add encodeSym(m, s, makeUnique)
+  var params = ""
+  var staticLists = ""
   if s.typ.len > 1: #we dont care about the return param
     for i in 1..<s.typ.len:
       if s.typ[i].isNil: continue
-      result.add encodeType(m, s.typ[i])
+      params.add encodeType(m, s.typ[i], staticLists)
+
+  result.add encodeSym(m, s, makeUnique, staticLists)
+  result.add params
 
   if result in m.g.mangledPrcs:
     result = mangleProc(m, s, true)

--- a/compiler/ccgutils.nim
+++ b/compiler/ccgutils.nim
@@ -11,7 +11,7 @@
 
 import
   ast, types, msgs, wordrecg,
-  platform, trees, options, cgendata, mangleutils
+  platform, trees, options, cgendata, mangleutils, renderer
 
 import std/[hashes, strutils, formatfloat]
 
@@ -120,14 +120,14 @@ proc makeUnique(m: BModule; s: PSym, name: string = ""): string =
   result.add "_u"
   result.add $s.itemId.item
 
-proc encodeSym*(m: BModule; s: PSym; makeUnique: bool = false): string =
+proc encodeSym*(m: BModule; s: PSym; makeUnique: bool = false; extra: string = ""): string =
   #Module::Type
-  var name = s.name.s
+  var name = s.name.s & extra
   if makeUnique:
     name = makeUnique(m, s, name)
   "N" & encodeName(s.skipGenericOwner.name.s) & encodeName(name) & "E"
 
-proc encodeType*(m: BModule; t: PType): string =
+proc encodeType*(m: BModule; t: PType; staticLists: var string): string =
   result = ""
   var kindName = ($t.kind)[2..^1]
   kindName[0] = toLower($kindName[0])[0]
@@ -138,10 +138,10 @@ proc encodeType*(m: BModule; t: PType): string =
     result = encodeName(t[0].sym.name.s)
     result.add "I"
     for i in 1..<t.len - 1:
-      result.add encodeType(m, t[i])
+      result.add encodeType(m, t[i], staticLists)
     result.add "E"
   of tySequence, tyOpenArray, tyArray, tyVarargs, tyTuple, tyProc, tySet, tyTypeDesc,
-    tyPtr, tyRef, tyVar, tyLent, tySink, tyStatic, tyUncheckedArray, tyOr, tyAnd, tyBuiltInTypeClass:
+    tyPtr, tyRef, tyVar, tyLent, tySink, tyUncheckedArray, tyOr, tyAnd, tyBuiltInTypeClass:
     result =
       case t.kind:
       of tySequence: encodeName("seq")
@@ -150,8 +150,13 @@ proc encodeType*(m: BModule; t: PType): string =
     for i in 0..<t.len:
       let s = t[i]
       if s.isNil: continue
-      result.add encodeType(m, s)
+      result.add encodeType(m, s, staticLists)
     result.add "E"
+  of tyStatic:
+    if t.n != nil:
+      staticLists.add "_s" & renderTree(t.n)
+    else:
+      raiseAssert "unreachable"
   of tyRange:
     var val = "range_"
     if t.n[0].typ.kind in {tyFloat..tyFloat128}:
@@ -164,7 +169,7 @@ proc encodeType*(m: BModule; t: PType): string =
   of tyString..tyUInt64, tyPointer, tyBool, tyChar, tyVoid, tyAnything, tyNil, tyEmpty:
     result = encodeName(kindName)
   of tyAlias, tyInferred, tyOwned:
-    result = encodeType(m, t.elementType)
+    result = encodeType(m, t.elementType, staticLists)
   else:
     assert false, "encodeType " & $t.kind
 

--- a/tests/codegen/titaniummangle.nim
+++ b/tests/codegen/titaniummangle.nim
@@ -29,6 +29,8 @@ discard """
   ccodecheck: "'_ZN14titaniummangle8testFuncE9ContainerI3intE'"
   ccodecheck: "'_ZN14titaniummangle8testFuncE10Container2I5int325int32E'"
   ccodecheck: "'_ZN14titaniummangle8testFuncE9ContainerI10Container2I5int325int32EE'"
+  ccodecheck: "'_ZN14titaniummangle7xxx_s10E'"
+  ccodecheck: "'_ZN14titaniummangle7xxx_s20E'"
 """
 
 #When debugging this notice that if one check fails, it can be due to any of the above.
@@ -151,6 +153,9 @@ proc testFunc(a: int, xs: varargs[string]) =
   for x in xs:
     echo x
 
+proc xxx(v: static int) =
+  echo v
+
 proc testFunc() = 
   var a = 2
   var aPtr = a.addr
@@ -188,6 +193,8 @@ proc testFunc() =
   let c2 = Container2[int32, int32](data: 10, data2: 20)
   testFunc(c2)
   testFunc(Container[Container2[int32, int32]](data: c2))
-  
+  xxx(10)
+  xxx(20)
+
 
 testFunc()


### PR DESCRIPTION
fixes #24705

```nim
proc xxx(v: static int) =
  echo v
xxx(10)
xxx(20)
```

They are mangled as `_ZN14titaniummangle7xxx_s10E` and `_ZN14titaniummangle7xxx_s20E` with `--debugger:native`. Static parameters are prefixed with `_s` to distinguish simple cases like `xxx(10, 15)` and `xxx(101, 5)` if `xxx` supports two `static[int]` parameters
