### PR TITLE
fix tuple nodes from VM inserting hidden conv to keep old type

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2951,7 +2951,7 @@ proc semTupleFieldsConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType
     let conversion = indexTypesMatch(c, oldType, typ, result)
     # ignore matching error, the goal is just to keep the original type info
     if conversion != nil:
-      result = conversion
+      result.typ() = oldType
 
 proc semTuplePositionsConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = n                  # we don't modify n, but compute the type:
@@ -2982,7 +2982,7 @@ proc semTuplePositionsConstr(c: PContext, n: PNode, flags: TExprFlags; expectedT
     let conversion = indexTypesMatch(c, oldType, typ, result)
     # ignore matching error, the goal is just to keep the original type info
     if conversion != nil:
-      result = conversion
+      result.typ() = oldType
 
 include semobjconstr
 
@@ -3073,7 +3073,7 @@ proc semExport(c: PContext, n: PNode): PNode =
 proc semTupleConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = semTuplePositionsConstr(c, n, flags, expectedType)
   var tupexp = result
-  while tupexp.kind == nkHiddenSubConv: tupexp = tupexp[1] 
+  while tupexp.kind == nkHiddenSubConv: tupexp = tupexp[1]
   var isTupleType: bool = false
   if tupexp.len > 0: # don't interpret () as type
     internalAssert c.config, tupexp.kind == nkTupleConstr

--- a/tests/tuples/tstatictuple.nim
+++ b/tests/tuples/tstatictuple.nim
@@ -1,0 +1,33 @@
+# issue #24755
+
+type
+  Field = object
+  FieldS = object
+  FieldOps = enum
+    foNeg, foAdd, foSub, foMul, foDiv, foAdj, foToSingle, foToDouble
+  FieldUnop[Op: static FieldOps, T1] = object
+    f1: T1
+  FieldAddSub[S: static tuple, T: tuple] = object
+    field: T
+  SomeField = Field | FieldS | FieldUnop | FieldAddSub
+  SomeField2 = Field | FieldS | FieldUnop | FieldAddSub
+
+template fieldUnop[X:SomeField](o: static FieldOps, x: X): auto =
+  FieldUnop[o,X](f1: x)
+template fieldAddSub[X,Y](sx: static int, x: X, sy: static int, y: Y): auto =
+  FieldAddSub[(a:sx,b:sy),tuple[a:X,b:Y]](field:(a:x,b:y))
+
+template `:=`*(r: var FieldS, x: SomeField) =
+  discard
+template toSingle(x: SomeField): auto =
+  fieldUnop(foToSingle, x)
+template toDouble(x: SomeField): auto =
+  fieldUnop(foToDouble, x)
+template `+`(x: SomeField, y: SomeField2): auto =
+  fieldAddSub(1, x, 1, y)
+
+var
+  fd: Field
+  fs,fs2: FieldS
+
+fs2 := toSingle(fs.toDouble + fd)


### PR DESCRIPTION
fixes #24755, refs #24710

Instead of using the node from `indexTypesMatch` which inserts a hidden conv node, just change the type of the node back to the old type directly