### PR TITLE
add `srcDir` variable to nim.cfg

### DIFF
--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -207,7 +207,6 @@ proc parseAssignment(L: var Lexer, tok: var Token;
       checkSymbol(L, tok)
       val.add($tok)
       confTok(L, tok, config, condStack)
-  config.currentConfigDir = parentDir(filename.string)
   if percent:
     processSwitch(s, strtabs.`%`(val, config.configVars,
                                 {useEnvironment, useEmpty}), passPP, info, config)
@@ -249,7 +248,8 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
   setDefaultLibpath(conf)
   template readConfigFile(path) =
     let configPath = path
-    setConfigVar(conf, "selfDir", configPath.splitFile.dir.string)
+    conf.currentConfigDir = configPath.splitFile.dir.string
+    setConfigVar(conf, "selfDir", conf.currentConfigDir)
     if readConfigFile(configPath, cache, conf):
       conf.configFiles.add(configPath)
 

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -223,7 +223,6 @@ proc readConfigFile*(filename: AbsoluteFile; cache: IdentCache;
   stream = llStreamOpen(filename, fmRead)
   if stream != nil:
     openLexer(L, filename, stream, cache, config)
-    setConfigVar(config, "srcDir", parentDir(filename.string))
     tok = Token(tokType: tkEof)       # to avoid a pointless warning
     var condStack: seq[bool] = @[]
     confTok(L, tok, config, condStack)           # read in the first token
@@ -250,6 +249,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
   setDefaultLibpath(conf)
   template readConfigFile(path) =
     let configPath = path
+    setConfigVar(conf, "selfDir", configPath.splitFile.dir.string)
     if readConfigFile(configPath, cache, conf):
       conf.configFiles.add(configPath)
 

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -223,6 +223,7 @@ proc readConfigFile*(filename: AbsoluteFile; cache: IdentCache;
   stream = llStreamOpen(filename, fmRead)
   if stream != nil:
     openLexer(L, filename, stream, cache, config)
+    setConfigVar(config, "srcDir", parentDir(filename.string))
     tok = Token(tokType: tkEof)       # to avoid a pointless warning
     var condStack: seq[bool] = @[]
     confTok(L, tok, config, condStack)           # read in the first token


### PR DESCRIPTION
There might be a way to do this but I couldn't find anything about it. This is a very simple thing that goes a long way in certain situations. Trying to avoid needing to switch to nimscript just to get:
```nim
# config.nims
import os
let srcDir = currentSourcePath.parentDir()
switch("define", &"ProjPath:\"{srcDir}\"")
```
with this change just needs:
```
# nim.cfg
d %= "ProjPath=$srcDir"
```