### PR TITLE
Update nativesockets.nim, `namelen` should be the len of `name`

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -723,7 +723,7 @@ when useNimNetLite:
     ##
     ## Similar to POSIX's `getsockname`:idx:.
     template sockGetNameOrRaiseError(socket: untyped, name: untyped) =
-      var namelen = sizeof(socket).SockLen
+      var namelen = sizeof(name).SockLen
       if getsockname(socket, cast[ptr SockAddr](addr(name)),
                     addr(namelen)) == -1'i32:
         raiseOSError(osLastError())


### PR DESCRIPTION
In other places where `getsockname` is called, the size of the 'name' is used.

https://github.com/nim-lang/Nim/blob/d573578b28bc4393dac7f3154b5da29b1fa75358/lib/pure/nativesockets.nim#L347-L351
https://github.com/nim-lang/Nim/blob/d573578b28bc4393dac7f3154b5da29b1fa75358/lib/pure/nativesockets.nim#L585-L595
https://github.com/nim-lang/Nim/blob/d573578b28bc4393dac7f3154b5da29b1fa75358/lib/pure/nativesockets.nim#L622-L624
https://github.com/nim-lang/Nim/blob/d573578b28bc4393dac7f3154b5da29b1fa75358/lib/pure/nativesockets.nim#L347-L350

I have checked the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-getsockname#remarks), and it describes it like this: "On call, the namelen parameter contains the size of the name buffer, in bytes. On return, the namelen parameter contains the actual size in bytes of the name parameter."

[https://www.man7.org/linux/man-pages/man2/getsockname.2.html](https://www.man7.org/linux/man-pages/man2/getsockname.2.html) say:
The addrlen argument should be initialized to indicate the amount of space (in bytes) pointed to by addr.
