### PR TITLE
fixes #25109; fixes #25111 transform `addr(conv(x))` -> `conv(addr(x))`

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -981,7 +981,11 @@ proc genAddr(p: BProc, e: PNode, d: var TLoc) =
     var a: TLoc = initLocExpr(p, e[0])
     if e[0].kind in {nkHiddenStdConv, nkHiddenSubConv, nkConv} and not ignoreConv(e[0]):
       # addr (conv x) introduces a temp because `conv x` is not a rvalue
-      putIntoDest(p, d, e, addrLoc(p.config, expressionsNeedsTmp(p, a)), a.storage)
+      # transform addr ( conv ( x ) ) -> conv ( addr ( x ) )
+      var exprLoc: TLoc = initLocExpr(p, e[0][1])
+      var tmp = getTemp(p, e.typ, needsInit=false)
+      putIntoDest(p, tmp, e, cCast(getTypeDesc(p.module, e.typ), addrLoc(p.config, exprLoc)))
+      putIntoDest(p, d, e, rdLoc(tmp))
     else:
       putIntoDest(p, d, e, addrLoc(p.config, a), a.storage)
 

--- a/tests/ccgbugs/taddrconvs.nim
+++ b/tests/ccgbugs/taddrconvs.nim
@@ -25,3 +25,23 @@ block:
     var m = uint64(12)
     foo(culonglong(m))
   main()
+
+block: # bug #25109
+  type T = culonglong
+  proc r(c: var T) = c = 1
+  proc h(a: var culonglong) = r(T(a))
+  var a: culonglong
+  h(a)
+  doAssert a == 1
+
+block: # bug #25111
+  type T = culonglong
+  proc r(c: var T) = c = 1
+
+  proc foo =
+    var a: uint64
+    r(T(a))
+    doAssert a == 1
+
+  foo()
+


### PR DESCRIPTION
follows up https://github.com/nim-lang/Nim/pull/24818
relates to https://github.com/nim-lang/Nim/issues/23923

fixes #25109
fixes #25111

transform `addr ( conv ( x ) )` -> `conv ( addr ( x ) )` so that it is the original value that is being modified


```c
T1_ = ((unsigned long long*) ((&a_1)));
r(T1_);
```