### PR TITLE
whitelist prev types to reuse in `newOrPrevType`

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -39,7 +39,9 @@ const
   errInOutFlagNotExtern = "the '$1' modifier can be used only with imported types"
 
 proc reusePrev(prev: PType): bool {.inline.} =
+  # only overwrite `prev` if it is a forward type, partial object or magic type
   result = prev != nil and (prev.kind == tyForward or (prev.sym != nil and
+    # partial object marks sym as `sfForward`
     (sfForward in prev.sym.flags or prev.sym.magic != mNone)))
 
 proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext, son: sink PType): PType =

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -38,21 +38,25 @@ const
   errNoGenericParamsAllowedForX = "no generic parameters allowed for $1"
   errInOutFlagNotExtern = "the '$1' modifier can be used only with imported types"
 
+proc reusePrev(prev: PType): bool {.inline.} =
+  result = prev != nil and (prev.kind == tyForward or (prev.sym != nil and
+    (sfForward in prev.sym.flags or prev.sym.magic != mNone)))
+
 proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext, son: sink PType): PType =
-  if prev == nil or prev.kind == tyGenericBody:
-    result = newTypeS(kind, c, son)
-  else:
+  if reusePrev(prev):
     result = prev
     result.setSon(son)
     if result.kind == tyForward: result.kind = kind
+  else:
+    result = newTypeS(kind, c, son)
   #if kind == tyError: result.flags.incl tfCheckedForDestructor
 
 proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext): PType =
-  if prev == nil or prev.kind == tyGenericBody:
-    result = newTypeS(kind, c)
-  else:
+  if reusePrev(prev):
     result = prev
     if result.kind == tyForward: result.kind = kind
+  else:
+    result = newTypeS(kind, c)
 
 proc newConstraint(c: PContext, k: TTypeKind): PType =
   result = newTypeS(tyBuiltInTypeClass, c)

--- a/tests/types/tresemtypesection.nim
+++ b/tests/types/tresemtypesection.nim
@@ -41,6 +41,16 @@ foo:
   discard Bar[int](x: 123)
   discard Bar[string](x: "abc")
 
+  type
+    Generic1[T] = object
+    Generic2[T] = ref int
+    Generic3[T] = ref Generic1[T]
+    Generic4[T] = Generic2[T]
+    GenericInst1 = Generic1[int]
+    GenericInst2 = Generic2[int]
+    GenericInst3 = Generic3[int]
+    GenericInst4 = Generic4[int]
+
   # regression test:
   template templ(): untyped =
     proc injected() {.inject.} = discard
@@ -49,6 +59,7 @@ foo:
   type TestInject = templ()
   var x1: TestInject
   injected() # normally works
+
 echo $NONE
 echo a
 var x2: TestInject

--- a/tests/types/tresemtypesection.nim
+++ b/tests/types/tresemtypesection.nim
@@ -53,3 +53,8 @@ echo $NONE
 echo a
 var x2: TestInject
 injected()
+
+block: # issue #24898
+  type V[W] = object
+  template g(d: int) = discard d
+  g((; type J = V[int]; 0))


### PR DESCRIPTION
fixes #24898

A type is only overwritten if it is definitely a forward type, partial object (symbol marked `sfForward`) or a magic type. Maybe worse for performance but should be more correct. Another option might be to provide a different value for `prev` for the `preserveSym` case but then we cannot easily ignore only nominal type nodes.