### PR TITLE
fixes #24844; Invalid C codegen refc with generic types containing gc memory

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -2003,7 +2003,7 @@ proc genTypeInfoV1(m: BModule; t: PType; info: TLineInfo): Rope =
     if m.config.selectedGC in {gcMarkAndSweep, gcRefc, gcGo}:
       # it may not be used in other places except in `genTraverseProc`,
       # we have to generate a typedesc for this case, not a weak one
-      discard getTypeDesc(m, origType.base)
+      discard getTypeDesc(m, origType.last)
       let markerProc = genTraverseProc(m, origType, sig)
       m.s[cfsTypeInit3].addFieldAssignment(tiNameForHcr(m, result), "marker", markerProc)
   of tyPtr, tyRange, tyUncheckedArray: genTypeInfoAux(m, t, t, result, info)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -2001,8 +2001,8 @@ proc genTypeInfoV1(m: BModule; t: PType; info: TLineInfo): Rope =
   of tyRef:
     genTypeInfoAux(m, t, t, result, info)
     if m.config.selectedGC in {gcMarkAndSweep, gcRefc, gcGo}:
-      # it may not be used in other places exccept in `genTraverseProc`,
-      # we have to generate a typedesc for this case
+      # it may not be used in other places except in `genTraverseProc`,
+      # we have to generate a typedesc for this case, not a weak one
       discard getTypeDesc(m, origType.base)
       let markerProc = genTraverseProc(m, origType, sig)
       m.s[cfsTypeInit3].addFieldAssignment(tiNameForHcr(m, result), "marker", markerProc)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -2001,6 +2001,9 @@ proc genTypeInfoV1(m: BModule; t: PType; info: TLineInfo): Rope =
   of tyRef:
     genTypeInfoAux(m, t, t, result, info)
     if m.config.selectedGC in {gcMarkAndSweep, gcRefc, gcGo}:
+      # it may not be used in other places exccept in `genTraverseProc`,
+      # we have to generate a typedesc for this case
+      discard getTypeDesc(m, origType.base)
       let markerProc = genTraverseProc(m, origType, sig)
       m.s[cfsTypeInit3].addFieldAssignment(tiNameForHcr(m, result), "marker", markerProc)
   of tyPtr, tyRange, tyUncheckedArray: genTypeInfoAux(m, t, t, result, info)

--- a/tests/refc/m24844.nim
+++ b/tests/refc/m24844.nim
@@ -1,0 +1,8 @@
+type
+  S*[T] = ref object of RootObj
+    k: string
+  A*[T] = ref object of S[T]
+
+proc p*[T](): S[T] = S[T]()
+proc u*() = discard A[int]()
+discard A[int]()

--- a/tests/refc/t24844.nim
+++ b/tests/refc/t24844.nim
@@ -1,0 +1,11 @@
+discard """
+  matrix: "--mm:refc; --mm:arc"
+  joinable: false
+"""
+
+import m24844
+
+u()
+
+type E = distinct int
+discard p[E]()


### PR DESCRIPTION
fixes #24844


it may not be used in other places except in `genTraverseProc`,
we have to generate a `typedesc` for this case, not a weak `typedec`