### PR TITLE
fixes generic types `sink T` cannot be inferred for passed arguments

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1234,9 +1234,10 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     else:
       var candidate = f
 
-      case f.kind
+      let fType = f.skipTypes({tySink})
+      case fType.kind
       of tyGenericParam:
-        var prev = lookup(c.bindings, f)
+        var prev = lookup(c.bindings, fType)
         if prev != nil: candidate = prev
       of tyFromExpr:
         let computedType = tryResolvingStaticExpr(c, f.n).typ

--- a/tests/concepts/tconcept_old.nim
+++ b/tests/concepts/tconcept_old.nim
@@ -1,0 +1,18 @@
+type
+  Map[K, V] = concept m, var mvar
+    m[K] is V
+    m[K] = V
+
+  Table[K, V] = object
+
+proc `[]=`[K, V](m: Table[K, V], x: sink K, y: sink V) =
+  let s = x
+
+proc `[]`[K, V](m: Table[K, V], x: sink K): V =
+  let s = x
+
+proc bat[K, V](x: Map[K, V]): V =
+  let m = x
+
+var s = Table[int, string]()
+discard bat(s)


### PR DESCRIPTION
Otherwise, `sink T` is kept as it is. This PR treats sink types as its base types for the arguments. So the concept would match both cases

Required by https://github.com/nim-lang/Nim/pull/24724