### PR TITLE
undeprecates `var T` destructors

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2158,9 +2158,6 @@ proc bindTypeHook(c: PContext; s: PSym; n: PNode; op: TTypeAttachedOp) =
       elif obj.kind == tyGenericInvocation: obj = obj.genericHead
       else: break
     if obj.kind in {tyObject, tyDistinct, tySequence, tyString}:
-      if op == attachedDestructor and t.firstParamType.kind == tyVar and
-          c.config.selectedGC in {gcArc, gcAtomicArc, gcOrc}:
-        message(c.config, n.info, warnDeprecated, "A custom '=destroy' hook which takes a 'var T' parameter is deprecated; it should take a 'T' parameter")
       obj = canonType(c, obj)
       let ao = getAttachedOp(c.graph, obj, op)
       if ao == s:

--- a/doc/destructors.md
+++ b/doc/destructors.md
@@ -129,7 +129,8 @@ other associated resources. Variables are destroyed via this hook when
 they go out of scope or when the routine they were declared in is about
 to return.
 
-A `=destroy` hook is allowed to have a parameter of a `var T` or `T` type. Taking a `var T` type is deprecated. The prototype of this hook for a type `T` needs to be:
+A `=destroy` hook is allowed to have a parameter of a `var T` or `T` type.
+The prototype of this hook for a type `T` needs to be:
 
   ```nim
   proc `=destroy`(x: T)


### PR DESCRIPTION
Both cases are now valid. Though, it could be problematic to mix two cases together as built-in types have non var T destructors