### PR TITLE
makes `DuplicateModuleImport` back to an error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@ errors.
 
 - `std/parsesql` has been moved to a nimble package, use `nimble` or `atlas` to install it.
 
+- With `-d:nimPreviewDuplicateModuleError`, importing two modules that share the same name becomes a compile-time error. This includes importing the same module more than once. Use `import foo as foo1` (or other aliases) to avoid collisions.
+
 ## Standard library additions and changes
 
 [//]: # "Additions:"

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -173,4 +173,5 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasXorSet")
 
   defineSymbol("nimHasSetLengthSeqUninitMagic")
+  defineSymbol("nimHasPreviewDuplicateModuleError")
 

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -388,7 +388,7 @@ proc addDeclAt*(c: PContext; scope: PScope, sym: PSym, info: TLineInfo) =
   if sym.name.id == ord(wUnderscore): return
   let conflict = scope.addUniqueSym(sym)
   if conflict != nil:
-    if sym.kind == skModule and conflict.kind == skModule:
+    if sym.kind == skModule and conflict.kind == skModule and not c.config.isDefined("nimPreviewDuplicateModuleError"):
       # e.g.: import foo; import foo
       # xxx we could refine this by issuing a different hint for the case
       # where a duplicate import happens inside an include.

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -12,6 +12,8 @@ define:nimPreviewNonVarDestructor
 define:nimPreviewCheckedClose
 define:nimPreviewAsmSemSymbol
 define:nimPreviewCStringComparisons
+define:nimPreviewDuplicateModuleError
+
 threads:off
 
 #import:"$projectpath/testability"

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -35,7 +35,7 @@
 import prefixmatches, suggestsymdb
 from wordrecg import wDeprecated, wError, wAddr, wYield
 
-import std/[algorithm, sets, parseutils, tables, os]
+import std/[algorithm, sets, parseutils, os]
 
 when defined(nimsuggest):
   import pathutils # importer

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -926,8 +926,6 @@ when defined(windows):
     stdout.write "\n"
 
 else:
-  import std/termios
-
   proc readPasswordFromStdin*(prompt: string, password: var string):
                             bool {.tags: [ReadIOEffect, WriteIOEffect].} =
     password.setLen(0)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -100,7 +100,7 @@ const
   stylePrefix = "\e["
 
 when defined(windows):
-  import std/[winlean, os]
+  import std/os
 
   const
     DUPLICATE_SAME_ACCESS = 2
@@ -978,9 +978,6 @@ proc resetAttributes*() {.noconv.} =
 proc isTrueColorSupported*(): bool =
   ## Returns true if a terminal supports true color.
   return getTerminal().trueColorIsSupported
-
-when defined(windows):
-  import std/os
 
 proc enableTrueColors*() =
   ## Enables true color.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2303,6 +2303,9 @@ when notJSnotNims:
     else:
       result = n.sons[n.len]
 
+import std/private/digitsutils
+export addInt
+
 when notJSnotNims and hasAlloc:
   {.push profiler: off.}
   include "system/mmdisp"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2303,9 +2303,6 @@ when notJSnotNims:
     else:
       result = n.sons[n.len]
 
-import std/private/digitsutils
-export addInt
-
 when notJSnotNims and hasAlloc:
   {.push profiler: off.}
   include "system/mmdisp"
@@ -2426,6 +2423,8 @@ proc finished*[T: iterator {.closure.}](x: T): bool {.noSideEffect, inline, magi
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
 
+import std/private/digitsutils
+export addInt
 
 when defined(js) and not defined(nimscript):
   # nimscript can be defined if config file for js compilation

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2423,8 +2423,6 @@ proc finished*[T: iterator {.closure.}](x: T): bool {.noSideEffect, inline, magi
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
 
-from std/private/digitsutils import addInt
-export addInt
 
 when defined(js) and not defined(nimscript):
   # nimscript can be defined if config file for js compilation

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2423,7 +2423,7 @@ proc finished*[T: iterator {.closure.}](x: T): bool {.noSideEffect, inline, magi
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
 
-import std/private/digitsutils
+from std/private/digitsutils import addInt
 export addInt
 
 when defined(js) and not defined(nimscript):

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -12,7 +12,6 @@
 
 include osalloc
 import std/private/syslocks
-import std/sysatomics
 
 template track(op, address, size) =
   when defined(memTracker):

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -8,6 +8,7 @@
 #
 
 # Compilerprocs for strings that do not depend on the string implementation.
+import std/private/digitsutils as digitsutils2
 
 proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let alen = a.len

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -9,9 +9,6 @@
 
 # Compilerprocs for strings that do not depend on the string implementation.
 
-import std/private/digitsutils
-export addInt
-
 proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let alen = a.len
   let blen = b.len

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -10,7 +10,7 @@
 # Compilerprocs for strings that do not depend on the string implementation.
 
 import std/private/digitsutils
-
+export addInt
 
 proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let alen = a.len


### PR DESCRIPTION
fixes #24998

Basically it retraces back to the situation before https://github.com/nim-lang/Nim/pull/18366 and https://github.com/nim-lang/Nim/pull/18362, i.e.

```nim
import fuzz/a
import fuzz/a
```

```nim
import fuzz/a
from buzz/a
```

```nim
import fuzz/a except nil
from fuzz/a import addInt
```

All of these cases are now flagged as invalid and triggers a redefinition error, i.e., each module name importing is treated as consistent as the symbol definition


kinda annoying for importing/exporting with `when conditions` though

ref https://github.com/nim-lang/Nim/issues/18762 https://github.com/nim-lang/Nim/issues/20907

```nim
from std/strutils import toLower
when not defined(js):
  from std/strutils import toUpper
```