### PR TITLE
overhaul hook injections

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -400,7 +400,7 @@ proc genWasMoved(c: var Con, n: PNode): PNode =
     result = genOp(c, op, n)
   else:
     result = newNodeI(nkCall, n.info)
-    result.add(newSymNode(createMagic(c.graph, c.idgen, "`=wasMoved`", mWasMoved)))
+    result.add(newSymNode(createMagic(c.graph, c.idgen, "wasMoved", mWasMoved)))
     result.add copyTree(n) #mWasMoved does not take the address
     #if n.kind != nkSym:
     #  message(c.graph.config, n.info, warnUser, "wasMoved(" & $n & ")")

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -17,14 +17,14 @@ import
   ast, astalgo, msgs, renderer, magicsys, types, idents,
   options, lowerings, modulegraphs,
   lineinfos, parampatterns, sighashes, liftdestructors, optimizer,
-  varpartitions, aliasanalysis, dfa, wordrecg, trees
+  varpartitions, aliasanalysis, dfa, wordrecg
 
 import std/[strtabs, tables, strutils, intsets]
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
 
-from trees import exprStructuralEquivalent, getRoot, whichPragma
+from trees import exprStructuralEquivalent, getRoot, whichPragma, getPotentialWrites
 
 type
   Con = object

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -149,14 +149,12 @@ proc destructorCall(c: var TLiftCtx; op: PSym; x: PNode): PNode =
     c.canRaise = true
   if c.addMemReset:
     result = newTree(nkStmtList, destroy, genBuiltin(c, mWasMoved,  "wasMoved", x))
-    # result = newTree(nkStmtList, destroy, genBuiltin(c, mWasMoved,  "`=wasMoved`", x))
   else:
     result = destroy
 
 proc genWasMovedCall(c: var TLiftCtx; op: PSym; x: PNode): PNode =
   result = newNodeIT(nkCall, x.info, op.typ.returnType)
   result.add(newSymNode(op))
-  result.add x
   result.add genAddr(c, x)
 
 proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool, enforceWasMoved = false) =
@@ -171,7 +169,6 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool, 
     else:
       if enforceWasMoved:
         body.add genBuiltin(c, mWasMoved, "wasMoved", x.dotField(f))
-        # body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x.dotField(f))
       fillBody(c, f.typ, body, x.dotField(f), b)
   of nkNilLit: discard
   of nkRecCase:
@@ -282,7 +279,6 @@ proc fillBodyObjT(c: var TLiftCtx; t: PType, body, x, y: PNode) =
     var wasMovedCall = newNodeI(nkCall, c.info)
     wasMovedCall.add(newSymNode(createMagic(c.g, c.idgen, "wasMoved", mWasMoved)))
 
-    # wasMovedCall.add(newSymNode(createMagic(c.g, c.idgen, "`=wasMoved`", mWasMoved)))
     wasMovedCall.add x # mWasMoved does not take the address
     body.add wasMovedCall
 

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -157,7 +157,7 @@ proc genWasMovedCall(c: var TLiftCtx; op: PSym; x: PNode): PNode =
   result = newNodeIT(nkCall, x.info, op.typ.returnType)
   result.add(newSymNode(op))
   result.add x
-  # result.add genAddr(c, x)
+  result.add genAddr(c, x)
 
 proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool, enforceWasMoved = false) =
   case n.kind

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -91,7 +91,7 @@ proc defaultOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     call.typ() = t
     body.add newAsgnStmt(x, call)
   elif c.kind == attachedWasMoved:
-    body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+    body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc genAddr(c: var TLiftCtx; x: PNode): PNode =
   if x.kind == nkHiddenDeref:
@@ -148,14 +148,16 @@ proc destructorCall(c: var TLiftCtx; op: PSym; x: PNode): PNode =
   if sfNeverRaises notin op.flags:
     c.canRaise = true
   if c.addMemReset:
-    result = newTree(nkStmtList, destroy, genBuiltin(c, mWasMoved,  "`=wasMoved`", x))
+    result = newTree(nkStmtList, destroy, genBuiltin(c, mWasMoved,  "wasMoved", x))
+    # result = newTree(nkStmtList, destroy, genBuiltin(c, mWasMoved,  "`=wasMoved`", x))
   else:
     result = destroy
 
 proc genWasMovedCall(c: var TLiftCtx; op: PSym; x: PNode): PNode =
   result = newNodeIT(nkCall, x.info, op.typ.returnType)
   result.add(newSymNode(op))
-  result.add genAddr(c, x)
+  result.add x
+  # result.add genAddr(c, x)
 
 proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool, enforceWasMoved = false) =
   case n.kind
@@ -168,7 +170,8 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool, 
       defaultOp(c, f.typ, body, x.dotField(f), b)
     else:
       if enforceWasMoved:
-        body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x.dotField(f))
+        body.add genBuiltin(c, mWasMoved, "wasMoved", x.dotField(f))
+        # body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x.dotField(f))
       fillBody(c, f.typ, body, x.dotField(f), b)
   of nkNilLit: discard
   of nkRecCase:
@@ -277,7 +280,9 @@ proc fillBodyObjT(c: var TLiftCtx; t: PType, body, x, y: PNode) =
     #body.add newAsgnStmt(blob, x)
 
     var wasMovedCall = newNodeI(nkCall, c.info)
-    wasMovedCall.add(newSymNode(createMagic(c.g, c.idgen, "`=wasMoved`", mWasMoved)))
+    wasMovedCall.add(newSymNode(createMagic(c.g, c.idgen, "wasMoved", mWasMoved)))
+
+    # wasMovedCall.add(newSymNode(createMagic(c.g, c.idgen, "`=wasMoved`", mWasMoved)))
     wasMovedCall.add x # mWasMoved does not take the address
     body.add wasMovedCall
 
@@ -612,7 +617,7 @@ proc fillSeqOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     if canFormAcycle(c.g, t.elemType):
       # follow all elements:
       forallElements(c, t, body, x, y)
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc useSeqOrStrOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   createTypeBoundOps(c.g, c.c, t, body.info, c.idgen)
@@ -650,7 +655,7 @@ proc useSeqOrStrOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
       if op == nil:
         return # protect from recursion
       body.add newHookCall(c, op, x, y)
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
   of attachedDup:
     # XXX: replace these with assertions.
     let op = getAttachedOp(c.g, t, c.kind)
@@ -672,7 +677,7 @@ proc fillStrOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genBuiltin(c, mDestroy, "destroy", x)
   of attachedTrace:
     discard "strings are atomic and have no inner elements that are to trace"
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc cyclicType*(g: ModuleGraph, t: PType): bool =
   case t.kind
@@ -771,7 +776,7 @@ proc atomicRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         # If the ref is polymorphic we have to account for this
         body.add callCodegenProc(c.g, "nimTraceRefDyn", c.info, genAddrOf(x, c.idgen), y)
       #echo "can follow ", elemType, " static ", isFinal(elemType)
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
   of attachedDup:
     if isCyclic:
       body.add newAsgnStmt(x, y)
@@ -838,7 +843,7 @@ proc atomicClosureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of attachedDeepCopy: assert(false, "cannot happen")
   of attachedTrace:
     body.add callCodegenProc(c.g, "nimTraceRefDyn", c.info, genAddrOf(xenv, c.idgen), y)
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc weakrefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   case c.kind
@@ -866,7 +871,7 @@ proc weakrefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
       body.sons.insert(des, 0)
   of attachedDeepCopy: assert(false, "cannot happen")
   of attachedTrace: discard
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc ownedRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   var actions = newNodeI(nkStmtList, c.info)
@@ -894,7 +899,7 @@ proc ownedRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genIf(c, x, actions)
   of attachedDeepCopy: assert(false, "cannot happen")
   of attachedTrace: discard
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc closureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   if c.kind == attachedDeepCopy:
@@ -934,7 +939,7 @@ proc closureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         body.sons.insert(des, 0)
     of attachedDeepCopy: assert(false, "cannot happen")
     of attachedTrace: discard
-    of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+    of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc ownedClosureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   let xx = genBuiltin(c, mAccessEnv, "accessEnv", x)
@@ -952,7 +957,7 @@ proc ownedClosureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     body.add genIf(c, xx, actions)
   of attachedDeepCopy: assert(false, "cannot happen")
   of attachedTrace: discard
-  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+  of attachedWasMoved: body.add genBuiltin(c, mWasMoved, "wasMoved", x)
 
 proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   case t.kind
@@ -1021,7 +1026,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         of {attachedAsgn, attachedSink, attachedDup}:
           body.add newAsgnStmt(x, y)
         of attachedWasMoved:
-          body.add genBuiltin(c, mWasMoved, "`=wasMoved`", x)
+          body.add genBuiltin(c, mWasMoved, "wasMoved", x)
         else:
           fillBodyObjT(c, t, body, x, y)
       else:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -244,14 +244,6 @@ proc effectProblem(f, a: PType; result: var string; c: PContext) =
         if not c.graph.compatibleProps(c.graph, f, a):
           result.add "\n  The `.requires` or `.ensures` properties are incompatible."
 
-proc renderNotLValue(n: PNode): string =
-  result = $n
-  let n = if n.kind == nkHiddenDeref: n[0] else: n
-  if n.kind == nkHiddenCallConv and n.len > 1:
-    result = $n[0] & "(" & result & ")"
-  elif n.kind in {nkHiddenStdConv, nkHiddenSubConv} and n.len == 2:
-    result = typeToString(n.typ.skipTypes(abstractVar)) & "(" & result & ")"
-
 proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
                             (TPreferedDesc, string) =
   var prefer = preferName

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -16,7 +16,8 @@ when defined(nimPreviewSlimSystem):
 
 import
   options, ast, msgs, idents, renderer,
-  magicsys, vmdef, modulegraphs, lineinfos, pathutils, layeredtable
+  magicsys, vmdef, modulegraphs, lineinfos, pathutils, layeredtable,
+  types, lowerings, trees
 
 import ic / ic
 
@@ -635,3 +636,52 @@ proc rememberExpansion*(c: PContext; info: TLineInfo; expandedSym: PSym) =
   ## delegated to the "rod" file mechanism.
   if c.config.symbolFiles != disabledSf:
     storeExpansion(c.encoder, c.packedRepr, info, expandedSym)
+
+proc replaceHookMagic*(c: PContext, n: PNode, kind: TTypeAttachedOp): PNode =
+  ## Replaces builtin generic hooks with lifted hooks.
+  case kind
+  of attachedDestructor:
+    result = n
+    let t = n[1].typ.skipTypes(abstractVar)
+    let op = getAttachedOp(c.graph, t, attachedDestructor)
+    if op != nil:
+      result[0] = newSymNode(op)
+      if op.typ != nil and op.typ.len == 2 and op.typ.firstParamType.kind != tyVar:
+        if n[1].kind == nkSym and n[1].sym.kind == skParam and
+            n[1].typ.kind == tyVar:
+          result[1] = genDeref(n[1])
+        else:
+          result[1] = skipAddr(n[1])
+  of attachedTrace:
+    result = n
+    let t = n[1].typ.skipTypes(abstractVar)
+    let op = getAttachedOp(c.graph, t, attachedTrace)
+    if op != nil:
+      result[0] = newSymNode(op)
+  of attachedDup:
+    result = n
+    let t = n[1].typ.skipTypes(abstractVar)
+    let op = getAttachedOp(c.graph, t, attachedDup)
+    if op != nil:
+      result[0] = newSymNode(op)
+      if op.typ.len == 3:
+        let boolLit = newIntLit(c.graph, n.info, 1)
+        boolLit.typ() = getSysType(c.graph, n.info, tyBool)
+        result.add boolLit
+  of attachedWasMoved:
+    result = n
+    let t = n[1].typ.skipTypes(abstractVar)
+    let op = getAttachedOp(c.graph, t, attachedWasMoved)
+    if op != nil:
+      result[0] = newSymNode(op)
+      # TODO:
+      # let addrExp = newNodeIT(nkHiddenAddr, result[1].info, makePtrType(c, t))
+      # addrExp.add result[1]
+      # result[1] = addrExp
+  of attachedSink, attachedAsgn, attachedDeepCopy:
+    # TODO: `nkSinkAsgn`, `nkAsgn`
+    result = n
+    let t = n[1].typ.skipTypes(abstractVar)
+    let op = getAttachedOp(c.graph, t, kind)
+    if op != nil:
+      result[0] = newSymNode(op)

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -9,7 +9,7 @@
 
 ## This module contains the data structures for the semantic checking phase.
 
-import std/[tables, intsets, sets]
+import std/[tables, intsets, sets, strutils]
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -17,7 +17,7 @@ when defined(nimPreviewSlimSystem):
 import
   options, ast, msgs, idents, renderer,
   magicsys, vmdef, modulegraphs, lineinfos, pathutils, layeredtable,
-  types, lowerings, trees
+  types, lowerings, trees, parampatterns
 
 import ic / ic
 
@@ -637,6 +637,120 @@ proc rememberExpansion*(c: PContext; info: TLineInfo; expandedSym: PSym) =
   if c.config.symbolFiles != disabledSf:
     storeExpansion(c.encoder, c.packedRepr, info, expandedSym)
 
+const
+  errVarForOutParamNeededX = "for a 'var' type a variable needs to be passed; but '$1' is immutable"
+  errXStackEscape = "address of '$1' may not escape its stack frame"
+
+proc renderNotLValue*(n: PNode): string =
+  result = $n
+  let n = if n.kind == nkHiddenDeref: n[0] else: n
+  if n.kind == nkHiddenCallConv and n.len > 1:
+    result = $n[0] & "(" & result & ")"
+  elif n.kind in {nkHiddenStdConv, nkHiddenSubConv} and n.len == 2:
+    result = typeToString(n.typ.skipTypes(abstractVar)) & "(" & result & ")"
+
+proc isAssignable(c: PContext, n: PNode): TAssignableResult =
+  result = parampatterns.isAssignable(c.p.owner, n)
+
+proc newHiddenAddrTaken(c: PContext, n: PNode, isOutParam: bool): PNode =
+  if n.kind == nkHiddenDeref and not (c.config.backend == backendCpp or
+                                      sfCompileToCpp in c.module.flags):
+    checkSonsLen(n, 1, c.config)
+    result = n[0]
+  else:
+    result = newNodeIT(nkHiddenAddr, n.info, makeVarType(c, n.typ))
+    result.add n
+    let aa = isAssignable(c, n)
+    let sym = getRoot(n)
+    if aa notin {arLValue, arLocalLValue}:
+      if aa == arDiscriminant and c.inUncheckedAssignSection > 0:
+        discard "allow access within a cast(unsafeAssign) section"
+      elif strictDefs in c.features and aa == arAddressableConst and
+              sym != nil and sym.kind == skLet and isOutParam:
+        discard "allow let varaibles to be passed to out parameters"
+      else:
+        localError(c.config, n.info, errVarForOutParamNeededX % renderNotLValue(n))
+
+proc analyseIfAddressTaken(c: PContext, n: PNode, isOutParam: bool): PNode =
+  result = n
+  case n.kind
+  of nkSym:
+    # n.sym.typ can be nil in 'check' mode ...
+    if n.sym.typ != nil and
+        skipTypes(n.sym.typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
+      incl(n.sym.flags, sfAddrTaken)
+      result = newHiddenAddrTaken(c, n, isOutParam)
+  of nkDotExpr:
+    checkSonsLen(n, 2, c.config)
+    if n[1].kind != nkSym:
+      internalError(c.config, n.info, "analyseIfAddressTaken")
+      return
+    if skipTypes(n[1].sym.typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
+      incl(n[1].sym.flags, sfAddrTaken)
+      result = newHiddenAddrTaken(c, n, isOutParam)
+  of nkBracketExpr:
+    checkMinSonsLen(n, 1, c.config)
+    if skipTypes(n[0].typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
+      if n[0].kind == nkSym: incl(n[0].sym.flags, sfAddrTaken)
+      result = newHiddenAddrTaken(c, n, isOutParam)
+  else:
+    result = newHiddenAddrTaken(c, n, isOutParam)
+
+proc analyseIfAddressTakenInCall*(c: PContext, n: PNode, isConverter = false) =
+  checkMinSonsLen(n, 1, c.config)
+  if n[0].typ == nil:
+    # n[0] might be erroring node in nimsuggest
+    return
+  const
+    FakeVarParams = {mNew, mNewFinalize, mInc, ast.mDec, mIncl, mExcl,
+      mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
+      mAppendSeqElem, mNewSeq, mShallowCopy, mDeepCopy, mMove, mWasMoved}
+
+  template checkIfConverterCalled(c: PContext, n: PNode) =
+    ## Checks if there is a converter call which wouldn't be checked otherwise
+    # Call can sometimes be wrapped in a deref
+    let node = if n.kind == nkHiddenDeref: n[0] else: n
+    if node.kind == nkHiddenCallConv:
+      analyseIfAddressTakenInCall(c, node, true)
+  # get the real type of the callee
+  # it may be a proc var with a generic alias type, so we skip over them
+  var t = n[0].typ.skipTypes({tyGenericInst, tyAlias, tySink})
+  if n[0].kind == nkSym and n[0].sym.magic in FakeVarParams:
+    # BUGFIX: check for L-Value still needs to be done for the arguments!
+    # note sometimes this is eval'ed twice so we check for nkHiddenAddr here:
+    for i in 1..<n.len:
+      if i < t.len and t[i] != nil and
+          skipTypes(t[i], abstractInst-{tyTypeDesc}).kind in {tyVar}:
+        let it = n[i]
+        let aa = isAssignable(c, it)
+        if aa notin {arLValue, arLocalLValue}:
+          if it.kind != nkHiddenAddr:
+            if aa == arDiscriminant and c.inUncheckedAssignSection > 0:
+              discard "allow access within a cast(unsafeAssign) section"
+            else:
+              localError(c.config, it.info, errVarForOutParamNeededX % $it)
+        # Make sure to still check arguments for converters
+        c.checkIfConverterCalled(n[i])
+    # bug #5113: disallow newSeq(result) where result is a 'var T':
+    if n[0].sym.magic in {mNew, mNewFinalize, mNewSeq}:
+      var arg = n[1] #.skipAddr
+      if arg.kind == nkHiddenDeref: arg = arg[0]
+      if arg.kind == nkSym and arg.sym.kind == skResult and
+          arg.typ.skipTypes(abstractInst).kind in {tyVar, tyLent}:
+        localError(c.config, n.info, errXStackEscape % renderTree(n[1], {renderNoComments}))
+
+    return
+  for i in 1..<n.len:
+    let n = if n.kind == nkHiddenDeref: n[0] else: n
+    c.checkIfConverterCalled(n[i])
+    if i < t.len and
+        skipTypes(t[i], abstractInst-{tyTypeDesc}).kind in {tyVar}:
+      # Converters wrap var parameters in nkHiddenAddr but they haven't been analysed yet.
+      # So we need to make sure we are checking them still when in a converter call
+      if n[i].kind != nkHiddenAddr or isConverter:
+        n[i] = analyseIfAddressTaken(c, n[i].skipAddr(), isOutParam(skipTypes(t[i], abstractInst-{tyTypeDesc})))
+
+
 proc replaceHookMagic*(c: PContext, n: PNode, kind: TTypeAttachedOp): PNode =
   ## Replaces builtin generic hooks with lifted hooks.
   case kind
@@ -674,10 +788,7 @@ proc replaceHookMagic*(c: PContext, n: PNode, kind: TTypeAttachedOp): PNode =
     let op = getAttachedOp(c.graph, t, attachedWasMoved)
     if op != nil:
       result[0] = newSymNode(op)
-      # TODO:
-      # let addrExp = newNodeIT(nkHiddenAddr, result[1].info, makePtrType(c, t))
-      # addrExp.add result[1]
-      # result[1] = addrExp
+      analyseIfAddressTakenInCall(c, result, false)
   of attachedSink, attachedAsgn, attachedDeepCopy:
     # TODO: `nkSinkAsgn`, `nkAsgn`
     result = n

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -917,8 +917,7 @@ proc analyseIfAddressTakenInCall(c: PContext, n: PNode, isConverter = false) =
   const
     FakeVarParams = {mNew, mNewFinalize, mInc, ast.mDec, mIncl, mExcl,
       mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
-      mAppendSeqElem, mNewSeq, mShallowCopy, mDeepCopy, mMove,
-      mWasMoved}
+      mAppendSeqElem, mNewSeq, mShallowCopy, mDeepCopy, mMove}
 
   template checkIfConverterCalled(c: PContext, n: PNode) =
     ## Checks if there is a converter call which wouldn't be checked otherwise

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -16,7 +16,6 @@ when defined(nimCompilerStacktraceHints):
 const
   errExprXHasNoType = "expression '$1' has no type (or is ambiguous)"
   errXExpectsTypeOrValue = "'$1' expects a type or value"
-  errVarForOutParamNeededX = "for a 'var' type a variable needs to be passed; but '$1' is immutable"
   errXStackEscape = "address of '$1' may not escape its stack frame"
   errExprHasNoAddress = "expression has no address"
   errCannotInterpretNodeX = "cannot evaluate '$1'"
@@ -864,104 +863,6 @@ proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
     for i in 0..<n.safeLen:
       if hasUnresolvedArgs(c, n[i]): return true
     return false
-
-proc newHiddenAddrTaken(c: PContext, n: PNode, isOutParam: bool): PNode =
-  if n.kind == nkHiddenDeref and not (c.config.backend == backendCpp or
-                                      sfCompileToCpp in c.module.flags):
-    checkSonsLen(n, 1, c.config)
-    result = n[0]
-  else:
-    result = newNodeIT(nkHiddenAddr, n.info, makeVarType(c, n.typ))
-    result.add n
-    let aa = isAssignable(c, n)
-    let sym = getRoot(n)
-    if aa notin {arLValue, arLocalLValue}:
-      if aa == arDiscriminant and c.inUncheckedAssignSection > 0:
-        discard "allow access within a cast(unsafeAssign) section"
-      elif strictDefs in c.features and aa == arAddressableConst and
-              sym != nil and sym.kind == skLet and isOutParam:
-        discard "allow let varaibles to be passed to out parameters"
-      else:
-        localError(c.config, n.info, errVarForOutParamNeededX % renderNotLValue(n))
-
-proc analyseIfAddressTaken(c: PContext, n: PNode, isOutParam: bool): PNode =
-  result = n
-  case n.kind
-  of nkSym:
-    # n.sym.typ can be nil in 'check' mode ...
-    if n.sym.typ != nil and
-        skipTypes(n.sym.typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
-      incl(n.sym.flags, sfAddrTaken)
-      result = newHiddenAddrTaken(c, n, isOutParam)
-  of nkDotExpr:
-    checkSonsLen(n, 2, c.config)
-    if n[1].kind != nkSym:
-      internalError(c.config, n.info, "analyseIfAddressTaken")
-      return
-    if skipTypes(n[1].sym.typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
-      incl(n[1].sym.flags, sfAddrTaken)
-      result = newHiddenAddrTaken(c, n, isOutParam)
-  of nkBracketExpr:
-    checkMinSonsLen(n, 1, c.config)
-    if skipTypes(n[0].typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
-      if n[0].kind == nkSym: incl(n[0].sym.flags, sfAddrTaken)
-      result = newHiddenAddrTaken(c, n, isOutParam)
-  else:
-    result = newHiddenAddrTaken(c, n, isOutParam)
-
-proc analyseIfAddressTakenInCall(c: PContext, n: PNode, isConverter = false) =
-  checkMinSonsLen(n, 1, c.config)
-  if n[0].typ == nil:
-    # n[0] might be erroring node in nimsuggest
-    return
-  const
-    FakeVarParams = {mNew, mNewFinalize, mInc, ast.mDec, mIncl, mExcl,
-      mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
-      mAppendSeqElem, mNewSeq, mShallowCopy, mDeepCopy, mMove}
-
-  template checkIfConverterCalled(c: PContext, n: PNode) =
-    ## Checks if there is a converter call which wouldn't be checked otherwise
-    # Call can sometimes be wrapped in a deref
-    let node = if n.kind == nkHiddenDeref: n[0] else: n
-    if node.kind == nkHiddenCallConv:
-      analyseIfAddressTakenInCall(c, node, true)
-  # get the real type of the callee
-  # it may be a proc var with a generic alias type, so we skip over them
-  var t = n[0].typ.skipTypes({tyGenericInst, tyAlias, tySink})
-  if n[0].kind == nkSym and n[0].sym.magic in FakeVarParams:
-    # BUGFIX: check for L-Value still needs to be done for the arguments!
-    # note sometimes this is eval'ed twice so we check for nkHiddenAddr here:
-    for i in 1..<n.len:
-      if i < t.len and t[i] != nil and
-          skipTypes(t[i], abstractInst-{tyTypeDesc}).kind in {tyVar}:
-        let it = n[i]
-        let aa = isAssignable(c, it)
-        if aa notin {arLValue, arLocalLValue}:
-          if it.kind != nkHiddenAddr:
-            if aa == arDiscriminant and c.inUncheckedAssignSection > 0:
-              discard "allow access within a cast(unsafeAssign) section"
-            else:
-              localError(c.config, it.info, errVarForOutParamNeededX % $it)
-        # Make sure to still check arguments for converters
-        c.checkIfConverterCalled(n[i])
-    # bug #5113: disallow newSeq(result) where result is a 'var T':
-    if n[0].sym.magic in {mNew, mNewFinalize, mNewSeq}:
-      var arg = n[1] #.skipAddr
-      if arg.kind == nkHiddenDeref: arg = arg[0]
-      if arg.kind == nkSym and arg.sym.kind == skResult and
-          arg.typ.skipTypes(abstractInst).kind in {tyVar, tyLent}:
-        localError(c.config, n.info, errXStackEscape % renderTree(n[1], {renderNoComments}))
-
-    return
-  for i in 1..<n.len:
-    let n = if n.kind == nkHiddenDeref: n[0] else: n
-    c.checkIfConverterCalled(n[i])
-    if i < t.len and
-        skipTypes(t[i], abstractInst-{tyTypeDesc}).kind in {tyVar}:
-      # Converters wrap var parameters in nkHiddenAddr but they haven't been analysed yet.
-      # So we need to make sure we are checking them still when in a converter call
-      if n[i].kind != nkHiddenAddr or isConverter:
-        n[i] = analyseIfAddressTaken(c, n[i].skipAddr(), isOutParam(skipTypes(t[i], abstractInst-{tyTypeDesc})))
 
 include semmagic
 

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -653,42 +653,13 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mNewFinalize:
     result = semNewFinalize(c, n)
   of mDestroy:
-    result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedDestructor)
-    if op != nil:
-      result[0] = newSymNode(op)
-      if op.typ != nil and op.typ.len == 2 and op.typ.firstParamType.kind != tyVar:
-        if n[1].kind == nkSym and n[1].sym.kind == skParam and
-            n[1].typ.kind == tyVar:
-          result[1] = genDeref(n[1])
-        else:
-          result[1] = skipAddr(n[1])
+    result = replaceHookMagic(c, n, attachedDestructor)
   of mTrace:
-    result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedTrace)
-    if op != nil:
-      result[0] = newSymNode(op)
+    result = replaceHookMagic(c, n, attachedTrace)
   of mDup:
-    result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedDup)
-    if op != nil:
-      result[0] = newSymNode(op)
-      if op.typ.len == 3:
-        let boolLit = newIntLit(c.graph, n.info, 1)
-        boolLit.typ() = getSysType(c.graph, n.info, tyBool)
-        result.add boolLit
+    result = replaceHookMagic(c, n, attachedDup)
   of mWasMoved:
-    result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedWasMoved)
-    if op != nil:
-      result[0] = newSymNode(op)
-      let addrExp = newNodeIT(nkHiddenAddr, result[1].info, makePtrType(c, t))
-      addrExp.add result[1]
-      result[1] = addrExp
+    result = replaceHookMagic(c, n, attachedWasMoved)
   of mUnown:
     result = semUnown(c, n)
   of mExists, mForall:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -981,6 +981,25 @@ proc markCaughtExceptions(tracked: PEffects; g: ModuleGraph; info: TLineInfo; s:
     if optIdeExceptionInlayHints in tracked.config.globalOptions:
       internalMarkCaughtExceptions(tracked, g.suggestSymbols.mgetOrPut(info.fileIndex, newSuggestFileSymbolDatabase(info.fileIndex, true)), info)
 
+proc findHookKind(name: string): (bool, TTypeAttachedOp) =
+  case name.normalize
+  of "=wasmoved":
+    result = (true, attachedWasMoved)
+  of "=destroy":
+    result = (true, attachedDestructor)
+  of "=copy", "=":
+    result = (true, attachedAsgn)
+  of "=dup":
+    result = (true, attachedDup)
+  of "=sink":
+    result = (true, attachedSink)
+  of "=trace":
+    result = (true, attachedTrace)
+  of "=deepcopy":
+    result = (true, attachedDeepCopy)
+  else:
+    result = (false, attachedWasMoved)
+
 proc trackCall(tracked: PEffects; n: PNode) =
   template gcsafeAndSideeffectCheck() =
     if notGcSafe(op) and not importedFromC(a):
@@ -1069,25 +1088,17 @@ proc trackCall(tracked: PEffects; n: PNode) =
       checkBounds(tracked, n[1], n[2])
 
 
+  var n = n
   if a.kind == nkSym and a.sym.name.s.len > 0 and a.sym.name.s[0] == '=' and
         tracked.owner.kind != skMacro:
-    var opKind = find(AttachedOpToStr, a.sym.name.s.normalize)
-    if a.sym.name.s == "=": opKind = attachedAsgn.int
-    if opKind != -1:
+    var (isHook, opKind) = findHookKind(a.sym.name.s)
+    if isHook:
       # rebind type bounds operations after createTypeBoundOps call
       let t = n[1].typ.skipTypes({tyAlias, tyVar})
-      if a.sym != getAttachedOp(tracked.graph, t, TTypeAttachedOp(opKind)):
+      if a.sym != getAttachedOp(tracked.graph, t, opKind):
         createTypeBoundOps(tracked, t, n.info, explicit = true)
-        let op = getAttachedOp(tracked.graph, t, TTypeAttachedOp(opKind))
-        if op != nil:
-          n[0].sym = op
-          if TTypeAttachedOp(opKind) == attachedDestructor and
-              op.typ.len == 2 and op.typ.firstParamType.kind != tyVar:
-            if n[1].kind == nkSym and n[1].sym.kind == skParam and
-                n[1].typ.kind == tyVar:
-              n[1] = genDeref(n[1])
-            else:
-              n[1] = skipAddr(n[1])
+        # replace builtin hooks with lifted ones
+        n = replaceHookMagic(tracked.c, n, opKind)
 
   if op != nil and op.kind == tyProc:
     for i in 1..<min(n.safeLen, op.signatureLen):

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1459,13 +1459,15 @@ elif not defined(useNimRtl):
   proc peekableOutputStream(p: Process): Stream =
     streamAccess(p)
     if p.outStream == nil:
-      p.outStream = createStream(p.outHandle, fmRead).newPipeOutStream
+      {.cast(raises: []), cast(tags: []).}:
+        p.outStream = createStream(p.outHandle, fmRead).newPipeOutStream
     return p.outStream
 
   proc peekableErrorStream(p: Process): Stream =
     streamAccess(p)
     if p.errStream == nil:
-      p.errStream = createStream(p.errHandle, fmRead).newPipeOutStream
+      {.cast(raises: []), cast(tags: []).}:
+        p.errStream = createStream(p.errHandle, fmRead).newPipeOutStream
     return p.errStream
 
   proc csystem(cmd: cstring): cint {.nodecl, importc: "system",

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1459,15 +1459,13 @@ elif not defined(useNimRtl):
   proc peekableOutputStream(p: Process): Stream =
     streamAccess(p)
     if p.outStream == nil:
-      {.cast(raises: []), cast(tags: []).}:
-        p.outStream = createStream(p.outHandle, fmRead).newPipeOutStream
+      p.outStream = createStream(p.outHandle, fmRead).newPipeOutStream
     return p.outStream
 
   proc peekableErrorStream(p: Process): Stream =
     streamAccess(p)
     if p.errStream == nil:
-      {.cast(raises: []), cast(tags: []).}:
-        p.errStream = createStream(p.errHandle, fmRead).newPipeOutStream
+      p.errStream = createStream(p.errHandle, fmRead).newPipeOutStream
     return p.errStream
 
   proc csystem(cmd: cstring): cint {.nodecl, importc: "system",

--- a/lib/pure/streamwrapper.nim
+++ b/lib/pure/streamwrapper.nim
@@ -105,7 +105,8 @@ proc newPipeOutStream*[T](s: sink (ref T)): owned PipeOutStream[T] =
   new(result)
   for dest, src in fields((ref T)(result)[], s[]):
     dest = src
-  wasMoved(s[])
+  {.cast(raises: []), cast(tags: []).}:
+    wasMoved(s[])
   if result.readLineImpl != nil:
     result.baseReadLineImpl = result.readLineImpl
     result.readLineImpl = posReadLine[T]

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -161,12 +161,10 @@ else:
 proc `=wasMoved`*[T](obj: var T) {.magic: "WasMoved", noSideEffect.} =
   ## Generic `wasMoved`:idx: implementation that can be overridden.
 
-proc wasMoved*[T](obj: var T) {.inline, noSideEffect.} =
+proc wasMoved*[T](obj: var T) {.magic: "WasMoved", noSideEffect.}
   ## Resets an object `obj` to its initial (binary zero) value to signify
   ## it was "moved" and to signify its destructor should do nothing and
   ## ideally be optimized away.
-  {.cast(raises: []), cast(tags: []).}:
-    `=wasMoved`(obj)
 
 proc move*[T](x: var T): T {.magic: "Move", noSideEffect.} =
   result = x


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/issues/24764 

To keep destructors injected consistently, we need to transform `mAsgn` properly into `nkSinkAsgn` and `nkAsgn`. This PR is the first step towards overhauling hook injections.

In this PR, hooks (except mAsgn) are treated consistently whether it is resolved in matching or instantiated by sempass2. It also fixes a spelling `=wasMoved` to its normalized version, which caused no replacing generic hook calls with lifted hook calls.