### PR TITLE
bring back index folding errors

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -348,6 +348,7 @@ type
     unitSep*: string
     evalTemplateCounter*: int
     evalMacroCounter*: int
+    disableFoldErrorCounter*: int
     exitcode*: int8
     cmd*: Command  # raw command parsed as enum
     cmdInput*: string  # input command

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -471,20 +471,23 @@ proc foldArrayAccess(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNo
       if result.kind == nkExprColonExpr: result = result[1]
     else:
       result = nil
-      #localError(g.config, n.info, formatErrorIndexBound(idx, x.len-1) & $n)
+      if g.config.disableFoldErrorCounter == 0:
+        localError(g.config, n.info, formatErrorIndexBound(idx, x.len-1) & ": " & $n)
   of nkBracket:
     idx -= toInt64(firstOrd(g.config, x.typ))
     if idx >= 0 and idx < x.len: result = x[int(idx)]
     else:
       result = nil
-      #localError(g.config, n.info, formatErrorIndexBound(idx, x.len-1) & $n)
+      if g.config.disableFoldErrorCounter == 0:
+        localError(g.config, n.info, formatErrorIndexBound(idx, x.len-1) & ": " & $n)
   of nkStrLit..nkTripleStrLit:
     result = newNodeIT(nkCharLit, x.info, n.typ)
     if idx >= 0 and idx < x.strVal.len:
       result.intVal = ord(x.strVal[int(idx)])
     else:
       result = nil
-      #localError(g.config, n.info, formatErrorIndexBound(idx, x.strVal.len-1) & $n)
+      if g.config.disableFoldErrorCounter == 0:
+        localError(g.config, n.info, formatErrorIndexBound(idx, x.strVal.len-1) & ": " & $n)
   else: result = nil
 
 proc foldFieldAccess(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -1181,7 +1181,9 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
                           n.typ != nil and
                           n.typ.kind == tyPointer
   if not exprIsPointerCast and not noConstFold:
+    inc c.graph.config.disableFoldErrorCounter, ord(c.inlining > 0)
     var cnst = getConstExpr(c.module, result, c.idgen, c.graph)
+    dec c.graph.config.disableFoldErrorCounter, ord(c.inlining > 0)
     # we inline constants if they are not complex constants:
     if cnst != nil and not dontInlineConstant(n, cnst):
       result = cnst # do not miss an optimization

--- a/tests/errmsgs/tconstbadindex.nim
+++ b/tests/errmsgs/tconstbadindex.nim
@@ -1,0 +1,3 @@
+if false:
+  discard "abc"[4] #[tt.Error
+               ^ index 4 not in 0 ..2: "abc"[4]]#


### PR DESCRIPTION
follows up #24689

Closing after opening because this doesn't seem to catch any useful cases anyway and is counterproductive when there are guards as described in #24689, array indexes are already caught by the conversion to the index type