### PR TITLE
wip: implemements `@`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -563,9 +563,9 @@ const
     mEqStr, mLeStr, mLtStr,
     mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mXorSet,
     mConStrStr, mAppendStrCh, mAppendStrStr, mAppendSeqElem,
-    mInSet, mRepr, mOpenArrayToSeq}
+    mInSet, mRepr, mOpenArrayToSeq, mArrToSeq}
 
-  generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq}
+  generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq, mArrToSeq}
     ## magics that are generated as normal procs in the backend
 
 type

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3012,7 +3012,6 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     genCall(p, e, d)
   of mDefault, mZeroDefault: genDefault(p, e, d)
   of mEcho: genEcho(p, e[1].skipConv)
-  of mArrToSeq: genArrToSeq(p, e, d)
   of mNLen..mNError, mSlurp..mQuoteAst:
     localError(p.config, e.info, strutils.`%`(errXMustBeCompileTime, e[0].sym.name.s))
   of mSpawn:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -851,6 +851,13 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
     if x.calleeSym.kind notin {skMacro, skTemplate}:
       if x.calleeSym.magic in {mArrGet, mArrPut}:
         finalCallee = x.calleeSym
+      elif x.calleeSym.magic == mArrToSeq:
+        if expectedType != nil:
+          c.inheritBindings(x, expectedType)
+          x.bindings.put(x.callee.returnType.base, expectedType.base)
+          finalCallee = generateInstance(c, x.calleeSym, x.bindings, n.info)
+        else:
+          finalCallee = x.calleeSym
       else:
         c.inheritBindings(x, expectedType)
         finalCallee = generateInstance(c, x.calleeSym, x.bindings, n.info)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1088,7 +1088,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}, m: TMag
     c.genAsgnPatch(n[1], d)
     c.freeTemp(d)
   of mOrd, mChr, mArrToSeq, mUnown: c.gen(n[1], dest)
-  of generatedMagics:
+  of generatedMagics-{mArrToSeq}:
     genCall(c, n, dest)
   of mNew, mNewFinalize:
     unused(c, n, dest)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -897,21 +897,7 @@ proc cmp*(x, y: string): int {.noSideEffect.}
   ## **Note**: The precise result values depend on the used C runtime library and
   ## can differ between operating systems!
 
-proc `@`* [IDX, T](a: sink array[IDX, T]): seq[T] {.magic: "ArrToSeq", noSideEffect.}
-  ## Turns an array into a sequence.
-  ##
-  ## This most often useful for constructing
-  ## sequences with the array constructor: `@[1, 2, 3]` has the type
-  ## `seq[int]`, while `[1, 2, 3]` has the type `array[0..2, int]`.
-  ##
-  ##   ```nim
-  ##   let
-  ##     a = [1, 3, 5]
-  ##     b = "foo"
-  ##
-  ##   echo @a # => @[1, 3, 5]
-  ##   echo @b # => @['f', 'o', 'o']
-  ##   ```
+
 
 proc default*[T](_: typedesc[T]): T {.magic: "Default", noSideEffect.} =
   ## Returns the default value of the type `T`. Contrary to `zeroDefault`, it takes default fields
@@ -1448,6 +1434,10 @@ proc isNil*(x: cstring): bool {.noSideEffect, magic: "IsNil".}
 proc isNil*[T: proc | iterator {.closure.}](x: T): bool {.noSideEffect, magic: "IsNil".}
   ## Fast check whether `x` is nil. This is sometimes more efficient than
   ## `== nil`.
+
+proc `@`* [IDX, T](a: array[IDX, T]): seq[T] {.magic: "ArrToSeq", noSideEffect.} =
+  newSeq(result, a.len)
+  for i in 0..a.len-1: result[i] = a[i]
 
 when defined(nimHasTopDownInference):
   # magic used for seq type inference


### PR DESCRIPTION
It seems that type inference is not good enough for empty array in templates. I'm struggling with

```nim
import std/tables

template accResult() =
  var s = newTable[int, seq[int]]()

  var x = 2
  discard mgetOrPut(s, x, @[])

  # var x = newSeq[int]()
  # x = @[]

proc splitWhitespace*() =
  accResult()

splitWhitespace()

```
