### PR TITLE
`conv` needs to be picky about aliases and introduces a temp for `addr conv`

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -338,7 +338,7 @@ proc withTmpIfNeeded(p: BProc, a: TLoc, needsTmp: bool): TLoc =
   else:
     result = a
 
-proc literalsNeedsTmp(p: BProc, a: TLoc): TLoc =
+proc expressionsNeedsTmp(p: BProc, a: TLoc): TLoc =
   result = getTemp(p, a.lode.typ, needsInit=false)
   genAssignment(p, result, a, {})
 
@@ -358,7 +358,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Builder; n
     (optByRef notin param.options or not p.module.compileToCpp):
     a = initLocExpr(p, n)
     if n.kind in {nkCharLit..nkNilLit}:
-      addAddrLoc(p.config, literalsNeedsTmp(p, a), result)
+      addAddrLoc(p.config, expressionsNeedsTmp(p, a), result)
     else:
       addAddrLoc(p.config, withTmpIfNeeded(p, a, needsTmp), result)
   elif p.module.compileToCpp and param.typ.kind in {tyVar} and

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -962,7 +962,7 @@ proc cowBracket(p: BProc; n: PNode) =
 proc cow(p: BProc; n: PNode) {.inline.} =
   if n.kind == nkHiddenAddr: cowBracket(p, n[0])
 
-template noSomeCast(e: PNode): bool =
+template ignoreConv(e: PNode): bool =
   let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
   let srcType = e[1].typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
   sameBackendTypePickyAliases(destType, srcType)
@@ -979,7 +979,7 @@ proc genAddr(p: BProc, e: PNode, d: var TLoc) =
     d.lode = e
   else:
     var a: TLoc = initLocExpr(p, e[0])
-    if e[0].kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv} and not noSomeCast(e[0]):
+    if e[0].kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv} and not ignoreConv(e[0]):
       # addr (conv x) introduces a temp because `conv x` is not a rvalue
       putIntoDest(p, d, e, addrLoc(p.config, expressionsNeedsTmp(p, a)), a.storage)
     else:
@@ -2646,7 +2646,7 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc) =
     putIntoDest(p, d, n, cCast(destType, wrapPar(val)), a.storage)
 
 proc genConv(p: BProc, e: PNode, d: var TLoc) =
-  if noSomeCast(e):
+  if ignoreConv(e):
     expr(p, e[1], d)
   else:
     genSomeCast(p, e, d)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2639,7 +2639,7 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc) =
 proc genConv(p: BProc, e: PNode, d: var TLoc) =
   let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
   let srcType = e[1].typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
-  if sameBackendTypeIgnoreRange(destType, srcType):
+  if sameBackendTypePickyAliases(destType, srcType):
     expr(p, e[1], d)
   else:
     genSomeCast(p, e, d)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -962,6 +962,11 @@ proc cowBracket(p: BProc; n: PNode) =
 proc cow(p: BProc; n: PNode) {.inline.} =
   if n.kind == nkHiddenAddr: cowBracket(p, n[0])
 
+template noSomeCast(e: PNode): bool =
+  let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
+  let srcType = e[1].typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
+  sameBackendTypePickyAliases(destType, srcType)
+
 proc genAddr(p: BProc, e: PNode, d: var TLoc) =
   # careful  'addr(myptrToArray)' needs to get the ampersand:
   if e[0].typ.skipTypes(abstractInstOwned).kind in {tyRef, tyPtr}:
@@ -974,7 +979,11 @@ proc genAddr(p: BProc, e: PNode, d: var TLoc) =
     d.lode = e
   else:
     var a: TLoc = initLocExpr(p, e[0])
-    putIntoDest(p, d, e, addrLoc(p.config, a), a.storage)
+    if e[0].kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv} and not noSomeCast(e[0]):
+      # addr (conv x) introduces a temp because `conv x` is not a rvalue
+      putIntoDest(p, d, e, addrLoc(p.config, expressionsNeedsTmp(p, a)), a.storage)
+    else:
+      putIntoDest(p, d, e, addrLoc(p.config, a), a.storage)
 
 template inheritLocation(d: var TLoc, a: TLoc) =
   if d.k == locNone: d.storage = a.storage
@@ -2637,9 +2646,7 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc) =
     putIntoDest(p, d, n, cCast(destType, wrapPar(val)), a.storage)
 
 proc genConv(p: BProc, e: PNode, d: var TLoc) =
-  let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
-  let srcType = e[1].typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
-  if sameBackendTypePickyAliases(destType, srcType):
+  if noSomeCast(e):
     expr(p, e[1], d)
   else:
     genSomeCast(p, e, d)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -484,6 +484,35 @@ proc transformYield(c: PTransf, n: PNode): PNode =
     result.add(introduceNewLocalVars(c, c.transCon.forLoopBody))
     c.isIntroducingNewLocalVars = false
 
+proc transformAddrConv(c: PTransf, n: PNode): PNode =
+  # transform addr ( conv ( x ) ) -> conv ( addr ( x ) )
+  # because `conv(x)` is not a lvalue, you are not supposed to
+  # address an expression. So we move `conv` chains outside the
+  # address
+  var p = n[0]
+  let typeKind = n.typ.kind
+  var nodes = newSeq[PNode]()
+  while p.kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv}:
+    var newNode = newTransNode(p.kind, p, 2)
+    let newType = toVar(p.typ, typeKind, c.idgen)
+    newType.flags.incl tfVarIsPtr
+    newNode.typ() = newType
+    newNode[0] = p[0]
+    newNode[0].typ() = newType
+    nodes.add newNode
+    p = p[1]
+
+  if nodes.len > 0:
+    result = newTransNode(n.kind, n.info, 1)
+    result.typ() = toVar(p.typ, typeKind, c.idgen)
+    result.typ.flags.incl tfVarIsPtr
+    result[0] = p
+    for i in countdown(nodes.high, 0):
+      nodes[i][1] = result
+      result = nodes[i]
+  else:
+    result = n
+
 proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false): PNode =
   result = transformSons(c, n, noConstFold = isAddr)
   # inlining of 'var openarray' iterators; bug #19977
@@ -1098,6 +1127,8 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
     result = transformCall(c, n)
   of nkAddr, nkHiddenAddr:
     result = transformAddrDeref(c, n, {nkDerefExpr, nkHiddenDeref}, isAddr = true)
+    if result.kind in {nkAddr, nkHiddenAddr}:
+      result = transformAddrConv(c, result)
   of nkDerefExpr:
     result = transformAddrDeref(c, n, {nkAddr, nkHiddenAddr})
   of nkHiddenDeref:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -484,35 +484,6 @@ proc transformYield(c: PTransf, n: PNode): PNode =
     result.add(introduceNewLocalVars(c, c.transCon.forLoopBody))
     c.isIntroducingNewLocalVars = false
 
-proc transformAddrConv(c: PTransf, n: PNode): PNode =
-  # transform addr ( conv ( x ) ) -> conv ( addr ( x ) )
-  # because `conv(x)` is not a lvalue, you are not supposed to
-  # address an expression. So we move `conv` chains outside the
-  # address
-  var p = n[0]
-  let typeKind = n.typ.kind
-  var nodes = newSeq[PNode]()
-  while p.kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv}:
-    var newNode = newTransNode(p.kind, p, 2)
-    let newType = toVar(p.typ, typeKind, c.idgen)
-    newType.flags.incl tfVarIsPtr
-    newNode.typ() = newType
-    newNode[0] = p[0]
-    newNode[0].typ() = newType
-    nodes.add newNode
-    p = p[1]
-
-  if nodes.len > 0:
-    result = newTransNode(n.kind, n.info, 1)
-    result.typ() = toVar(p.typ, typeKind, c.idgen)
-    result.typ.flags.incl tfVarIsPtr
-    result[0] = p
-    for i in countdown(nodes.high, 0):
-      nodes[i][1] = result
-      result = nodes[i]
-  else:
-    result = n
-
 proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false): PNode =
   result = transformSons(c, n, noConstFold = isAddr)
   # inlining of 'var openarray' iterators; bug #19977
@@ -1127,8 +1098,6 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
     result = transformCall(c, n)
   of nkAddr, nkHiddenAddr:
     result = transformAddrDeref(c, n, {nkDerefExpr, nkHiddenDeref}, isAddr = true)
-    if result.kind in {nkAddr, nkHiddenAddr}:
-      result = transformAddrConv(c, result)
   of nkDerefExpr:
     result = transformAddrDeref(c, n, {nkAddr, nkHiddenAddr})
   of nkHiddenDeref:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1420,7 +1420,7 @@ proc sameBackendTypeIgnoreRange*(x, y: PType): bool =
 
 proc sameBackendTypePickyAliases*(x, y: PType): bool =
   var c = initSameTypeClosure()
-  c.flags.incl {IgnoreTupleFields, PickyCAliases, PickyBackendAliases}
+  c.flags.incl {IgnoreTupleFields, IgnoreRangeShallow, PickyCAliases, PickyBackendAliases}
   c.cmp = dcEqIgnoreDistinct
   result = sameTypeAux(x, y, c)
 

--- a/tests/ccgbugs/taddrconvs.nim
+++ b/tests/ccgbugs/taddrconvs.nim
@@ -13,8 +13,7 @@ block:
   proc foo(x: var culonglong) {.importc: "foo", nodecl.}
 
   proc main(x: var uint64) =
-    var m = uint64(12)
-    foo(culonglong m)
+    foo(culonglong x)
 
   var u = uint64(12)
   main(u)

--- a/tests/ccgbugs/taddrconvs.nim
+++ b/tests/ccgbugs/taddrconvs.nim
@@ -1,0 +1,28 @@
+discard """
+  targets: "c cpp"
+  matrix: "--mm:refc; --mm:orc"
+"""
+
+{.emit:"""
+void foo(unsigned long long* x)
+{
+}
+""".}
+
+block:
+  proc foo(x: var culonglong) {.importc: "foo", nodecl.}
+
+  proc main(x: var uint64) =
+    var m = uint64(12)
+    foo(culonglong m)
+
+  var u = uint64(12)
+  main(u)
+
+block:
+  proc foo(x: var culonglong) {.importc: "foo", nodecl.}
+
+  proc main() =
+    var m = uint64(12)
+    foo(culonglong(m))
+  main()


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/24817
ref https://github.com/nim-lang/Nim/pull/24815
ref https://github.com/status-im/nim-eth/pull/784


```nim
{.emit:"""
void foo(unsigned long long* x)
{
}
""".}


proc foo(x: var culonglong) {.importc: "foo", nodecl.}

proc main(x: var uint64) =
  # var s: culonglong = u # TODO:
  var m = uint64(12)
  # var s = culonglong(m)
  foo(culonglong m)

var u = uint64(12)
main(u)
```
Notes that this code gives incompatible errors in 2.0.0, 2.2.0 and the devel branch. With this PR, `conv` is kept, but it seems to go back to https://github.com/nim-lang/Nim/pull/24807