### PR TITLE
move nim version in issue template to the top

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,22 +11,22 @@ body:
       Reports with a reproducible example or detailed information will likely receive fixes faster.
 
 - type: textarea
+  id: nim-version
+  attributes:
+    label: Nim Version
+    description: |
+      Can be obtained from `nim -v` on the command line along with the OS/architecture.
+      For development versions, including the commit hash may help.
+  validations:
+    required: true
+
+- type: textarea
   id: description
   attributes:
     label: Description
     description: |
       Describe the problem. Code example can be given here.
     placeholder: Bug reports with reproducible code or detailed information will be fixed faster.
-  validations:
-    required: true
-    
-- type: textarea
-  id: nim-version
-  attributes:
-    label: Nim Version
-    description: |
-      Can be obtained from `nim -v` on the command line along with the OS/architecture.
-      For development versions, make sure to include the commit hash.
   validations:
     required: true
 


### PR DESCRIPTION
The point is to move it out of the current place between "Description" and "Current Output" as often these are related to each other and including the nim version in the middle breaks the flow of reading. I also thought of moving it below "Expected Output" but this felt too low for a required field and also has the same problem of overshadowing the remaining sections. Not sure if it being at the top is annoying in some other way though.