### PR TITLE
fixes #24905; resolves push/pop pragmas in generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -634,6 +634,9 @@ proc semGenericStmt(c: PContext, n: PNode,
         # only sem if not a language-level pragma 
         # treat as mixin context for user pragmas & macro args
         result[i] = semGenericStmt(c, x, flags+{withinMixin}, ctx)
+      elif prag in {wPush, wPop}:
+        # resolves push/pop pragmas; i.e. options
+        pragma(c, c.p.owner, n, stmtPragmas, true)
   of nkExprColonExpr, nkExprEqExpr:
     checkMinSonsLen(n, 2, c.config)
     result[1] = semGenericStmt(c, n[1], flags, ctx)

--- a/tests/generics/tpushpop.nim
+++ b/tests/generics/tpushpop.nim
@@ -1,0 +1,11 @@
+discard """
+  matrix: "--warningAsError:Deprecated"
+"""
+
+proc y() {.deprecated.} = discard
+proc v(_: int | int) =
+  {.push warning[Deprecated]: off.}
+  y()
+  {.pop.}
+
+v(1)


### PR DESCRIPTION
fixes #24905
We should process options for the first phase of generic procs because the deprecation is checked in this phase