### PR TITLE
Fix for `pure/random.nim` / `sample` triggering `ProveInit`

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -435,6 +435,7 @@ proc sample*[T](r: var Rand; s: set[T]): T =
     let s = {1, 3, 5, 7, 9}
     assert r.sample(s) in s
 
+  result = default(T)
   assert card(s) != 0
   var i = rand(r, card(s) - 1)
   for e in s:


### PR DESCRIPTION
Simple fix for `sample*[T](r: var Rand; s: set[T]): T` triggering `ProveInit`
```nim
.nim/lib/pure/random.nim(425, 3) Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
```