### PR TITLE
don't set sym of generic param type value to generic param sym

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1292,7 +1292,9 @@ proc readTypeParameter(c: PContext, typ: PType,
             # This seems semantically correct and then we'll be able
             # to return the section symbol directly here
             let foundType = makeTypeDesc(c, def[2].typ)
-            return newSymNode(copySym(def[0].sym, c.idgen).linkTo(foundType), info)
+            let s = copySym(def[0].sym, c.idgen)
+            s.typ = foundType
+            return newSymNode(s, info)
 
       of nkConstSection:
         for def in statement:
@@ -1317,7 +1319,9 @@ proc readTypeParameter(c: PContext, typ: PType,
             return c.graph.emptyNode
         else:
           let foundTyp = makeTypeDesc(c, rawTyp)
-          return newSymNode(copySym(tParam.sym, c.idgen).linkTo(foundTyp), info)
+          let s = copySym(tParam.sym, c.idgen)
+          s.typ = foundTyp
+          return newSymNode(s, info)
 
   return nil
 

--- a/tests/pragmas/tgenericparamcustompragma.nim
+++ b/tests/pragmas/tgenericparamcustompragma.nim
@@ -1,0 +1,13 @@
+# issue #23713
+
+import std/macros
+
+template p {.pragma.}
+
+type
+  X {.p.} = object
+
+  Y[T] = object
+    t: T
+
+doAssert Y[X].T.hasCustomPragma(p)


### PR DESCRIPTION
fixes #23713

`linkTo` normally sets the sym of the type as well as the type of the sym, but this is not wanted for custom pragmas as it would look up the definition of the generic param and not the definition of its value. I don't see a practical use for this either.