### PR TITLE
account for invalid data in enum `$` on arc/orc

### DIFF
--- a/compiler/enumtostr.nim
+++ b/compiler/enumtostr.nim
@@ -33,6 +33,10 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
     caseStmt.add newTree(nkOfBranch, newIntTypeNode(field.position, t),
       newTree(nkStmtList, newTree(nkFastAsgn, newSymNode(res), newStrNode(val, info))))
     #newIntTypeNode(nkIntLit, field.position, t)
+  # safety branch for invalid data:
+  caseStmt.add newTree(nkElse,
+    newTree(nkStmtList, newTree(nkFastAsgn, newSymNode(res),
+      newStrNode("invalid data", info))))
 
   body.add(caseStmt)
 

--- a/compiler/enumtostr.nim
+++ b/compiler/enumtostr.nim
@@ -36,7 +36,7 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
   # safety branch for invalid data:
   caseStmt.add newTree(nkElse,
     newTree(nkStmtList, newTree(nkFastAsgn, newSymNode(res),
-      newStrNode("invalid data", info))))
+      newStrNode("", info))))
 
   body.add(caseStmt)
 

--- a/tests/arc/tinvalidenumtostr.nim
+++ b/tests/arc/tinvalidenumtostr.nim
@@ -1,9 +1,3 @@
-discard """
-  output: '''
-invalid data
-'''
-"""
-
 # issue #24875
 
 type
@@ -11,4 +5,5 @@ type
     One = 1
 
 var x = cast[MyEnum](0)
-echo x
+let s = $x
+doAssert s == ""

--- a/tests/arc/tinvalidenumtostr.nim
+++ b/tests/arc/tinvalidenumtostr.nim
@@ -1,0 +1,14 @@
+discard """
+  output: '''
+invalid data
+'''
+"""
+
+# issue #24875
+
+type
+  MyEnum = enum
+    One = 1
+
+var x = cast[MyEnum](0)
+echo x


### PR DESCRIPTION
closes #24875

Refc gives `0 (invalid data!)`, but since enum `$` procs on arc are generated during enum declarations we might not have access to string concatenation and integer `$`, so it generates a static string. Just chose an empty string for this.