### PR TITLE
loosen compiler assert for ident node in dotcall matching [backport:2.2]

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -581,7 +581,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
   let overloadsState = result.state
   if overloadsState != csMatch:
     if nfDotField in n.flags:
-      internalAssert c.config, f.kind == nkIdent and n.len >= 2
+      internalAssert c.config, f.kind in nkIdentKinds and n.len >= 2
 
       # leave the op head symbol empty,
       # we are going to try multiple variants

--- a/tests/generics/twrongdotcallcrash.nim
+++ b/tests/generics/twrongdotcallcrash.nim
@@ -1,0 +1,6 @@
+# issue #25000
+
+proc r(T: typedesc[int]): int = discard
+proc c[J: typedesc[uint]](u = J.r) = discard #[tt.Error
+                               ^ undeclared field: 'r']#
+c[uint]()


### PR DESCRIPTION
fixes #25000

A failed match on `nfDotField` tries to assert that the name of the dot field is an identifier node. I am not exactly sure how but at some point typed generics causes an `nfDotField` call to contain a symchoice for the field name. The compiler does not use the fact that the field name is an identifier, so the assert is loosened to allow any identifier-like node kind. Could also investigate why the symchoice gets created, my guess is that typed generics detects that the match fails but still sends it through generic prechecking and doesn't remove the `nfDotField`, which is harmless and it might cause more trouble to work around it.