### PR TITLE
rework sqlparse foreignkey ast & renderer a bit

### DIFF
--- a/lib/pure/parsesql.nim
+++ b/lib/pure/parsesql.nim
@@ -876,6 +876,32 @@ proc parseIfNotExists(p: var SqlParser, k: SqlNodeKind): SqlNode =
   else:
     result = newNode(k)
 
+
+proc parseForeignKey(p: var SqlParser): SqlNode =
+  getTok(p)
+  eat(p, "key")
+  result = newNode(nkForeignKey)
+
+  var n = newNode(nkColumnList)
+  parseParIdentList(p, n)
+  result.add(n)
+
+
+  eat(p, "references")
+  var m = newNode(nkReferences)
+
+  expectIdent(p)
+  m.add(newNode(nkIdent, p.tok.literal))
+  getTok(p)
+
+  var l = newNode(nkColumnList)
+  parseParIdentList(p, l)
+
+  m.add(l)
+
+  result.add(m)
+
+
 proc parseTableConstraint(p: var SqlParser): SqlNode =
   if isKeyw(p, "primary"):
     getTok(p)
@@ -883,14 +909,7 @@ proc parseTableConstraint(p: var SqlParser): SqlNode =
     result = newNode(nkPrimaryKey)
     parseParIdentList(p, result)
   elif isKeyw(p, "foreign"):
-    getTok(p)
-    eat(p, "key")
-    result = newNode(nkForeignKey)
-    parseParIdentList(p, result)
-    eat(p, "references")
-    var m = newNode(nkReferences)
-    m.add(parseColumnReference(p))
-    result.add(m)
+    result = parseForeignKey(p)
   elif isKeyw(p, "unique"):
     getTok(p)
     eat(p, "key")
@@ -1324,7 +1343,7 @@ proc ra(n: SqlNode, s: var SqlWriter) =
     rs(n, s)
   of nkForeignKey:
     s.addKeyw("foreign key")
-    rs(n, s)
+    rs(n, s, "", "", "")
   of nkNotNull:
     s.addKeyw("not null")
   of nkNull:
@@ -1360,7 +1379,7 @@ proc ra(n: SqlNode, s: var SqlWriter) =
     s.add(')')
   of nkReferences:
     s.addKeyw("references")
-    ra(n.sons[0], s)
+    rs(n, s, "", "", "")
   of nkDefault:
     s.addKeyw("default")
     ra(n.sons[0], s)

--- a/tests/stdlib/tparsesql.nim
+++ b/tests/stdlib/tparsesql.nim
@@ -302,3 +302,9 @@ SELECT `SELECT`, `FROM` as `GROUP` FROM `WHERE`;
 doAssert $parseSql("""
 SELECT "SELECT", "FROM" as "GROUP" FROM "WHERE";
 """) == """select "SELECT", "FROM" as "GROUP" from "WHERE";"""
+
+# foreign key should parse
+
+doAssert $parseSql("""
+CREATE TABLE content(artist_id_artist integer, FOREIGN KEY (artist_id_artist) REFERENCES artist(artist_id))
+""") == "create table content(artist_id_artist  integer , foreign key (artist_id_artist ) references artist (artist_id ) );;"


### PR DESCRIPTION
Fixes nim-lang/parsesql#3

This is a breaking change since it messes with the AST a little bit to go from:

    nkForeignKey
      nkIdent artist_id_artist
      nkReferences
        nkCall
          nkIdent artist
          nkIdent artist_id

to

    nkForeignKey
      nkColumnList
        nkIdent artist_id_artist
      nkReferences
        nkIdent artist
        nkColumnList
          nkIdent artist_id

Which I honestly feel fine/good about, especially considering it lines up closer to https://www.sqlite.org/syntax/table-constraint.html + https://www.sqlite.org/syntax/foreign-key-clause.html & represents the constraint columnes & referenced columns as potential lists, as opposed to calls as it was before (why was it parsing this as a call? I see why but also it makes no sense)