### PR TITLE
fixes #24806; generates `=wasMoved` for seqs self-assignment to reset the buffer

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -575,12 +575,14 @@ proc forallElements(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.sons.setLen counterIdx
 
 proc checkSelfAssignment(c: var TLiftCtx; t: PType; body, x, y: PNode) =
+  let addrX = newTreeIT(nkAddr, c.info, makePtrType(c.fn, x.typ, c.idgen), x)
+  let addrY = newTreeIT(nkAddr, c.info, makePtrType(c.fn, y.typ, c.idgen), y)
   var cond = callCodegenProc(c.g, "sameSeqPayload", c.info,
-      newTreeIT(nkAddr, c.info, makePtrType(c.fn, x.typ, c.idgen), x),
-      newTreeIT(nkAddr, c.info, makePtrType(c.fn, y.typ, c.idgen), y)
+      addrX, addrY
       )
   cond.typ() = getSysType(c.g, c.info, tyBool)
-  body.add genIf(c, cond, newTreeI(nkReturnStmt, c.info, newNodeI(nkEmpty, c.info)))
+  body.add genIf(c, cond, 
+    genBuiltin(c, mWasMoved, "`=wasMoved`", addrX))
 
 proc fillSeqOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   case c.kind
@@ -590,10 +592,10 @@ proc fillSeqOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of attachedAsgn, attachedDeepCopy:
     # we generate:
     # if x.p == y.p:
-    #   return
-    # setLen(dest, y.len)
+    #   wasMoved(x)
+    # setLen(x, y.len)
     # var i = 0
-    # while i < y.len: dest[i] = y[i]; inc(i)
+    # while i < y.len: x[i] = y[i]; inc(i)
     # This is usually more efficient than a destroy/create pair.
     checkSelfAssignment(c, t, body, x, y)
     body.add setLenSeqCall(c, t, x, y)

--- a/tests/arc/tmalloc.nim
+++ b/tests/arc/tmalloc.nim
@@ -14,3 +14,51 @@ block: # bug #22058
     V(v: foo())
 
   doAssert bar().v == @[byte(0)]
+
+type
+  GlobFilter* = object
+    incl*: bool
+    glob*: string
+
+  GlobState* = object
+    one: int
+    two: int
+
+proc aa() =
+  let filters = @[GlobFilter(incl: true, glob: "**")]
+  var wbg = newSeqOfCap[GlobState](1)
+  wbg.add GlobState()
+  var
+    dirc = @[wbg]
+  while true:
+    wbg = dirc[^1]
+    dirc.add wbg
+    break
+
+var handlerLocs = newSeq[string]()
+handlerLocs.add "sammich"
+aa()
+aa()
+
+block: # bug #24806
+  block:
+    proc aa() =
+      var
+        a = @[0]
+        b = @[a]
+      block:
+        a = b[0]
+        b.add a
+
+    aa()
+
+  block:
+    proc aa() =
+      var
+        a = @[0]
+        b = @[a]
+      block:
+        a = b[^1]
+        b.add a
+
+    aa()


### PR DESCRIPTION
fixes #24806

In the case of self assignments, `x.p` is the same as `y.p`. We cannot modify `x.p` without changing `y.p` as well. We need to reset `x.p` to `nil` so that `setLen` will initialize `x` with uninit values. Now it's okay to copy values of `y.p`

```nim
proc `=copy`(x, y: seq) =
  if x.p == y.p:
    wasMoved(x)
  setLen(x, y.len)
  var i = 0
  while i < y.len: `=copy`(x[i], y[i]); inc(i)
```