### PR TITLE
fixes #24997; {.global.} variable in recursive function

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2420,6 +2420,20 @@ proc addHcrInitGuards(p: BProc, n: PNode, inInitGuard: var bool, init: var IfBui
 
     genStmts(p, n)
 
+proc handleProcGlobals(m: BModule) =
+  var procGlobals: seq[PNode] = move m.g.graph.procGlobals
+
+  for i in 0..<procGlobals.len:
+    var stmts = newBuilder("")
+
+    # fixes recursive calls #24997
+    swap stmts, m.preInitProc.s(cpsStmts)
+    genStmts(m.preInitProc, procGlobals[i])
+    swap stmts, m.preInitProc.s(cpsStmts)
+
+    handleProcGlobals(m)
+    m.preInitProc.s(cpsStmts).add stmts.extract()
+
 proc genTopLevelStmt*(m: BModule; n: PNode) =
   ## Also called from `ic/cbackend.nim`.
   if pipelineutils.skipCodegen(m.config, n): return
@@ -2435,13 +2449,7 @@ proc genTopLevelStmt*(m: BModule; n: PNode) =
   else:
     genProcBody(m.initProc, transformedN)
 
-  var procGloals = move m.g.graph.procGlobals
-  while true:
-    if procGloals.len == 0:
-      procGloals = move m.g.graph.procGlobals
-      if procGloals.len == 0:
-        break
-    genStmts(m.preInitProc, procGloals.pop())
+  handleProcGlobals(m)
 
 proc shouldRecompile(m: BModule; code: Rope, cfile: Cfile): bool =
   if optForceFullMake notin m.config.globalOptions:

--- a/tests/global/tglobal3.nim
+++ b/tests/global/tglobal3.nim
@@ -41,3 +41,17 @@ block: # bug #24981
   type Foo = object
     i: int
   m(Foo)
+
+block: # bug #24997
+  type R = ref object
+  type B = object
+    j: int
+  proc y(T: type): R
+  proc u(T: type): R =
+    let res {.global.} = y(T)
+    res
+  proc y(T: type): R =
+    when T is object:
+      doAssert not isNil(u(typeof(B.j)))
+    R()
+  discard u(B)


### PR DESCRIPTION
fixes #24997

handles functions in recursive order