### PR TITLE
fixes tnewruntime_strutils.nim not to raise AssertionDefect

### DIFF
--- a/tests/destructor/tnewruntime_strutils.nim
+++ b/tests/destructor/tnewruntime_strutils.nim
@@ -53,7 +53,7 @@ proc nonStaticTests =
   block: # formatSize tests
     when not defined(js):
       doAssert formatSize((1'i64 shl 31) + (300'i64 shl 20)) == "2.293GiB"   # <=== bug #8231
-    doAssert formatSize((2.234*1024*1024).int) == "2.234MiB"
+    doAssert formatSize((2.234*1024*1024).int) == "2.233MiB"
     doAssert formatSize(4096) == "4KiB"
     doAssert formatSize(4096, prefix=bpColloquial, includeSpace=true) == "4 kB"
     doAssert formatSize(4096, includeSpace=true) == "4 KiB"

--- a/tests/destructor/tnewruntime_strutils.nim
+++ b/tests/destructor/tnewruntime_strutils.nim
@@ -57,7 +57,7 @@ proc nonStaticTests =
     doAssert formatSize(4096) == "4KiB"
     doAssert formatSize(4096, prefix=bpColloquial, includeSpace=true) == "4 kB"
     doAssert formatSize(4096, includeSpace=true) == "4 KiB"
-    doAssert formatSize(5_378_934, prefix=bpColloquial, decimalSep=',') == "5,13MB"
+    doAssert formatSize(5_378_934, prefix=bpColloquial, decimalSep=',') == "5,129MB"
 
   block: # formatEng tests
     doAssert formatEng(0, 2, trim=false) == "0.00"


### PR DESCRIPTION
Follow up to https://github.com/nim-lang/Nim/pull/25126
It changed `formatSize` outputs from some inputs, so some of existing test code related to it need to be updated.
Sorry, I didn't know `tests/destructor/tnewruntime_strutils.nim` has tests calls `formatSize`.