### PR TITLE
fixes address of sink parameters

### DIFF
--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -166,4 +166,4 @@ proc makeAddr*(n: PNode; idgen: IdGenerator): PNode =
     result = n
   else:
     result = newTree(nkHiddenAddr, n)
-    result.typ() = makePtrType(n.typ, idgen)
+    result.typ() = makePtrType(n.typ.skipTypes({tySink}), idgen)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -38,7 +38,7 @@ proc semAddr(c: PContext; n: PNode): PNode =
   if isAssignable(c, x) notin {arLValue, arLocalLValue, arAddressableConst, arLentValue}:
     localError(c.config, n.info, errExprHasNoAddress)
   result.add x
-  result.typ() = makePtrType(c, x.typ)
+  result.typ() = makePtrType(c, x.typ.skipTypes({tySink}))
 
 proc semTypeOf(c: PContext; n: PNode): PNode =
   var m = BiggestInt 1 # typeOfIter

--- a/tests/destructor/tsink.nim
+++ b/tests/destructor/tsink.nim
@@ -68,3 +68,11 @@ block: # bug #24175
     static:
       foo()
     foo()
+
+proc create(value: sink int): ptr int =
+  let s = addr value
+  result = addr value
+  result = s
+
+
+let xxx = create(12)


### PR DESCRIPTION
In `semExprWithType`: `if result.typ.kind in {tyVar, tyLent}: result = newDeref(result)` derefed `var`/`lent`. Since it is not done for `sink`, we need to skip `tySink` in the corresponding procs