### PR TITLE
fixes #24800; Invalid C code generation with a method, case object in refc

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2638,7 +2638,8 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc) =
 
 proc genConv(p: BProc, e: PNode, d: var TLoc) =
   let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
-  if sameBackendTypeIgnoreRange(destType, e[1].typ):
+  let srcType = e[1].typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
+  if sameBackendTypeIgnoreRange(destType, srcType):
     expr(p, e[1], d)
   else:
     genSomeCast(p, e, d)

--- a/tests/tuples/ttuples_various.nim
+++ b/tests/tuples/ttuples_various.nim
@@ -1,11 +1,12 @@
 discard """
+matrix: "--mm:refc; --mm:arc"
 output: '''
 it's nil
 @[1, 2, 3]
 '''
 """
 
-import macros
+import std/[options, macros]
 
 
 block anontuples:
@@ -209,3 +210,21 @@ block: # tuple unpacking assignment with underscore
   doAssert (a, b) == (6, 2)
   (b, _) = (7, 8)
   doAssert (a, b) == (6, 7)
+
+# bug #24800
+type
+  B[T] = object
+    case r: bool
+    of false:
+      v: ref int
+    of true:
+      x: T
+  U = ref object of RootObj
+
+method y(_: U) {.base.} =
+  var s = default(B[tuple[f: B[int], w: B[int]]])
+  discard some(s.x)
+
+proc foo =
+  var s = U()
+  y(s)


### PR DESCRIPTION
fixes #24800

This PR avoids a conversion from `sink T` to `T`

I will add a test case 