### PR TITLE
fixes `lastRead` uses the `when nimvm` branch

### DIFF
--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -439,8 +439,8 @@ proc gen(c: var Con; n: PNode) =
     genUse(c, n)
   of nkIfStmt, nkIfExpr: genIf(c, n)
   of nkWhenStmt:
-    # This is "when nimvm" node. Chose the first branch.
-    gen(c, n[0][1])
+    # This is "when nimvm" node. Chose the second branch.
+    gen(c, n[1][0])
   of nkCaseStmt: genCase(c, n)
   of nkWhileStmt: genWhile(c, n)
   of nkBlockExpr, nkBlockStmt: genBlock(c, n)

--- a/tests/destructor/t23837.nim
+++ b/tests/destructor/t23837.nim
@@ -49,3 +49,17 @@ proc main() =
   echo s
 
 main()
+
+block:
+  proc foo =
+    var x = "1234"
+    var y = x
+    when nimvm:
+      discard
+    else:
+      var s = x
+      doAssert s == "1234"
+    doAssert y == "1234"
+
+  static: foo()
+  foo()


### PR DESCRIPTION
```nim
proc foo =
  var x = "1234"
  var y = x
  when nimvm:
    discard
  else:
    var s = x
    doAssert s == "1234"
  doAssert y == "1234"

static: foo()
foo()
```
`dfa` chooses the `nimvm` branch, `x` is misread as a last read and `wasMoved`. 

`injectDestructor` is used for codegen and is not used for vmgen. It's reasonable to choose the codegen path instead of the `nimvm` path so the code works for codegen. Though the problem is often hidden by `cursorinference` or `optimizer`.

found in https://github.com/nim-lang/Nim/pull/24831