### PR TITLE
Fix scanTuple undeclared identifier 'scanf'

### DIFF
--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -512,7 +512,7 @@ macro scanTuple*(input: untyped; pattern: static[string]; matcherTypes: varargs[
           inc userMatches
       else: discard
     inc p
-  result.add nnkTupleConstr.newTree(newCall(ident("scanf"), input, newStrLitNode(pattern)))
+  result.add nnkTupleConstr.newTree(newCall(bindSym("scanf"), input, newStrLitNode(pattern)))
   for arg in arguments:
     result[^1][0].add arg
     result[^1].add arg

--- a/tests/stdlib/mstrscans_undecl_scanf.nim
+++ b/tests/stdlib/mstrscans_undecl_scanf.nim
@@ -1,0 +1,4 @@
+import std/strscans
+
+proc scan*[T](s: string): (bool, string) =
+  s.scanTuple("$+")

--- a/tests/stdlib/tstrscans_undecl_scanf.nim
+++ b/tests/stdlib/tstrscans_undecl_scanf.nim
@@ -1,0 +1,3 @@
+import std/assertions
+import ./mstrscans_undecl_scanf
+doAssert scan[int]("foo") == (true, "foo")


### PR DESCRIPTION
Without this fix, trying to use `scanTuple` in a generic proc imported from a different module fails to compile (`undeclared identifier: 'scanf'`):

```nim
# module.nim
import std/strscans

proc scan*[T](s: string): (bool, string) =
  s.scanTuple("$+")
```

```nim
# main.nim
import ./module
 
echo scan[int]("foo")
```

Workaround is to `export scanf` in `module.nim` or `import std/strscans` in `main.nim`.