### PR TITLE
fixes #24754; {.gcsafe.} block breaks move analysis

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1198,7 +1198,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
         c.finishCopy(result, dest, flags, isFromSink = false)
     of nkHiddenSubConv, nkHiddenStdConv, nkConv, nkObjDownConv, nkObjUpConv, nkCast:
       result = c.genSink(s, dest, p(ri, c, s, sinkArg), flags)
-    of nkStmtListExpr, nkBlockExpr, nkIfExpr, nkCaseStmt, nkTryStmt:
+    of nkStmtListExpr, nkBlockExpr, nkIfExpr, nkCaseStmt, nkTryStmt, nkPragmaBlock:
       template process(child, s): untyped = moveOrCopy(dest, child, c, s, flags)
       # We know the result will be a stmt so we use that fact to optimize
       handleNestedTempl(ri, process, willProduceStmt = true)

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -898,3 +898,17 @@ proc bar =
   mutate(("1.2", 0, 0))
 
 bar()
+
+block: # bug #24754
+  type NoCopy = object
+    id: int
+
+  proc `=copy`(a: var NoCopy, b: NoCopy) {.error.}
+
+
+  proc foo(): NoCopy =
+    {.gcsafe.}:
+      let s = 12
+      NoCopy(id: s)
+
+  doAssert foo().id == 12


### PR DESCRIPTION
fixes #24754