### PR TITLE
Fix `nim-gdb.py` script

### DIFF
--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -46,11 +46,11 @@ for i, expected in enumerate(outputs):
   if i == 6:
     # myArray is passed as pointer to int to myDebug. I look up myArray up in the stack
     gdb.execute("up")
-    raw = gdb.parse_and_eval("myArray")    
+    raw = gdb.parse_and_eval("myArray_1")
   elif i == 9:
     # myOtherArray is passed as pointer to int to myDebug. I look up myOtherArray up in the stack
     gdb.execute("up")
-    raw = gdb.parse_and_eval("myOtherArray")
+    raw = gdb.parse_and_eval("myOtherArray_1")
   else:
     rawArg = re.sub(noSuitableRegex, "", gdb.execute("info args", to_string = True))
     raw = rawArg.split("=", 1)[-1].strip()

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -27,7 +27,7 @@ outputs = [
   'seq(3, 3) = {1, 2, 3}',
   'seq(3, 3) = {"one", "two", "three"}',
   'Table(3, 64) = {[4] = "four", [5] = "five", [6] = "six"}',
-  'Table(3, 8) = {["two"] = 2, ["three"] = 3, ["one"] = 1}',
+  'Table(3, 8) = {["three"] = 3, ["one"] = 1, ["two"] = 2}',
   '{a = 1, b = "some string"}',
   '("hello", 42)'
 ]

--- a/tests/untestable/gdb/gdb_pretty_printer_test.py
+++ b/tests/untestable/gdb/gdb_pretty_printer_test.py
@@ -32,9 +32,9 @@ outputs = [
   '("hello", 42)'
 ]
 
-argRegex = re.compile("^.* = (?:No suitable Nim \$ operator found for type: \w+\s*)*(.*)$")
+argRegex = re.compile(r"^.* = (?:No suitable Nim \$ operator found for type: \w+\s*)*(.*)$")
 # Remove this error message which can pop up
-noSuitableRegex = re.compile("(No suitable Nim \$ operator found for type: \w+\s*)")
+noSuitableRegex = re.compile(r"(No suitable Nim \$ operator found for type: \w+\s*)")
 
 for i, expected in enumerate(outputs):
   gdb.write(f"\x1b[38;5;105m{i+1}) expecting: {expected}: \x1b[0m", gdb.STDLOG)

--- a/tools/debug/nim-gdb.py
+++ b/tools/debug/nim-gdb.py
@@ -152,8 +152,8 @@ class DollarPrintFunction (gdb.Function):
   "Nim's equivalent of $ operator as a gdb function, available in expressions `print $dollar(myvalue)"
 
   dollar_functions = re.findall(
-    r'(?:NimStringDesc \*|NimStringV2)\s?(dollar__[A-z0-9_]+?)\(([^,)]*)\);',
-    gdb.execute("info functions dollar__", True, True)
+    r'(?:NimStringDesc \*|NimStringV2)\s?([A-z0-9_]+?dollar_[A-z0-9_]+?)\(([^,)]*)\);',
+    gdb.execute("info functions dollar_", True, True)
   )
 
   def __init__ (self):

--- a/tools/debug/nim-gdb.py
+++ b/tools/debug/nim-gdb.py
@@ -1,4 +1,5 @@
 import gdb
+import gdb.types
 import re
 import sys
 import traceback


### PR DESCRIPTION
Script wasn't working on my machine with GDB 16.2
Main issues
 - `gdb.types` wasn't imported, leading to import error on initial load
 - dollar function didn't work with the new mangling scheme

Fixes them, also updates the test script to work with some new mangling changes.

Test evidence
![image](https://github.com/user-attachments/assets/450b020f-1665-4ed2-9073-d02537150914)
