### PR TITLE
Maybe close https://github.com/nim-lang/Nim/issues/24932 by simply

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2335,9 +2335,9 @@ iterator mvalues*[A, B](t: OrderedTableRef[A, B]): var B =
 
 type
   CountTable*[A] = object
-    ## Hash table that counts the number of each key.  Uses zero count to signal
-    ## empty & so does not cache hash values for comparison reduction or resize
-    ## acceleration.
+    ## Hash table that counts the number of each key.  Unlike `Table<#Table>`_,
+    ## this uses a zero count to signal "empty" & so does not cache hash values
+    ## for comparison reduction or resize acceleration.
     ##
     ## For creating an empty CountTable, use `initCountTable proc
     ## <#initCountTable>`_.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -107,7 +107,7 @@ runnableExamples:
 ## container (e.g. string, sequence or array), as it is a mapping where the
 ## items are the keys, and their number of occurrences are the values.
 ## For that purpose `toCountTable proc<#toCountTable,openArray[A]>`_
-## comes handy:
+## comes in handy:
 
 runnableExamples:
   let myString = "abracadabra"
@@ -2329,19 +2329,15 @@ iterator mvalues*[A, B](t: OrderedTableRef[A, B]): var B =
     yield t.data[h].val
     assert(len(t) == L, "the length of the table changed while iterating over it")
 
-
-
-
-
-
-
 # -------------------------------------------------------------------------
 # ------------------------------ CountTable -------------------------------
 # -------------------------------------------------------------------------
 
 type
   CountTable*[A] = object
-    ## Hash table that counts the number of each key.
+    ## Hash table that counts the number of each key.  Uses zero count to signal
+    ## empty & so does not cache hash values for comparison reduction or resize
+    ## acceleration.
     ##
     ## For creating an empty CountTable, use `initCountTable proc
     ## <#initCountTable>`_.
@@ -2733,10 +2729,6 @@ iterator mvalues*[A](t: var CountTable[A]): var int =
     if t.data[h].val != 0:
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
-
-
-
-
 
 
 


### PR DESCRIPTION
explaining why the result may not be so surprising.  Clean-up of stray whitespace and insert of missing "in" along for the ride.

It's just not always faster or slower than `Table`.  The difference depends upon many factors such as (at least!): A) how much (if anything - for `int` keys it is nothing) hash-comparison before `==` comparison saves B) how much resizing happens (which may even vary from run to run if end users are allowed to provide scale guess input), C) how much comparison happens at all (i.e., table density), D) how much space/size matters - like how close to a specific deployment "available" cache size the table is.

If we want, we could add a sentence suggesting performance fans also try `Table`, but the kind of low-level nature of the explanation strikes me as already along those lines.