### PR TITLE
closes #25084 : docs: fix example for *+ operator 

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -4062,7 +4062,7 @@ notation. (Thus an operator can have more than two parameters):
     # Multiply and add
     result = a * b + c
 
-  assert `*+`(3, 4, 6) == `+`(`*`(a, b), c)
+  assert `*+`(3, 4, 6) == `+`(`*`(3, 4), 6)
   ```
 
 


### PR DESCRIPTION
## Description

Fixed an inconsistency in the Nim manual's example for the `*+` operator.

Previously, the example on line 4065 of `doc/manual.md` used variables `a`, `b`, and `c`:

```nim
assert `*+`(3, 4, 6) == `+`(`*`(a, b), c)
```

This did not match the preceding call which directly used literals `3`, `4`, `6`.

Updated the example to:

```nim
assert `*+`(3, 4, 6) == `+`(`*`(3, 4), 6)
```

This change makes the example consistent with the function call and immediately understandable to readers without requiring prior variable definitions.

## Rationale

* Improves clarity by avoiding undefined variables in a code snippet.
* Matches the example usage in the preceding line.
* Helps beginners understand the operator's behavior without additional context.

## Changes

* **Edited**: `doc/manual.md` line 4065 — replaced variables `a`, `b`, `c` with literals `3`, `4`, `6`.

## Issue

Closes #25084
