### PR TITLE
Confrom to standard C's strict aliasing rules in seqs_v2

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -107,6 +107,8 @@ when not defined(gcDestructors):
     const GenericSeqSize = 2 * sizeof(int)
 
 else:
+  from system/ansi_c import c_memcpy
+
   include system/seqs_v2_reimpl
 
 from std/private/strimpl import cmpNimIdentifier
@@ -202,10 +204,12 @@ proc invokeNewSeq*(x: Any, len: int) =
   ## Performs `newSeq(x, len)`. `x` needs to represent a `seq`.
   assert x.rawType.kind == tySequence
   when defined(gcDestructors):
-    var s = cast[ptr NimSeqV2Reimpl](x.value)
+    var s {.noinit.}: NimSeqV2Reimpl
+    s.readNimSeqV2Reimpl x.value
     s.len = len
     let elem = x.rawType.base
     s.p = cast[ptr NimSeqPayloadReimpl](newSeqPayload(len, elem.size, elem.align))
+    x.value.storeNimSeqV2Reimpl s
   else:
     var z = newSeq(x.rawType, len)
     genericShallowAssign(x.value, addr(z), x.rawType)
@@ -214,12 +218,15 @@ proc extendSeq*(x: Any) =
   ## Performs `setLen(x, x.len+1)`. `x` needs to represent a `seq`.
   assert x.rawType.kind == tySequence
   when defined(gcDestructors):
-    var s = cast[ptr NimSeqV2Reimpl](x.value)
+    var s {.noinit.}: NimSeqV2Reimpl
+    s.readNimSeqV2Reimpl x.value
     let elem = x.rawType.base
-    if s.p == nil or s.p.cap < s.len+1:
+    let newLen = s.len + 1
+    if s.p == nil or s.p[] < newLen:
       s.p = cast[ptr NimSeqPayloadReimpl](prepareSeqAddUninit(s.len, s.p, 1, elem.size, elem.align))
     zeroNewElements(s.len, s.p, 1, elem.size, elem.align)
-    inc s.len
+    s.len = newLen
+    x.value.storeNimSeqV2Reimpl s
   else:
     var y = cast[ptr PGenSeq](x.value)[]
     var z = incrSeq(y, x.rawType.base.size, x.rawType.base.align)
@@ -253,7 +260,8 @@ proc `[]`*(x: Any, i: int): Any =
     return newAny(x.value +!! i*bs, x.rawType.base)
   of tySequence:
     when defined(gcDestructors):
-      var s = cast[ptr NimSeqV2Reimpl](x.value)
+      var s {.noinit.}: NimSeqV2Reimpl
+      s.readNimSeqV2Reimpl x.value
       if i >=% s.len:
         raise newException(IndexDefect, formatErrorIndexBound(i, s.len-1))
       let bs = x.rawType.base.size
@@ -280,7 +288,8 @@ proc `[]=`*(x: Any, i: int, y: Any) =
     genericAssign(x.value +!! i*bs, y.value, y.rawType)
   of tySequence:
     when defined(gcDestructors):
-      var s = cast[ptr NimSeqV2Reimpl](x.value)
+      var s {.noinit.}: NimSeqV2Reimpl
+      s.readNimSeqV2Reimpl x.value
       if i >=% s.len:
         raise newException(IndexDefect, formatErrorIndexBound(i, s.len-1))
       let bs = x.rawType.base.size
@@ -288,6 +297,7 @@ proc `[]=`*(x: Any, i: int, y: Any) =
       let headerSize = align(sizeof(int), ba)
       assert y.rawType == x.rawType.base
       genericAssign(s.p +!! (headerSize+i*bs), y.value, y.rawType)
+      x.value.storeNimSeqV2Reimpl s
     else:
       var s = cast[ppointer](x.value)[]
       if s == nil: raise newException(ValueError, "sequence is nil")
@@ -305,7 +315,9 @@ proc len*(x: Any): int =
     result = x.rawType.size div x.rawType.base.size
   of tySequence:
     when defined(gcDestructors):
-      result = cast[ptr NimSeqV2Reimpl](x.value).len
+      var s {.noinit.}: NimSeqV2Reimpl
+      s.readNimSeqV2Reimpl x.value
+      result = s.len
     else:
       let pgenSeq = cast[PGenSeq](cast[ppointer](x.value)[])
       if isNil(pgenSeq):

--- a/lib/system/comparisons.nim
+++ b/lib/system/comparisons.nim
@@ -316,8 +316,8 @@ proc `==`*[T](x, y: seq[T]): bool {.noSideEffect.} =
     when not defined(js):
       proc seqToPtr[T](x: seq[T]): pointer {.inline, noSideEffect.} =
         when defined(nimSeqsV2):
-          var xu {.noinit.}: NimRawSeq
-          xu.readNimRawSeq x
+          var xu {.noinit.}: NimSeqV2[T]
+          xu.readNimSeqV2 x
           result = xu.p
         else:
           result = cast[pointer](x)

--- a/lib/system/comparisons.nim
+++ b/lib/system/comparisons.nim
@@ -316,7 +316,9 @@ proc `==`*[T](x, y: seq[T]): bool {.noSideEffect.} =
     when not defined(js):
       proc seqToPtr[T](x: seq[T]): pointer {.inline, noSideEffect.} =
         when defined(nimSeqsV2):
-          result = cast[NimSeqV2[T]](x).p
+          var xu {.noinit.}: NimRawSeq
+          xu.readNimRawSeq x
+          result = xu.p
         else:
           result = cast[pointer](x)
 

--- a/lib/system/deepcopy.nim
+++ b/lib/system/deepcopy.nim
@@ -16,12 +16,12 @@ type
     data: array[TableSize, (pointer, pointer)]
 
 template hashPtr(key: pointer): int = cast[int](key) shr 8
-template allocPtrTable: untyped =
+template allocPtrTable(cap: int): untyped =
   cast[PtrTable](alloc0(sizeof(int)*2 + sizeof(pointer)*2*cap))
 
 proc rehash(t: PtrTable): PtrTable =
   let cap = (t.max+1) * 2
-  result = allocPtrTable()
+  result = allocPtrTable(cap)
   result.counter = t.counter
   result.max = cap-1
   for i in 0..t.max:
@@ -34,7 +34,7 @@ proc rehash(t: PtrTable): PtrTable =
 
 proc initPtrTable(): PtrTable =
   const cap = 32
-  result = allocPtrTable()
+  result = allocPtrTable(cap)
   result.counter = 0
   result.max = cap-1
 

--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -39,10 +39,10 @@ template cap(p: ptr NimSeqPayloadBase): int =
 template `cap=`(p: ptr NimSeqPayloadBase; n: int) =
   p[] = NimSeqPayloadBase(n)
 
-template readNimRawSeq*[T](xu: var NimRawSeq; x: seq[T]) =
+template readNimSeqV2*[T](xu: var NimSeqV2[T]; x: seq[T]) =
   c_memcpy(addr xu, unsafeAddr x, csize_t(sizeof(xu)))
 
-template storeNimRawSeq[T](x: var seq[T]; xu: NimRawSeq) =
+template storeNimSeqV2[T](x: var seq[T]; xu: NimSeqV2[T]) =
   c_memcpy(addr x, unsafeAddr xu, csize_t(sizeof(xu)))
 
 const nimSeqVersion {.core.} = 2
@@ -151,11 +151,11 @@ proc grow*[T](x: var seq[T]; newLen: Natural; value: T) {.nodestroy.} =
   #sysAssert newLen >= x.len, "invalid newLen parameter for 'grow'"
   if newLen <= oldLen: return
   var xu {.noinit.}: NimRawSeq
-  xu.readNimRawSeq x
+  xu.readNimSeqV2 x
   if xu.p == nil or (xu.p.cap and not strlitFlag) < newLen:
     xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newLen - oldLen, sizeof(T), alignof(T)))
   xu.len = newLen
-  x.storeNimRawSeq xu
+  x.storeNimSeqV2 xu
   {.push boundChecks: off.}
   let data = cast[ptr UncheckedArray[T]](addr x[0])
   {.pop.}
@@ -176,12 +176,12 @@ proc add*[T](x: var seq[T]; y: sink T) {.magic: "AppendSeqElem", noSideEffect, n
   {.cast(noSideEffect).}:
     let oldLen = x.len
     let newLen = oldLen+1
-    var xu {.noinit.}: NimRawSeq
-    xu.readNimRawSeq x
+    var xu {.noinit.}: NimSeqV2[T]
+    xu.readNimSeqV2 x
     if xu.p == nil or (xu.p.cap and not strlitFlag) < newLen:
       xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, 1, sizeof(T), alignof(T)))
     xu.len = newLen
-    x.storeNimRawSeq xu
+    x.storeNimSeqV2 xu
     # .nodestroy means `xu.p.data[oldLen] = value` is compiled into a
     # copyMem(). This is fine as know by construction that
     # in `xu.p.data[oldLen]` there is nothing to destroy.
@@ -198,12 +198,12 @@ proc setLen[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
     else:
       let oldLen = s.len
       if newlen <= oldLen: return
-      var xu {.noinit.}: NimRawSeq
-      xu.readNimRawSeq s
+      var xu {.noinit.}: NimSeqV2[T]
+      xu.readNimSeqV2 s
       if xu.p == nil or (xu.p.cap and not strlitFlag) < newlen:
         xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newlen - oldLen, sizeof(T), alignof(T)))
       xu.len = newlen
-      s.storeNimRawSeq xu
+      s.storeNimSeqV2 xu
       {.push boundChecks: off.}
       let data = cast[ptr UncheckedArray[T]](addr s[0])
       {.pop.}
@@ -230,8 +230,8 @@ func capacity*[T](self: seq[T]): int {.inline.} =
     lst.add "Nim"
     assert lst.capacity == 42
 
-  var sek {.noinit.}: NimRawSeq
-  sek.readNimRawSeq self
+  var sek {.noinit.}: NimSeqV2[T]
+  sek.readNimSeqV2 self
   result = if sek.p != nil: sek.p.cap and not strlitFlag else: 0
 
 func setLenUninit[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
@@ -254,11 +254,11 @@ func setLenUninit[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
     else:
       let oldLen = s.len
       if newlen <= oldLen: return
-      var xu {.noinit.}: NimRawSeq
-      xu.readNimRawSeq s
+      var xu {.noinit.}: NimSeqV2[T]
+      xu.readNimSeqV2 s
       if xu.p == nil or (xu.p.cap and not strlitFlag) < newlen:
         xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newlen - oldLen, sizeof(T), alignof(T)))
       xu.len = newlen
-      s.storeNimRawSeq xu
+      s.storeNimSeqV2 xu
 
 {.pop.}  # See https://github.com/nim-lang/Nim/issues/21401

--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -18,8 +18,7 @@
 
 ## Default seq implementation used by Nim's core.
 type
-  NimSeqPayloadBase = object
-    cap: int
+  NimSeqPayloadBase = distinct int
 
   NimSeqPayload[T] = object
     cap: int
@@ -30,9 +29,21 @@ type
     len: int
     p: ptr NimSeqPayload[T]
 
-  NimRawSeq = object
+  NimRawSeq* = object
     len: int
-    p: pointer
+    p: ptr NimSeqPayloadBase
+
+template cap(p: ptr NimSeqPayloadBase): int =
+  int(p[])
+
+template `cap=`(p: ptr NimSeqPayloadBase; n: int) =
+  p[] = NimSeqPayloadBase(n)
+
+template readNimRawSeq*[T](xu: var NimRawSeq; x: seq[T]) =
+  c_memcpy(addr xu, unsafeAddr x, csize_t(sizeof(xu)))
+
+template storeNimRawSeq[T](x: var seq[T]; xu: NimRawSeq) =
+  c_memcpy(addr x, unsafeAddr xu, csize_t(sizeof(xu)))
 
 const nimSeqVersion {.core.} = 2
 
@@ -133,22 +144,27 @@ proc shrink*[T](x: var seq[T]; newLen: Natural) {.tags: [], raises: [].} =
         reset x[i]
     # XXX This is wrong for const seqs that were moved into 'x'!
     {.noSideEffect.}:
-      cast[ptr NimSeqV2[T]](addr x).len = newLen
+      cast[ptr int](addr x)[] = newLen
 
 proc grow*[T](x: var seq[T]; newLen: Natural; value: T) {.nodestroy.} =
   let oldLen = x.len
   #sysAssert newLen >= x.len, "invalid newLen parameter for 'grow'"
   if newLen <= oldLen: return
-  var xu = cast[ptr NimSeqV2[T]](addr x)
+  var xu {.noinit.}: NimRawSeq
+  xu.readNimRawSeq x
   if xu.p == nil or (xu.p.cap and not strlitFlag) < newLen:
     xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newLen - oldLen, sizeof(T), alignof(T)))
   xu.len = newLen
+  x.storeNimRawSeq xu
+  {.push boundChecks: off.}
+  let data = cast[ptr UncheckedArray[T]](addr x[0])
+  {.pop.}
   for i in oldLen .. newLen-1:
     when (NimMajor, NimMinor, NimPatch) >= (2, 3, 1):
-      xu.p.data[i] = `=dup`(value)
+      data[i] = `=dup`(value)
     else:
-      wasMoved(xu.p.data[i])
-      `=copy`(xu.p.data[i], value)
+      wasMoved(data[i])
+      `=copy`(data[i], value)
 
 proc add*[T](x: var seq[T]; y: sink T) {.magic: "AppendSeqElem", noSideEffect, nodestroy.} =
   ## Generic proc for adding a data item `y` to a container `x`.
@@ -159,15 +175,21 @@ proc add*[T](x: var seq[T]; y: sink T) {.magic: "AppendSeqElem", noSideEffect, n
   ## respected.
   {.cast(noSideEffect).}:
     let oldLen = x.len
-    var xu = cast[ptr NimSeqV2[T]](addr x)
-    if xu.p == nil or (xu.p.cap and not strlitFlag) < oldLen+1:
+    let newLen = oldLen+1
+    var xu {.noinit.}: NimRawSeq
+    xu.readNimRawSeq x
+    if xu.p == nil or (xu.p.cap and not strlitFlag) < newLen:
       xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, 1, sizeof(T), alignof(T)))
-    xu.len = oldLen+1
+    xu.len = newLen
+    x.storeNimRawSeq xu
     # .nodestroy means `xu.p.data[oldLen] = value` is compiled into a
     # copyMem(). This is fine as know by construction that
     # in `xu.p.data[oldLen]` there is nothing to destroy.
     # We also save the `wasMoved + destroy` pair for the sink parameter.
-    xu.p.data[oldLen] = y
+    {.push boundChecks: off.}
+    let data = cast[ptr UncheckedArray[T]](addr x[0])
+    {.pop.}
+    data[oldLen] = y
 
 proc setLen[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
   {.noSideEffect.}:
@@ -176,19 +198,28 @@ proc setLen[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
     else:
       let oldLen = s.len
       if newlen <= oldLen: return
-      var xu = cast[ptr NimSeqV2[T]](addr s)
+      var xu {.noinit.}: NimRawSeq
+      xu.readNimRawSeq s
       if xu.p == nil or (xu.p.cap and not strlitFlag) < newlen:
         xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newlen - oldLen, sizeof(T), alignof(T)))
       xu.len = newlen
+      s.storeNimRawSeq xu
+      {.push boundChecks: off.}
+      let data = cast[ptr UncheckedArray[T]](addr s[0])
+      {.pop.}
       for i in oldLen..<newlen:
-        xu.p.data[i] = default(T)
+        data[i] = default(T)
 
 proc newSeq[T](s: var seq[T], len: Natural) =
   shrink(s, 0)
   setLen(s, len)
 
 proc sameSeqPayload(x: pointer, y: pointer): bool {.compilerRtl, inl.} =
-  result = cast[ptr NimRawSeq](x)[].p == cast[ptr NimRawSeq](y)[].p
+  var xr {.noinit.}: NimRawSeq
+  var yr {.noinit.}: NimRawSeq
+  c_memcpy(addr xr, x, csize_t(sizeof(xr)))
+  c_memcpy(addr yr, y, csize_t(sizeof(yr)))
+  result = xr.p == yr.p
 
 
 func capacity*[T](self: seq[T]): int {.inline.} =
@@ -199,7 +230,8 @@ func capacity*[T](self: seq[T]): int {.inline.} =
     lst.add "Nim"
     assert lst.capacity == 42
 
-  let sek = cast[ptr NimSeqV2[T]](unsafeAddr self)
+  var sek {.noinit.}: NimRawSeq
+  sek.readNimRawSeq self
   result = if sek.p != nil: sek.p.cap and not strlitFlag else: 0
 
 func setLenUninit[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
@@ -222,9 +254,11 @@ func setLenUninit[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
     else:
       let oldLen = s.len
       if newlen <= oldLen: return
-      var xu = cast[ptr NimSeqV2[T]](addr s)
+      var xu {.noinit.}: NimRawSeq
+      xu.readNimRawSeq s
       if xu.p == nil or (xu.p.cap and not strlitFlag) < newlen:
         xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newlen - oldLen, sizeof(T), alignof(T)))
       xu.len = newlen
+      s.storeNimRawSeq xu
 
 {.pop.}  # See https://github.com/nim-lang/Nim/issues/21401

--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -29,7 +29,7 @@ type
     len: int
     p: ptr NimSeqPayload[T]
 
-  NimRawSeq* = object
+  NimRawSeq = object
     len: int
     p: ptr NimSeqPayloadBase
 
@@ -150,7 +150,7 @@ proc grow*[T](x: var seq[T]; newLen: Natural; value: T) {.nodestroy.} =
   let oldLen = x.len
   #sysAssert newLen >= x.len, "invalid newLen parameter for 'grow'"
   if newLen <= oldLen: return
-  var xu {.noinit.}: NimRawSeq
+  var xu {.noinit.}: NimSeqV2[T]
   xu.readNimSeqV2 x
   if xu.p == nil or (xu.p.cap and not strlitFlag) < newLen:
     xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newLen - oldLen, sizeof(T), alignof(T)))

--- a/lib/system/seqs_v2_reimpl.nim
+++ b/lib/system/seqs_v2_reimpl.nim
@@ -8,16 +8,20 @@
 #
 
 type
-  NimSeqPayloadReimpl = object
-    cap: int
-    data: pointer
+  NimSeqPayloadReimpl = int
 
   NimSeqV2Reimpl = object
     len: int
     p: ptr NimSeqPayloadReimpl
 
+template readNimSeqV2Reimpl(s: var NimSeqV2Reimpl; value: pointer) =
+  c_memcpy(addr s, value, csize_t(sizeof(s)))
+
+template storeNimSeqV2Reimpl(value: pointer; s: NimSeqV2Reimpl) =
+  c_memcpy(value, unsafeAddr s, csize_t(sizeof(s)))
+
 template frees(s: NimSeqV2Reimpl) =
-  if s.p != nil and (s.p.cap and strlitFlag) != strlitFlag:
+  if s.p != nil and (s.p[] and strlitFlag) != strlitFlag:
     when compileOption("threads"):
       deallocShared(s.p)
     else:


### PR DESCRIPTION
Alternative to #25067; fixes #24596.

Pros:
* No codegen changes needed.
* No negative changes in generated code size.
* Works with all standard-conforming C compilers - conceptually, memcpy treats both structs as character types, which are compatible with all types.

Cons: it's very ugly.