### PR TITLE
fix generic converter regression with `var`/subtype args

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -688,7 +688,9 @@ proc instGenericConvertersArg*(c: PContext, a: PNode, x: TCandidate) =
     if s.isGenericRoutineStrict:
       var src = s.typ.firstParamType
       var convMatch = newCandidate(c, src)
-      let srca = typeRel(convMatch, src, a[1].typ)
+      var arg = a[1]
+      if arg.kind in {nkHiddenAddr, nkHiddenSubConv}: arg = arg[^1]
+      let srca = typeRel(convMatch, src, arg.typ)
       if srca notin {isEqual, isGeneric, isSubtype}:
         internalError(c.config, a.info, "generic converter failed rematch")
       let finalCallee = generateInstance(c, s, convMatch.bindings, a.info)

--- a/tests/converter/tvargenericconverter.nim
+++ b/tests/converter/tvargenericconverter.nim
@@ -1,0 +1,7 @@
+# regression test
+
+converter toPtr[T](x: var T): ptr T =
+  result = addr x
+
+var x = 123
+let y: ptr int = x


### PR DESCRIPTION
refs #24867, https://github.com/nim-lang/Nim/pull/24867#issuecomment-2821315971

The argument node of the converter can be wrapped in [hidden `addr` or subtype conversion nodes](https://github.com/nim-lang/Nim/blob/dc100c5caa673b039155e9e5d4c7fc0c239f4eb5/compiler/sigmatch.nim#L2327-L2335) which have to be skipped when matching the type again, since the type of the node is the uninstantiated type taken from the proc parameter.