### PR TITLE
fixes #24800; Invalid C code generation with a method, case object in refc 

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -401,6 +401,7 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
         # uses a temp if `src` is an expression because the address of
         # `src` needs to be taken
         tmp = getTemp(p, src.t)
+        tmp.storage = src.storage
         simpleAsgn(p.s(cpsStmts), tmp, src)
       if dest.t.kidsLen <= 4: genOptAsgnTuple(p, dest, tmp, flags)
       else: genGenericAsgn(p, dest, tmp, flags)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -395,8 +395,15 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
       simpleAsgn(p.s(cpsStmts), dest, src)
   of tyTuple:
     if containsGarbageCollectedRef(dest.t):
-      if dest.t.kidsLen <= 4: genOptAsgnTuple(p, dest, src, flags)
-      else: genGenericAsgn(p, dest, src, flags)
+      var tmp = src
+      if optSeqDestructors notin p.config.globalOptions and
+          src.k == locExpr:
+        # uses a temp if `src` is an expression because the address of
+        # `src` needs to be taken
+        tmp = getTemp(p, src.t)
+        simpleAsgn(p.s(cpsStmts), tmp, src)
+      if dest.t.kidsLen <= 4: genOptAsgnTuple(p, dest, tmp, flags)
+      else: genGenericAsgn(p, dest, tmp, flags)
     else:
       simpleAsgn(p.s(cpsStmts), dest, src)
   of tyObject:


### PR DESCRIPTION
fixes #24800

related to https://github.com/nim-lang/Nim/pull/5205

It uses a temp if `src` is an expression because the address of `src` needs to be taken. But `src` might be a rvalue, which doesn't have an address. The address is needed by `genGenericAsgn`, which takes a parameter of a ptr type:

```nim
    let rad = addrLoc(p.config, dest)
    let ras = addrLoc(p.config, src)
    p.s(cpsStmts).addCallStmt(cgsymValue(p.module, "genericAssign"),
      cCast(CPointer, rad),
      cCast(CPointer, ras),
      genTypeInfoV1(p.module, dest.t, dest.lode.info))
```
It won't work if `src` is an expression: e.g. `((tyTuple) *val)`.

