### PR TITLE
Allow assignment of nested non-closure procs to globals

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -725,7 +725,7 @@ template isLocalSym(sym: PSym): bool =
       sym.typ.kind == tyTypeDesc or
       sfCompileTime in sym.flags) or
       sym.kind in {skProc, skFunc, skIterator} and
-      sfGlobal notin sym.flags
+      sfGlobal notin sym.flags and sym.typ.callConv == ccClosure
 
 proc usesLocalVar(n: PNode): bool =
   case n.kind

--- a/tests/global/tglobalclosure.nim
+++ b/tests/global/tglobalclosure.nim
@@ -1,0 +1,14 @@
+discard """
+  errormsg: "cannot assign local to global variable"
+  line: 11
+"""
+
+proc main() =
+  var x = "hi"
+  proc p() =
+    echo x
+
+  let a {.global.} = p
+  p()
+
+main()

--- a/tests/global/tglobalclosure2.nim
+++ b/tests/global/tglobalclosure2.nim
@@ -1,0 +1,17 @@
+discard """
+  errormsg: "cannot assign local to global variable"
+  line: 14
+"""
+
+type X = object
+  p: proc() {.closure.}
+
+proc main() =
+  var x = "hi"
+  proc p() =
+    echo x
+
+  let a {.global.} = X(p: p)
+  b.p()
+
+main()

--- a/tests/global/tglobalclosure2.nim
+++ b/tests/global/tglobalclosure2.nim
@@ -12,6 +12,6 @@ proc main() =
     echo x
 
   let a {.global.} = X(p: p)
-  b.p()
+  a.p()
 
 main()

--- a/tests/global/tglobalproc.nim
+++ b/tests/global/tglobalproc.nim
@@ -12,7 +12,7 @@ proc main() =
 
   let a {.global.} = p
   let b {.global.} = X(p: p)
-  p()
+  a()
   b.p()
 
 main()

--- a/tests/global/tglobalproc.nim
+++ b/tests/global/tglobalproc.nim
@@ -1,6 +1,5 @@
 discard """
-output: hi
-hi
+output: "hi\nhi"
 """
 
 type X = object

--- a/tests/global/tglobalproc.nim
+++ b/tests/global/tglobalproc.nim
@@ -1,0 +1,18 @@
+discard """
+output: hi
+hi
+"""
+
+type X = object
+  p: proc() {.nimcall.}
+
+proc main() =
+  proc p() =
+    echo "hi"
+
+  let a {.global.} = p
+  let b {.global.} = X(p: p)
+  p()
+  b.p()
+
+main()


### PR DESCRIPTION
For memory-safety, this only seems problematic in case of closures, so I just special cased that.

Fixes #25131