### PR TITLE
disable "dest register is set" for vm statements

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2315,7 +2315,9 @@ proc genStmt*(c: PCtx; n: PNode): int =
   c.gen(n, d)
   c.gABC(n, opcEof)
   if d >= 0:
-    globalError(c.config, n.info, "VM problem: dest register is set")
+    # for discardable calls etc, otherwise not valid
+    freeTemp(c, d)
+    #globalError(c.config, n.info, "VM problem: dest register is set")
 
 proc genExpr*(c: PCtx; n: PNode, requiresValue = true): int =
   c.removeLastEof

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2313,11 +2313,11 @@ proc genStmt*(c: PCtx; n: PNode): int =
   result = c.code.len
   var d: TDest = -1
   c.gen(n, d)
-  c.gABC(n, opcEof)
   if d >= 0:
     # for discardable calls etc, otherwise not valid
     freeTemp(c, d)
     #globalError(c.config, n.info, "VM problem: dest register is set")
+  c.gABC(n, opcEof)
 
 proc genExpr*(c: PCtx; n: PNode, requiresValue = true): int =
   c.removeLastEof

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -136,3 +136,10 @@ block:  # cpDir, cpFile, dirExists, fileExists, mkDir, mvDir, mvFile, rmDir, rmF
 block:
   # check parseopt can get command line:
   discard initOptParser()
+
+# issue #24780:
+
+proc discardableCall(cmd: string): int {.discardable.} =
+  result = 123
+
+discardableCall "echo hi"


### PR DESCRIPTION
closes #24780

This proc `genStmt` is only called to run the VM in `vm.evalStmt`, otherwise it's not used in vmgen. Now it acts the same as `proc gen(PCtx, PNode)`, used by `discard` statements, which just calls `freeTemp` on the dest if it was set rather than erroring.