### PR TITLE
rename / deprecate `normalize` in `strutil` 

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -144,7 +144,7 @@ proc splitSwitch(conf: ConfigRef; switch: string, cmd, arg: var string, pass: TC
 
 template switchOn(arg: string): bool =
   # xxx use `switchOn` wherever appropriate
-  case arg.normalize
+  case arg.cfgIdentNormalize
   of "", "on": true
   of "off": false
   else:
@@ -153,7 +153,7 @@ template switchOn(arg: string): bool =
 
 proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                         info: TLineInfo) =
-  case arg.normalize
+  case arg.cfgIdentNormalize
   of "", "on": conf.options.incl op
   of "off": conf.options.excl op
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
@@ -161,7 +161,7 @@ proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLi
 proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                               info: TLineInfo): bool =
   result = false
-  case arg.normalize
+  case arg.cfgIdentNormalize
   of "on": conf.options.incl op
   of "off": conf.options.excl op
   of "list": result = true
@@ -169,7 +169,7 @@ proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: 
 
 proc processOnOffSwitchG(conf: ConfigRef; op: TGlobalOptions, arg: string, pass: TCmdLinePass,
                          info: TLineInfo) =
-  case arg.normalize
+  case arg.cfgIdentNormalize
   of "", "on": conf.globalOptions.incl op
   of "off": conf.globalOptions.excl op
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
@@ -213,12 +213,12 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
         message(conf, info, warnUnknownNotes, "unknown $#: $#" % [name, id])
       else:
         localError(conf, info, "unknown $#: $#" % [name, id])
-  case id.normalize
+  case id.cfgIdentNormalize
   of "all": # other note groups would be easy to support via additional cases
     notes = if isSomeHint: {hintMin..hintMax} else: {warnMin..warnMax}
   elif isSomeHint: findNote(hintMin, hintMax, "hint")
   else: findNote(warnMin, warnMax, "warning")
-  var val = substr(arg, i).normalize
+  var val = substr(arg, i).cfgIdentNormalize
   if val == "": val = "on"
   if val notin ["on", "off"]:
     # xxx in future work we should also allow users to have control over `foreignPackageNotes`
@@ -226,7 +226,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     localError(conf, info, errOnOrOffExpectedButXFound % arg)
   else:
     let isOn = val == "on"
-    if isOn and id.normalize == "all":
+    if isOn and id.cfgIdentNormalize == "all":
       localError(conf, info, "only 'all:off' is supported")
     for n in notes:
       if n notin conf.cmdlineNotes or pass == passCmd1:
@@ -258,9 +258,9 @@ template deprecatedAlias(oldName, newName: string) =
   warningDeprecated(conf, info, "'$#' is a deprecated alias for '$#'" % [oldName, newName])
 
 proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo): bool =
-  case switch.normalize
+  case switch.cfgIdentNormalize
   of "gc", "mm":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "boehm": result = conf.selectedGC == gcBoehm
     of "refc": result = conf.selectedGC == gcRefc
     of "markandsweep": result = conf.selectedGC == gcMarkAndSweep
@@ -275,7 +275,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
       result = false
       localError(conf, info, errNoneBoehmRefcExpectedButXFound % arg)
   of "opt":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "speed": result = contains(conf.options, optOptimizeSpeed)
     of "size": result = contains(conf.options, optOptimizeSize)
     of "none": result = conf.options * {optOptimizeSpeed, optOptimizeSize} == {}
@@ -284,7 +284,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
       localError(conf, info, errNoneSpeedOrSizeExpectedButXFound % arg)
   of "verbosity": result = $conf.verbosity == arg
   of "app":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "gui": result = contains(conf.globalOptions, optGenGuiApp)
     of "console": result = not contains(conf.globalOptions, optGenGuiApp)
     of "lib": result = contains(conf.globalOptions, optGenDynLib) and
@@ -297,7 +297,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
   of "dynliboverride":
     result = isDynlibOverride(conf, arg)
   of "exceptions":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "cpp": result = conf.exc == excCpp
     of "setjmp": result = conf.exc == excSetjmp
     of "quirky": result = conf.exc == excQuirky
@@ -316,7 +316,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
     invalidCmdLineOption(conf, passCmd1, switch, info)
 
 proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool =
-  case switch.normalize
+  case switch.cfgIdentNormalize
   of "debuginfo": result = contains(conf.globalOptions, optCDebug)
   of "compileonly", "c": result = contains(conf.globalOptions, optCompileOnly)
   of "nolinking": result = contains(conf.globalOptions, optNoLinking)
@@ -356,7 +356,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "tlsemulation": result = contains(conf.globalOptions, optTlsEmulation)
   of "implicitstatic": result = contains(conf.options, optImplicitStatic)
   of "patterns", "trmacros":
-    if switch.normalize == "patterns": deprecatedAlias(switch, "trmacros")
+    if switch.cfgIdentNormalize == "patterns": deprecatedAlias(switch, "trmacros")
     result = contains(conf.options, optTrMacros)
   of "excessivestacktrace": result = contains(conf.globalOptions, optExcessiveStackTrace)
   of "nilseqs", "nilchecks", "taintmode":
@@ -468,7 +468,7 @@ proc handleCmdInput*(conf: ConfigRef) =
   handleStdinOrCmdInput()
 
 proc parseCommand*(command: string): Command =
-  case command.normalize
+  case command.cfgIdentNormalize
   of "c", "cc", "compile", "compiletoc": cmdCompileToC
   of "cpp", "compiletocpp": cmdCompileToCpp
   of "objc", "compiletooc": cmdCompileToOC
@@ -572,7 +572,7 @@ proc processMemoryManagementOption(switch, arg: string, pass: TCmdLinePass,
   if conf.backend == backendJs: return # for: bug #16033
   expectArg(conf, switch, arg, pass, info)
   if pass in {passCmd2, passPP}:
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "boehm":
       unregisterArcOrc(conf)
       conf.selectedGC = gcBoehm
@@ -630,7 +630,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
                     conf: ConfigRef) =
   var key = ""
   var val = ""
-  case switch.normalize
+  case switch.cfgIdentNormalize
   of "eval":
     expectArg(conf, switch, arg, pass, info)
     conf.projectIsCmd = true
@@ -688,7 +688,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "docroot":
     conf.docRoot = if arg.len == 0: docRootDefault else: arg
   of "backend", "b":
-    let backend = parseEnum(arg.normalize, TBackend.default)
+    let backend = parseEnum(arg.cfgIdentNormalize, TBackend.default)
     if backend == TBackend.default: localError(conf, info, "invalid backend: '$1'" % arg)
     if backend == backendJs: # bug #21209
       conf.globalOptions.excl {optThreadAnalysis, optThreads}
@@ -751,7 +751,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "excessivestacktrace": processOnOffSwitchG(conf, {optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch(conf, {optLineTrace}, arg, pass, info)
   of "debugger":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "on", "native", "gdb":
       conf.globalOptions.incl optCDebug
       conf.options.incl optLineDir
@@ -812,11 +812,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "implicitstatic":
     processOnOffSwitch(conf, {optImplicitStatic}, arg, pass, info)
   of "patterns", "trmacros":
-    if switch.normalize == "patterns": deprecatedAlias(switch, "trmacros")
+    if switch.cfgIdentNormalize == "patterns": deprecatedAlias(switch, "trmacros")
     processOnOffSwitch(conf, {optTrMacros}, arg, pass, info)
   of "opt":
     expectArg(conf, switch, arg, pass, info)
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "speed":
       incl(conf.options, optOptimizeSpeed)
       excl(conf.options, optOptimizeSize)
@@ -829,7 +829,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else: localError(conf, info, errNoneSpeedOrSizeExpectedButXFound % arg)
   of "app":
     expectArg(conf, switch, arg, pass, info)
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "gui":
       incl(conf.globalOptions, optGenGuiApp)
       defineSymbol(conf.symbols, "executable")
@@ -872,7 +872,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "nimbasepattern":
     if conf != nil: conf.nimbasePattern = arg
   of "index":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "", "on": conf.globalOptions.incl {optGenIndex}
     of "only": conf.globalOptions.incl {optGenIndexOnly, optGenIndex}
     of "off": conf.globalOptions.excl {optGenIndex, optGenIndexOnly}
@@ -964,10 +964,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectNoArg(conf, switch, arg, pass, info)
     helpOnError(conf, pass)
   of "symbolfiles", "incremental", "ic":
-    if switch.normalize == "symbolfiles": deprecatedAlias(switch, "incremental")
+    if switch.cfgIdentNormalize == "symbolfiles": deprecatedAlias(switch, "incremental")
       # xxx maybe also ic, since not in help?
     if pass in {passCmd2, passPP}:
-      case arg.normalize
+      case arg.cfgIdentNormalize
       of "on": conf.symbolFiles = v2Sf
       of "off": conf.symbolFiles = disabledSf
       of "writeonly": conf.symbolFiles = writeOnlySf
@@ -985,7 +985,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "skipparentcfg":
     processOnOffSwitchG(conf, {optSkipParentConfigFiles}, arg, pass, info)
   of "genscript", "gendeps":
-    if switch.normalize == "gendeps": deprecatedAlias(switch, "genscript")
+    if switch.cfgIdentNormalize == "gendeps": deprecatedAlias(switch, "genscript")
     processOnOffSwitchG(conf, {optGenScript}, arg, pass, info)
     processOnOffSwitchG(conf, {optCompileOnly}, arg, pass, info)
   of "gencdeps":
@@ -1026,7 +1026,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "stdout":
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info)
   of "filenames":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "abs": conf.filenameOption = foAbs
     of "canonical": conf.filenameOption = foCanonical
     of "legacyrelproj": conf.filenameOption = foLegacyRelProj
@@ -1034,7 +1034,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "processing":
     incl(conf.notes, hintProcessing)
     incl(conf.mainPackageNotes, hintProcessing)
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "dots": conf.hintProcessingDots = true
     of "filenames": conf.hintProcessingDots = false
     of "off":
@@ -1077,7 +1077,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectNoArg(conf, switch, arg, pass, info)
     showNonExportedFields(conf)
   of "exceptions":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "cpp": conf.exc = excCpp
     of "setjmp": conf.exc = excSetjmp
     of "quirky": conf.exc = excQuirky
@@ -1106,7 +1106,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if pass in {passCmd2, passPP}:
       defineSymbol(conf.symbols, "nimSeqsV2")
   of "stylecheck":
-    case arg.normalize
+    case arg.cfgIdentNormalize
     of "off": conf.globalOptions = conf.globalOptions - {optStyleHint, optStyleError}
     of "hint": conf.globalOptions = conf.globalOptions + {optStyleHint} - {optStyleError}
     of "error": conf.globalOptions = conf.globalOptions + {optStyleError}

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -144,7 +144,7 @@ proc splitSwitch(conf: ConfigRef; switch: string, cmd, arg: var string, pass: TC
 
 template switchOn(arg: string): bool =
   # xxx use `switchOn` wherever appropriate
-  case arg.cfgIdentNormalize
+  case arg.normalizeStyle
   of "", "on": true
   of "off": false
   else:
@@ -153,7 +153,7 @@ template switchOn(arg: string): bool =
 
 proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                         info: TLineInfo) =
-  case arg.cfgIdentNormalize
+  case arg.normalizeStyle
   of "", "on": conf.options.incl op
   of "off": conf.options.excl op
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
@@ -161,7 +161,7 @@ proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLi
 proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                               info: TLineInfo): bool =
   result = false
-  case arg.cfgIdentNormalize
+  case arg.normalizeStyle
   of "on": conf.options.incl op
   of "off": conf.options.excl op
   of "list": result = true
@@ -169,7 +169,7 @@ proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: 
 
 proc processOnOffSwitchG(conf: ConfigRef; op: TGlobalOptions, arg: string, pass: TCmdLinePass,
                          info: TLineInfo) =
-  case arg.cfgIdentNormalize
+  case arg.normalizeStyle
   of "", "on": conf.globalOptions.incl op
   of "off": conf.globalOptions.excl op
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
@@ -213,12 +213,12 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
         message(conf, info, warnUnknownNotes, "unknown $#: $#" % [name, id])
       else:
         localError(conf, info, "unknown $#: $#" % [name, id])
-  case id.cfgIdentNormalize
+  case id.normalizeStyle
   of "all": # other note groups would be easy to support via additional cases
     notes = if isSomeHint: {hintMin..hintMax} else: {warnMin..warnMax}
   elif isSomeHint: findNote(hintMin, hintMax, "hint")
   else: findNote(warnMin, warnMax, "warning")
-  var val = substr(arg, i).cfgIdentNormalize
+  var val = substr(arg, i).normalizeStyle
   if val == "": val = "on"
   if val notin ["on", "off"]:
     # xxx in future work we should also allow users to have control over `foreignPackageNotes`
@@ -226,7 +226,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     localError(conf, info, errOnOrOffExpectedButXFound % arg)
   else:
     let isOn = val == "on"
-    if isOn and id.cfgIdentNormalize == "all":
+    if isOn and id.normalizeStyle == "all":
       localError(conf, info, "only 'all:off' is supported")
     for n in notes:
       if n notin conf.cmdlineNotes or pass == passCmd1:
@@ -258,9 +258,9 @@ template deprecatedAlias(oldName, newName: string) =
   warningDeprecated(conf, info, "'$#' is a deprecated alias for '$#'" % [oldName, newName])
 
 proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo): bool =
-  case switch.cfgIdentNormalize
+  case switch.normalizeStyle
   of "gc", "mm":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "boehm": result = conf.selectedGC == gcBoehm
     of "refc": result = conf.selectedGC == gcRefc
     of "markandsweep": result = conf.selectedGC == gcMarkAndSweep
@@ -275,7 +275,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
       result = false
       localError(conf, info, errNoneBoehmRefcExpectedButXFound % arg)
   of "opt":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "speed": result = contains(conf.options, optOptimizeSpeed)
     of "size": result = contains(conf.options, optOptimizeSize)
     of "none": result = conf.options * {optOptimizeSpeed, optOptimizeSize} == {}
@@ -284,7 +284,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
       localError(conf, info, errNoneSpeedOrSizeExpectedButXFound % arg)
   of "verbosity": result = $conf.verbosity == arg
   of "app":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "gui": result = contains(conf.globalOptions, optGenGuiApp)
     of "console": result = not contains(conf.globalOptions, optGenGuiApp)
     of "lib": result = contains(conf.globalOptions, optGenDynLib) and
@@ -297,7 +297,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
   of "dynliboverride":
     result = isDynlibOverride(conf, arg)
   of "exceptions":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "cpp": result = conf.exc == excCpp
     of "setjmp": result = conf.exc == excSetjmp
     of "quirky": result = conf.exc == excQuirky
@@ -316,7 +316,7 @@ proc testCompileOptionArg*(conf: ConfigRef; switch, arg: string, info: TLineInfo
     invalidCmdLineOption(conf, passCmd1, switch, info)
 
 proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool =
-  case switch.cfgIdentNormalize
+  case switch.normalizeStyle
   of "debuginfo": result = contains(conf.globalOptions, optCDebug)
   of "compileonly", "c": result = contains(conf.globalOptions, optCompileOnly)
   of "nolinking": result = contains(conf.globalOptions, optNoLinking)
@@ -356,7 +356,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "tlsemulation": result = contains(conf.globalOptions, optTlsEmulation)
   of "implicitstatic": result = contains(conf.options, optImplicitStatic)
   of "patterns", "trmacros":
-    if switch.cfgIdentNormalize == "patterns": deprecatedAlias(switch, "trmacros")
+    if switch.normalizeStyle == "patterns": deprecatedAlias(switch, "trmacros")
     result = contains(conf.options, optTrMacros)
   of "excessivestacktrace": result = contains(conf.globalOptions, optExcessiveStackTrace)
   of "nilseqs", "nilchecks", "taintmode":
@@ -468,7 +468,7 @@ proc handleCmdInput*(conf: ConfigRef) =
   handleStdinOrCmdInput()
 
 proc parseCommand*(command: string): Command =
-  case command.cfgIdentNormalize
+  case command.normalizeStyle
   of "c", "cc", "compile", "compiletoc": cmdCompileToC
   of "cpp", "compiletocpp": cmdCompileToCpp
   of "objc", "compiletooc": cmdCompileToOC
@@ -572,7 +572,7 @@ proc processMemoryManagementOption(switch, arg: string, pass: TCmdLinePass,
   if conf.backend == backendJs: return # for: bug #16033
   expectArg(conf, switch, arg, pass, info)
   if pass in {passCmd2, passPP}:
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "boehm":
       unregisterArcOrc(conf)
       conf.selectedGC = gcBoehm
@@ -630,7 +630,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
                     conf: ConfigRef) =
   var key = ""
   var val = ""
-  case switch.cfgIdentNormalize
+  case switch.normalizeStyle
   of "eval":
     expectArg(conf, switch, arg, pass, info)
     conf.projectIsCmd = true
@@ -688,7 +688,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "docroot":
     conf.docRoot = if arg.len == 0: docRootDefault else: arg
   of "backend", "b":
-    let backend = parseEnum(arg.cfgIdentNormalize, TBackend.default)
+    let backend = parseEnum(arg.normalizeStyle, TBackend.default)
     if backend == TBackend.default: localError(conf, info, "invalid backend: '$1'" % arg)
     if backend == backendJs: # bug #21209
       conf.globalOptions.excl {optThreadAnalysis, optThreads}
@@ -751,7 +751,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "excessivestacktrace": processOnOffSwitchG(conf, {optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch(conf, {optLineTrace}, arg, pass, info)
   of "debugger":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "on", "native", "gdb":
       conf.globalOptions.incl optCDebug
       conf.options.incl optLineDir
@@ -812,11 +812,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "implicitstatic":
     processOnOffSwitch(conf, {optImplicitStatic}, arg, pass, info)
   of "patterns", "trmacros":
-    if switch.cfgIdentNormalize == "patterns": deprecatedAlias(switch, "trmacros")
+    if switch.normalizeStyle == "patterns": deprecatedAlias(switch, "trmacros")
     processOnOffSwitch(conf, {optTrMacros}, arg, pass, info)
   of "opt":
     expectArg(conf, switch, arg, pass, info)
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "speed":
       incl(conf.options, optOptimizeSpeed)
       excl(conf.options, optOptimizeSize)
@@ -829,7 +829,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else: localError(conf, info, errNoneSpeedOrSizeExpectedButXFound % arg)
   of "app":
     expectArg(conf, switch, arg, pass, info)
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "gui":
       incl(conf.globalOptions, optGenGuiApp)
       defineSymbol(conf.symbols, "executable")
@@ -872,7 +872,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "nimbasepattern":
     if conf != nil: conf.nimbasePattern = arg
   of "index":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "", "on": conf.globalOptions.incl {optGenIndex}
     of "only": conf.globalOptions.incl {optGenIndexOnly, optGenIndex}
     of "off": conf.globalOptions.excl {optGenIndex, optGenIndexOnly}
@@ -964,10 +964,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectNoArg(conf, switch, arg, pass, info)
     helpOnError(conf, pass)
   of "symbolfiles", "incremental", "ic":
-    if switch.cfgIdentNormalize == "symbolfiles": deprecatedAlias(switch, "incremental")
+    if switch.normalizeStyle == "symbolfiles": deprecatedAlias(switch, "incremental")
       # xxx maybe also ic, since not in help?
     if pass in {passCmd2, passPP}:
-      case arg.cfgIdentNormalize
+      case arg.normalizeStyle
       of "on": conf.symbolFiles = v2Sf
       of "off": conf.symbolFiles = disabledSf
       of "writeonly": conf.symbolFiles = writeOnlySf
@@ -985,7 +985,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "skipparentcfg":
     processOnOffSwitchG(conf, {optSkipParentConfigFiles}, arg, pass, info)
   of "genscript", "gendeps":
-    if switch.cfgIdentNormalize == "gendeps": deprecatedAlias(switch, "genscript")
+    if switch.normalizeStyle == "gendeps": deprecatedAlias(switch, "genscript")
     processOnOffSwitchG(conf, {optGenScript}, arg, pass, info)
     processOnOffSwitchG(conf, {optCompileOnly}, arg, pass, info)
   of "gencdeps":
@@ -1026,7 +1026,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "stdout":
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info)
   of "filenames":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "abs": conf.filenameOption = foAbs
     of "canonical": conf.filenameOption = foCanonical
     of "legacyrelproj": conf.filenameOption = foLegacyRelProj
@@ -1034,7 +1034,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "processing":
     incl(conf.notes, hintProcessing)
     incl(conf.mainPackageNotes, hintProcessing)
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "dots": conf.hintProcessingDots = true
     of "filenames": conf.hintProcessingDots = false
     of "off":
@@ -1077,7 +1077,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectNoArg(conf, switch, arg, pass, info)
     showNonExportedFields(conf)
   of "exceptions":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "cpp": conf.exc = excCpp
     of "setjmp": conf.exc = excSetjmp
     of "quirky": conf.exc = excQuirky
@@ -1106,7 +1106,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if pass in {passCmd2, passPP}:
       defineSymbol(conf.symbols, "nimSeqsV2")
   of "stylecheck":
-    case arg.cfgIdentNormalize
+    case arg.normalizeStyle
     of "off": conf.globalOptions = conf.globalOptions - {optStyleHint, optStyleError}
     of "hint": conf.globalOptions = conf.globalOptions + {optStyleHint} - {optStyleError}
     of "error": conf.globalOptions = conf.globalOptions + {optStyleError}

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -897,7 +897,7 @@ proc getSymbol(L: var Lexer, tok: var Token) =
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
     if suspicious and {optStyleHint, optStyleError} * L.config.globalOptions != {}:
-      lintReport(L.config, getLineInfo(L), tok.ident.s.cfgIdentNormalize, tok.ident.s)
+      lintReport(L.config, getLineInfo(L), tok.ident.s.normalizeStyle, tok.ident.s)
   L.bufpos = pos
 
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -897,7 +897,7 @@ proc getSymbol(L: var Lexer, tok: var Token) =
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
     if suspicious and {optStyleHint, optStyleError} * L.config.globalOptions != {}:
-      lintReport(L.config, getLineInfo(L), tok.ident.s.normalize, tok.ident.s)
+      lintReport(L.config, getLineInfo(L), tok.ident.s.cfgIdentNormalize, tok.ident.s)
   L.bufpos = pos
 
 

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -50,12 +50,12 @@ proc `<`*(ver: Version, ver2: Version): bool =
   result = false
   # Handling for special versions such as "#head" or "#branch".
   if ver.isSpecial or ver2.isSpecial:
-    if ver2.isSpecial and ($ver2).normalize == "#head":
-      return ($ver).normalize != "#head"
+    if ver2.isSpecial and ($ver2).toLowerAscii == "#head":
+      return ($ver).toLowerAscii != "#head"
 
     if not ver2.isSpecial:
       # `#aa111 < 1.1`
-      return ($ver).normalize != "#head"
+      return ($ver).toLowerAscii != "#head"
 
   # Handling for normal versions such as "0.1.0" or "1.0".
   var sVer = string(ver).split('.')

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -132,7 +132,7 @@ proc parseDirective(L: var Lexer, tok: var Token; config: ConfigRef; condStack: 
                                 {useEnvironment, useKey}))
     ppGetTok(L, tok)
   else:
-    case tok.ident.s.normalize
+    case tok.ident.s.cfgIdentNormalize
     of "putenv":
       ppGetTok(L, tok)
       var key = $tok

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -132,7 +132,7 @@ proc parseDirective(L: var Lexer, tok: var Token; config: ConfigRef; condStack: 
                                 {useEnvironment, useKey}))
     ppGetTok(L, tok)
   else:
-    case tok.ident.s.cfgIdentNormalize
+    case tok.ident.s.normalizeStyle
     of "putenv":
       ppGetTok(L, tok)
       var key = $tok

--- a/compiler/optimizer.nim
+++ b/compiler/optimizer.nim
@@ -119,7 +119,7 @@ proc analyse(c: var Con; b: var BasicBlock; n: PNode) =
     var reverse = false
     if n[0].kind == nkSym:
       let s = n[0].sym
-      let name = s.name.s.normalize
+      let name = s.name.s.cfgIdentNormalize
       if name == "=wasmoved":
         b.wasMovedLocs.add n
         special = true

--- a/compiler/optimizer.nim
+++ b/compiler/optimizer.nim
@@ -119,7 +119,7 @@ proc analyse(c: var Con; b: var BasicBlock; n: PNode) =
     var reverse = false
     if n[0].kind == nkSym:
       let s = n[0].sym
-      let name = s.name.s.cfgIdentNormalize
+      let name = s.name.s.normalizeStyle
       if name == "=wasmoved":
         b.wasMovedLocs.add n
         special = true

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -633,7 +633,7 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
   elif cmpIgnoreStyle(symbol, platform.OS[conf.target.targetOS].name) == 0:
     result = true
   else:
-    case symbol.normalize
+    case symbol.cfgIdentNormalize
     of "x86": result = conf.target.targetCPU == cpuI386
     of "itanium": result = conf.target.targetCPU == cpuIa64
     of "x8664": result = conf.target.targetCPU == cpuAmd64

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -633,7 +633,7 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
   elif cmpIgnoreStyle(symbol, platform.OS[conf.target.targetOS].name) == 0:
     result = true
   else:
-    case symbol.cfgIdentNormalize
+    case symbol.normalizeStyle
     of "x86": result = conf.target.targetCPU == cpuI386
     of "itanium": result = conf.target.targetCPU == cpuIa64
     of "x8664": result = conf.target.targetCPU == cpuAmd64

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -85,7 +85,7 @@ proc compileConstraints(p: PNode, result: var TPatternCode; conf: ConfigRef) =
     else:
       patternError(p, conf)
   of nkIdent:
-    let spec = p.ident.s.cfgIdentNormalize
+    let spec = p.ident.s.normalizeStyle
     case spec
     of "atom": result.add(ppAtom)
     of "lit": result.add(ppLit)

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -85,7 +85,7 @@ proc compileConstraints(p: PNode, result: var TPatternCode; conf: ConfigRef) =
     else:
       patternError(p, conf)
   of nkIdent:
-    let spec = p.ident.s.normalize
+    let spec = p.ident.s.cfgIdentNormalize
     case spec
     of "atom": result.add(ppAtom)
     of "lit": result.add(ppLit)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -462,7 +462,7 @@ proc tryProcessOption(c: PContext, n: PNode, resOptions: var TOptions): bool =
         if n[1].kind != nkIdent:
           invalidPragma(c, n)
         else:
-          case n[1].ident.s.normalize
+          case n[1].ident.s.toLowerAscii
           of "speed":
             incl(resOptions, optOptimizeSpeed)
             excl(resOptions, optOptimizeSize)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -550,7 +550,7 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
     t1 = t1.base
 
   if n[2].kind in {nkStrLit..nkTripleStrLit}:
-    case n[2].strVal.normalize
+    case n[2].strVal.toLowerAscii
     of "closure":
       let t = skipTypes(t1, abstractRange)
       res = t.kind == tyProc and

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1071,7 +1071,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
 
   if a.kind == nkSym and a.sym.name.s.len > 0 and a.sym.name.s[0] == '=' and
         tracked.owner.kind != skMacro:
-    var opKind = find(AttachedOpToStr, a.sym.name.s.cfgIdentNormalize)
+    var opKind = find(AttachedOpToStr, a.sym.name.s.normalizeStyle)
     if a.sym.name.s == "=": opKind = attachedAsgn.int
     if opKind != -1:
       # rebind type bounds operations after createTypeBoundOps call

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1071,7 +1071,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
 
   if a.kind == nkSym and a.sym.name.s.len > 0 and a.sym.name.s[0] == '=' and
         tracked.owner.kind != skMacro:
-    var opKind = find(AttachedOpToStr, a.sym.name.s.normalize)
+    var opKind = find(AttachedOpToStr, a.sym.name.s.cfgIdentNormalize)
     if a.sym.name.s == "=": opKind = attachedAsgn.int
     if opKind != -1:
       # rebind type bounds operations after createTypeBoundOps call

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2189,7 +2189,7 @@ proc bindTypeHook(c: PContext; s: PSym; n: PNode; op: TTypeAttachedOp) =
   incl(s.flags, sfOverridden)
 
 proc semOverride(c: PContext, s: PSym, n: PNode) =
-  let name = s.name.s.cfgIdentNormalize
+  let name = s.name.s.normalizeStyle
   case name
   of "=destroy":
     bindTypeHook(c, s, n, attachedDestructor)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2189,7 +2189,7 @@ proc bindTypeHook(c: PContext; s: PSym; n: PNode; op: TTypeAttachedOp) =
   incl(s.flags, sfOverridden)
 
 proc semOverride(c: PContext, s: PSym, n: PNode) =
-  let name = s.name.s.normalize
+  let name = s.name.s.cfgIdentNormalize
   case name
   of "=destroy":
     bindTypeHook(c, s, n, attachedDestructor)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -145,6 +145,6 @@ const
 
 
 from std/enumutils import genEnumCaseStmt
-from std/strutils import normalize
+from std/strutils import cfgIdentNormalize
 proc findStr*[T: enum](a, b: static[T], s: string, default: T): T =
-  genEnumCaseStmt(T, s, default, ord(a), ord(b), normalize)
+  genEnumCaseStmt(T, s, default, ord(a), ord(b), cfgIdentNormalize)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -145,6 +145,6 @@ const
 
 
 from std/enumutils import genEnumCaseStmt
-from std/strutils import cfgIdentNormalize
+from std/strutils import normalizeStyle
 proc findStr*[T: enum](a, b: static[T], s: string, default: T): T =
-  genEnumCaseStmt(T, s, default, ord(a), ord(b), cfgIdentNormalize)
+  genEnumCaseStmt(T, s, default, ord(a), ord(b), normalizeStyle)

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1229,7 +1229,7 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
         p.key = "-"
         if processArgument(pass, p, argsCount, config): break
       else:
-        case p.key.normalize
+        case p.key.cfgIdentNormalize
         of "assumeunique":
           assumeUniqueness = true
         else:

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1229,7 +1229,7 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
         p.key = "-"
         if processArgument(pass, p, argsCount, config): break
       else:
-        case p.key.cfgIdentNormalize
+        case p.key.normalizeStyle
         of "assumeunique":
           assumeUniqueness = true
         else:

--- a/koch.nim
+++ b/koch.nim
@@ -716,7 +716,7 @@ when isMainModule:
     op.next()
     case op.kind
     of cmdLongOption, cmdShortOption:
-      case normalize(op.key)
+      case cfgIdentNormalize(op.key)
       of "help", "h": showHelp(success = true)
       of "latest": latest = true
       of "stable": latest = false
@@ -729,7 +729,7 @@ when isMainModule:
         skipIntegrityCheck = true
       else: showHelp(success = false)
     of cmdArgument:
-      case normalize(op.key)
+      case cfgIdentNormalize(op.key)
       of "boot": boot(op.cmdLineRest, skipIntegrityCheck)
       of "clean": clean(op.cmdLineRest)
       of "doc", "docs": buildDocs(op.cmdLineRest & " --d:nimPreviewSlimSystem " & paCode, localDocsOnly, localDocsOut)

--- a/koch.nim
+++ b/koch.nim
@@ -716,7 +716,7 @@ when isMainModule:
     op.next()
     case op.kind
     of cmdLongOption, cmdShortOption:
-      case cfgIdentNormalize(op.key)
+      case normalizeStyle(op.key)
       of "help", "h": showHelp(success = true)
       of "latest": latest = true
       of "stable": latest = false
@@ -729,7 +729,7 @@ when isMainModule:
         skipIntegrityCheck = true
       else: showHelp(success = false)
     of cmdArgument:
-      case cfgIdentNormalize(op.key)
+      case normalizeStyle(op.key)
       of "boot": boot(op.cmdLineRest, skipIntegrityCheck)
       of "clean": clean(op.cmdLineRest)
       of "doc", "docs": buildDocs(op.cmdLineRest & " --d:nimPreviewSlimSystem " & paCode, localDocsOnly, localDocsOut)

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -340,8 +340,8 @@ macro async*(prc: untyped): untyped =
 proc splitParamType(paramType: NimNode, async: bool): NimNode =
   result = paramType
   if paramType.kind == nnkInfix and paramType[0].strVal in ["|", "or"]:
-    let firstAsync = "async" in paramType[1].toStrLit().strVal.normalize
-    let secondAsync = "async" in paramType[2].toStrLit().strVal.normalize
+    let firstAsync = "async" in paramType[1].toStrLit().strVal.toLowerAscii
+    let secondAsync = "async" in paramType[2].toStrLit().strVal.toLowerAscii
 
     if firstAsync:
       result = paramType[if async: 1 else: 2]

--- a/lib/pure/cstrutils.nim
+++ b/lib/pure/cstrutils.nim
@@ -73,7 +73,7 @@ func endsWith*(s, suffix: cstring): bool {.rtl, extern: "csuEndsWith".} =
       if suffix[i] == '\0': return true
 
 func cmpIgnoreStyle*(a, b: cstring): int {.rtl, extern: "csuCmpIgnoreStyle".} =
-  ## Semantically the same as `cmp(cfgIdentNormalize($a), cfgIdentNormalize($b))`. It
+  ## Semantically the same as `cmp(normalizeStyle($a), normalizeStyle($b))`. It
   ## is just optimized to not allocate temporary strings. This should
   ## NOT be used to compare Nim identifier names, use `macros.eqIdent`
   ## for that. Returns:

--- a/lib/pure/cstrutils.nim
+++ b/lib/pure/cstrutils.nim
@@ -73,7 +73,7 @@ func endsWith*(s, suffix: cstring): bool {.rtl, extern: "csuEndsWith".} =
       if suffix[i] == '\0': return true
 
 func cmpIgnoreStyle*(a, b: cstring): int {.rtl, extern: "csuCmpIgnoreStyle".} =
-  ## Semantically the same as `cmp(normalize($a), normalize($b))`. It
+  ## Semantically the same as `cmp(cfgIdentNormalize($a), cfgIdentNormalize($b))`. It
   ## is just optimized to not allocate temporary strings. This should
   ## NOT be used to compare Nim identifier names, use `macros.eqIdent`
   ## for that. Returns:

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -60,7 +60,7 @@ const
 proc getIdent(e: NimNode): string =
   case e.kind
   of nnkIdent:
-    result = e.strVal.normalize
+    result = e.strVal.cfgIdentNormalize
   of nnkAccQuoted:
     result = getIdent(e[0])
     for i in 1 .. e.len-1:

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -60,7 +60,7 @@ const
 proc getIdent(e: NimNode): string =
   case e.kind
   of nnkIdent:
-    result = e.strVal.cfgIdentNormalize
+    result = e.strVal.normalizeStyle
   of nnkAccQuoted:
     result = getIdent(e[0])
     for i in 1 .. e.len-1:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -331,8 +331,8 @@ func cfgIdentNormalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
       inc j
   if j != s.len: setLen(result, j)
 
-func normalize*(s: string): string {.depreciated.} =
-  cfgIdentNormalize(s)
+#func normalize*(s: string): string {.deprecated.} =
+#  cfgIdentNormalize(s)
 
 func cmpIgnoreCase*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreCase".} =
   ## Compares two strings in a case insensitive manner. Returns:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -232,7 +232,7 @@ func toLowerAscii*(s: string): string {.rtl, extern: "nsuToLowerAsciiStr".} =
   ## character.
   ##
   ## See also:
-  ## * `cfgIdentNormalize func<#cfgIdentNormalize,string>`_
+  ## * `normalizeStyle func<#normalizeStyle,string>`_
   runnableExamples:
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
@@ -309,7 +309,7 @@ func nimIdentNormalize*(s: string): string =
       inc j
   if j != s.len: setLen(result, j)
 
-func cfgIdentNormalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
+func normalizeStyle*(s: string): string {.rtl, extern: "nsuNormalize".} =
   ## Normalizes the string `s`.
   ##
   ## That means to convert it to lower case and remove any '_'. This
@@ -318,8 +318,8 @@ func cfgIdentNormalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
   ## See also:
   ## * `toLowerAscii func<#toLowerAscii,string>`_
   runnableExamples:
-    doAssert cfgIdentNormalize("Foo_bar") == "foobar"
-    doAssert cfgIdentNormalize("Foo Bar") == "foo bar"
+    doAssert normalizeStyle("Foo_bar") == "foobar"
+    doAssert normalizeStyle("Foo Bar") == "foo bar"
   result = newString(s.len)
   var j = 0
   for i in 0..len(s) - 1:
@@ -331,8 +331,8 @@ func cfgIdentNormalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
       inc j
   if j != s.len: setLen(result, j)
 
-#func normalize*(s: string): string {.deprecated.} =
-#  cfgIdentNormalize(s)
+func normalize*(s: string): string {.deprecated.} =
+  normalizeStyle(s)
 
 func cmpIgnoreCase*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreCase".} =
   ## Compares two strings in a case insensitive manner. Returns:
@@ -350,7 +350,7 @@ func cmpIgnoreCase*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreCase".} =
                                       # thus we compile without checks here
 
 func cmpIgnoreStyle*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreStyle".} =
-  ## Semantically the same as `cmp(cfgIdentNormalize(a), cfgIdentNormalize(b))`. It
+  ## Semantically the same as `cmp(normalizeStyle(a), normalizeStyle(b))`. It
   ## is just optimized to not allocate temporary strings. This should
   ## NOT be used to compare Nim identifier names.
   ## Use `macros.eqIdent<macros.html#eqIdent,string,string>`_ for that.

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -232,7 +232,7 @@ func toLowerAscii*(s: string): string {.rtl, extern: "nsuToLowerAsciiStr".} =
   ## character.
   ##
   ## See also:
-  ## * `normalize func<#normalize,string>`_
+  ## * `cfgIdentNormalize func<#cfgIdentNormalize,string>`_
   runnableExamples:
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
@@ -309,7 +309,7 @@ func nimIdentNormalize*(s: string): string =
       inc j
   if j != s.len: setLen(result, j)
 
-func normalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
+func cfgIdentNormalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
   ## Normalizes the string `s`.
   ##
   ## That means to convert it to lower case and remove any '_'. This
@@ -318,8 +318,8 @@ func normalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
   ## See also:
   ## * `toLowerAscii func<#toLowerAscii,string>`_
   runnableExamples:
-    doAssert normalize("Foo_bar") == "foobar"
-    doAssert normalize("Foo Bar") == "foo bar"
+    doAssert cfgIdentNormalize("Foo_bar") == "foobar"
+    doAssert cfgIdentNormalize("Foo Bar") == "foo bar"
   result = newString(s.len)
   var j = 0
   for i in 0..len(s) - 1:
@@ -330,6 +330,9 @@ func normalize*(s: string): string {.rtl, extern: "nsuNormalize".} =
       result[j] = s[i]
       inc j
   if j != s.len: setLen(result, j)
+
+func normalize*(s: string): string {.depreciated.} =
+  cfgIdentNormalize(s)
 
 func cmpIgnoreCase*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreCase".} =
   ## Compares two strings in a case insensitive manner. Returns:
@@ -347,7 +350,7 @@ func cmpIgnoreCase*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreCase".} =
                                       # thus we compile without checks here
 
 func cmpIgnoreStyle*(a, b: string): int {.rtl, extern: "nsuCmpIgnoreStyle".} =
-  ## Semantically the same as `cmp(normalize(a), normalize(b))`. It
+  ## Semantically the same as `cmp(cfgIdentNormalize(a), cfgIdentNormalize(b))`. It
   ## is just optimized to not allocate temporary strings. This should
   ## NOT be used to compare Nim identifier names.
   ## Use `macros.eqIdent<macros.html#eqIdent,string,string>`_ for that.
@@ -1297,7 +1300,7 @@ func parseBool*(s: string): bool =
     let a = "n"
     doAssert parseBool(a) == false
 
-  case normalize(s)
+  case toLowerAscii(s)
   of "y", "yes", "true", "1", "on": result = true
   of "n", "no", "false", "0", "off": result = false
   else: raise newException(ValueError, "cannot interpret as a bool: " & s)
@@ -2818,7 +2821,7 @@ func formatEng*(f: BiggestFloat,
     result &= "e" & $exponent
   result &= suffix
 
-func findNormalized(x: string, inArray: openArray[string]): int =
+func findIngoreStyle(x: string, inArray: openArray[string]): int =
   var i = 0
   while i < high(inArray):
     if cmpIgnoreStyle(x, inArray[i]) == 0: return i
@@ -2875,14 +2878,14 @@ func addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.rtl,
           if idx < 0 or idx > a.high: invalidFormatString(formatstr)
           add s, a[idx]
         else:
-          var x = findNormalized(substr(formatstr, i+2, j-1), a)
+          var x = findIngoreStyle(substr(formatstr, i+2, j-1), a)
           if x >= 0 and x < high(a): add s, a[x+1]
           else: invalidFormatString(formatstr)
         i = j+1
       of 'a'..'z', 'A'..'Z', '\128'..'\255', '_':
         var j = i+1
         while j < formatstr.len and formatstr[j] in PatternChars: inc(j)
-        var x = findNormalized(substr(formatstr, i+1, j-1), a)
+        var x = findIngoreStyle(substr(formatstr, i+1, j-1), a)
         if x >= 0 and x < high(a): add s, a[x+1]
         else: invalidFormatString(formatstr)
         i = j

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -142,7 +142,7 @@ proc main =
         infiles.add(key.addFileExt(".nim"))
 
     of cmdLongOption, cmdShortOption:
-      case normalize(key)
+      case cfgIdentNormalize(key)
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
       of "backup": backup = parseBool(val)

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -142,7 +142,7 @@ proc main =
         infiles.add(key.addFileExt(".nim"))
 
     of cmdLongOption, cmdShortOption:
-      case cfgIdentNormalize(key)
+      case normalizeStyle(key)
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
       of "backup": backup = parseBool(val)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -513,7 +513,7 @@ proc execCmd(cmd: string; graph: ModuleGraph; cachedMsgs: CachedMsgs) =
 
   var opc = ""
   var i = parseIdent(cmd, opc, 0)
-  case opc.normalize
+  case opc.cfgIdentNormalize
   of "sug": conf.ideCmd = ideSug
   of "con": conf.ideCmd = ideCon
   of "def": conf.ideCmd = ideDef
@@ -675,7 +675,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
     case p.kind
     of cmdEnd: break
     of cmdLongOption, cmdShortOption:
-      case p.key.normalize
+      case p.key.cfgIdentNormalize
       of "help", "h":
         stdout.writeLine(Usage)
         quit()
@@ -706,7 +706,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
       of "v3": conf.suggestVersion = 3
       of "v4": conf.suggestVersion = 4
       of "info":
-        case p.val.normalize
+        case p.val.cfgIdentNormalize
         of "protocolver":
           stdout.writeLine(HighestSuggestProtocolVersion)
           quit 0
@@ -719,7 +719,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         else:
           processSwitch(pass, p, conf)
       of "exceptioninlayhints":
-        case p.val.normalize
+        case p.val.cfgIdentNormalize
         of "", "on": incl(conf.globalOptions, optIdeExceptionInlayHints)
         of "off": excl(conf.globalOptions, optIdeExceptionInlayHints)
         else: processSwitch(pass, p, conf)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -513,7 +513,7 @@ proc execCmd(cmd: string; graph: ModuleGraph; cachedMsgs: CachedMsgs) =
 
   var opc = ""
   var i = parseIdent(cmd, opc, 0)
-  case opc.cfgIdentNormalize
+  case opc.normalizeStyle
   of "sug": conf.ideCmd = ideSug
   of "con": conf.ideCmd = ideCon
   of "def": conf.ideCmd = ideDef
@@ -675,7 +675,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
     case p.kind
     of cmdEnd: break
     of cmdLongOption, cmdShortOption:
-      case p.key.cfgIdentNormalize
+      case p.key.normalizeStyle
       of "help", "h":
         stdout.writeLine(Usage)
         quit()
@@ -706,7 +706,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
       of "v3": conf.suggestVersion = 3
       of "v4": conf.suggestVersion = 4
       of "info":
-        case p.val.cfgIdentNormalize
+        case p.val.normalizeStyle
         of "protocolver":
           stdout.writeLine(HighestSuggestProtocolVersion)
           quit 0
@@ -719,7 +719,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         else:
           processSwitch(pass, p, conf)
       of "exceptioninlayhints":
-        case p.val.cfgIdentNormalize
+        case p.val.normalizeStyle
         of "", "on": incl(conf.globalOptions, optIdeExceptionInlayHints)
         of "off": excl(conf.globalOptions, optIdeExceptionInlayHints)
         else: processSwitch(pass, p, conf)

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -550,7 +550,7 @@ proc `&.?`(a, b: string): string =
 proc processSingleTest(r: var TResults, cat: Category, options, test: string, targets: set[TTarget], targetsSet: bool) =
   var targets = targets
   if not targetsSet:
-    let target = if cat.string.cfgIdentNormalize == "js": targetJS else: targetC
+    let target = if cat.string.normalizeStyle == "js": targetJS else: targetC
     targets = {target}
   doAssert fileExists(test), test & " test does not exist"
   testSpec r, makeTest(test, options, cat), targets
@@ -681,7 +681,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
 proc processCategory(r: var TResults, cat: Category,
                      options, testsDir: string,
                      runJoinableTests: bool) =
-  let cat2 = cat.string.cfgIdentNormalize
+  let cat2 = cat.string.normalizeStyle
   var handled = false
   if isNimRepoTests():
     handled = true

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -550,7 +550,7 @@ proc `&.?`(a, b: string): string =
 proc processSingleTest(r: var TResults, cat: Category, options, test: string, targets: set[TTarget], targetsSet: bool) =
   var targets = targets
   if not targetsSet:
-    let target = if cat.string.normalize == "js": targetJS else: targetC
+    let target = if cat.string.cfgIdentNormalize == "js": targetJS else: targetC
     targets = {target}
   doAssert fileExists(test), test & " test does not exist"
   testSpec r, makeTest(test, options, cat), targets
@@ -681,7 +681,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
 proc processCategory(r: var TResults, cat: Category,
                      options, testsDir: string,
                      runJoinableTests: bool) =
-  let cat2 = cat.string.normalize
+  let cat2 = cat.string.cfgIdentNormalize
   var handled = false
   if isNimRepoTests():
     handled = true

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -125,7 +125,7 @@ proc defaultOptions*(a: TTarget): string =
 when not declared(parseCfgBool):
   # candidate for the stdlib:
   proc parseCfgBool(s: string): bool =
-    case normalize(s)
+    case toLowerAscii(s)
     of "y", "yes", "true", "1", "on": result = true
     of "n", "no", "false", "0", "off": result = false
     else: raise newException(ValueError, "cannot interpret as a bool: " & s)
@@ -300,7 +300,7 @@ proc extractSpec(filename: string; spec: var TSpec): string =
 
 proc parseTargets*(value: string): set[TTarget] =
   result = default(set[TTarget])
-  for v in value.normalize.splitWhitespace:
+  for v in value.cfgIdentNormalize.splitWhitespace:
     case v
     of "c": result.incl(targetC)
     of "cpp", "c++": result.incl(targetCpp)
@@ -329,7 +329,7 @@ proc parseSpec*(filename: string): TSpec =
     var e = next(p)
     case e.kind
     of cfgKeyValuePair:
-      let key = e.key.normalize
+      let key = e.key.cfgIdentNormalize
       const whiteListMulti = ["disabled", "ccodecheck"]
         ## list of flags that are correctly handled when passed multiple times
         ## (instead of being overwritten)
@@ -338,7 +338,7 @@ proc parseSpec*(filename: string): TSpec =
       flags.incl key
       case key
       of "action":
-        case e.value.normalize
+        case e.value.cfgIdentNormalize
         of "compile":
           result.action = actionCompile
         of "run":
@@ -390,7 +390,7 @@ proc parseSpec*(filename: string): TSpec =
         result.unjoinable = not parseCfgBool(e.value)
       of "valgrind":
         when defined(linux) and sizeof(int) == 8:
-          result.useValgrind = if e.value.normalize == "leaks": leaking
+          result.useValgrind = if e.value.cfgIdentNormalize == "leaks": leaking
                                else: ValgrindSpec(parseCfgBool(e.value))
           result.unjoinable = true
           if result.useValgrind != disabled:
@@ -400,7 +400,7 @@ proc parseSpec*(filename: string): TSpec =
           # Valgrind only supports OSX <= 17.x
           result.useValgrind = disabled
       of "disabled":
-        let value = e.value.normalize
+        let value = e.value.cfgIdentNormalize
         case value
         of "y", "yes", "true", "1", "on": result.err = reDisabled
         of "n", "no", "false", "0", "off": discard
@@ -442,9 +442,9 @@ proc parseSpec*(filename: string): TSpec =
           block checkHost:
             for os in platform.OS:
               # Check if the value exists as OS.
-              if value == os.name.normalize:
+              if value == os.name.cfgIdentNormalize:
                 # The value exists; is it the same as the current host?
-                if value == hostOS.normalize:
+                if value == hostOS.cfgIdentNormalize:
                   # The value exists and is the same as the current host,
                   # so disable the test.
                   result.err = reDisabled
@@ -453,9 +453,9 @@ proc parseSpec*(filename: string): TSpec =
                 break checkHost
             for cpu in platform.CPU:
               # Check if the value exists as CPU.
-              if value == cpu.name.normalize:
+              if value == cpu.name.cfgIdentNormalize:
                 # The value exists; is it the same as the current host?
-                if value == hostCPU.normalize:
+                if value == hostCPU.cfgIdentNormalize:
                   # The value exists and is the same as the current host,
                   # so disable the test.
                   result.err = reDisabled

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -300,7 +300,7 @@ proc extractSpec(filename: string; spec: var TSpec): string =
 
 proc parseTargets*(value: string): set[TTarget] =
   result = default(set[TTarget])
-  for v in value.cfgIdentNormalize.splitWhitespace:
+  for v in value.normalizeStyle.splitWhitespace:
     case v
     of "c": result.incl(targetC)
     of "cpp", "c++": result.incl(targetCpp)
@@ -329,7 +329,7 @@ proc parseSpec*(filename: string): TSpec =
     var e = next(p)
     case e.kind
     of cfgKeyValuePair:
-      let key = e.key.cfgIdentNormalize
+      let key = e.key.normalizeStyle
       const whiteListMulti = ["disabled", "ccodecheck"]
         ## list of flags that are correctly handled when passed multiple times
         ## (instead of being overwritten)
@@ -338,7 +338,7 @@ proc parseSpec*(filename: string): TSpec =
       flags.incl key
       case key
       of "action":
-        case e.value.cfgIdentNormalize
+        case e.value.normalizeStyle
         of "compile":
           result.action = actionCompile
         of "run":
@@ -390,7 +390,7 @@ proc parseSpec*(filename: string): TSpec =
         result.unjoinable = not parseCfgBool(e.value)
       of "valgrind":
         when defined(linux) and sizeof(int) == 8:
-          result.useValgrind = if e.value.cfgIdentNormalize == "leaks": leaking
+          result.useValgrind = if e.value.normalizeStyle == "leaks": leaking
                                else: ValgrindSpec(parseCfgBool(e.value))
           result.unjoinable = true
           if result.useValgrind != disabled:
@@ -400,7 +400,7 @@ proc parseSpec*(filename: string): TSpec =
           # Valgrind only supports OSX <= 17.x
           result.useValgrind = disabled
       of "disabled":
-        let value = e.value.cfgIdentNormalize
+        let value = e.value.normalizeStyle
         case value
         of "y", "yes", "true", "1", "on": result.err = reDisabled
         of "n", "no", "false", "0", "off": discard
@@ -442,9 +442,9 @@ proc parseSpec*(filename: string): TSpec =
           block checkHost:
             for os in platform.OS:
               # Check if the value exists as OS.
-              if value == os.name.cfgIdentNormalize:
+              if value == os.name.normalizeStyle:
                 # The value exists; is it the same as the current host?
-                if value == hostOS.cfgIdentNormalize:
+                if value == hostOS.normalizeStyle:
                   # The value exists and is the same as the current host,
                   # so disable the test.
                   result.err = reDisabled
@@ -453,9 +453,9 @@ proc parseSpec*(filename: string): TSpec =
                 break checkHost
             for cpu in platform.CPU:
               # Check if the value exists as CPU.
-              if value == cpu.name.cfgIdentNormalize:
+              if value == cpu.name.normalizeStyle:
                 # The value exists; is it the same as the current host?
-                if value == hostCPU.cfgIdentNormalize:
+                if value == hostCPU.normalizeStyle:
                   # The value exists and is the same as the current host,
                   # so disable the test.
                   result.err = reDisabled

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -580,7 +580,7 @@ proc changeTarget(extraOptions: string; defaultTarget: TTarget): TTarget =
     of cmdEnd: break
     of cmdLongOption, cmdShortOption:
       if p.key == "b" or p.key == "backend":
-        result = parseEnum[TTarget](p.val.normalize)
+        result = parseEnum[TTarget](p.val.cfgIdentNormalize)
         # chooses the last one
     else:
       discard
@@ -693,7 +693,7 @@ proc main() =
   var p = initOptParser()
   p.next()
   while p.kind in {cmdLongOption, cmdShortOption}:
-    case p.key.normalize
+    case p.key.cfgIdentNormalize
     of "print": optPrintResults = true
     of "verbose": optVerbose = true
     of "failing": optFailing = true
@@ -756,7 +756,7 @@ proc main() =
     p.next()
   if p.kind != cmdArgument:
     quit Usage
-  var action = p.key.normalize
+  var action = p.key.cfgIdentNormalize
   p.next()
   var r = initResults()
   case action

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -580,7 +580,7 @@ proc changeTarget(extraOptions: string; defaultTarget: TTarget): TTarget =
     of cmdEnd: break
     of cmdLongOption, cmdShortOption:
       if p.key == "b" or p.key == "backend":
-        result = parseEnum[TTarget](p.val.cfgIdentNormalize)
+        result = parseEnum[TTarget](p.val.normalizeStyle)
         # chooses the last one
     else:
       discard
@@ -693,7 +693,7 @@ proc main() =
   var p = initOptParser()
   p.next()
   while p.kind in {cmdLongOption, cmdShortOption}:
-    case p.key.cfgIdentNormalize
+    case p.key.normalizeStyle
     of "print": optPrintResults = true
     of "verbose": optVerbose = true
     of "failing": optFailing = true
@@ -756,7 +756,7 @@ proc main() =
     p.next()
   if p.kind != cmdArgument:
     quit Usage
-  var action = p.key.cfgIdentNormalize
+  var action = p.key.normalizeStyle
   p.next()
   var r = initResults()
   case action

--- a/tools/finish.nim
+++ b/tools/finish.nim
@@ -71,7 +71,7 @@ when defined(windows):
       return true
     while true:
       try:
-        let answer = stdin.readLine().normalize
+        let answer = stdin.readLine().toLowerAscii
         case answer
         of "y", "yes":
           return true

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -1263,7 +1263,7 @@ for kind, key, val in getopt():
         reportError("empty string given for option --" & key &
                     " (did you forget `:`?)")
       s.add name
-    case cfgIdentNormalize(key)
+    case normalizeStyle(key)
     of "find", "f": incl(options, optFind)
     of "replace", "!": incl(options, optReplace)
     of "peg":
@@ -1344,7 +1344,7 @@ for kind, key, val in getopt():
       of "", "on", "always", "true": useWriteStyled = true
       else: reportError("invalid value '" & val & "' for --color")
     of "colortheme", "color-theme":
-      colortheme = cfgIdentNormalize(val)
+      colortheme = normalizeStyle(val)
       if colortheme notin ["simple", "bnw", "ack", "gnu"]:
         reportError("unknown colortheme '" & val & "'")
     of "beforecontext", "before-context", "b":

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -166,7 +166,7 @@ proc ask(msg: string): string =
 
 proc confirm: TConfirmEnum =
   while true:
-    case normalize(ask("     [a]bort; [y]es, a[l]l, [n]o, non[e]: "))
+    case toLowerAscii(ask("     [a]bort; [y]es, a[l]l, [n]o, non[e]: "))
     of "a", "abort": return ceAbort
     of "y", "yes": return ceYes
     of "l", "all": return ceAll
@@ -1263,7 +1263,7 @@ for kind, key, val in getopt():
         reportError("empty string given for option --" & key &
                     " (did you forget `:`?)")
       s.add name
-    case normalize(key)
+    case cfgIdentNormalize(key)
     of "find", "f": incl(options, optFind)
     of "replace", "!": incl(options, optReplace)
     of "peg":
@@ -1327,7 +1327,7 @@ for kind, key, val in getopt():
     of "text", "t": searchOpt.checkBin = biOff
     of "count": incl(options, optCount)
     of "sorttime", "sort-time", "s":
-      case normalize(val)
+      case toLowerAscii(val)
       of "off": sortTime = false
       of "", "on", "asc", "ascending":
         sortTime = true
@@ -1344,7 +1344,7 @@ for kind, key, val in getopt():
       of "", "on", "always", "true": useWriteStyled = true
       else: reportError("invalid value '" & val & "' for --color")
     of "colortheme", "color-theme":
-      colortheme = normalize(val)
+      colortheme = cfgIdentNormalize(val)
       if colortheme notin ["simple", "bnw", "ack", "gnu"]:
         reportError("unknown colortheme '" & val & "'")
     of "beforecontext", "before-context", "b":

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -172,7 +172,7 @@ proc parseCmdLine(c: var ConfigData) =
     case kind
     of cmdArgument:
       if c.actions == {}:
-        for a in split(cfgIdentNormalize(key), {';', ','}):
+        for a in split(normalizeStyle(key), {';', ','}):
           case a
           of "csource": incl(c.actions, actionCSource)
           of "scripts": incl(c.actions, actionScripts)
@@ -314,14 +314,14 @@ proc parseIniFile(c: var ConfigData) =
       case k.kind
       of cfgEof: break
       of cfgSectionStart:
-        section = cfgIdentNormalize(k.section)
+        section = normalizeStyle(k.section)
       of cfgKeyValuePair:
         var v = `%`(k.value, c.vars, {useEnvironment, useEmpty})
         c.vars[k.key] = v
 
         case section
         of "project":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "name": c.name = v
           of "displayname": c.displayName = v
           of "version": c.version = v
@@ -343,7 +343,7 @@ proc parseIniFile(c: var ConfigData) =
           of "authors": c.authors = split(v, {';'})
           of "description": c.description = v
           of "app":
-            case cfgIdentNormalize(v)
+            case normalizeStyle(v)
             of "console": c.app = appConsole
             of "gui": c.app = appGUI
             else: quit(errorStr(p, "expected: console or gui"))
@@ -354,21 +354,21 @@ proc parseIniFile(c: var ConfigData) =
         of "config": filesOnly(p, k.key, v, c.cat[fcConfig])
         of "data": filesOnly(p, k.key, v, c.cat[fcData])
         of "documentation":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "files": addFiles(c.cat[fcDoc], split(v, {';'}))
           of "start": addFiles(c.cat[fcDocStart], split(v, {';'}))
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "lib": filesOnly(p, k.key, v, c.cat[fcLib])
         of "other": filesOnly(p, k.key, v, c.cat[fcOther])
         of "windows":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "files": addFiles(c.cat[fcWindows], split(v, {';'}))
           of "binpath": c.binPaths = split(v, {';'})
           of "innosetup": c.innoSetupFlag = yesno(p, v)
           of "download": c.downloads.add(v)
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "unix":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "files": addFiles(c.cat[fcUnix], split(v, {';'}))
           of "installscript": c.installScript = yesno(p, v)
           of "uninstallscript": c.uninstallScript = yesno(p, v)
@@ -379,7 +379,7 @@ proc parseIniFile(c: var ConfigData) =
         of "ccompiler": pathFlags(p, k.key, v, c.ccompiler)
         of "linker": pathFlags(p, k.key, v, c.linker)
         of "deb":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "builddepends":
             c.debOpts.buildDepends = v
           of "packagedepends", "pkgdepends":
@@ -409,7 +409,7 @@ proc parseIniFile(c: var ConfigData) =
               inc(i)
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "nimble":
-          case cfgIdentNormalize(k.key)
+          case normalizeStyle(k.key)
           of "pkgname":
             c.nimblePkgName = v
           of "pkgfiles":
@@ -441,7 +441,7 @@ proc readCFiles(c: var ConfigData, osA, cpuA: int) =
       case k.kind
       of cfgEof: break
       of cfgSectionStart:
-        section = cfgIdentNormalize(k.section)
+        section = normalizeStyle(k.section)
       of cfgKeyValuePair:
         case section
         of "ccompiler": pathFlags(p, k.key, k.value, c.ccompiler)

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -172,7 +172,7 @@ proc parseCmdLine(c: var ConfigData) =
     case kind
     of cmdArgument:
       if c.actions == {}:
-        for a in split(normalize(key), {';', ','}):
+        for a in split(cfgIdentNormalize(key), {';', ','}):
           case a
           of "csource": incl(c.actions, actionCSource)
           of "scripts": incl(c.actions, actionScripts)
@@ -187,7 +187,7 @@ proc parseCmdLine(c: var ConfigData) =
         c.nimArgs = cmdLineRest(p)
         break
     of cmdLongOption, cmdShortOption:
-      case normalize(key)
+      case toLowerAscii(key)
       of "help", "h":
         stdout.write(Usage)
         quit(0)
@@ -266,18 +266,18 @@ proc addFiles(s: var seq[string], patterns: seq[string]) =
 
 proc pathFlags(p: var CfgParser, k, v: string,
                t: var tuple[path, flags: string]) =
-  case normalize(k)
+  case toLowerAscii(k)
   of "path": t.path = v
   of "flags": t.flags = v
   else: quit(errorStr(p, "unknown variable: " & k))
 
 proc filesOnly(p: var CfgParser, k, v: string, dest: var seq[string]) =
-  case normalize(k)
+  case toLowerAscii(k)
   of "files": addFiles(dest, split(v, {';'}))
   else: quit(errorStr(p, "unknown variable: " & k))
 
 proc yesno(p: var CfgParser, v: string): bool =
-  case normalize(v)
+  case toLowerAscii(v)
   of "yes", "y", "on", "true":
     result = true
   of "no", "n", "off", "false":
@@ -314,14 +314,14 @@ proc parseIniFile(c: var ConfigData) =
       case k.kind
       of cfgEof: break
       of cfgSectionStart:
-        section = normalize(k.section)
+        section = cfgIdentNormalize(k.section)
       of cfgKeyValuePair:
         var v = `%`(k.value, c.vars, {useEnvironment, useEmpty})
         c.vars[k.key] = v
 
         case section
         of "project":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "name": c.name = v
           of "displayname": c.displayName = v
           of "version": c.version = v
@@ -343,7 +343,7 @@ proc parseIniFile(c: var ConfigData) =
           of "authors": c.authors = split(v, {';'})
           of "description": c.description = v
           of "app":
-            case normalize(v)
+            case cfgIdentNormalize(v)
             of "console": c.app = appConsole
             of "gui": c.app = appGUI
             else: quit(errorStr(p, "expected: console or gui"))
@@ -354,21 +354,21 @@ proc parseIniFile(c: var ConfigData) =
         of "config": filesOnly(p, k.key, v, c.cat[fcConfig])
         of "data": filesOnly(p, k.key, v, c.cat[fcData])
         of "documentation":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "files": addFiles(c.cat[fcDoc], split(v, {';'}))
           of "start": addFiles(c.cat[fcDocStart], split(v, {';'}))
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "lib": filesOnly(p, k.key, v, c.cat[fcLib])
         of "other": filesOnly(p, k.key, v, c.cat[fcOther])
         of "windows":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "files": addFiles(c.cat[fcWindows], split(v, {';'}))
           of "binpath": c.binPaths = split(v, {';'})
           of "innosetup": c.innoSetupFlag = yesno(p, v)
           of "download": c.downloads.add(v)
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "unix":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "files": addFiles(c.cat[fcUnix], split(v, {';'}))
           of "installscript": c.installScript = yesno(p, v)
           of "uninstallscript": c.uninstallScript = yesno(p, v)
@@ -379,7 +379,7 @@ proc parseIniFile(c: var ConfigData) =
         of "ccompiler": pathFlags(p, k.key, v, c.ccompiler)
         of "linker": pathFlags(p, k.key, v, c.linker)
         of "deb":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "builddepends":
             c.debOpts.buildDepends = v
           of "packagedepends", "pkgdepends":
@@ -409,7 +409,7 @@ proc parseIniFile(c: var ConfigData) =
               inc(i)
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "nimble":
-          case normalize(k.key)
+          case cfgIdentNormalize(k.key)
           of "pkgname":
             c.nimblePkgName = v
           of "pkgfiles":
@@ -441,7 +441,7 @@ proc readCFiles(c: var ConfigData, osA, cpuA: int) =
       case k.kind
       of cfgEof: break
       of cfgSectionStart:
-        section = normalize(k.section)
+        section = cfgIdentNormalize(k.section)
       of cfgKeyValuePair:
         case section
         of "ccompiler": pathFlags(p, k.key, k.value, c.ccompiler)


### PR DESCRIPTION
Wasn't expecting this to be so invasive. It might be preference, but the way I see it, `strutils` is going to be a very common import and although `normalize` is used a lot in the compiler, it's not a very good fit for the name in general. I don't think reserving the identifier for it's current purpose makes sense.
Besides, it offers very little that `toLowerAscii` doesn't cover in terms of functionality.

Maybe the name I chose is bad too. I think that matching it with `cmpIgnoreStyle` as opposed to `nimIdentNormalize` might be better. Like `normalizeStyle` or something.