### PR TITLE
std/setutils: add extra set utils procs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,11 @@ errors.
 - `setutils.symmetricDifference` along with its operator version
   `` setutils.`-+-` `` and in-place version `setutils.toggle` have been added
   to more efficiently calculate the symmetric difference of bitsets.
+
+- `setutils.isFull` along with `setutils.isEmpty` to check if a set has all elements possible or is empty.
+- `` setutils.`[]` `` companion to `` setutils.`[]=` `` to check if an element is inside.
+- `setutils.emptySet` alternative to `default(set[T])` to create an empty set with similar usage of it's opposite `setutils.fullSet`.
+
 - `strutils.multiReplace` overload for character set replacements in a single pass.
 	Useful for string sanitation. Follows existing multiReplace semantics.
 

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -38,6 +38,16 @@ template toSet*(iter: untyped): untyped =
 
 macro enumElementsAsSet(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
+func emptySet*[T](U: typedesc[T]): set[T] {.inline.} =
+  ## Returns an empty `set[T]`,
+  ## same as `var x: set[T] = {}`
+  runnableExamples:
+    type A = enum
+      a0, a1, a2, a3
+    let s = emptySet(A)
+    assert s == {}
+  result = {}
+
 # func fullSet*(T: typedesc): set[T] {.inline.} = # xxx would give: Error: ordinal type expected
 func fullSet*[T](U: typedesc[T]): set[T] {.inline.} =
   ## Returns a set containing all elements in `U`.
@@ -62,6 +72,26 @@ func complement*[T](s: set[T]): set[T] {.inline.} =
     assert complement({'0'..'9'}) == {0.char..255.char} - {'0'..'9'}
   fullSet(T) - s
 
+func isEmpty*[T](s: set[T]): bool {.inline.} =
+  ## Check if the `set[T]` is empty,
+  ## same as `s == {}`
+  runnableExamples:
+    var a: set[char] = {}
+    var b: set[char] = {'a', 'b'}
+    assert a.isEmpty() == true
+    assert b.isEmpty() == false
+  s == {}
+
+func isFull*[T](s: set[T]): bool {.inline.} =
+  ## Check if the `set[T]` has all the elements,
+  ## same as `s == fullSet(set[T])`
+  runnableExamples:
+    type A = enum
+      a0, a1, a2, a3
+    assert isFull({a0, a3}) == false
+    assert isFull({a0, a1, a2, a3}) == true
+  s == fullSet(T)
+
 func `[]=`*[T](t: var set[T], key: T, val: bool) {.inline.} =
   ## Syntax sugar for `if val: t.incl key else: t.excl key`
   runnableExamples:
@@ -75,6 +105,17 @@ func `[]=`*[T](t: var set[T], key: T, val: bool) {.inline.} =
     s[a3] = true
     assert s == {a2, a3}
   if val: t.incl key else: t.excl key
+
+func `[]`*[T](x: set[T], key: T): bool {.inline.} =
+  ## Check if an element is inside the `set[T]`
+  ## Syntax sugar of `x.contains(element)`
+  runnableExamples:
+    type A = enum
+      a0, a1, a2, a3
+    var s = {a0, a3}
+    assert s[a0] == true
+    assert s[a1] == false
+  x.contains(key)
 
 when defined(nimHasXorSet):
   func symmetricDifference*[T](x, y: set[T]): set[T] {.magic: "XorSet".} =
@@ -92,6 +133,19 @@ proc `-+-`*[T](x, y: set[T]): set[T] {.inline.} =
   runnableExamples:
     assert {1, 2, 3} -+- {2, 3, 4} == {1, 4}
   result = symmetricDifference(x, y)
+
+proc toggle*[T](x: var set[T], y: T) {.inline.} =
+  ## Toggles the element `y` in the set `x`.
+  ## If the element `y` is in `x`, it is excluded from `x`;
+  ## otherwise it is included.
+  ## Equivalent to `x = symmetricDifference(x, {y})`.
+  runnableExamples:
+    var x = {1, 2, 3}
+    x.toggle(2)
+    x.toggle(3)
+    x.toggle(4)
+    assert x == {1, 4}
+  x = symmetricDifference(x, {y})
 
 proc toggle*[T](x: var set[T], y: set[T]) {.inline.} =
   ## Toggles the existence of each value of `y` in `x`.

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -138,7 +138,7 @@ proc toggle*[T](x: var set[T], y: T) {.inline.} =
   ## Toggles the element `y` in the set `x`.
   ## If the element `y` is in `x`, it is excluded from `x`;
   ## otherwise it is included.
-  ## Equivalent to `x = symmetricDifference(x, {y})`.
+  ## Equivalent to `if y in x: x.excl(y) else: x.incl(y)`.
   runnableExamples:
     var x = {1, 2, 3}
     x.toggle(2)

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -40,7 +40,7 @@ macro enumElementsAsSet(enm: typed): untyped = result = newNimNode(nnkCurly).add
 
 func emptySet*[T](U: typedesc[T]): set[T] {.inline.} =
   ## Returns an empty `set[T]`,
-  ## same as `var x: set[T] = {}`
+  ## same as `default(set[T])`
   runnableExamples:
     type A = enum
       a0, a1, a2, a3
@@ -145,7 +145,9 @@ proc toggle*[T](x: var set[T], y: T) {.inline.} =
     x.toggle(3)
     x.toggle(4)
     assert x == {1, 4}
-  x = symmetricDifference(x, {y})
+  if y in x:
+    x.excl(y)
+  else: x.incl(y)
 
 proc toggle*[T](x: var set[T], y: set[T]) {.inline.} =
   ## Toggles the existence of each value of `y` in `x`.

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -20,6 +20,12 @@ template main =
     type A = distinct char
     doAssert [A('x')].toSet == {A('x')}
 
+  block: # emptySet
+    doAssert emptySet(Colors) == {}
+    doAssert emptySet(char) == {}
+    doAssert emptySet(Bar) == {}
+    doAssert emptySet(bool) == {}
+
   block: # fullSet
     doAssert fullSet(Colors) == {red, green, blue}
     doAssert fullSet(char) == {0.chr..255.chr}
@@ -34,6 +40,17 @@ template main =
     doAssert {range[0..10](0), 1, 2, 3}.complement == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.complement == {0.char..255.char} - {'0'..'9'}
 
+  block: # isEmpty
+    doAssert emptySet(Colors).isEmpty() == true
+    doAssert fullSet(Colors).isEmpty() == false
+    doAssert {red, blue}.isEmpty() == false
+
+  block: # isFull
+    doAssert fullSet(Colors).isFull() == true
+    doAssert {red, blue, green}.isFull() == true
+    doAssert emptySet(Colors).isFull() == false
+    doAssert {red, blue}.isFull() == false
+
   block: # `[]=`
     type A = enum
       a0, a1, a2, a3
@@ -45,6 +62,13 @@ template main =
     s[a3] = true
     doAssert s == {a2, a3}
   
+  block: # `[]`
+    type A = enum
+      a0, a1, a2, a3
+    var s = {a0, a3}
+    doAssert s[a0] == true
+    doAssert s[a1] == false
+
   block: # set symmetric difference (xor), https://github.com/nim-lang/RFCs/issues/554
     type T = set[range[0..15]]
     let x: T = {1, 4, 5, 8, 9}
@@ -63,6 +87,13 @@ template main =
     z.toggle({1, 5})
     doAssert z == {4, 8, 9}
     z.toggle({3, 8})
+    doAssert z == {3, 4, 9}
+    # Toggle with the enum item
+    z.toggle(3)
+    z.toggle(8)
+    doAssert z == {4, 8, 9}
+    z.toggle(3)
+    z.toggle(8)
     doAssert z == {3, 4, 9}
 
 main()


### PR DESCRIPTION
add extra set utils procs to match https://github.com/nim-lang/nimony/pull/928, 
adds the following procs to make the module less incomplete, beginner friendly and more symmetric (fullSet proc implies the existence of emptySet proc for example):
- `emptySet(T)`: the opposite of `fullSet(T)`, useful when `{}` may be ambiguous
- `isEmpty()`: alternative syntax to `x == {}`
- `isFull()`: alternative syntax to `x == fullSet(T)`
- `[]`: companion to `[]=`, check if an element is inside
- `toggle(val: T)`: toggles single element