### PR TITLE
try weakened distinct

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -399,6 +399,7 @@ type
     tfIsOutParam
     tfSendable
     tfImplicitStatic
+    tfWeakened        # for tyDistinct means "weak distinct"
 
   TTypeFlags* = set[TTypeFlag]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1712,10 +1712,11 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags, afterOverloading = f
         result = n
         result.typ() = elemType(arr)
     # Other types have a bit more of leeway
-    elif n[1].typ.skipTypes(abstractRange-{tyDistinct}).kind in
+    elif n[1].typ.skipTypes(abstractRange).kind in
         {tyInt..tyInt64, tyUInt..tyUInt64}:
-      result = n
-      result.typ() = elemType(arr)
+      if n[1].typ.kind != tyDistinct or tfWeakened in n[1].typ.flags:
+        result = n
+        result.typ() = elemType(arr)
   of tyTypeDesc:
     # The result so far is a tyTypeDesc bound
     # a tyGenericBody. The line below will substitute

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -332,7 +332,7 @@ proc addSonSkipIntLitChecked(c: PContext; father, son: PType; it: PNode, id: IdG
     propagateToOwner(father, s)
 
 proc semDistinct(c: PContext, n: PNode, prev: PType): PType =
-  if n.kind != nkDistinctTy or n.len == 0: return newConstraint(c, tyDistinct)
+  if n.len == 0: return newConstraint(c, tyDistinct)
   if prevIsKind(prev, tyDistinct):
     # the symbol already has a distinct type (likely resem), don't create a new type
     return skipGenericPrev(prev)
@@ -2344,8 +2344,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
   of nkPtrTy: result = semAnyRef(c, n, tyPtr, prev)
   of nkVarTy: result = semVarOutType(c, n, prev, {})
   of nkOutTy: result = semVarOutType(c, n, prev, {tfIsOutParam})
-  of nkDistinctTy:
-    result = semDistinct(c, n, prev)
+  of nkDistinctTy: result = semDistinct(c, n, prev)
   of nkStaticTy: result = semStaticType(c, n[0], prev)
   of nkProcTy, nkIteratorTy:
     if n.len == 0 or n[0].kind == nkEmpty:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -332,7 +332,7 @@ proc addSonSkipIntLitChecked(c: PContext; father, son: PType; it: PNode, id: IdG
     propagateToOwner(father, s)
 
 proc semDistinct(c: PContext, n: PNode, prev: PType): PType =
-  if n.len == 0: return newConstraint(c, tyDistinct)
+  if n.kind != nkDistinctTy or n.len == 0: return newConstraint(c, tyDistinct)
   if prevIsKind(prev, tyDistinct):
     # the symbol already has a distinct type (likely resem), don't create a new type
     return skipGenericPrev(prev)
@@ -2291,6 +2291,11 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = s.typ.base
     elif prev == nil:
       result = s.typ
+    elif prev.sym != nil and sfImportc in prev.sym.flags:
+      let tmp = newNode(nkDistinctTy)
+      tmp.add n
+      result = semDistinct(c, tmp, prev)
+      result.flags.incl tfWeakened
     else:
       let alias = maybeAliasType(c, s.typ, prev)
       if alias != nil:
@@ -2339,7 +2344,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
   of nkPtrTy: result = semAnyRef(c, n, tyPtr, prev)
   of nkVarTy: result = semVarOutType(c, n, prev, {})
   of nkOutTy: result = semVarOutType(c, n, prev, {tfIsOutParam})
-  of nkDistinctTy: result = semDistinct(c, n, prev)
+  of nkDistinctTy:
+    result = semDistinct(c, n, prev)
   of nkStaticTy: result = semStaticType(c, n[0], prev)
   of nkProcTy, nkIteratorTy:
     if n.len == 0 or n[0].kind == nkEmpty:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1561,10 +1561,10 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           inc c.inheritancePenalty, depth + ord(c.inheritancePenalty < 0)
           result = isSubtype
   of tyDistinct:
-    a = a.skipTypes({tyOwned, tyGenericInst, tyRange})
+    let af = a.skipTypes({tyOwned, tyGenericInst, tyRange})
     let coerceDistincts = c.coerceDistincts or tfWeakened in f.flags
     if a.kind == tyDistinct:
-      if sameDistinctTypes(f, a): result = isEqual
+      if sameDistinctTypes(f, af): result = isEqual
       #elif f.base.kind == tyAnything: result = isGeneric  # issue 4435
       elif coerceDistincts:
         inc c.inheritancePenalty

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -319,7 +319,7 @@ proc sumGeneric(t: PType): int =
   while true:
     case t.kind
     of tyAlias, tySink, tyNot: t = t.skipModifier
-    of tyArray, tyRef, tyPtr, tyDistinct, tyUncheckedArray,
+    of tyArray, tyRef, tyPtr, tyUncheckedArray,
         tyOpenArray, tyVarargs, tySet, tyRange, tySequence,
         tyLent, tyOwned, tyVar:
       t = t.elementType
@@ -364,6 +364,9 @@ proc sumGeneric(t: PType): int =
       for _, a in t.paramTypes:
         result += sumGeneric(a)
       break
+    of tyDistinct:
+      result += ord(tfWeakened notin t.flags)
+      t = t.base
     else:
       if t.isConcept:
         result += t.reduceToBase.conceptBody.len
@@ -1357,6 +1360,13 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         # Foo[templateCall(T)] shouldn't fail early if Foo has a constraint
         # and we can't evaluate `templateCall(T)` yet
         return isGeneric
+  of tyDistinct:
+    if f.kind != tyDistinct:
+      let coerceDistincts = c.coerceDistincts or tfWeakened in a.flags
+      if coerceDistincts:
+        inc c.inheritancePenalty
+        return typeRel(c, f, a.base, flags)
+    
   else: discard
 
   case f.kind
@@ -1552,11 +1562,16 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
           result = isSubtype
   of tyDistinct:
     a = a.skipTypes({tyOwned, tyGenericInst, tyRange})
+    let coerceDistincts = c.coerceDistincts or tfWeakened in f.flags
     if a.kind == tyDistinct:
       if sameDistinctTypes(f, a): result = isEqual
       #elif f.base.kind == tyAnything: result = isGeneric  # issue 4435
-      elif c.coerceDistincts: result = typeRel(c, f.base, a, flags)
-    elif c.coerceDistincts: result = typeRel(c, f.base, a, flags)
+      elif coerceDistincts:
+        inc c.inheritancePenalty
+        result = typeRel(c, f.base, a, flags)
+    elif coerceDistincts:
+      inc c.inheritancePenalty
+      result = typeRel(c, f.base, a, flags)
   of tySet:
     if a.kind == tySet:
       if f[0].kind != tyGenericParam and a[0].kind == tyEmpty:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1374,7 +1374,7 @@ proc uniRecv(socket: Socket, buffer: pointer, size, flags: cint): int =
 
 proc readIntoBuf(socket: Socket, flags: int32): int =
   result = 0
-  result = uniRecv(socket, addr(socket.buffer), socket.buffer.high, flags)
+  result = uniRecv(socket, addr(socket.buffer), socket.buffer.high.cint, flags)
   if result < 0:
     # Save it in case it gets reset (the Nim codegen occasionally may call
     # Win API functions which reset it).

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1374,7 +1374,7 @@ proc uniRecv(socket: Socket, buffer: pointer, size, flags: cint): int =
 
 proc readIntoBuf(socket: Socket, flags: int32): int =
   result = 0
-  result = uniRecv(socket, addr(socket.buffer), socket.buffer.high.cint, flags)
+  result = uniRecv(socket, addr(socket.buffer), socket.buffer.high, flags)
   if result < 0:
     # Save it in case it gets reset (the Nim codegen occasionally may call
     # Win API functions which reset it).

--- a/tests/distinct/tweakened.nim
+++ b/tests/distinct/tweakened.nim
@@ -1,0 +1,2 @@
+let bar = @[1.cdouble] 
+let foo: seq[float] = bar


### PR DESCRIPTION
offshoot of #24964

I first tried to make `importc` types a new kind of type and allow it to accept it's Nim equivalent, but this was difficult, took a lot of time and in the end I couldn't get it to fully work. The main problem was that Nim converts types to and from `importc` types regularly, so this new type had to do a bunch of odd things to not break those behaviors.

Trying this out was much easier since I could just re-use most of the logic for `distinct` however there are some concerns I have at this time:
- `sameType` proc might need some attention
- I haven't looked at the generated C code so it might be inefficient
  - I'd be interested to see `seq[T]` varients and such
- ~Conversions are still needed in some situations with this where they weren't before, but so far I haven't seen anything that looked like it should work. For example a previous automatic conversion from a non literal `int` to `cint` needed a patch, but why did that work without a conversion in the first place?~
  - ~primitive conversion semantics probably have to be looked at again but I forget where that is / how that works~
- this accepts the type both ways with equal penalties and such and I haven't really thought about if that is a mistake

in general I think that something like
```nim
type
  myType {.importc:"int".} = int32
```
always must mean that the backend will map Nim's representation of `int32` to `int`, if this is not a guarantee then something like `nodecl` and a proper exclusive definition has to be used to make the type opaque and I don't think there is a way around that.


