### PR TITLE
Revert "`std/locks` use header files instead of dlls on windows"

### DIFF
--- a/lib/std/private/syslocks.nim
+++ b/lib/std/private/syslocks.nim
@@ -51,20 +51,20 @@ when defined(windows):
 
   proc initializeConditionVariable(
     conditionVariable: var SysCond
-  ) {.stdcall, noSideEffect, header: "<windows.h>", importc: "InitializeConditionVariable".}
+  ) {.stdcall, noSideEffect, dynlib: "kernel32", importc: "InitializeConditionVariable".}
 
   proc sleepConditionVariableCS(
     conditionVariable: var SysCond,
     PCRITICAL_SECTION: var SysLock,
     dwMilliseconds: int
-  ): int32 {.stdcall, noSideEffect, header: "<windows.h>", importc: "SleepConditionVariableCS".}
+  ): int32 {.stdcall, noSideEffect, dynlib: "kernel32", importc: "SleepConditionVariableCS".}
 
 
   proc signalSysCond*(hEvent: var SysCond) {.stdcall, noSideEffect,
-    header: "<windows.h>", importc: "WakeConditionVariable".}
+    dynlib: "kernel32", importc: "WakeConditionVariable".}
 
   proc broadcastSysCond*(hEvent: var SysCond) {.stdcall, noSideEffect,
-    header: "<windows.h>", importc: "WakeAllConditionVariable".}
+    dynlib: "kernel32", importc: "WakeAllConditionVariable".}
 
   proc initSysCond*(cond: var SysCond) {.inline.} =
     initializeConditionVariable(cond)


### PR DESCRIPTION
Reverts nim-lang/Nim#25090


It seems to cause problems for C++ and i686


```
2025-08-08T02:37:55.5976232Z c:/a/nightlies/nightlies/external/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.1.0/../../../../i686-w64-mingw32/bin/ld.exe: C:\Users\runneradmin\nimcache\manual_experimental_snippet_106_d\@pstd@sprivate@ssyslocks.nim.c.o:@pstd@sprivate@ssyslocks.nim.c:(.text+0x29): undefined reference to `SleepConditionVariableCS'
2025-08-08T02:37:55.5978066Z c:/a/nightlies/nightlies/external/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.1.0/../../../../i686-w64-mingw32/bin/ld.exe: C:\Users\runneradmin\nimcache\manual_experimental_snippet_106_d\@pthreadpool.nim.c.o:@pthreadpool.nim.c:(.text+0x26): undefined reference to `InitializeConditionVariable'
2025-08-08T02:37:55.5980101Z c:/a/nightlies/nightlies/external/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.1.0/../../../../i686-w64-mingw32/bin/ld.exe: C:\Users\runneradmin\nimcache\manual_experimental_snippet_106_d\@pthreadpool.nim.c.o:@pthreadpool.nim.c:(.text+0x116): undefined reference to `WakeConditionVariable'
2025-08-08T02:37:55.5981093Z collect2.exe: error: ld returned 1 exit status
2025-08-08T02:37:55.5988564Z Error: execution of an external program failed: 'gcc.exe   -o 
```