### PR TITLE
skip semicolon in stmtlist expr parsing

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -705,7 +705,6 @@ proc parsePar(p: var Parser): PNode =
       # stmt context:
       result.add(a)
       getTok(p)
-      optInd(p, result)
       semiStmtList(p, result)
     else:
       a = colonOrEquals(p, a)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -700,7 +700,6 @@ proc parsePar(p: var Parser): PNode =
       result.add(asgn)
       if p.tok.tokType == tkSemiColon:
         getTok(p)
-        optInd(p, result)
         semiStmtList(p, result)
     elif p.tok.tokType == tkSemiColon:
       # stmt context:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -634,7 +634,7 @@ proc semiStmtList(p: var Parser, result: PNode) =
     result.add a
 
     while p.tok.tokType != tkEof:
-      if p.tok.tokType == tkSemiColon:
+      while p.tok.tokType == tkSemiColon:
         getTok(p)
       if p.tok.tokType == tkParRi:
         break

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -699,10 +699,14 @@ proc parsePar(p: var Parser): PNode =
       asgn.add b
       result.add(asgn)
       if p.tok.tokType == tkSemiColon:
+        getTok(p)
+        optInd(p, result)
         semiStmtList(p, result)
     elif p.tok.tokType == tkSemiColon:
       # stmt context:
       result.add(a)
+      getTok(p)
+      optInd(p, result)
       semiStmtList(p, result)
     else:
       a = colonOrEquals(p, a)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -634,7 +634,7 @@ proc semiStmtList(p: var Parser, result: PNode) =
     result.add a
 
     while p.tok.tokType != tkEof:
-      while p.tok.tokType == tkSemiColon:
+      if p.tok.tokType == tkSemiColon:
         getTok(p)
       if p.tok.tokType == tkParRi:
         break

--- a/tests/parser/tstmtlistexprempty.nim
+++ b/tests/parser/tstmtlistexprempty.nim
@@ -1,0 +1,23 @@
+discard """
+  nimout: '''
+StmtList
+  ReturnStmt
+    StmtListExpr
+      Call
+        DotExpr
+          Ident "x"
+          Ident "add"
+        StrLit "123"
+      Call
+        DotExpr
+          Ident "x"
+          Ident "add"
+        StrLit "123"
+      Ident "x"
+'''
+"""
+
+import std/macros
+
+dumpTree:
+  return (x.add("123"); x.add("123"); x)

--- a/tests/parser/tstmtlistexprempty.nim
+++ b/tests/parser/tstmtlistexprempty.nim
@@ -20,4 +20,4 @@ StmtList
 import std/macros
 
 dumpTree:
-  return (x.add("123"); x.add("123"); x)
+  return (x.add("123"); x.add("123");; x)

--- a/tests/parser/tstmtlistexprempty.nim
+++ b/tests/parser/tstmtlistexprempty.nim
@@ -20,4 +20,4 @@ StmtList
 import std/macros
 
 dumpTree:
-  return (x.add("123"); x.add("123");; x)
+  return (x.add("123"); x.add("123"); x)


### PR DESCRIPTION
Previously it would try to parse the semicolon as its own statement and produce an `nkEmpty` node

Also more than 1 semicolon in an expression list i.e. `(a;; b)` gives an "expression expected" error in `semiStmtList` when multiple semicolons are allowed in normal statements, this could be fixed by changing the `if tok.kind == tokSemicolon` check to a `while` but it does not match the grammar so not done here.