### PR TITLE
fixes #24981; the length of the seq changed of procGloals

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2433,8 +2433,13 @@ proc genTopLevelStmt*(m: BModule; n: PNode) =
   else:
     genProcBody(m.initProc, transformedN)
 
-  for g in m.g.graph.procGlobals:
-    genStmts(m.preInitProc, g)
+  var procGloals = move m.g.graph.procGlobals
+  while true:
+    if procGloals.len == 0:
+      procGloals = move m.g.graph.procGlobals
+      if procGloals.len == 0:
+        break
+    genStmts(m.preInitProc, procGloals.pop())
 
 proc shouldRecompile(m: BModule; code: Rope, cfile: Cfile): bool =
   if optForceFullMake notin m.config.globalOptions:

--- a/tests/global/tglobal3.nim
+++ b/tests/global/tglobal3.nim
@@ -28,3 +28,16 @@ proc f(v: static string): int =
 
 doAssert f("1") == 1
 doAssert f("1") == 1
+
+block: # bug #24981
+  func p(T: type): T {.compileTime.} = default(ptr T)[]
+  type W = ref object
+  proc g(T: type): W
+  proc m(T: type) =
+    let a {.global.} = g(T)
+  proc g(T: type): W =
+    when T is object:
+      m(typeof(p(T).i))
+  type Foo = object
+    i: int
+  m(Foo)


### PR DESCRIPTION
fxies #24981

`m.g.graph.procGlobals` could change because the right side of `.global` assignment (e.g. `let a {.global.} = g(T)`) may trigger injections for unhandled procs 