### PR TITLE
Fix extra newline from nimpretty when used with `--stdin`

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -111,7 +111,7 @@ proc handleStdinInput(opt: PrettyOptions) =
 
   prettyPrint(path, path, opt)
 
-  echo(readAll(cfile))
+  stdout.write(readAll(cfile))
 
   close(cfile)
   removeFile(path)


### PR DESCRIPTION
Using `echo` to print file contents to stdout automatically adds a newline at the end of the file contents. When using nimpretty to auto format files on save in some editors which replace the file contents with the formatted ones this means that with every save/format operation an additional newline is added to the end of the file. Using `stdout.write` does not automatically add a newline at the end preventing this issue.

Fixes #24950 