### PR TITLE
make `fillObjectFields` recur over base type

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -759,6 +759,8 @@ proc fillObjectFields*(m: BModule; typ: PType) =
   var check = initIntSet()
   var ignored = newBuilder("")
   addRecordFields(ignored, m, typ, check)
+  if typ.baseClass != nil:
+    fillObjectFields(m, typ.baseClass.skipTypes(skipPtrs))
 
 proc mangleDynLibProc(sym: PSym): Rope
 

--- a/tests/objects/t24847.nim
+++ b/tests/objects/t24847.nim
@@ -1,0 +1,30 @@
+# issue #24847
+
+block: # original issue test
+  type
+    R[C] = ref object of RootObj
+      b: C
+    K[S] = ref object of R[S]
+    W[J] = object
+      case y: bool
+      of false, true: discard
+
+  proc e[T]() = discard K[T]()
+  iterator h(): int {.closure.} = e[W[int]]()
+  let _ = h
+  type U = distinct int
+  e[W[U]]()
+
+block: # simplified
+  type
+    R[C] = ref object of RootObj
+      b: C
+    K[S] = ref object of R[S]
+    W[J] = object
+      case y: bool
+      of false, true: discard
+
+  type U = distinct int
+
+  discard K[W[int]]()
+  discard K[W[U]]()


### PR DESCRIPTION
fixes #24847

Object constructors call `fillObjectFields` when a field inside the constructor does not have a location, however when the field is from a base type this does not process it. Now `fillObjectFields` also calls itself for the base type to fix this but not sure if this is a good solution as `fillObjectFields` is used in other places too.