### PR TITLE
fixes #24772: system.NaN was negative when C

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -485,16 +485,22 @@ typedef char* NCSTRING;
 
 #define paramCount() cmdCount
 
-#ifndef NAN
-#  if defined(__GNUC__) || (defined(__clang__) && __has_builtin(__builtin_nanf))
+#ifndef NAN  /* use __builtin_nanf which is faster, if available */
+#  if defined(__GNUC__)
 #    define NAN (__builtin_nanf(""))
-#  else  // modified from math.h included in the Windows SDK version 10.0.26100.0
-#    ifndef _HUGE_ENUF
-#      define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
+#  elif defined(__clang__) /* XXX: writing __has_builtin this line cause MSVC complains. */
+#    if __has_builtin (__builtin_nanf)
+#      define NAN (__builtin_nanf(""))
 #    endif
-#    define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
-#    define NAN (-(float)(NAN_INFINITY * 0.0F))
 #  endif
+#endif
+
+#ifndef NAN  /* modified from math.h included in the Windows SDK version 10.0.26100.0 */
+#  ifndef _HUGE_ENUF
+#    define _HUGE_ENUF  1e+300  /* _HUGE_ENUF*_HUGE_ENUF must overflow */
+#  endif
+#  define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
+#  define NAN (-(float)(NAN_INFINITY * 0.0F))
 #endif
 
 #ifndef INF

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -485,13 +485,16 @@ typedef char* NCSTRING;
 
 #define paramCount() cmdCount
 
-// NAN definition copied from math.h included in the Windows SDK version 10.0.14393.0
 #ifndef NAN
-#  ifndef _HUGE_ENUF
-#    define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
+#  if defined(__GNUC__) || (defined(__clang__) && __has_builtin(__builtin_nanf))
+#    define NAN (__builtin_nanf(""))
+#  else  // modified from math.h included in the Windows SDK version 10.0.26100.0
+#    ifndef _HUGE_ENUF
+#      define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
+#    endif
+#    define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
+#    define NAN (-(float)(NAN_INFINITY * 0.0F))
 #  endif
-#  define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
-#  define NAN ((float)(NAN_INFINITY * 0.0F))
 #endif
 
 #ifndef INF


### PR DESCRIPTION
fixes #24772

The old implementation was said to copied  from Windows SDK,

but you can find the newer SDK's definition is updated and the sign is reversed compared to the old.


Also, `__builtin_nanf("")` is used if available,
which is more efficient than previous (In x86_64 gcc, latter produces 32B code but former just 8B).