### PR TITLE
fixes #25117; `requiresInit` not checked for result if it has been used

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -379,7 +379,9 @@ proc useVar(a: PEffects, n: PNode) =
       # If the variable is explicitly marked as .noinit. do not emit any error
       a.init.add s.id
     elif s.id notin a.init:
-      if s.typ.requiresInit:
+      if s.kind == skResult and tfRequiresInit in s.typ.flags:
+        localError(a.config, n.info, "'result' requires explicit initialization")
+      elif s.typ.requiresInit:
         message(a.config, n.info, warnProveInit, s.name.s)
       elif a.leftPartOfAsgn <= 0:
         if strictDefs in a.c.features:

--- a/koch.nim
+++ b/koch.nim
@@ -13,7 +13,7 @@ const
   # examples of possible values for repos: Head, ea82b54
   NimbleStableCommit = "9207e8b2bbdf66b5a4d1020214cff44d2d30df92" # 0.20.1
   AtlasStableCommit = "26cecf4d0cc038d5422fc1aa737eec9c8803a82b" # 0.9
-  ChecksumsStableCommit = "f8f6bd34bfa3fe12c64b919059ad856a96efcba0" # 2.0.1
+  ChecksumsStableCommit = "0b8e46379c5bc1bf73d8b3011908389c60fb9b98" # 2.0.1
   SatStableCommit = "faf1617f44d7632ee9601ebc13887644925dcc01"
 
   NimonyStableCommit = "1dbabac403ae32e185ee4c29f006d04e04b50c6d" # unversioned \

--- a/tests/errmsgs/t25117.nim
+++ b/tests/errmsgs/t25117.nim
@@ -1,0 +1,13 @@
+discard """
+  errormsg: "'result' requires explicit initialization"
+"""
+
+type RI {.requiresInit.} = object
+  v: int
+
+proc xxx(v: var RI) = discard
+
+proc f(T: type): T =
+  xxx(result) # Should fail
+
+discard f(RI)


### PR DESCRIPTION
fixes #25117


errors on `requiresInit` of `result` if it is used before initialization. Otherwise 

```nim
    # prevent superfluous warnings about the same variable:
    a.init.add s.id
```

It produces a warning, and this line prevents it from being recognized by the `requiresInit` check in `trackProc`