### PR TITLE
compile_commands.json support

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -1154,11 +1154,17 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     handleStdinInput(conf)
   of "nilseqs", "nilchecks", "symbol", "taintmode", "cs", "deadcodeelim": warningOptionNoop(switch)
   of "nimmainprefix": conf.nimMainPrefix = arg
-  of "compilecmdjson":
+  of "compilecmdsjson":
+    # TODO
+    # processOnOffSwitch(conf, {optCursorInference}, arg, pass, info)
     conf.compileCommandsJson = true
   of "projectcompilecmdjson":
+    # TODO
+    # processOnOffSwitch(conf, {optCursorInference}, arg, pass, info)
     conf.projectCompileCommandJsons = true
-  of "copycommandjson":
+  of "rootcompilecmdsjson":
+    # TODO
+    # processOnOffSwitch(conf, {optCursorInference}, arg, pass, info)
     conf.copyCompileCommandsJsonToCurDir = true
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -1154,6 +1154,12 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     handleStdinInput(conf)
   of "nilseqs", "nilchecks", "symbol", "taintmode", "cs", "deadcodeelim": warningOptionNoop(switch)
   of "nimmainprefix": conf.nimMainPrefix = arg
+  of "compilecmdjson":
+    conf.compileCommandsJson = true
+  of "projectcompilecmdjson":
+    conf.projectCompileCommandJsons = true
+  of "copycommandjson":
+    conf.copyCompileCommandsJsonToCurDir = true
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1004,9 +1004,6 @@ proc callCCompiler*(conf: ConfigRef) =
 template hashNimExe(): string = $secureHashFile(os.getAppFilename())
 
 iterator compileCommandsJsonFiles*(conf: ConfigRef): AbsoluteFile =
-  # `outFile` is better than `projectName`, as it allows having different json
-  # files for a given source file compiled with different options; it also
-  # works out of the box with `hashMainCompilationParams`.
   var rf = if conf.projectCompileCommandJsons:
     ("compile_commands_" & conf.outFile.changeFileExt("json").string).RelativeFile
   else:
@@ -1015,8 +1012,7 @@ iterator compileCommandsJsonFiles*(conf: ConfigRef): AbsoluteFile =
   yield getNimcacheDir(conf) / rf
 
   if conf.copyCompileCommandsJsonToCurDir:
-    # TODO
-    yield getNimcacheDir(conf) / rf
+    yield conf.projectPath / rf
   
 
 proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
@@ -1089,8 +1085,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef; deps: StringTableRef) =
 
   conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
 
-  # NOTE: compile_commands.json uses indent of 2 by convention
   if conf.compileCommandsJson:
+    # NOTE: compile_commands.json uses indent of 2 by convention
     let compileCmds = conf.jsonCompileCommands.pretty(2)
     for p in conf.compileCommandsJsonFiles:
       p.writeFile(compileCmds)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1003,6 +1003,22 @@ proc callCCompiler*(conf: ConfigRef) =
 
 template hashNimExe(): string = $secureHashFile(os.getAppFilename())
 
+iterator compileCommandsJsonFiles*(conf: ConfigRef): AbsoluteFile =
+  # `outFile` is better than `projectName`, as it allows having different json
+  # files for a given source file compiled with different options; it also
+  # works out of the box with `hashMainCompilationParams`.
+  var rf = if conf.projectCompileCommandJsons:
+    ("compile_commands_" & conf.outFile.changeFileExt("json").string).RelativeFile
+  else:
+    "compile_commands".RelativeFile
+
+  yield getNimcacheDir(conf) / rf
+
+  if conf.copyCompileCommandsJsonToCurDir:
+    # TODO
+    yield getNimcacheDir(conf) / rf
+  
+
 proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   # `outFile` is better than `projectName`, as it allows having different json
   # files for a given source file compiled with different options; it also
@@ -1026,6 +1042,16 @@ type BuildCache = object
   cmdline: string
   depfiles: seq[(string, string)]
   nimexe: string
+
+proc jsonCompileCommands*(conf: ConfigRef): JsonNode =
+  # ref: https://clang.llvm.org/docs/JSONCompilationDatabase.html
+  result = %*[]
+  for it in conf.toCompile:
+    result.add %*{
+      "file": it.cname.string,
+      "command": getCompileCFileCmd(conf, it),
+      "directory": conf.outDir.string,
+    }
 
 proc writeJsonBuildInstructions*(conf: ConfigRef; deps: StringTableRef) =
   var linkFiles = collect(for it in conf.externalToLink:
@@ -1060,7 +1086,14 @@ proc writeJsonBuildInstructions*(conf: ConfigRef; deps: StringTableRef) =
     if fileExists(bcache.outputFile):
       bcache.outputLastModificationTime = $getLastModificationTime(bcache.outputFile)
   conf.jsonBuildFile = conf.jsonBuildInstructionsFile
+
   conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
+
+  # NOTE: compile_commands.json uses indent of 2 by convention
+  if conf.compileCommandsJson:
+    let compileCmds = conf.jsonCompileCommands.pretty(2)
+    for p in conf.compileCommandsJsonFiles:
+      p.writeFile(compileCmds)
 
 proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
   result = false

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -448,6 +448,10 @@ type
     currentConfigDir*: string # used for passPP only; absolute dir
     clientProcessId*: int
 
+    compileCommandsJson*: bool
+    projectCompileCommandJsons*: bool
+    copyCompileCommandsJsonToCurDir*: bool
+
 
 
 proc assignIfDefault*[T](result: var T, val: T, def = default(T)) =

--- a/tests/compile_commands_json/foo.cpp
+++ b/tests/compile_commands_json/foo.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+#ifdef ENABLE_FOO
+extern "C" void foo() {
+    std::cout << "hello world\n";
+}
+#endif

--- a/tests/compile_commands_json/foo.nim
+++ b/tests/compile_commands_json/foo.nim
@@ -1,0 +1,6 @@
+{.compile("foo.cpp", "-DENABLE_FOO").}
+
+proc foo() {.importc.}
+
+when isMainModule:
+  foo()

--- a/tests/compile_commands_json/foo.nims
+++ b/tests/compile_commands_json/foo.nims
@@ -1,0 +1,1 @@
+--nimcache:"./nimcache"

--- a/tests/compile_commands_json/foo.nims
+++ b/tests/compile_commands_json/foo.nims
@@ -1,1 +1,2 @@
 --nimcache:"./nimcache"
+--compileCmdsJson:on


### PR DESCRIPTION
# Motivation

A [`compile_command.json`](https://clang.llvm.org/docs/JSONCompilationDatabase.html) enables your LSP to use appropriate compile flags for the C/C++/Objective-C files you're compiling in your project.

In a mixed Nim and C/C++/Objective-C project you have two options to integrate your C/C++/ObjC sources into your project:
1. Compile the set of C/C++/Objective-C sources into an object or library file (static, dynamic, or framework) and link it to your nim executable or library
2. Use `{.compile.}` pragmas in your nim files directly, i.e. use Nim as a frontend to your C compiler (clang/GCC/etc.)

If you opt to choose (2): then you miss out on the generation of `compile_commands.json` - unless you do it yourself in NimScript. If you choose option (1) then you're probably going to use CMake (or an alternative) to generate a `compile_commands.json`.

The `compile_commands.json` can be generated from NimScript by post-processing the build JSON for the Nim project/root file, but with a catch: this JSON file's `"compile"` field (which is what is required to generate the `compile_commands.json`) produced by the compiler is dependent on what files are in or out of the build cache - thus you need to handle this (by merging files you generate). In Nim/NimScript this looks something like this: https://gist.github.com/miguelmartin75/298a8b39664a89a69abd8b23a5a805a8 (this is taken from my codebase). Doing this task in NimScript is error-prone and buggy, e.g. if you remove a C file: it stays in your cache & there's a lot of LOC for something so simple.

To summarize, there are two motivating points stemming from the use-case of having LSP support (via a `compile_commands.json`) for mixed Nim & C/C++/ObjC projects:
1. LSP support for your C/C++/ObjC files compiled with Nim
2. Potentially enable developers to remove CMake as a dependency for their build toolchain. This is because this feature removes a feature CMake offers. Thus this could enable your build toolchain to be written in Nim/NimScript.

# Implementation

To add support, I've added the following compiler flags:
* `--compileCmdsJson:<bool>` (default off)
    * enables the generation of a `compile_commands.json` file
    * by default, this will output your compile commands JSON file to: `<nimcache>/compile_commands.json`
* `--projectCompileCmdJson:<bool>` (default off)
    * if on: this will output your compile commands JSON file to: `<nimcache>/compile_commands_<projectname>.json`
* `--rootCompileCmdsJson:<bool>` (default off)
    * copies the compile command JSON file to the root directory of your project, i.e. to quickly spit out `compile_commands.json` file for simpler projects (one binary file produced). Naming convention is respected by `projectCompileCmdJson` flag.

# Testing

TODO