### PR TITLE
fixes #25113; enforces `nodestroy` for `=wasmoved`

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2305,6 +2305,8 @@ proc semOverride(c: PContext, s: PSym, n: PNode) =
   of "=wasmoved":
     if s.magic != mWasMoved:
       bindTypeHook(c, s, n, attachedWasMoved)
+      # nodestroy for `=wasmoved`
+      incl(s.flags, sfGeneratedOp)
   of "=dup":
     if s.magic != mDup:
       bindDupHook(c, s, n, attachedDup)


### PR DESCRIPTION
fixes #25113


The problem in #25113 is that in the user-defined `=wasMoved`, hooks are injected for `engine.process = nil`
```nim
proc `=wasMoved`*(engine: var UciEngine) =
  engine.process = nil
  engine.alwaysFalseProbably = false
```

i.e., it becomes `=sink(engine.proces, nil)`. But `engine` should have been destroyed already before `=wasMoved` is called, for which`=sink` should not be injected.
