### PR TITLE
implement setter fallback for subscripts

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1951,19 +1951,27 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     # --> `[]=`(a, i, x)
     a = semSubscript(c, a, {efLValue})
     if a == nil:
-      result = buildOverloadedSubscripts(n[0], getIdent(c.cache, "[]="))
-      result.add(n[1])
       if mode == noOverloadedSubscript:
-        bracketNotFoundError(c, result, {})
-        return errorNode(c, n)
+        # `[]=` overloads failed and builtin subscript failed, try `[]` overloads for LHS
+        # will error if not found:
+        a = semExprWithType(c, n[0], {efLValue})
       else:
+        result = buildOverloadedSubscripts(n[0], getIdent(c.cache, "[]="))
+        result.add(n[1])
         result = semExprNoType(c, result)
         return result
   of nkCurlyExpr:
     # a{i} = x -->  `{}=`(a, i, x)
-    result = buildOverloadedSubscripts(n[0], getIdent(c.cache, "{}="))
-    result.add(n[1])
-    return semExprNoType(c, result)
+    let nOrig = n.copyTree
+    var asgnCall = buildOverloadedSubscripts(n[0], getIdent(c.cache, "[]="))
+    asgnCall.add(n[1])
+    result = semOverloadedCallAnalyseEffects(c, asgnCall, asgnCall.copyTree, {efNoUndeclared})
+    if result != nil:
+      result = afterCallActions(c, result, nOrig, {})
+      return
+    else:
+      # will error if `{}` overloads not found:
+      a = semExprWithType(c, a, {efLValue})
   of nkPar, nkTupleConstr:
     if a.len >= 2 or a.kind == nkTupleConstr:
       # unfortunately we need to rewrite ``(x, y) = foo()`` already here so

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1949,6 +1949,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
   of nkBracketExpr:
     # a[i] = x
     # --> `[]=`(a, i, x)
+    # try builtin subscript for LHS first:
     a = semSubscript(c, a, {efLValue})
     if a == nil:
       if mode == noOverloadedSubscript:
@@ -1956,16 +1957,20 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
         # will error if not found:
         a = semExprWithType(c, n[0], {efLValue})
       else:
+        # magic overload of `[]=` will always match so cannot check for mismatch here,
+        # will go to above `if` branch instead
         result = buildOverloadedSubscripts(n[0], getIdent(c.cache, "[]="))
         result.add(n[1])
         result = semExprNoType(c, result)
         return result
   of nkCurlyExpr:
     # a{i} = x -->  `{}=`(a, i, x)
+    # no builtin behavior/magic overloads for curly subscript,
+    # try `{}=` overloads first then try `{}` overloads for LHS:
     let nOrig = n.copyTree
-    var asgnCall = buildOverloadedSubscripts(n[0], getIdent(c.cache, "{}="))
-    asgnCall.add(n[1])
-    result = semOverloadedCallAnalyseEffects(c, asgnCall, asgnCall.copyTree, {efNoUndeclared})
+    result = buildOverloadedSubscripts(n[0], getIdent(c.cache, "{}="))
+    result.add(n[1])
+    result = semOverloadedCallAnalyseEffects(c, result, result.copyTree, {efNoUndeclared})
     if result != nil:
       result = afterCallActions(c, result, nOrig, {})
       return

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1963,7 +1963,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
   of nkCurlyExpr:
     # a{i} = x -->  `{}=`(a, i, x)
     let nOrig = n.copyTree
-    var asgnCall = buildOverloadedSubscripts(n[0], getIdent(c.cache, "[]="))
+    var asgnCall = buildOverloadedSubscripts(n[0], getIdent(c.cache, "{}="))
     asgnCall.add(n[1])
     result = semOverloadedCallAnalyseEffects(c, asgnCall, asgnCall.copyTree, {efNoUndeclared})
     if result != nil:

--- a/tests/errmsgs/t22753.nim
+++ b/tests/errmsgs/t22753.nim
@@ -1,50 +1,57 @@
 discard """
 cmd: "nim check --hints:off $file"
-errormsg: "type mismatch"
+action: "reject"
 nimoutFull: true
 nimout: '''
-t22753.nim(51, 13) Error: array expects two type parameters
-t22753.nim(52, 1) Error: expression 'x' has no type (or is ambiguous)
-t22753.nim(52, 1) Error: expression 'x' has no type (or is ambiguous)
-t22753.nim(52, 2) Error: type mismatch: got <>
+t22753.nim(58, 13) Error: array expects two type parameters
+t22753.nim(59, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(59, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(59, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(59, 1) Error: expression 'x' has no type (or is ambiguous)
+t22753.nim(59, 2) Error: type mismatch: got <>
 but expected one of:
-proc `[]=`(s: var string; i: BackwardsIndex; x: char)
+proc `[]`(s: string; i: BackwardsIndex): char
   first type mismatch at position: 2
   required type for i: BackwardsIndex
   but expression '0' is of type: int literal(0)
-proc `[]=`[I: Ordinal; T, S](a: T; i: I; x: sink S)
+proc `[]`(s: var string; i: BackwardsIndex): var char
+  first type mismatch at position: 2
+  required type for i: BackwardsIndex
+  but expression '0' is of type: int literal(0)
+proc `[]`[I: Ordinal; T](a: T; i: I): T
   first type mismatch at position: 0
-proc `[]=`[Idx, T; U, V: Ordinal](a: var array[Idx, T]; x: HSlice[U, V];
-                                  b: openArray[T])
+proc `[]`[Idx, T; U, V: Ordinal](a: array[Idx, T]; x: HSlice[U, V]): seq[T]
   first type mismatch at position: 2
-  required type for x: HSlice[[]=.U, []=.V]
+  required type for x: HSlice[[].U, [].V]
   but expression '0' is of type: int literal(0)
-proc `[]=`[Idx, T](a: var array[Idx, T]; i: BackwardsIndex; x: T)
-  first type mismatch at position: 2
-  required type for i: BackwardsIndex
-  but expression '0' is of type: int literal(0)
-proc `[]=`[T, U: Ordinal](s: var string; x: HSlice[T, U]; b: string)
-  first type mismatch at position: 2
-  required type for x: HSlice[[]=.T, []=.U]
-  but expression '0' is of type: int literal(0)
-proc `[]=`[T; U, V: Ordinal](s: var seq[T]; x: HSlice[U, V]; b: openArray[T])
-  first type mismatch at position: 2
-  required type for x: HSlice[[]=.U, []=.V]
-  but expression '0' is of type: int literal(0)
-proc `[]=`[T](s: var openArray[T]; i: BackwardsIndex; x: T)
+proc `[]`[Idx, T](a: array[Idx, T]; i: BackwardsIndex): T
   first type mismatch at position: 2
   required type for i: BackwardsIndex
   but expression '0' is of type: int literal(0)
-template `[]=`(a: WideCStringObj; idx: int; val: Utf16Char)
-  first type mismatch at position: 3
-  required type for val: Utf16Char
-  but expression '9' is of type: int literal(9)
-template `[]=`(s: string; i: int; val: char)
-  first type mismatch at position: 3
-  required type for val: char
-  but expression '9' is of type: int literal(9)
+proc `[]`[Idx, T](a: var array[Idx, T]; i: BackwardsIndex): var T
+  first type mismatch at position: 2
+  required type for i: BackwardsIndex
+  but expression '0' is of type: int literal(0)
+proc `[]`[T, U: Ordinal](s: string; x: HSlice[T, U]): string
+  first type mismatch at position: 2
+  required type for x: HSlice[[].T, [].U]
+  but expression '0' is of type: int literal(0)
+proc `[]`[T; U, V: Ordinal](s: openArray[T]; x: HSlice[U, V]): seq[T]
+  first type mismatch at position: 2
+  required type for x: HSlice[[].U, [].V]
+  but expression '0' is of type: int literal(0)
+proc `[]`[T](s: openArray[T]; i: BackwardsIndex): T
+  first type mismatch at position: 2
+  required type for i: BackwardsIndex
+  but expression '0' is of type: int literal(0)
+proc `[]`[T](s: var openArray[T]; i: BackwardsIndex): var T
+  first type mismatch at position: 2
+  required type for i: BackwardsIndex
+  but expression '0' is of type: int literal(0)
 
-expression: x[0] = 9
+expression: x[0]
+t22753.nim(59, 2) Error: expression '' has no type (or is ambiguous)
+t22753.nim(59, 2) Error: '' cannot be assigned to
 '''
 """
 

--- a/tests/specialops/tsetterfallbacksubscript.nim
+++ b/tests/specialops/tsetterfallbacksubscript.nim
@@ -1,0 +1,25 @@
+type Foo = object
+  x, y: float
+
+proc `[]`(foo: var Foo, i: int): var float =
+  if i == 0:
+    result = foo.x
+  else:
+    result = foo.y
+
+var pt = Foo(x: 0.0, y: 0.0)
+pt[0] += 1.0 # <-- fine
+`[]`(pt, 0) = 1.0 # <-- fine
+pt[0] = 1.0 # <-- does not compile
+
+# curly:
+
+proc `{}`(foo: var Foo, i: int): var float =
+  if i == 0:
+    result = foo.x
+  else:
+    result = foo.y
+
+pt{0} += 1.0 # <-- fine
+`{}`(pt, 0) = 1.0 # <-- fine
+pt{0} = 1.0 # <-- does not compile


### PR DESCRIPTION
follows up #24871

For subscript assignments, if an overload of `[]=`/`{}=` is not found, the LHS checks for overloads of `[]`/`{}` as a fallback, similar to what field setters do since #24871. This is accomplished by just compiling the LHS if the assignment overloads fail. This has the side effect that the error messages are different now, instead of displaying the overloads of `[]=`/`{}=` that did not match, it will display the ones for `[]`/`{}` instead. This could be fixed by checking for `efLValue` when giving the error messages for `[]`/`{}` but this is not done here.

The code for `[]` subscripts is a little different because of the `mArrGet`/`mArrPut` overloads that always match. If the `mArrPut` overload matches without a builtin subscript behavior for the LHS then it calls `semAsgn` again with `mode = noOverloadedSubscript`. Before this meant "fail to compile" but now it means "try to compile the LHS as normal", in both cases the overloads of `[]=` are not considered again.