### PR TITLE
consider proc return type as weak reference in codegen

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -587,7 +587,7 @@ proc genProcParams(m: BModule; t: PType, rettype: var Rope, params: var Builder,
   if t.returnType == nil or isInvalidReturnType(m.config, t):
     rettype = CVoid
   else:
-    rettype = getTypeDescAux(m, t.returnType, check, dkResult)
+    rettype = getTypeDescWeak(m, t.returnType, check, dkResult)
   var paramBuilder: ProcParamBuilder
   params.addProcParams(paramBuilder):
     for i in 1..<t.n.len:

--- a/tests/proc/trecursivereturntype.nim
+++ b/tests/proc/trecursivereturntype.nim
@@ -1,0 +1,15 @@
+# issue #7706
+
+type
+  Op = enum
+    Halt
+    Inc
+    Dec
+
+type
+  InstrNext = proc (val: var int, code: seq[Op], pc: var int, stop: var bool): OpH {.inline, nimcall.}
+
+  OpH = object
+    handler: InstrNext
+
+var a: OpH


### PR DESCRIPTION
fixes #7706