### PR TITLE
Make `loadConfig` available from NimScript

### DIFF
--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -540,10 +540,17 @@ proc loadConfig*(stream: Stream, filename: string = "[stream]"): Config =
 
 proc loadConfig*(filename: string): Config =
   ## Loads the specified configuration file into a new Config instance.
-  let file = open(filename, fmRead)
-  let fileStream = newFileStream(file)
-  defer: fileStream.close()
-  result = fileStream.loadConfig(filename)
+  when nimvm:
+    # HACK: As a workaround,
+    # since open() using {.importc.} is not available on NimScript.
+    let stringStream = newStringStream(readFile(filename))
+    defer: stringStream.close()
+    result = stringStream.loadConfig(filename)
+  else:
+    let file = open(filename, fmRead)
+    let fileStream = newFileStream(file)
+    defer: fileStream.close()
+    result = fileStream.loadConfig(filename)
 
 proc replace(s: string): string =
   var d = ""


### PR DESCRIPTION
fixes #24837 

I really wanted to name the variable just `stream` and leave `defer: ...` and `result =...` out, but the compiler says the variable is redefined, so this is the form.