### PR TITLE
generate `let _ =` to fully unpack partial tuple unpacking assignment for arc

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -563,7 +563,7 @@ proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
     if c.inLoop > 0:
       # unpacked tuple needs reset at every loop iteration
       res.add newTree(nkFastAsgn, v, genDefaultCall(v.typ, c, v.info))
-  elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
+  if sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
     if {sfGlobal, sfPure} <= v.sym.flags or sfGlobal in v.sym.flags and s.parent == nil:
       c.graph.globalDestructors.add c.genDestroy(v)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -185,13 +185,6 @@ proc isCursor(n: PNode): bool =
   else:
     false
 
-template isUnpackedTuple(n: PNode): bool =
-  ## we move out all elements of unpacked tuples,
-  ## hence unpacked tuples themselves don't need to be destroyed
-  ## except it's already a cursor
-  (n.kind == nkSym and n.sym.kind == skTemp and
-   n.sym.typ.kind == tyTuple and sfCursor notin n.sym.flags)
-
 proc checkForErrorPragma(c: Con; t: PType; ri: PNode; opname: string; inferredFromCopy = false) =
   var m = "'" & opname & "' is not available for type <" & typeToString(t) & ">"
   if inferredFromCopy:
@@ -275,7 +268,7 @@ proc deepAliases(dest, ri: PNode): bool =
     return aliases(dest, ri) != no
 
 proc genSink(c: var Con; s: var Scope; dest, ri: PNode; flags: set[MoveOrCopyFlag] = {}): PNode =
-  if (c.inLoopCond == 0 and (isUnpackedTuple(dest) or IsDecl in flags or
+  if (c.inLoopCond == 0 and (IsDecl in flags or
       (isAnalysableFieldAccess(dest, c.owner) and isFirstWrite(dest, c)))) or
       isNoInit(dest) or IsReturn in flags:
     # optimize sink call into a bitwise memcopy
@@ -559,11 +552,7 @@ proc cycleCheck(n: PNode; c: var Con) =
 proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
   # move the variable declaration to the top of the frame:
   s.vars.add v.sym
-  if isUnpackedTuple(v):
-    if c.inLoop > 0:
-      # unpacked tuple needs reset at every loop iteration
-      res.add newTree(nkFastAsgn, v, genDefaultCall(v.typ, c, v.info))
-  elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
+  if sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
     if {sfGlobal, sfPure} <= v.sym.flags or sfGlobal in v.sym.flags and s.parent == nil:
       c.graph.globalDestructors.add c.genDestroy(v)
@@ -1148,10 +1137,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
     of nkCallKinds:
       result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
     of nkBracketExpr:
-      if isUnpackedTuple(ri[0]):
-        # unpacking of tuple: take over the elements
-        result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
-      elif isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c, s):
+      if isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c, s):
         if aliases(dest, ri) == no:
           # Rule 3: `=sink`(x, z); wasMoved(z)
           if isAtom(ri[1]):

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -563,7 +563,7 @@ proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
     if c.inLoop > 0:
       # unpacked tuple needs reset at every loop iteration
       res.add newTree(nkFastAsgn, v, genDefaultCall(v.typ, c, v.info))
-  if sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
+  elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
     if {sfGlobal, sfPure} <= v.sym.flags or sfGlobal in v.sym.flags and s.parent == nil:
       c.graph.globalDestructors.add c.genDestroy(v)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -185,6 +185,14 @@ proc isCursor(n: PNode): bool =
   else:
     false
 
+template isFullyUnpackedTuple(n: PNode): bool =
+  ## we move out all elements of unpacked tuples,
+  ## hence unpacked tuples themselves don't need to be destroyed
+  ## except it's already a cursor
+  ## restricted to `skTemp`, tuple temps where not every field is unpacked should not use `skTemp`
+  (n.kind == nkSym and n.sym.kind == skTemp and
+   n.sym.typ.kind == tyTuple and sfCursor notin n.sym.flags)
+
 proc checkForErrorPragma(c: Con; t: PType; ri: PNode; opname: string; inferredFromCopy = false) =
   var m = "'" & opname & "' is not available for type <" & typeToString(t) & ">"
   if inferredFromCopy:
@@ -268,7 +276,7 @@ proc deepAliases(dest, ri: PNode): bool =
     return aliases(dest, ri) != no
 
 proc genSink(c: var Con; s: var Scope; dest, ri: PNode; flags: set[MoveOrCopyFlag] = {}): PNode =
-  if (c.inLoopCond == 0 and (IsDecl in flags or
+  if (c.inLoopCond == 0 and (isFullyUnpackedTuple(dest) or IsDecl in flags or
       (isAnalysableFieldAccess(dest, c.owner) and isFirstWrite(dest, c)))) or
       isNoInit(dest) or IsReturn in flags:
     # optimize sink call into a bitwise memcopy
@@ -552,7 +560,11 @@ proc cycleCheck(n: PNode; c: var Con) =
 proc pVarTopLevel(v: PNode; c: var Con; s: var Scope; res: PNode) =
   # move the variable declaration to the top of the frame:
   s.vars.add v.sym
-  if sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
+  if isFullyUnpackedTuple(v):
+    if c.inLoop > 0:
+      # unpacked tuple needs reset at every loop iteration
+      res.add newTree(nkFastAsgn, v, genDefaultCall(v.typ, c, v.info))
+  elif sfThread notin v.sym.flags and sfCursor notin v.sym.flags:
     # do not destroy thread vars for now at all for consistency.
     if {sfGlobal, sfPure} <= v.sym.flags or sfGlobal in v.sym.flags and s.parent == nil:
       c.graph.globalDestructors.add c.genDestroy(v)
@@ -1137,7 +1149,10 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, flags: set[MoveOrCopy
     of nkCallKinds:
       result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
     of nkBracketExpr:
-      if isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c, s):
+      if isFullyUnpackedTuple(ri[0]):
+        # unpacking of tuple: take over the elements
+        result = c.genSink(s, dest, p(ri, c, s, consumed), flags)
+      elif isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c, s):
         if aliases(dest, ri) == no:
           # Rule 3: `=sink`(x, z); wasMoved(z)
           if isAtom(ri[1]):

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1923,8 +1923,20 @@ proc makeTupleAssignments(c: PContext; n: PNode): PNode =
 
   for i in 0..<lhs.len:
     if lhs[i].kind == nkIdent and lhs[i].ident.id == ord(wUnderscore):
-      # skip _ assignments if we are using a temp as they are already evaluated
-      discard
+      # tuple unpacking `skTemp` does not generate a destructor and
+      # expects all fields to be unpacked, so instead of skipping,
+      # generate `let _ = temp[i]` which should generate a destructor
+      let utemp = newSym(skLet, lhs[i].ident, c.idgen, getCurrOwner(c), lhs[i].info)
+      utemp.typ = value.typ[i]
+      temp.flags.incl(sfGenSym)
+      var uv = newNodeI(nkLetSection, lhs[i].info)
+      let utempNode = newSymNode(utemp)
+      var uvpart = newNodeI(nkIdentDefs, v.info, 3)
+      uvpart[0] = utempNode
+      uvpart[1] = c.graph.emptyNode
+      uvpart[2] = newTupleAccessRaw(tempNode, i)
+      uv.add uvpart
+      result.add(uv)
     else:
       result.add newAsgnStmt(lhs[i], newTupleAccessRaw(tempNode, i))
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1923,8 +1923,22 @@ proc makeTupleAssignments(c: PContext; n: PNode): PNode =
 
   for i in 0..<lhs.len:
     if lhs[i].kind == nkIdent and lhs[i].ident.id == ord(wUnderscore):
-      # skip _ assignments if we are using a temp as they are already evaluated
-      discard
+      when false:
+        # disabled due to tuple unpacking behavior with destructors expecting all fields to be unpacked:
+        # skip _ assignments if we are using a temp as they are already evaluated
+        discard
+      # instead generate `let _ = temp[i]` so it gets destroyed
+      let utemp = newSym(skLet, lhs[i].ident, c.idgen, getCurrOwner(c), lhs[i].info)
+      utemp.typ = value.typ[i]
+      temp.flags.incl(sfGenSym)
+      var uv = newNodeI(nkLetSection, lhs[i].info)
+      let utempNode = newSymNode(utemp)
+      var uvpart = newNodeI(nkIdentDefs, v.info, 3)
+      uvpart[0] = utempNode
+      uvpart[1] = c.graph.emptyNode
+      uvpart[2] = newTupleAccessRaw(tempNode, i)
+      uv.add uvpart
+      result.add(uv)
     else:
       result.add newAsgnStmt(lhs[i], newTupleAccessRaw(tempNode, i))
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1923,22 +1923,8 @@ proc makeTupleAssignments(c: PContext; n: PNode): PNode =
 
   for i in 0..<lhs.len:
     if lhs[i].kind == nkIdent and lhs[i].ident.id == ord(wUnderscore):
-      when false:
-        # disabled due to tuple unpacking behavior with destructors expecting all fields to be unpacked:
-        # skip _ assignments if we are using a temp as they are already evaluated
-        discard
-      # instead generate `let _ = temp[i]` so it gets destroyed
-      let utemp = newSym(skLet, lhs[i].ident, c.idgen, getCurrOwner(c), lhs[i].info)
-      utemp.typ = value.typ[i]
-      temp.flags.incl(sfGenSym)
-      var uv = newNodeI(nkLetSection, lhs[i].info)
-      let utempNode = newSymNode(utemp)
-      var uvpart = newNodeI(nkIdentDefs, v.info, 3)
-      uvpart[0] = utempNode
-      uvpart[1] = c.graph.emptyNode
-      uvpart[2] = newTupleAccessRaw(tempNode, i)
-      uv.add uvpart
-      result.add(uv)
+      # skip _ assignments if we are using a temp as they are already evaluated
+      discard
     else:
       result.add newAsgnStmt(lhs[i], newTupleAccessRaw(tempNode, i))
 

--- a/tests/arc/tpartialtupleunpacking1.nim
+++ b/tests/arc/tpartialtupleunpacking1.nim
@@ -1,0 +1,19 @@
+discard """
+  output: '''
+destroyed
+'''
+"""
+
+# issue #24947
+
+type Foo = object
+
+proc `=destroy`(x: Foo) =
+  echo "destroyed"
+
+proc go(): void =
+  let a = (1,2,3, Foo())
+  var b,c,d: int
+  (b,c,d,_) = a # assignment unpacking
+
+go()

--- a/tests/arc/tpartialtupleunpacking2.nim
+++ b/tests/arc/tpartialtupleunpacking2.nim
@@ -1,0 +1,18 @@
+discard """
+  output: '''
+destroyed
+'''
+"""
+
+# issue #24947
+
+type Foo = object
+
+proc `=destroy`(x: Foo) =
+  echo "destroyed"
+
+proc go(): void =
+  let a = (1,2,3, Foo())
+  let (b,c,d,_) = a # let unpacking
+
+go()


### PR DESCRIPTION
fixes #24947

When injectdestructors detects that a variable is a tuple unpacking temp (i.e. it is an `skTemp`, is not a cursor, and has tuple type) it does not generate a destructor for it and only generates sink/bit assignments for its components. However the reason it does not generate a destructor is that it expects it to be fully unpacked, this is true for unpackings in for loops but not for tuple unpacking assignments which supports `_` since #22537. Tuple unpacking definitions for `var`/`let`/`const` do not generate `skTemp` and use the same symbol kind as the definition so they did not have this problem.

To keep this compatible, the `_` parts of the tuple unpacking assignments are now not ignored and unpacked into `let _ = ...`, which generates its own destructor. Another option might be to use `skLet` instead of `skTemp` but this might cause changes to behavior like additional copies, I am not sure about this though.