### PR TITLE
fixes #24770; Thread local not registed as GC root when =destroy exists

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -18,7 +18,7 @@ proc registerTraverseProc(p: BProc, v: PSym) =
   var traverseProc = ""
   if p.config.selectedGC in {gcMarkAndSweep, gcHooks, gcRefc} and
       optOwnedRefs notin p.config.globalOptions and
-      containsGarbageCollectedRef(v.loc.t):
+      containsManagedMemory(v.loc.t):
     # we register a specialized marked proc here; this has the advantage
     # that it works out of the box for thread local storage then :-)
     traverseProc = genTraverseProcForGlobal(p.module, v, v.info)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -364,15 +364,6 @@ proc containsGarbageCollectedRef*(typ: PType): bool =
   # things that are garbage-collected)
   result = searchTypeFor(typ, isGCRef)
 
-proc isGCRefRefc(t: PType): bool =
-  result = t.kind in GcTypeKinds or
-    (t.kind == tyProc and t.callConv == ccClosure)
-
-proc containsGarbageCollectedRefRefc*(typ: PType): bool =
-  # returns true if typ contains a reference, sequence or string (all the
-  # things that are garbage-collected)
-  result = searchTypeFor(typ, isGCRefRefc)
-
 proc isManagedMemory(t: PType): bool =
   result = t.kind in GcTypeKinds or
     (t.kind == tyProc and t.callConv == ccClosure)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -291,7 +291,7 @@ proc searchTypeForAux(t: PType, predicate: TTypePredicate,
     if not result: result = searchTypeNodeForAux(t.n, predicate, marker)
   of tyGenericInst, tyDistinct, tyAlias, tySink:
     result = searchTypeForAux(skipModifier(t), predicate, marker)
-  of tyArray, tySet, tyTuple, tySequence:
+  of tyArray, tySet, tyTuple:
     for a in t.kids:
       result = searchTypeForAux(a, predicate, marker)
       if result: return

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -291,7 +291,7 @@ proc searchTypeForAux(t: PType, predicate: TTypePredicate,
     if not result: result = searchTypeNodeForAux(t.n, predicate, marker)
   of tyGenericInst, tyDistinct, tyAlias, tySink:
     result = searchTypeForAux(skipModifier(t), predicate, marker)
-  of tyArray, tySet, tyTuple:
+  of tyArray, tySet, tyTuple, tySequence:
     for a in t.kids:
       result = searchTypeForAux(a, predicate, marker)
       if result: return
@@ -363,6 +363,15 @@ proc containsGarbageCollectedRef*(typ: PType): bool =
   # returns true if typ contains a reference, sequence or string (all the
   # things that are garbage-collected)
   result = searchTypeFor(typ, isGCRef)
+
+proc isGCRefRefc(t: PType): bool =
+  result = t.kind in GcTypeKinds or
+    (t.kind == tyProc and t.callConv == ccClosure)
+
+proc containsGarbageCollectedRefRefc*(typ: PType): bool =
+  # returns true if typ contains a reference, sequence or string (all the
+  # things that are garbage-collected)
+  result = searchTypeFor(typ, isGCRefRefc)
 
 proc isManagedMemory(t: PType): bool =
   result = t.kind in GcTypeKinds or


### PR DESCRIPTION
fixes #24770

e.g. `seq[(ObjectWithDestructors, string)]`/ For refc, a seq with elements that have destructors will have `hasAsgn` flags. The flag is the criteria whether a seq is thought as `containsGarbageCollectedRef`. i.e. whether to `registerTraverseProc` for the type. 
The culprit seems to be that `searchTypeForAux` doesn't consider the element type of sequence, even it contains a string that should belong to `GarbageCollectedRef`.

With this PR:

It now generates

```
nimRegisterThreadLocalMarker(TM__mSF73dT1lSI7DG58StKHLQ_5);
```

in refc