### PR TITLE
don't traverse inner procs to lift locals in closure iters

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -135,7 +135,7 @@ import
   renderer, magicsys, lowerings, lambdalifting, modulegraphs, lineinfos,
   options
 
-import std/tables
+import std/[tables, sets]
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -161,6 +161,7 @@ type
                     # is their finally. For finally it is parent finally. Otherwise -1
     idgen: IdGenerator
     varStates: Table[ItemId, int] # Used to detect if local variable belongs to multiple states
+    processedInnerProcStates: HashSet[(int, int)] # tracks which inner procs were processed in which state
 
 const
   nkSkip = {nkEmpty..nkNilLit, nkTemplateDef, nkTypeSection, nkStaticStmt,
@@ -1431,11 +1432,14 @@ proc preprocess(c: var PreprocessContext; n: PNode): PNode =
     for i in 0 ..< n.len:
       result[i] = preprocess(c, n[i])
 
-proc detectCapturedVars(c: var Ctx, n: PNode, stateIdx: int) =
+proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
   case n.kind
   of nkSym:
     let s = n.sym
-    if s.kind in {skResult, skVar, skLet, skForVar, skTemp} and sfGlobal notin s.flags and s.owner == c.fn:
+    if isInnerProc(s):
+      if not c.processedInnerProcStates.containsOrIncl((s.id, stateIdx)):
+        detectCapturedVars(c, s.ast, s, stateIdx)
+    elif s.kind in {skResult, skVar, skLet, skForVar, skTemp} and sfGlobal notin s.flags and s.owner == c.fn:
       let vs = c.varStates.getOrDefault(s.itemId, localNotSeen)
       if vs == localNotSeen: # First seing this variable
         c.varStates[s.itemId] = stateIdx
@@ -1448,24 +1452,26 @@ proc detectCapturedVars(c: var Ctx, n: PNode, stateIdx: int) =
       # we have a `result = result` expression produced by the closure
       # transform, let's not touch the LHS in order to make the lifting pass
       # correct when `result` is lifted
-      detectCapturedVars(c, n[0][1], stateIdx)
+      detectCapturedVars(c, n[0][1], owner, stateIdx)
     else:
-      detectCapturedVars(c, n[0], stateIdx)
+      detectCapturedVars(c, n[0], owner, stateIdx)
   of nkIdentDefs:
-    detectCapturedVars(c, n[^1], stateIdx)
+    detectCapturedVars(c, n[^1], owner, stateIdx)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
      nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
      nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
-     nkTypeOfExpr, nkMixinStmt, nkBindStmt,
-     nkLambdaKinds, nkIteratorDef:
+     nkTypeOfExpr, nkMixinStmt, nkBindStmt:
     discard
+  of nkLambdaKinds, nkIteratorDef:
+    if n.typ != nil:
+      detectCapturedVars(c, n[namePos], owner, stateIdx)
   else:
     for i in 0 ..< n.safeLen:
-      detectCapturedVars(c, n[i], stateIdx)
+      detectCapturedVars(c, n[i], owner, stateIdx)
 
 proc detectCapturedVars(c: var Ctx) =
   for i, s in c.states:
-    detectCapturedVars(c, s.body, i)
+    detectCapturedVars(c, s.body, c.fn, i)
 
 proc liftLocals(c: var Ctx, n: PNode): PNode =
   result = n

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -133,9 +133,9 @@
 import
   ast, msgs, idents,
   renderer, magicsys, lowerings, lambdalifting, modulegraphs, lineinfos,
-  options
+  options, transf
 
-import std/[tables, sets]
+import std/[tables, intsets]
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -161,7 +161,7 @@ type
                     # is their finally. For finally it is parent finally. Otherwise -1
     idgen: IdGenerator
     varStates: Table[ItemId, int] # Used to detect if local variable belongs to multiple states
-    processedInnerProcStates: HashSet[(int, int)] # tracks which inner procs were processed in which state
+    processedInnerProcs: IntSet
 
 const
   nkSkip = {nkEmpty..nkNilLit, nkTemplateDef, nkTypeSection, nkStaticStmt,
@@ -1437,11 +1437,12 @@ proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
   of nkSym:
     let s = n.sym
     if isInnerProc(s):
-      if not c.processedInnerProcStates.containsOrIncl((s.id, stateIdx)):
-        detectCapturedVars(c, s.ast, s, stateIdx)
+      if not c.processedInnerProcs.containsOrIncl(s.id):
+        let body = transformBody(c.g, c.idgen, s, {useCache})
+        detectCapturedVars(c, body, s, localRequiresLifting)
     elif s.kind in {skResult, skVar, skLet, skForVar, skTemp} and sfGlobal notin s.flags and s.owner == c.fn:
       let vs = c.varStates.getOrDefault(s.itemId, localNotSeen)
-      if vs == localNotSeen: # First seing this variable
+      if vs == localNotSeen and stateIdx != localRequiresLifting: # First seing this variable
         c.varStates[s.itemId] = stateIdx
       elif vs == localRequiresLifting:
         discard # Sym already marked
@@ -1455,8 +1456,6 @@ proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
       detectCapturedVars(c, n[0][1], owner, stateIdx)
     else:
       detectCapturedVars(c, n[0], owner, stateIdx)
-  of nkIdentDefs:
-    detectCapturedVars(c, n[^1], owner, stateIdx)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
      nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
      nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
@@ -1501,8 +1500,6 @@ proc liftLocals(c: var Ctx, n: PNode): PNode =
      nkTypeOfExpr, nkMixinStmt, nkBindStmt,
      nkLambdaKinds, nkIteratorDef:
     discard
-  of nkIdentDefs:
-    n[^1] = liftLocals(c, n[^1])
   else:
     for i in 0 ..< n.safeLen:
       n[i] = liftLocals(c, n[i])

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -1451,6 +1451,8 @@ proc detectCapturedVars(c: var Ctx, n: PNode, stateIdx: int) =
       detectCapturedVars(c, n[0][1], stateIdx)
     else:
       detectCapturedVars(c, n[0], stateIdx)
+  of nkIdentDefs:
+    detectCapturedVars(c, n[^1], stateIdx)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
      nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
      nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
@@ -1493,6 +1495,8 @@ proc liftLocals(c: var Ctx, n: PNode): PNode =
      nkTypeOfExpr, nkMixinStmt, nkBindStmt,
      nkLambdaKinds, nkIteratorDef:
     discard
+  of nkIdentDefs:
+    n[^1] = liftLocals(c, n[^1])
   else:
     for i in 0 ..< n.safeLen:
       n[i] = liftLocals(c, n[i])

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -1451,6 +1451,12 @@ proc detectCapturedVars(c: var Ctx, n: PNode, stateIdx: int) =
       detectCapturedVars(c, n[0][1], stateIdx)
     else:
       detectCapturedVars(c, n[0], stateIdx)
+  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
+     nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
+     nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
+     nkTypeOfExpr, nkMixinStmt, nkBindStmt,
+     nkLambdaKinds, nkIteratorDef:
+    discard
   else:
     for i in 0 ..< n.safeLen:
       detectCapturedVars(c, n[i], stateIdx)

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -133,9 +133,9 @@
 import
   ast, msgs, idents,
   renderer, magicsys, lowerings, lambdalifting, modulegraphs, lineinfos,
-  options, transf
+  options
 
-import std/[tables, intsets]
+import std/tables
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -161,7 +161,6 @@ type
                     # is their finally. For finally it is parent finally. Otherwise -1
     idgen: IdGenerator
     varStates: Table[ItemId, int] # Used to detect if local variable belongs to multiple states
-    processedInnerProcs: IntSet
 
 const
   nkSkip = {nkEmpty..nkNilLit, nkTemplateDef, nkTypeSection, nkStaticStmt,
@@ -1432,17 +1431,13 @@ proc preprocess(c: var PreprocessContext; n: PNode): PNode =
     for i in 0 ..< n.len:
       result[i] = preprocess(c, n[i])
 
-proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
+proc detectCapturedVars(c: var Ctx, n: PNode, stateIdx: int) =
   case n.kind
   of nkSym:
     let s = n.sym
-    if isInnerProc(s):
-      if not c.processedInnerProcs.containsOrIncl(s.id):
-        let body = transformBody(c.g, c.idgen, s, {useCache})
-        detectCapturedVars(c, body, s, localRequiresLifting)
-    elif s.kind in {skResult, skVar, skLet, skForVar, skTemp} and sfGlobal notin s.flags and s.owner == c.fn:
+    if s.kind in {skResult, skVar, skLet, skForVar, skTemp} and sfGlobal notin s.flags and s.owner == c.fn:
       let vs = c.varStates.getOrDefault(s.itemId, localNotSeen)
-      if vs == localNotSeen and stateIdx != localRequiresLifting: # First seing this variable
+      if vs == localNotSeen: # First seing this variable
         c.varStates[s.itemId] = stateIdx
       elif vs == localRequiresLifting:
         discard # Sym already marked
@@ -1453,9 +1448,9 @@ proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
       # we have a `result = result` expression produced by the closure
       # transform, let's not touch the LHS in order to make the lifting pass
       # correct when `result` is lifted
-      detectCapturedVars(c, n[0][1], owner, stateIdx)
+      detectCapturedVars(c, n[0][1], stateIdx)
     else:
-      detectCapturedVars(c, n[0], owner, stateIdx)
+      detectCapturedVars(c, n[0], stateIdx)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
      nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
      nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
@@ -1463,14 +1458,14 @@ proc detectCapturedVars(c: var Ctx, n: PNode, owner: PSym, stateIdx: int) =
     discard
   of nkLambdaKinds, nkIteratorDef:
     if n.typ != nil:
-      detectCapturedVars(c, n[namePos], owner, stateIdx)
+      detectCapturedVars(c, n[namePos], stateIdx)
   else:
     for i in 0 ..< n.safeLen:
-      detectCapturedVars(c, n[i], owner, stateIdx)
+      detectCapturedVars(c, n[i], stateIdx)
 
 proc detectCapturedVars(c: var Ctx) =
   for i, s in c.states:
-    detectCapturedVars(c, s.body, c.fn, i)
+    detectCapturedVars(c, s.body, i)
 
 proc liftLocals(c: var Ctx, n: PNode): PNode =
   result = n

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -1487,6 +1487,12 @@ proc liftLocals(c: var Ctx, n: PNode): PNode =
       n[0][1] = liftLocals(c, n[0][1])
     else:
       n[0] = liftLocals(c, n[0])
+  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit,
+     nkTemplateDef, nkTypeSection, nkProcDef, nkMethodDef,
+     nkConverterDef, nkMacroDef, nkFuncDef, nkCommentStmt,
+     nkTypeOfExpr, nkMixinStmt, nkBindStmt,
+     nkLambdaKinds, nkIteratorDef:
+    discard
   else:
     for i in 0 ..< n.safeLen:
       n[i] = liftLocals(c, n[i])

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -199,7 +199,7 @@ proc interestingVar(s: PSym): bool {.inline.} =
 proc illegalCapture(s: PSym): bool {.inline.} =
   result = classifyViewType(s.typ) != noView or s.kind == skResult
 
-proc isInnerProc(s: PSym): bool =
+proc isInnerProc*(s: PSym): bool =
   if s.kind in {skProc, skFunc, skMethod, skConverter, skIterator} and s.magic == mNone:
     result = s.skipGenericOwner.kind in routineKinds
   else:

--- a/tests/iter/t24863.nim
+++ b/tests/iter/t24863.nim
@@ -1,0 +1,30 @@
+# issue #24863
+
+type M = object
+  p: iterator(): M {.gcsafe.}
+
+template h(f: M): int =
+  yield f
+  0
+
+proc s(): M =
+  iterator g(): M {.closure.} = discard
+  let v = M(p: g)
+  doAssert(not isNil(v.p))
+  discard v.p()
+  v
+
+proc c(): M =
+  iterator b(): M {.closure.} =
+    let r = h(s())
+    doAssert r == 0
+    proc n(): M =
+      iterator y(): M {.closure.} =
+        let _ = r
+      let _ = y
+    let _ = proc () = discard n()
+  let j = M(p: b)
+  doAssert(not isNil(j.p))
+  discard j.p()
+
+let _ = c()

--- a/tests/iter/t24863.nim
+++ b/tests/iter/t24863.nim
@@ -5,7 +5,7 @@ type M = object
 
 template h(f: M): int =
   yield f
-  0
+  456
 
 proc s(): M =
   iterator g(): M {.closure.} = discard
@@ -17,7 +17,7 @@ proc s(): M =
 proc c(): M =
   iterator b(): M {.closure.} =
     let r = h(s())
-    doAssert r == 0
+    doAssert r == 456
     proc n(): M =
       iterator y(): M {.closure.} =
         let _ = r

--- a/tests/iter/tnestedclosures.nim
+++ b/tests/iter/tnestedclosures.nim
@@ -25,6 +25,9 @@ Test 7:
 0
 1
 2
+Test 8:
+123
+0
 '''
 """
 
@@ -156,3 +159,20 @@ block: # issue #12487
     doAssert s == @["something"]
 
   main()
+
+block: # issue #24863
+  echo "Test 8:"
+  proc c() =
+    iterator b(): int {.closure.} =
+      let r = 0
+      yield 123
+      proc n() =
+        echo r
+      let a = proc () = n()
+      a()
+
+    let j = b
+    echo j()
+    discard j()
+
+  c()

--- a/tests/iter/tnestedclosures.nim
+++ b/tests/iter/tnestedclosures.nim
@@ -27,7 +27,7 @@ Test 7:
 2
 Test 8:
 123
-0
+456
 '''
 """
 
@@ -164,7 +164,7 @@ block: # minimized issue #24863
   echo "Test 8:"
   proc c() =
     iterator b(): int {.closure.} =
-      let r = 0
+      let r = 456
       yield 123
       proc n() =
         echo r

--- a/tests/iter/tnestedclosures.nim
+++ b/tests/iter/tnestedclosures.nim
@@ -160,7 +160,7 @@ block: # issue #12487
 
   main()
 
-block: # issue #24863
+block: # minimized issue #24863
   echo "Test 8:"
   proc c() =
     iterator b(): int {.closure.} =


### PR DESCRIPTION
fixes #24863, refs #23787 and #24316

Working off the minimized example, my understanding of the issue is: `n` captures `r` as `:envP.r1` where `:envP` is the environment of `b`, then `proc () = n()` does the lambda lifting of `n` again (which isn't done if the `proc ()` is marked `{.closure.}`, hence the workaround) which then captures the `:envP` as another field inside the `:envP`, so it generates `:envP.:envP_2.r1` but the `.:envP_2` field is `nil`, so it causes a segfault.

The problem is that the capture of `r` in `n` is done inside `detectCapturedVars` for the surrounding closure iterator: inner procs are not special cased and traversed as regular nodes, so it thinks it's inside the iterator and generates a field access of `:envP` freely. The lambda lifting version of `detectCapturedVars` ignores inner procs and works off of symbol uses (anonymous iterator and lambda declarations pretend their symbol is used).

As a naive solution, closure iterators now also ignore inner proc declarations same as `lambdalifting.detectCapturedVars`, but unlike it they also don't do anything for the inner proc symbols. Lambdalifting seems to properly handle the lifted variables but in the worst case we can also make sure `closureiters.detectCapturedVars` traverses inner procs by marking every local of the closure iter used in them as needing lifting (but not doing the lifting). This does not seem necessary for now so it's not done (was done and reverted in [this commit](https://github.com/nim-lang/Nim/pull/24876/commits/9bb39a9259ecf7d93c64a096138f8a2d108333d5)), but regressions are still possible