### PR TITLE
use windows latest for docs CI

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -43,7 +43,7 @@ jobs:
           - target: linux
             os: ubuntu-22.04
           - target: windows
-            os: windows-2019
+            os: windows-latest
           - target: osx
             os: macos-13
 


### PR DESCRIPTION
2019 is currently browned out