### PR TITLE
fix #24912

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -909,15 +909,14 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
     if c.inGenericContext > 0 and c.matchedConcept == nil:
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
-    elif {efPreferNilResult, efExplain} * flags == {}:
+    elif efExplain notin flags:
       
       # repeat the overload resolution,
       # this time enabling all the diagnostic output (this should fail again)
       result = semOverloadedCall(c, n, nOrig, filter, flags + {efExplain})
     elif efNoUndeclared notin flags:
       result = nil
-      if efPreferNilResult notin flags:
-        notFoundError(c, n, errors)
+      notFoundError(c, n, errors)
     else:
       result = nil
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -614,19 +614,11 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
         if c.inGenericContext > 0 and nfExprCall in n.flags:
           # untyped expression calls end up here, see #24099
           return
-        if efPreferNilResult in flags:
-          result.state = csEmpty
-          #result.call = nil
-          return
         # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
         localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:
       if nfExprCall in n.flags:
-        if efPreferNilResult in flags:
-          result.state = csEmpty
-          #result.call = nil
-          return
         localError(c.config, n.info, "expression '$1' cannot be called" %
                    renderTree(n, {renderNoComments}))
       else:
@@ -637,10 +629,6 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       return
   if alt.state == csMatch and cmpCandidates(result, alt) == 0 and
       not sameMethodDispatcher(result.calleeSym, alt.calleeSym):
-    if efPreferNilResult in flags:
-      result.state = csEmpty
-      #result.call = nil
-      return
     internalAssert c.config, result.state == csMatch
     #writeMatches(result)
     #writeMatches(alt)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -614,11 +614,19 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
         if c.inGenericContext > 0 and nfExprCall in n.flags:
           # untyped expression calls end up here, see #24099
           return
+        if efPreferNilResult in flags:
+          result.state = csEmpty
+          #result.call = nil
+          return
         # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
         localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:
       if nfExprCall in n.flags:
+        if efPreferNilResult in flags:
+          result.state = csEmpty
+          #result.call = nil
+          return
         localError(c.config, n.info, "expression '$1' cannot be called" %
                    renderTree(n, {renderNoComments}))
       else:
@@ -629,6 +637,10 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       return
   if alt.state == csMatch and cmpCandidates(result, alt) == 0 and
       not sameMethodDispatcher(result.calleeSym, alt.calleeSym):
+    if efPreferNilResult in flags:
+      result.state = csEmpty
+      #result.call = nil
+      return
     internalAssert c.config, result.state == csMatch
     #writeMatches(result)
     #writeMatches(alt)
@@ -909,13 +921,15 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
     if c.inGenericContext > 0 and c.matchedConcept == nil:
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
-    elif efExplain notin flags:
+    elif {efPreferNilResult, efExplain} * flags == {}:
+      
       # repeat the overload resolution,
       # this time enabling all the diagnostic output (this should fail again)
       result = semOverloadedCall(c, n, nOrig, filter, flags + {efExplain})
     elif efNoUndeclared notin flags:
       result = nil
-      notFoundError(c, n, errors)
+      if efPreferNilResult notin flags:
+        notFoundError(c, n, errors)
     else:
       result = nil
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -910,7 +910,6 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
     elif efExplain notin flags:
-      
       # repeat the overload resolution,
       # this time enabling all the diagnostic output (this should fail again)
       result = semOverloadedCall(c, n, nOrig, filter, flags + {efExplain})

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1094,7 +1094,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
       return
-    elif n0.kind == nkDotExpr and n[0].typ().kind == tyTypeDesc:
+    elif n0.kind == nkDotExpr and n0.typ.kind != tyProc:
       result = n0
       result.transitionSonsKind(nkCall)
       for i in 1..<n.len: result.add n[i]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1094,7 +1094,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
       return
-    elif n0.kind == nkDotExpr and n0.typ.kind != tyProc:
+    elif n0.kind == nkDotExpr and n0.typ.kind notin {tyProc, tyGenericInst}:
       result = n0
       result.transitionSonsKind(nkCall)
       for i in 1..<n.len: result.add n[i]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1094,6 +1094,14 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
       return
+    elif n0.kind == nkDotExpr and n[0].typ().kind == tyTypeDesc:
+      result = n0
+      result.transitionSonsKind(nkCall)
+      for i in 1..<n.len: result.add n[i]
+      let tmp = result[1]
+      result[1] = result[0]
+      result[0] = tmp
+      return semDirectOp(c, result, flags, expectedType)
     else:
       n[0] = n0
   else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1075,6 +1075,17 @@ proc afterCallActions(c: PContext; n, orig: PNode, flags: TExprFlags; expectedTy
     # don't fold calls in concepts and typeof
     result = evalAtCompileTime(c, result)
 
+proc normalizeMethodCallSyntax(n: PNode): PNode =
+  # transforms A.b(C) to b(A, C)
+  # does not check if `b` is a field
+  result = n[0]
+  result.transitionSonsKind(nkCall)
+  for i in 1..<n.len: result.add n[i]
+  let tmp = result[1]
+  result[1] = result[0]
+  result[0] = tmp
+  result.typ() = nil
+
 proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = nil
   checkMinSonsLen(n, 1, c.config)
@@ -1153,13 +1164,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
     if result == nil or result.kind == nkEmpty:
       var tcall = n.copyTree
       if n[0].kind == nkDotExpr and n[0].typ.kind notin {tyProc, tyGenericInst, tyOwned}:
-        tcall = n[0]
-        tcall.transitionSonsKind(nkCall)
-        for i in 1..<n.len: tcall.add n[i]
-        let tmp = tcall[1]
-        tcall[1] = tcall[0]
-        tcall[0] = tmp
-        tcall.typ() = nil
+        tcall = normalizeMethodCallSyntax(tcall)
         nOrig = tcall.copyTree
       else:
         # Now that nkSym does not imply an iteration over the proc/iterator space,

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1107,12 +1107,6 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
   var t: PType = nil
   if n[0].typ != nil:
     t = skipTypes(n[0].typ, abstractInst+{tyOwned}-{tyTypeDesc, tyDistinct})
-
-  # think this might not be needed now
-  if t != nil and t.kind == tyTypeDesc and n[0] != nil and
-     n[0].kind == nkBracketExpr and n.len == 1:
-    # we don't overload `[]` on generic typeclasses
-    return semObjConstr(c, n, flags, expectedType)
   
   var nOrig = n.copyTree
   semOpAux(c, n)
@@ -1176,23 +1170,20 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       
       result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efPreferNilResult})
       if result == nil:
-        if t.kind in {tyFromExpr, tyTypeDesc}:
+        if t != nil and t.kind in {tyFromExpr, tyTypeDesc}:
           if n.len == 2:
             return semConv(c, n, flags)
           elif n.len == 1:
             return semObjConstr(c, n, flags, expectedType)
           else:
-            result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags)
-            #if result == nil:
-            #  return errorNode(c, n)
+            return errorNode(c, n)
         else:
           result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
-          return errorNode(c, n)
     elif result.kind notin nkCallKinds:
       # the semExpr() in overloadedCallOpr can even break this condition!
       # See bug #904 of how to trigger it:
       return result
-  if result.typ != nil and result.typ.kind == tyFromExpr and t.kind == tyTypeDesc:
+  if result.typ != nil and result.typ.kind == tyFromExpr and t != nil and t.kind == tyTypeDesc:
     # this is wrong but tyFromExpr doesn't always seem to be a valid result
     # anecdotally, this is what the compiler is trying to do but I think 
     # tyFromExpr needs to be handled elsewhere

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1104,11 +1104,11 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
     elif isSymChoice(n[0]) and nfDotField notin n.flags:
       # overloaded generic procs e.g. newSeq[int] can end up here
       return semDirectOp(c, n, flags, expectedType)
-
   var t: PType = nil
   if n[0].typ != nil:
     t = skipTypes(n[0].typ, abstractInst+{tyOwned}-{tyTypeDesc, tyDistinct})
 
+  # think this might not be needed now
   if t != nil and t.kind == tyTypeDesc and n[0] != nil and
      n[0].kind == nkBracketExpr and n.len == 1:
     # we don't overload `[]` on generic typeclasses
@@ -1183,6 +1183,8 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
             return semObjConstr(c, n, flags, expectedType)
           else:
             result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags)
+            #if result == nil:
+            #  return errorNode(c, n)
         else:
           result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
           return errorNode(c, n)
@@ -1190,6 +1192,11 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       # the semExpr() in overloadedCallOpr can even break this condition!
       # See bug #904 of how to trigger it:
       return result
+  if result.typ != nil and result.typ.kind == tyFromExpr and t.kind == tyTypeDesc:
+    # this is wrong but tyFromExpr doesn't always seem to be a valid result
+    # anecdotally, this is what the compiler is trying to do but I think 
+    # tyFromExpr needs to be handled elsewhere
+    return semObjConstr(c, n, flags, expectedType)
   if result[0].kind == nkSym:
     result = afterCallActions(c, result, nOrig, flags, expectedType)
   else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1094,7 +1094,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
       return
-    elif n0.kind == nkDotExpr and n0.typ.kind notin {tyProc, tyGenericInst}:
+    elif n0.kind == nkDotExpr and n0.typ.kind notin {tyProc, tyGenericInst, tyOwned}:
       result = n0
       result.transitionSonsKind(nkCall)
       for i in 1..<n.len: result.add n[i]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1159,7 +1159,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
     if result == nil or result.kind == nkEmpty:
       var tcall = n.copyTree
       if n[0].kind == nkDotExpr and n[0].typ.kind notin {tyProc, tyGenericInst, tyOwned}:
-        tcall = n[0] #semFieldAccess(c, n[0], {efIsDotCall})
+        tcall = n[0]
         tcall.transitionSonsKind(nkCall)
         for i in 1..<n.len: tcall.add n[i]
         let tmp = tcall[1]
@@ -1182,7 +1182,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
           elif n.len == 1:
             return semObjConstr(c, n, flags, expectedType)
           else:
-            result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags - {efPreferNilResult})
+            result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags)
         else:
           result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
           return errorNode(c, n)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1167,16 +1167,17 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
         tcall[0] = prc
         nOrig[0] = prc
         tcall.flags.incl nfExprCall
-      
-      result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efPreferNilResult})
+      let canspec = t != nil and t.kind in {tyFromExpr, tyTypeDesc}
+      var fflags = flags
+      if canspec:
+        fflags.incl efPreferNilResult
+      result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, fflags)
       if result == nil:
-        if t != nil and t.kind in {tyFromExpr, tyTypeDesc}:
+        if canspec:
           if n.len == 2:
             return semConv(c, n, flags)
           elif n.len == 1:
             return semObjConstr(c, n, flags, expectedType)
-        else:
-          result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
     elif result.kind notin nkCallKinds:
       # the semExpr() in overloadedCallOpr can even break this condition!
       # See bug #904 of how to trigger it:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1175,14 +1175,14 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
             return semConv(c, n, flags)
           elif n.len == 1:
             return semObjConstr(c, n, flags, expectedType)
-          else:
-            return errorNode(c, n)
         else:
           result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
     elif result.kind notin nkCallKinds:
       # the semExpr() in overloadedCallOpr can even break this condition!
       # See bug #904 of how to trigger it:
       return result
+  if result == nil:
+    return errorNode(c, n)
   if result.typ != nil and result.typ.kind == tyFromExpr and t != nil and t.kind == tyTypeDesc:
     # this is wrong but tyFromExpr doesn't always seem to be a valid result
     # anecdotally, this is what the compiler is trying to do but I think 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1084,7 +1084,6 @@ proc normalizeMethodCallSyntax(n: PNode): PNode =
   let tmp = result[1]
   result[1] = result[0]
   result[0] = tmp
-  result.typ() = nil
 
 proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = nil

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1170,7 +1170,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       let canspec = t != nil and t.kind in {tyFromExpr, tyTypeDesc}
       var fflags = flags
       if canspec:
-        fflags.incl efPreferNilResult
+        fflags.incl efNoUndeclared
       result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, fflags)
       if result == nil:
         if canspec:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -994,18 +994,18 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
     let callee = result[0].sym
     case callee.kind
     of skMacro, skTemplate: discard
-    else:
-      if callee.kind == skIterator and callee.id == c.p.owner.id and
-          not isClosureIterator(c.p.owner.typ):
+    of skIterator:
+      if callee.id == c.p.owner.id and not isClosureIterator(c.p.owner.typ):
         localError(c.config, n.info, errRecursiveDependencyIteratorX % callee.name.s)
         # error correction, prevents endless for loop elimination in transf.
         # See bug #2051:
         result[0] = newSymNode(errorSym(c, n))
-      elif callee.kind == skIterator:
-        if efWantIterable in flags:
-          let typ = newTypeS(tyIterable, c)
-          rawAddSon(typ, result.typ)
-          result.typ() = typ
+      elif efWantIterable in flags:
+        let typ = newTypeS(tyIterable, c)
+        rawAddSon(typ, result.typ)
+        result.typ() = typ
+    else:
+      discard
 
 proc resolveIndirectCall(c: PContext; n, nOrig: PNode;
                          t: PType): TCandidate =
@@ -1094,14 +1094,6 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
       result = semGenericStmt(c, n)
       result.typ() = makeTypeFromExpr(c, result.copyTree)
       return
-    elif n0.kind == nkDotExpr and n0.typ.kind notin {tyProc, tyGenericInst, tyOwned}:
-      result = n0
-      result.transitionSonsKind(nkCall)
-      for i in 1..<n.len: result.add n[i]
-      let tmp = result[1]
-      result[1] = result[0]
-      result[0] = tmp
-      return semDirectOp(c, result, flags, expectedType)
     else:
       n[0] = n0
   else:
@@ -1116,11 +1108,13 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
   var t: PType = nil
   if n[0].typ != nil:
     t = skipTypes(n[0].typ, abstractInst+{tyOwned}-{tyTypeDesc, tyDistinct})
-  if t != nil and t.kind == tyTypeDesc:
-    if n.len == 1: return semObjConstr(c, n, flags, expectedType)
-    return semConv(c, n, flags)
 
-  let nOrig = n.copyTree
+  if t != nil and t.kind == tyTypeDesc and n[0] != nil and
+     n[0].kind == nkBracketExpr and n.len == 1:
+    # we don't overload `[]` on generic typeclasses
+    return semObjConstr(c, n, flags, expectedType)
+  
+  var nOrig = n.copyTree
   semOpAux(c, n)
   if t != nil and t.kind == tyProc:
     # This is a proc variable, apply normal overload resolution
@@ -1162,21 +1156,40 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
 
   else:
     result = overloadedCallOpr(c, n) # this uses efNoUndeclared
-    # Now that nkSym does not imply an iteration over the proc/iterator space,
-    # the old ``prc`` (which is likely an nkIdent) has to be restored:
     if result == nil or result.kind == nkEmpty:
-      # XXX: hmm, what kind of symbols will end up here?
-      # do we really need to try the overload resolution?
-      n[0] = prc
-      nOrig[0] = prc
-      n.flags.incl nfExprCall
-      result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags)
-      if result == nil: return errorNode(c, n)
+      var tcall = n.copyTree
+      if n[0].kind == nkDotExpr and n[0].typ.kind notin {tyProc, tyGenericInst, tyOwned}:
+        tcall = n[0] #semFieldAccess(c, n[0], {efIsDotCall})
+        tcall.transitionSonsKind(nkCall)
+        for i in 1..<n.len: tcall.add n[i]
+        let tmp = tcall[1]
+        tcall[1] = tcall[0]
+        tcall[0] = tmp
+        tcall.typ() = nil
+        nOrig = tcall.copyTree
+      else:
+        # Now that nkSym does not imply an iteration over the proc/iterator space,
+        # the old ``prc`` (which is likely an nkIdent) has to be restored:
+        tcall[0] = prc
+        nOrig[0] = prc
+        tcall.flags.incl nfExprCall
+      
+      result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efPreferNilResult})
+      if result == nil:
+        if t.kind in {tyFromExpr, tyTypeDesc}:
+          if n.len == 2:
+            return semConv(c, n, flags)
+          elif n.len == 1:
+            return semObjConstr(c, n, flags, expectedType)
+          else:
+            result = semOverloadedCallAnalyseEffects(c, n, nOrig, flags - {efPreferNilResult})
+        else:
+          result = semOverloadedCallAnalyseEffects(c, tcall, nOrig, flags + {efExplain})
+          return errorNode(c, n)
     elif result.kind notin nkCallKinds:
       # the semExpr() in overloadedCallOpr can even break this condition!
       # See bug #904 of how to trigger it:
       return result
-  #result = afterCallActions(c, result, nOrig, flags)
   if result[0].kind == nkSym:
     result = afterCallActions(c, result, nOrig, flags, expectedType)
   else:

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -2,8 +2,6 @@ discard """
 action: run
 """
 
-doAssert false # is this test even running??
-
 #24913
 block: 
   type
@@ -36,17 +34,17 @@ block:
 
   Rule[int](p: sp).spring()
 
-block:
-  type
-    Cont[T] = ref RootObj
-    Rule[T] = object
-      p: Cont[T]
+# cant be in a block
+type
+  Cont[T] = ref RootObj
+  Rule[T] = object
+    p: Cont[T]
 
-  proc p(x: Rule[int]; y: int): int = 5
+proc p(x: Rule[int]; y: int): int = 5
 
-  proc spring[T](rule: Rule[T]) =
-    let p = proc (x: T) =
-      doAssert rule.p(x) == 5
-    p(default(T))
+proc spring[T](rule: Rule[T]) =
+  let p = proc (x: T) =
+    doAssert rule.p(x) == 5
+  p(default(T))
 
-  Rule[int]().spring()
+Rule[int]().spring()

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -2,6 +2,8 @@ discard """
 action: run
 """
 
+doAssert false # is this test even running??
+
 #24913
 block: 
   type

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -1,0 +1,17 @@
+discard """
+action: run
+"""
+
+block: #24913
+  type
+    A = object
+      b: int
+    B = object
+      b: proc(x: float): int
+
+  proc b(T: typedesc[A]; s: float): int = 5
+  proc b(T: typedesc[B]; s: float): int = 7
+  proc testme(x: float): int = 3
+  doAssert A.b(1.0) == 5
+  doAssert B.b(1.0) == 7
+  doAssert B(b: testme).b(1.0) == 3

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -34,6 +34,19 @@ block:
 
   Rule[int](p: sp).spring()
 
+block:
+  type
+    A = object
+
+  proc new(T: type A): ref A =
+    let c = (ref T)()
+    c
+
+  proc p[K](rng=A.new()) = 
+    discard new(A)
+
+  p[int]()
+
 # cant be in a block
 type
   Cont[T] = ref RootObj

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -2,7 +2,8 @@ discard """
 action: run
 """
 
-block: #24913
+#24913
+block: 
   type
     A = object
       b: int
@@ -15,3 +16,35 @@ block: #24913
   doAssert A.b(1.0) == 5
   doAssert B.b(1.0) == 7
   doAssert B(b: testme).b(1.0) == 3
+
+block:
+  type
+    Proc[T] = proc(text: T): int {.closure.}
+    
+    Rule[T] = object
+      p: Proc[T]
+
+  proc p(x: Rule[int]; y: float): int = 5
+  proc sp(y: int): int = 3
+
+  proc spring*[T](rule: Rule[T]) =
+    let p = proc (text: T) =
+      doAssert rule.p(text) == 3
+    p(default(T))
+
+  Rule[int](p: sp).spring()
+
+block:
+  type
+    Cont[T] = ref RootObj
+    Rule[T] = object
+      p: Cont[T]
+
+  proc p(x: Rule[int]; y: int): int = 5
+
+  proc spring*[T](rule: Rule[T]) =
+    let p = proc (x: T) =
+      doAssert rule.p(x) == 5
+    p(default(T))
+
+  Rule[int]().spring()

--- a/tests/exprs/tdots.nim
+++ b/tests/exprs/tdots.nim
@@ -27,7 +27,7 @@ block:
   proc p(x: Rule[int]; y: float): int = 5
   proc sp(y: int): int = 3
 
-  proc spring*[T](rule: Rule[T]) =
+  proc spring[T](rule: Rule[T]) =
     let p = proc (text: T) =
       doAssert rule.p(text) == 3
     p(default(T))
@@ -42,7 +42,7 @@ block:
 
   proc p(x: Rule[int]; y: int): int = 5
 
-  proc spring*[T](rule: Rule[T]) =
+  proc spring[T](rule: Rule[T]) =
     let p = proc (x: T) =
       doAssert rule.p(x) == 5
     p(default(T))


### PR DESCRIPTION
#24912
Although this appears to work as far as I know the method is kinda dumb, frankly. I know the dot expression can have complexities but I have wondered a couple times why the compiler doesn't often transform the call similar to this and toss it into `semDirectOp`. If anyone cares to enlighten me I'll listen.

Right now this checks for `tyTyepDescr` explicitly but I'm thinking that it would make more sense to check if the field access is looking at a `proc` type, but maybe I'll commit again and check that out after I see how this goes.