### PR TITLE
fixes `=copy` is transformed into `nkFastAsgn` and unify `mAsgn` handling

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -755,6 +755,7 @@ proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PCo
   result.semTypeNode = semTypeNode
   result.instTypeBoundOp = sigmatch.instTypeBoundOp
   result.hasUnresolvedArgs = hasUnresolvedArgs
+  result.semAsgnOpr = semAsgnOpr
   result.templInstCounter = new int
 
   pushProcCon(result, module)

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -174,6 +174,9 @@ type
     importModuleLookup*: Table[int, seq[int]] # (module.ident.id, [module.id])
     skipTypes*: seq[PNode] # used to skip types between passes in type section. So far only used for inheritance, sets and generic bodies.
     inTypeofContext*: int
+
+    semAsgnOpr*: proc (c: PContext; n: PNode; k: TNodeKind): PNode {.nimcall.}
+
   TBorrowState* = enum
     bsNone, bsReturnNotMatch, bsNoDistinct, bsGeneric, bsNotSupported, bsMatch
 
@@ -789,8 +792,11 @@ proc replaceHookMagic*(c: PContext, n: PNode, kind: TTypeAttachedOp): PNode =
     if op != nil:
       result[0] = newSymNode(op)
       analyseIfAddressTakenInCall(c, result, false)
-  of attachedSink, attachedAsgn, attachedDeepCopy:
-    # TODO: `nkSinkAsgn`, `nkAsgn`
+  of attachedSink:
+    result = c.semAsgnOpr(c, n, nkSinkAsgn)
+  of attachedAsgn:
+    result = c.semAsgnOpr(c, n, nkAsgn)
+  of attachedDeepCopy:
     result = n
     let t = n[1].typ.skipTypes(abstractVar)
     let op = getAttachedOp(c.graph, t, kind)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -612,9 +612,10 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mArrPut:
     result = semArrPut(c, n, flags)
   of mAsgn:
-    if n[0].sym.name.s == "=":
+    case n[0].sym.name.s
+    of "=", "=copy":
       result = semAsgnOpr(c, n, nkAsgn)
-    elif n[0].sym.name.s == "=sink":
+    of "=sink":
       result = semAsgnOpr(c, n, nkSinkAsgn)
     else:
       result = semShallowCopy(c, n, flags)


### PR DESCRIPTION
`=copy` should be treated like `=` instead of `shallowCopy`, i.e., `nkFastAsgn` by default. `mAsgn` is treated similar in sempass2 too