### PR TITLE
repl: alter #24784

### DIFF
--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -89,7 +89,9 @@ const
   LineContinuationTokens = [
     "let", "var", "const", "type",  # section
     "object", "tuple",
-    "and", "or", "xor",  
+    # from ./layouter.oprSet
+    "div", "mod", "shl", "shr", "in", "not_in", "is",
+    "is_not", "not", "of", "as", "from", "..", "and", "or", "xor", 
   ]
 
 proc endsWith(s, subs: string, endIdx: var int): bool =

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -109,7 +109,10 @@ proc llReadFromStdin(s: PLLStream, buf: pointer, bufLen: int): int =
   s.rd = 0
   var line = newStringOfCap(120)
   var triples = 0
-  while readLineFromStdin(if s.s.len == 0: ">>> " else: "... ", line):
+  while true:
+    if not readLineFromStdin(if s.s.len == 0: ">>> " else: "... ", line):
+      # now readLineFromStdin meets EOF (ctrl-D/Z) or ctrl-C
+      quit()
     s.s.add(line)
     s.s.add("\n")
     inc triples, countTriples(line)

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -11,7 +11,7 @@
 
 import
   pathutils
-
+import std/strutils
 when defined(nimPreviewSlimSystem):
   import std/syncio
 
@@ -86,6 +86,36 @@ const
   LineContinuationOprs = {'+', '-', '*', '/', '\\', '<', '>', '!', '?', '^',
                           '|', '%', '&', '$', '@', '~', ','}
   AdditionalLineContinuationOprs = {'#', ':', '='}
+  LineContinuationTokens = [
+    "let", "var", "const", "type",  # section
+    "object", "tuple",
+    "and", "or", "xor",  
+  ]
+
+proc endsWith(s, subs: string, endIdx: var int): bool =
+  endIdx.dec subs.len
+  result = s.continuesWith(subs, endIdx+1)
+
+proc containsObjectOf(x: string): bool =
+  const sep = ' '
+  var idx = x.rfind(sep)
+  if idx == -1: return
+
+  template eatWord(word) =  
+    while x[idx] == sep: idx.dec
+    result = x.endsWith(word, idx)
+    if not result: return
+
+  eatWord "of"
+  eatWord "object"
+  result = true
+
+proc endsWithLineContinuationToken(x: string): bool =
+  result = false
+  for tok in LineContinuationTokens:
+    if x.endsWith(tok):
+      return true
+  result = x.containsObjectOf
 
 proc endsWithOpr*(x: string): bool =
   result = x.endsWith(LineContinuationOprs)
@@ -93,7 +123,9 @@ proc endsWithOpr*(x: string): bool =
 proc continueLine(line: string, inTripleString: bool): bool {.inline.} =
   result = inTripleString or line.len > 0 and (
         line[0] == ' ' or
-        line.endsWith(LineContinuationOprs+AdditionalLineContinuationOprs))
+        line.endsWith(LineContinuationOprs+AdditionalLineContinuationOprs) or
+        line.endsWithLineContinuationToken()
+      )
 
 proc countTriples(s: string): int =
   result = 0

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -10,8 +10,8 @@
 ## Low-level streams for high performance.
 
 import
-  pathutils
-import std/strutils
+  pathutils, replutils
+export endsWith, endsWithOpr
 when defined(nimPreviewSlimSystem):
   import std/syncio
 
@@ -73,79 +73,6 @@ when not declared(readLineFromStdin):
     if not result:
       stdout.write("\n")
       quit(0)
-
-proc endsWith*(x: string, s: set[char]): bool =
-  var i = x.len-1
-  while i >= 0 and x[i] == ' ': dec(i)
-  if i >= 0 and x[i] in s:
-    result = true
-  else:
-    result = false
-
-const
-  LineContinuationOprs = {'+', '-', '*', '/', '\\', '<', '>', '!', '?', '^',
-                          '|', '%', '&', '$', '@', '~', ','}
-  AdditionalLineContinuationOprs = {'#', ':', '='}
-  LineContinuationTokens = [
-    "let", "var", "const", "type",  # section
-    "object", "tuple",
-    # from ./layouter.oprSet
-    "div", "mod", "shl", "shr", "in", "notin", "is",
-    "isnot", "not", "of", "as", "from", "..", "and", "or", "xor", 
-  ]  # must be all `nimIdentNormalized`-ed
-
-proc eqIdent(a, bNormalized: string): bool =
-  a.nimIdentNormalize == bNormalized
-
-proc endsWithIdent(s, subs: string): bool =
-  let le = subs.len
-  if le > s.len: return false
-  s[^le .. ^1].eqIdent subs
-
-proc continuesWithIdent(s, subs: string, start: int): bool =
-  s.substr(start, start+subs.high).eqIdent subs
-
-proc endsWithIdent(s, subs: string, endIdx: var int): bool =
-  endIdx.dec subs.len
-  result = s.continuesWithIdent(subs, endIdx+1)
-
-proc containsObjectOf(x: string): bool =
-  const sep = ' '
-  var idx = x.rfind(sep)
-  if idx == -1: return
-  template eatWord(word) =  
-    while x[idx] == sep: idx.dec
-    result = x.endsWithIdent(word, idx)
-    if not result: return
-  eatWord "of"
-  eatWord "object"
-  result = true
-
-proc endsWithLineContinuationToken(x: string): bool =
-  result = false
-  for tok in LineContinuationTokens:
-    if x.endsWithIdent(tok):
-      return true
-  result = x.containsObjectOf
-
-proc endsWithOpr*(x: string): bool =
-  result = x.endsWith(LineContinuationOprs)
-
-proc continueLine(line: string, inTripleString: bool): bool {.inline.} =
-  result = inTripleString or line.len > 0 and (
-        line[0] == ' ' or
-        line.endsWith(LineContinuationOprs+AdditionalLineContinuationOprs) or
-        line.endsWithLineContinuationToken()
-      )
-
-proc countTriples(s: string): int =
-  result = 0
-  var i = 0
-  while i+2 < s.len:
-    if s[i] == '"' and s[i+1] == '"' and s[i+2] == '"':
-      inc result
-      inc i, 2
-    inc i
 
 proc llReadFromStdin(s: PLLStream, buf: pointer, bufLen: int): int =
   s.s = ""

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -90,24 +90,33 @@ const
     "let", "var", "const", "type",  # section
     "object", "tuple",
     # from ./layouter.oprSet
-    "div", "mod", "shl", "shr", "in", "not_in", "is",
-    "is_not", "not", "of", "as", "from", "..", "and", "or", "xor", 
-  ]
+    "div", "mod", "shl", "shr", "in", "notin", "is",
+    "isnot", "not", "of", "as", "from", "..", "and", "or", "xor", 
+  ]  # must be all `nimIdentNormalized`-ed
 
-proc endsWith(s, subs: string, endIdx: var int): bool =
+proc eqIdent(a, bNormalized: string): bool =
+  a.nimIdentNormalize == bNormalized
+
+proc endsWithIdent(s, subs: string): bool =
+  let le = subs.len
+  if le > s.len: return false
+  s[^le .. ^1].eqIdent subs
+
+proc continuesWithIdent(s, subs: string, start: int): bool =
+  s.substr(start, start+subs.high).eqIdent subs
+
+proc endsWithIdent(s, subs: string, endIdx: var int): bool =
   endIdx.dec subs.len
-  result = s.continuesWith(subs, endIdx+1)
+  result = s.continuesWithIdent(subs, endIdx+1)
 
 proc containsObjectOf(x: string): bool =
   const sep = ' '
   var idx = x.rfind(sep)
   if idx == -1: return
-
   template eatWord(word) =  
     while x[idx] == sep: idx.dec
-    result = x.endsWith(word, idx)
+    result = x.endsWithIdent(word, idx)
     if not result: return
-
   eatWord "of"
   eatWord "object"
   result = true
@@ -115,7 +124,7 @@ proc containsObjectOf(x: string): bool =
 proc endsWithLineContinuationToken(x: string): bool =
   result = false
   for tok in LineContinuationTokens:
-    if x.endsWith(tok):
+    if x.endsWithIdent(tok):
       return true
   result = x.containsObjectOf
 

--- a/compiler/replutils.nim
+++ b/compiler/replutils.nim
@@ -1,0 +1,76 @@
+
+import std/strutils
+
+const
+  LineContinuationOprs = {'+', '-', '*', '/', '\\', '<', '>', '!', '?', '^',
+                          '|', '%', '&', '$', '@', '~', ','}
+  AdditionalLineContinuationOprs = {'#', ':', '='}
+  LineContinuationTokens = [
+    "let", "var", "const", "type",  # section
+    "object", "tuple",
+    # from ./layouter.oprSet
+    "div", "mod", "shl", "shr", "in", "notin", "is",
+    "isnot", "not", "of", "as", "from", "..", "and", "or", "xor", 
+  ]  # must be all `nimIdentNormalized`-ed
+
+
+proc endsWith*(x: string, s: set[char]): bool =
+  var i = x.len-1
+  while i >= 0 and x[i] == ' ': dec(i)
+  if i >= 0 and x[i] in s:
+    result = true
+  else:
+    result = false
+
+proc eqIdent(a, bNormalized: string): bool =
+  a.nimIdentNormalize == bNormalized
+
+proc endsWithIdent(s, subs: string): bool =
+  let le = subs.len
+  if le > s.len: return false
+  s[^le .. ^1].eqIdent subs
+
+proc continuesWithIdent(s, subs: string, start: int): bool =
+  s.substr(start, start+subs.high).eqIdent subs
+
+proc endsWithIdent(s, subs: string, endIdx: var int): bool =
+  endIdx.dec subs.len
+  result = s.continuesWithIdent(subs, endIdx+1)
+
+proc containsObjectOf(x: string): bool =
+  const sep = ' '
+  var idx = x.rfind(sep)
+  if idx == -1: return
+  template eatWord(word) =  
+    while x[idx] == sep: idx.dec
+    result = x.endsWithIdent(word, idx)
+    if not result: return
+  eatWord "of"
+  eatWord "object"
+  result = true
+
+proc endsWithLineContinuationToken(x: string): bool =
+  result = false
+  for tok in LineContinuationTokens:
+    if x.endsWithIdent(tok):
+      return true
+  result = x.containsObjectOf
+
+proc endsWithOpr*(x: string): bool =
+  result = x.endsWith(LineContinuationOprs)
+
+proc continueLine*(line: string, inTripleString: bool): bool {.inline.} =
+  result = inTripleString or line.len > 0 and (
+        line[0] == ' ' or
+        line.endsWith(LineContinuationOprs+AdditionalLineContinuationOprs) or
+        line.endsWithLineContinuationToken()
+      )
+
+proc countTriples*(s: string): int =
+  result = 0
+  var i = 0
+  while i+2 < s.len:
+    if s[i] == '"' and s[i+1] == '"' and s[i+2] == '"':
+      inc result
+      inc i, 2
+    inc i

--- a/compiler/replutils.nim
+++ b/compiler/replutils.nim
@@ -1,10 +1,8 @@
 
 import std/strutils
+from lexer import OpChars
 
 const
-  LineContinuationOprs = {'+', '-', '*', '/', '\\', '<', '>', '!', '?', '^',
-                          '|', '%', '&', '$', '@', '~', ','}
-  AdditionalLineContinuationOprs = {'#', ':', '='}
   LineContinuationTokens = [
     "let", "var", "const", "type",  # section
     "object", "tuple",
@@ -57,12 +55,12 @@ proc endsWithLineContinuationToken(x: string): bool =
   result = x.containsObjectOf
 
 proc endsWithOpr*(x: string): bool =
-  result = x.endsWith(LineContinuationOprs)
+  result = x.endsWith(OpChars)
 
 proc continueLine*(line: string, inTripleString: bool): bool {.inline.} =
   result = inTripleString or line.len > 0 and (
         line[0] == ' ' or
-        line.endsWith(LineContinuationOprs+AdditionalLineContinuationOprs) or
+        line.endsWithOpr() or
         line.endsWithLineContinuationToken()
       )
 


### PR DESCRIPTION
This branch splits from
branch [*lit-impr-repl*](https://github.com/litlighilit/Nim/tree/lit-impr-repl) in
commit [**fixup(repl): perform nimIdentNormalize for eqIdent**](https://github.com/litlighilit/Nim/commit/f1311010ca7a5fe5bf402a6ea8f19420782f52e5),

in order to introduce fewer refactor,

inspired by https://github.com/nim-lang/Nim/pull/24784#discussion_r2003558335

And added:

- **refact(repl): split replutils from llstream**
- **impr(repl): no dup of lexer.OpChar**

