### PR TITLE
fixes broken discriminators of float types by disabling it

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -813,7 +813,7 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   case typ.kind
   of shouldChckCovered:
     chckCovered = true
-  of tyFloat..tyFloat128, tyError:
+  of tyError:
     discard
   of tyRange:
     if skipTypes(typ.elementType, abstractInst).kind in shouldChckCovered:
@@ -821,7 +821,8 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   of tyForward:
     errorUndeclaredIdentifier(c, n[0].info, typ.sym.name.s)
   elif not isOrdinalType(typ):
-    localError(c.config, n[0].info, "selector must be of an ordinal type, float")
+    localError(c.config, n[0].info, "selector must be of an ordinal type")
+
   if firstOrd(c.config, typ) != 0:
     localError(c.config, n.info, "low(" & $a[0].sym.name.s &
                                      ") must be 0 for discriminant")

--- a/tests/errmsgs/tobjectvariants.nim
+++ b/tests/errmsgs/tobjectvariants.nim
@@ -1,0 +1,13 @@
+discard """
+  errormsg: "selector must be of an ordinal type"
+"""
+
+type
+  Case = object
+    case x: float
+    of 1.0:
+      id: int
+    else:
+      ta: float
+
+var s = Case(x: 4.0, id: 1)


### PR DESCRIPTION
```nim
type
  Case = object
    case x: float
    of 1.0:
      id: int
    else:
      ta: float
```

It segfaults with `fatal error: invalid kind for firstOrd(tyFloat)`

It was caused by https://github.com/nim-lang/Nim/pull/12591 and has affected discriminators of float types since 1.2.x

I think no one is using discriminators of float types anyway so I simply disable it like what was done to discriminators of string types (ref https://github.com/nim-lang/Nim/pull/15080)


ref https://github.com/nim-lang/nimony/pull/1069