### PR TITLE
Improve error message for keywords as parameters

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1156,7 +1156,10 @@ proc parseParamList(p: var Parser, retColon = true): PNode =
         parMessage(p, errGenerated, "the syntax is 'parameter: var T', not 'var parameter: T'")
         break
       else:
-        parMessage(p, "expected closing ')'")
+        if p.tok.tokType > tokKeywordLow and p.tok.tokType < tokKeywordHigh:
+          parMessage(p, errGenerated, "'" & $p.tok.ident.s & "' is a keyword and cannot be used as a parameter name")
+        else:
+          parMessage(p, "expected closing ')'")
         break
       result.add(a)
       if p.tok.tokType notin {tkComma, tkSemiColon}: break

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1156,7 +1156,7 @@ proc parseParamList(p: var Parser, retColon = true): PNode =
         parMessage(p, errGenerated, "the syntax is 'parameter: var T', not 'var parameter: T'")
         break
       else:
-        if p.tok.tokType > tokKeywordLow and p.tok.tokType < tokKeywordHigh:
+        if p.tok.tokType in tokKeywordLow..tokKeywordHigh:
           parMessage(p, errGenerated, "'" & $p.tok.ident.s & "' is a keyword and cannot be used as a parameter name")
         else:
           parMessage(p, "expected closing ')'")

--- a/tests/errmsgs/tkeywordparam.nim
+++ b/tests/errmsgs/tkeywordparam.nim
@@ -1,0 +1,2 @@
+proc myproc(type: int) =
+  echo type

--- a/tests/errmsgs/tkeywordparam.nim
+++ b/tests/errmsgs/tkeywordparam.nim
@@ -1,2 +1,10 @@
+discard """
+cmd: "nim check $file"
+errormsg: "'type' is a keyword and cannot be used as a parameter name"
+nimout: '''
+tkeywordparam.nim(1, 13) Error: 'type' is a keyword and cannot be used as a parameter name
+'''
+"""
+
 proc myproc(type: int) =
   echo type


### PR DESCRIPTION
A function with an illegal parameter name like
```nim
proc myproc(type: int) =
  echo type
```
would uninformatively fail like so:
```nim
tkeywordparam.nim(1, 13) Error: expected closing ')'
```

This commit makes it return the following error:
```nim
tkeywordparam.nim(1, 13) Error: 'type' is a keyword and cannot be used as a parameter name
```