### PR TITLE
fixes #24974; SIGSEGV when raising Defect/doAssert

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1234,7 +1234,9 @@ proc allPathsAsgnResult(p: BProc; n: PNode): InitResultEnum =
       else:
         allPathsInBranch(n[i].lastSon)
   of nkCallKinds:
-    if canRaiseDisp(p, n[0]):
+    if canRaiseDisp(p, n[0]) or
+        (n[0].kind == nkSym and sfNoReturn in n[0].sym.flags):
+      # requires initializations when encountering unreachable code
       result = InitRequired
     else:
       for i in 0..<n.safeLen:

--- a/tests/errmsgs/t24974.nim
+++ b/tests/errmsgs/t24974.nim
@@ -1,0 +1,22 @@
+discard """
+  exitcode: 1
+  output: '''
+t24974.nim(22)           t24974
+t24974.nim(19)           d
+t24974.nim(16)           s
+assertions.nim(41)       failedAssertImpl
+assertions.nim(36)       raiseAssert
+fatal.nim(53)            sysFatal
+Error: unhandled exception: t24974.nim(16, 26) `false`  [AssertionDefect]
+'''
+"""
+
+
+type B = seq[array[1, byte]]
+proc s(_: var B): bool = doAssert false
+proc d(): B =
+  var k: B
+  if s(k): discard
+  quit 0
+  k
+for _ in [0]: discard d()


### PR DESCRIPTION
fixes #24974

 requires `result` initializations when encountering unreachable code (e.g. `quit`)