### PR TITLE
always skip static types for result of `typeof`

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -55,7 +55,7 @@ proc semTypeOf(c: PContext; n: PNode): PNode =
   result.add typExpr
   if typExpr.typ.kind == tyFromExpr:
     typExpr.typ.flags.incl tfNonConstExpr
-  result.typ() = makeTypeDesc(c, typExpr.typ)
+  result.typ() = makeTypeDesc(c, typExpr.typ.skipTypes({tyStatic}))
 
 type
   SemAsgnMode = enum asgnNormal, noOverloadedSubscript, noOverloadedAsgn

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1736,10 +1736,10 @@ proc maybeAliasType(c: PContext; typeExpr, prev: PType): PType =
   else:
     result = nil
 
-proc fixupTypeOf(c: PContext, prev: PType, typExpr: PNode) =
+proc fixupTypeOf(c: PContext, prev: PType, typ: PType) =
   if prev != nil:
     let result = newTypeS(tyAlias, c)
-    result.rawAddSon typExpr.typ
+    result.rawAddSon typ
     result.sym = prev.sym
     if prev.kind != tyGenericBody:
       assignType(prev, result)
@@ -1931,10 +1931,11 @@ proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
   inc c.inTypeofContext
   defer: dec c.inTypeofContext # compiles can raise an exception
-  let t = semExprWithType(c, n, {efInTypeof})
+  let ex = semExprWithType(c, n, {efInTypeof})
   closeScope(c)
+  let t = ex.typ.skipTypes({tyStatic})
   fixupTypeOf(c, prev, t)
-  result = t.typ
+  result = t
   if result.kind == tyFromExpr:
     result.flags.incl tfNonConstExpr
 
@@ -1949,10 +1950,11 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
       m = mode.intVal
   inc c.inTypeofContext
   defer: dec c.inTypeofContext # compiles can raise an exception
-  let t = semExprWithType(c, n[1], if m == 1: {efInTypeof} else: {})
+  let ex = semExprWithType(c, n[1], if m == 1: {efInTypeof} else: {})
   closeScope(c)
+  let t = ex.typ.skipTypes({tyStatic})
   fixupTypeOf(c, prev, t)
-  result = t.typ
+  result = t
   if result.kind == tyFromExpr:
     result.flags.incl tfNonConstExpr
 

--- a/tests/generics/ttypeofstatic.nim
+++ b/tests/generics/ttypeofstatic.nim
@@ -1,0 +1,9 @@
+# issue #24715
+
+type H[c: static[float64]] = object
+  value: typeof(c)
+
+proc u[T: H](_: typedesc[T]) =
+  discard default(T)
+
+u(H[1'f64])


### PR DESCRIPTION
fixes #24715

In generic typechecking, unresolved static param symbols (i.e. `skGenericParam`) have [the static type itself](https://github.com/nim-lang/Nim/blob/1f8da3835f6e395d068c92f86787f0fa77fb6d08/compiler/semexprs.nim#L1483-L1485) as their type when used in an expression. This is not the case when the static param is resolved (the type is wrapped in static when necessary), but semchecking of types and generic typechecking expects the type of the value to be wrapped in `static` (at least `array[N, int]` breaks). So for now, to solve the issue, `typeof` just skips static types.