### PR TITLE
Update asyncfile.nim: support write to > 2GB file on Windows

### DIFF
--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -428,7 +428,7 @@ proc write*(f: AsyncFile, data: string): Future[void] =
           dealloc buffer
           buffer = nil
     )
-    ol.offset = DWORD(f.offset and 0xffffffff)
+    ol.offset = cast[DWORD](f.offset and 0xffffffff)
     ol.offsetHigh = DWORD(f.offset shr 32)
     f.offset.inc(data.len)
 


### PR DESCRIPTION
`DWORD` is defined as `int32`, so `DWORD(...)` would not work as expected. When writing to files larger than 2GB, exception occurs:

```
unhandled exception: value out of range: 4294967295 notin -2147483648 .. 2147483647 [RangeDefect]
```

This PR is a quick fix for this.

P.S. Why `DWORD` is defined as `int32`?