### PR TITLE
Add linking options for tinycc backend

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -257,8 +257,8 @@ compiler tcc:
     linkerExe: "tcc",
     linkTmpl: "-o $exefile $options $buildgui $builddll $objfiles",
     includeCmd: " -I",
-    linkDirCmd: "", # XXX: not supported yet
-    linkLibCmd: "", # XXX: not supported yet
+    linkDirCmd: " -L",
+    linkLibCmd: " -l$1",
     debug: " -g ",
     pic: "",
     asmStmtFrmt: "asm($1);$n",


### PR DESCRIPTION
 ### Issue

When using `tcc` as backend to compile a trivial program

```
nim c  --cc:tcc  --skipCfg a.nim
```

, errors reported:

```
tcc: error: undefined symbol 'fabs'
```

### Solution

 `fabs` belongs to libm. With these two options added, one can compile with an additional clib option:

```
nim c  --cc:tcc  --skipCfg --clib:m a.nim
```


