### PR TITLE
fixes #4594; disallow {.global.} uses local vars for basic expressions

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -727,9 +727,6 @@ template isLocalSym(sym: PSym): bool =
       sym.kind in {skProc, skFunc, skIterator} and
       sfGlobal notin sym.flags
 
-template isLocalVarSym(n: PNode): bool =
-  n.kind == nkSym and isLocalSym(n.sym)
-
 proc usesLocalVar(n: PNode): bool =
   case n.kind
   of nkSym:
@@ -754,7 +751,7 @@ proc usesLocalVar(n: PNode): bool =
     result = false
 
 proc globalVarInitCheck(c: PContext, n: PNode) =
-  if n.isLocalVarSym or usesLocalVar(n):
+  if usesLocalVar(n):
     localError(c.config, n.info, errCannotAssignToGlobal)
 
 const

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -731,16 +731,30 @@ template isLocalVarSym(n: PNode): bool =
   n.kind == nkSym and isLocalSym(n.sym)
 
 proc usesLocalVar(n: PNode): bool =
-  result = false
-  for z in 1 ..< n.len:
-    if n[z].isLocalVarSym:
-      return true
-    elif n[z].kind in nkCallKinds:
-      if usesLocalVar(n[z]):
+  case n.kind
+  of nkSym:
+    result = isLocalSym(n.sym)
+  of nkCallKinds, nkObjConstr:
+    result = false
+    for i in 1 ..< n.len:
+      if usesLocalVar(n[i]):
         return true
+  of nkTupleConstr, nkPar, nkBracket, nkCurly:
+    result = false
+    for i in 0 ..< n.len:
+      if usesLocalVar(n[i]):
+        return true
+  of nkDotExpr, nkCheckedFieldExpr,
+       nkBracketExpr, nkAddr, nkHiddenAddr,
+       nkObjDownConv, nkObjUpConv:
+    result = usesLocalVar(n[0])
+  of nkHiddenStdConv, nkHiddenSubConv, nkCast, nkExprColonExpr:
+    result = usesLocalVar(n[1])
+  else:
+    result = false
 
 proc globalVarInitCheck(c: PContext, n: PNode) =
-  if n.isLocalVarSym or n.kind in nkCallKinds and usesLocalVar(n):
+  if n.isLocalVarSym or usesLocalVar(n):
     localError(c.config, n.info, errCannotAssignToGlobal)
 
 const


### PR DESCRIPTION
fixes #4594