### PR TITLE
fixes  #24764; cross-module sink analysis broken

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1197,7 +1197,10 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
         result.add p(ri, c, s, consumed)
         c.finishCopy(result, dest, flags, isFromSink = false)
     of nkHiddenSubConv, nkHiddenStdConv, nkConv, nkObjDownConv, nkObjUpConv, nkCast:
-      result = c.genSink(s, dest, p(ri, c, s, sinkArg), flags)
+      if IsExplicitSink in flags:
+        result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
+      else:
+        result = c.genSink(s, dest, p(ri, c, s, sinkArg), flags)
     of nkStmtListExpr, nkBlockExpr, nkIfExpr, nkCaseStmt, nkTryStmt, nkPragmaBlock:
       template process(child, s): untyped = moveOrCopy(dest, child, c, s, flags)
       # We know the result will be a stmt so we use that fact to optimize

--- a/tests/arc/m24764.nim
+++ b/tests/arc/m24764.nim
@@ -1,0 +1,4 @@
+type QObject* {.inheritable.} = object
+proc `=destroy`(self: var QObject) = discard
+proc `=sink`(dest: var QObject, source: QObject) = discard
+proc `=copy`(dest: var QObject, source: QObject) {.error.}

--- a/tests/arc/t24764.nim
+++ b/tests/arc/t24764.nim
@@ -1,0 +1,22 @@
+discard """
+  matrix: "--mm:arc"
+"""
+
+import m24764
+
+type QWidget* = object of QObject
+proc `=copy`(dest: var QWidget, source: QWidget) {.error.}
+proc `=sink`(dest: var QWidget, source: QWidget) =
+  `=sink`(QObject(dest), QObject(source))
+
+proc show(v: QWidget) = discard
+
+proc main() =
+  let btn = QWidget()
+
+  let tmp = proc() =
+    btn.show()
+
+  btn.show()
+
+main()


### PR DESCRIPTION
fixes  #24764

It now consumes the `conv(x)` arg for the explicit sinking. So the explicit sinking is kept as it is.

Follows up https://github.com/nim-lang/Nim/pull/20585

Related issues: https://github.com/nim-lang/Nim/issues/20572

Probably the same needs to be applied to explicit `copy` to prevent a copy turning into a sink