### PR TITLE
fix regression with enum types wrongly matching [backport:2.2]

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1568,8 +1568,11 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
             # set['a'..'z'] and set[char] have different representations
             result = isNone
           else:
-            # but we can convert individual elements of the constructor
-            result = isConvertible
+            if result >= isConvertible:
+              # but we can convert individual elements of the constructor
+              result = isConvertible
+            else:
+              result = isNone
   of tyPtr, tyRef:
     a = reduceToBase(a)
     if a.kind == f.kind:

--- a/tests/proc/tgenericdefaultparam.nim
+++ b/tests/proc/tgenericdefaultparam.nim
@@ -104,7 +104,7 @@ block: # issue #24484
   foo[E]()
 
   proc bar[T](t: set[T] = {T(0), 5}) =
-    doAssert t == {0, 5}
+    doAssert t == {T(0), 5}
   bar[uint8]()
   doAssert not compiles(bar[string]())
 

--- a/tests/sets/twrongsetmatch.nim
+++ b/tests/sets/twrongsetmatch.nim
@@ -1,0 +1,16 @@
+# issue #25009
+
+type EnumOne {.pure.} = enum
+  aaa
+  bbb
+
+type EnumTwo {.pure.} = enum
+  ccc
+  ddd
+  eee
+
+proc doStuff(e: set[EnumOne]) =
+  echo e
+
+doStuff({EnumTwo.ddd}) #[tt.Error
+       ^ type mismatch]#


### PR DESCRIPTION
fixes #25009

Introduced by #24176, when matching a set type to another, if the given set is a constructor and the element types match worse than a generic match (which includes the case with no match), the match is always set to a convertible match, without checking that it is at least a convertible match. This is fixed by checking this.