### PR TITLE
clean up opensym encounters in compiler

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -933,8 +933,7 @@ proc getPIdent*(a: PNode): PIdent {.inline.} =
   case a.kind
   of nkSym: a.sym.name
   of nkIdent: a.ident
-  of nkOpenSymChoice, nkClosedSymChoice: a.sons[0].sym.name
-  of nkOpenSym: getPIdent(a.sons[0])
+  of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym: a.sons[0].sym.name
   else: nil
 
 const

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -58,13 +58,11 @@ proc considerQuotedIdent*(c: PContext; n: PNode, origin: PNode = nil): PIdent =
         of nkLiterals - nkFloatLiterals: id.add(x.renderTree)
         else: handleError(n, origin)
       result = getIdent(c.cache, id)
-  of nkOpenSymChoice, nkClosedSymChoice:
+  of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
     if n[0].kind == nkSym:
       result = n[0].sym.name
     else:
       handleError(n, origin)
-  of nkOpenSym:
-    result = considerQuotedIdent(c, n[0], origin)
   else:
     handleError(n, origin)
 

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -77,7 +77,7 @@ proc inSymChoice(sc, x: PNode): bool =
     result = false
     for i in 0..<sc.len:
       if sc[i].sym == x.sym: return true
-  elif sc.kind == nkOpenSymChoice:
+  elif sc.kind in {nkOpenSymChoice, nkOpenSym}:
     # same name suffices for open sym choices!
     result = sc[0].sym.name.id == x.sym.name.id
   else:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -410,7 +410,7 @@ proc atom(g: TSrcGen; n: PNode): string =
   of nkEmpty: result = ""
   of nkIdent: result = n.ident.s
   of nkSym: result = n.sym.name.s
-  of nkClosedSymChoice, nkOpenSymChoice: result = n[0].sym.name.s
+  of nkClosedSymChoice, nkOpenSymChoice, nkOpenSym: result = n[0].sym.name.s
   of nkStrLit: result = ""; result.addQuoted(n.strVal)
   of nkRStrLit: result = "r\"" & replace(n.strVal, "\"", "\"\"") & '\"'
   of nkTripleStrLit: result = "\"\"\"" & n.strVal & "\"\"\""
@@ -1008,7 +1008,7 @@ type
 proc bracketKind*(g: TSrcGen, n: PNode): BracketKind =
   if renderIds notin g.flags:
     case n.kind
-    of nkClosedSymChoice, nkOpenSymChoice:
+    of nkClosedSymChoice, nkOpenSymChoice, nkOpenSym:
       if n.len > 0: result = bracketKind(g, n[0])
       else: result = bkNone
     of nkSym:
@@ -1421,10 +1421,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
   of nkPrefix:
     gsub(g, n, 0)
     if n.len > 1:
-      let opr = if n[0].kind == nkIdent: n[0].ident
-                elif n[0].kind == nkSym: n[0].sym.name
-                elif n[0].kind in {nkOpenSymChoice, nkClosedSymChoice}: n[0][0].sym.name
-                else: nil
+      let opr = getPIdent(n[0])
       let nNext = skipHiddenNodes(n[1])
       if nNext.kind == nkPrefix or (opr != nil and renderer.isKeyword(opr)):
         put(g, tkSpaces, Space)

--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -93,7 +93,7 @@ proc computeDeps(cache: IdentCache; n: PNode, declares, uses: var IntSet; topLev
   of nkIdent: uses.incl n.ident.id
   of nkSym: uses.incl n.sym.name.id
   of nkAccQuoted: uses.incl accQuoted(cache, n).id
-  of nkOpenSymChoice, nkClosedSymChoice:
+  of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
     uses.incl n[0].sym.name.id
   of nkStmtList, nkStmtListExpr, nkWhenStmt, nkElifBranch, nkElse, nkStaticStmt:
     for i in 0..<n.len: computeDeps(cache, n[i], declares, uses, topLevel)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2167,10 +2167,8 @@ proc lookUpForDeclared(c: PContext, n: PNode, onlyCurrentScope: bool): PSym =
         result = someSym(c.graph, m, ident)
   of nkSym:
     result = n.sym
-  of nkOpenSymChoice, nkClosedSymChoice:
+  of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
     result = n[0].sym
-  of nkOpenSym:
-    result = lookUpForDeclared(c, n[0], onlyCurrentScope)
   else:
     localError(c.config, n.info, "identifier expected, but got: " & renderTree(n))
     result = nil

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -131,8 +131,8 @@ proc isRange*(n: PNode): bool {.inline.} =
     let callee = n[0]
     if (callee.kind == nkIdent and callee.ident.id == ord(wDotDot)) or
        (callee.kind == nkSym and callee.sym.name.id == ord(wDotDot)) or
-       (callee.kind in {nkClosedSymChoice, nkOpenSymChoice} and
-        callee[1].sym.name.id == ord(wDotDot)):
+       (callee.kind in {nkClosedSymChoice, nkOpenSymChoice, nkOpenSym} and
+        callee[0].sym.name.id == ord(wDotDot)):
       result = true
     else:
       result = false
@@ -145,7 +145,7 @@ proc whichPragma*(n: PNode): TSpecialWord =
   of nkIdent: result = whichKeyword(key.ident)
   of nkSym: result = whichKeyword(key.sym.name)
   of nkCast: return wCast
-  of nkClosedSymChoice, nkOpenSymChoice:
+  of nkClosedSymChoice, nkOpenSymChoice, nkOpenSym:
     return whichPragma(key[0])
   of nkBracketExpr:
     if n.kind notin nkPragmaCallKinds: return wInvalid

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2051,7 +2051,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         aStrVal = aNode.ident.s.cstring
       of nkSym:
         aStrVal = aNode.sym.name.s.cstring
-      of nkOpenSymChoice, nkClosedSymChoice:
+      of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
         aStrVal = aNode[0].sym.name.s.cstring
       else:
         discard
@@ -2063,7 +2063,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         bStrVal = bNode.ident.s.cstring
       of nkSym:
         bStrVal = bNode.sym.name.s.cstring
-      of nkOpenSymChoice, nkClosedSymChoice:
+      of nkOpenSymChoice, nkClosedSymChoice, nkOpenSym:
         bStrVal = bNode[0].sym.name.s.cstring
       else:
         discard

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1011,7 +1011,7 @@ proc genBindSym(c: PCtx; n: PNode; dest: var TDest) =
   # if dynamicBindSym notin c.config.features:
   if n.len == 2: # hmm, reliable?
     # bindSym with static input
-    if n[1].kind in {nkClosedSymChoice, nkOpenSymChoice, nkSym}:
+    if n[1].kind in {nkClosedSymChoice, nkOpenSymChoice, nkOpenSym, nkSym}:
       let idx = c.genLiteral(n[1])
       if dest < 0: dest = c.getTemp(n.typ)
       c.gABx(n, opcNBindSym, dest, idx)


### PR DESCRIPTION
To protect against crashes when this stops being experimental, in most places handled the exact same as normal symchoices (not encountered in typed ast)