### PR TITLE
fixes usenimrtl with `useMalloc`

### DIFF
--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -55,7 +55,8 @@ elif defined(gogc):
   include system / mm / go
 
 elif (defined(nogc) or defined(gcDestructors)) and defined(useMalloc):
-  include system / mm / malloc
+  when not defined(useNimRtl):
+    include system / mm / malloc
 
   when defined(nogc):
     proc GC_getStatistics(): string = ""


### PR DESCRIPTION
Follow up https://github.com/nim-lang/Nim/pull/19512

ref https://github.com/nim-lang/Nim/issues/24794

Otherwise, `/Users/blue/Desktop/Nim/lib/system/mm/malloc.nim(4, 1) Error: redefinition of 'allocImpl'; previous declaration here: /Users/blue/Desktop/Nim/lib/system/memalloc.nim(51, 8)`


In `proc allocImpl*(size: Natural): pointer {.noconv, rtl, tags: [], benign, raises: [].}`, `rtl` means it is an `importc` function instead of a proc forward decl.