### PR TITLE
fix stmtlist expression indent regression

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -638,8 +638,9 @@ proc semiStmtList(p: var Parser, result: PNode) =
         getTok(p)
       if p.tok.tokType == tkParRi:
         break
-      elif not (sameOrNoInd(p) or realInd(p)):
-        parMessage(p, errInvalidIndentation)
+      # ignore indent:
+      #elif not (sameOrNoInd(p) or realInd(p)):
+      #  parMessage(p, errInvalidIndentation)
       let a = complexOrSimpleStmt(p)
       if a.kind == nkEmpty:
         parMessage(p, errExprExpected, p.tok)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -638,7 +638,7 @@ proc semiStmtList(p: var Parser, result: PNode) =
         getTok(p)
       if p.tok.tokType == tkParRi:
         break
-      elif not (sameInd(p) or realInd(p)):
+      elif not (sameOrNoInd(p) or realInd(p)):
         parMessage(p, errInvalidIndentation)
       let a = complexOrSimpleStmt(p)
       if a.kind == nkEmpty:

--- a/tests/parser/tstmtlistexprindent.nim
+++ b/tests/parser/tstmtlistexprindent.nim
@@ -2,5 +2,6 @@ type E = enum A, B, C
 proc junk(e: E) =
   case e
   of A: (echo "a";
-         discard; discard)
+         discard; discard;
+  discard)
   else: discard

--- a/tests/parser/tstmtlistexprindent.nim
+++ b/tests/parser/tstmtlistexprindent.nim
@@ -1,0 +1,6 @@
+type E = enum A, B, C
+proc junk(e: E) =
+  case e
+  of A: (echo "a";
+         discard; discard)
+  else: discard


### PR DESCRIPTION
follows up #24855

Before #24855, the test would work because the indentation of the `;` token would be passed to `semiStmtList` and so its indentation of `-1` would be used. Now the `;` token is skipped and the indentation of the first `discard` is used which is > -1. However the second discard has an indentation of -1 because it's on the same line: this fails the `sameInd(p) or realInd(p)` check since -1 is never >= the indent of the first discard.

For compatibility with the parser up to this point this indent check is entirely removed, meaning the indent is ignored. Because the `;` is basically never on a separate line, this was already the case for basically every use. `semiStmtList` is wrapped in a `withInd` anyway which resets the indent after it's done, since the entire statement list is wrapped in a `()`. To disallow dedents, the above check could be fixed to use `sameOrNoInd` instead of `sameInd`, which is done in the commented version of this check.