### PR TITLE
fix generic converter subtype match regression

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2328,7 +2328,8 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       # it is correct
       var param: PNode = nil
       if srca == isSubtype:
-        param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
+        # convMatch used here to use its bindings to instantiate subtype:
+        param = implicitConv(nkHiddenSubConv, src, copyTree(arg), convMatch, c)
       elif src.kind in {tyVar}:
         # Analyse the converter return type.
         param = newNodeIT(nkHiddenAddr, arg.info, s.typ.firstParamType)

--- a/tests/converter/tgenericsubtypeconverter.nim
+++ b/tests/converter/tgenericsubtypeconverter.nim
@@ -1,0 +1,14 @@
+# issue #25014
+
+type
+  FooBase[T] {.inheritable.} = object
+    val: T
+  FooChild[T] = object of FooBase[T]
+
+converter toValue*[T](r: FooBase[T]): T = r.val
+
+proc foo(a: int) = discard
+var f: FooChild[int]
+foo(f)
+proc fooGeneric[T](a: T) = discard
+fooGeneric(f)


### PR DESCRIPTION
fixes #25014

`implicitConv` tries to instantiate the supertype to convert to, previously the bindings of `m` was shared with the bindings of the converter but now an isolated match `convMatch` holds the bindings, so `convMatch` is now used in the call to `implicitConv` instead of `m` so that its bindings are used when instantiating the supertype.