### PR TITLE
fixes #25205 #14873; resets `importc` obj with `nimZeroMem` in `specializeResetT` for `refc`

### DIFF
--- a/compiler/ccgreset.nim
+++ b/compiler/ccgreset.nim
@@ -67,7 +67,14 @@ proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =
     var x = typ.baseClass
     if x != nil: x = x.skipTypes(skipPtrs)
     specializeResetT(p, accessor.parentObj(p.module), x)
-    if typ.n != nil: specializeResetN(p, accessor, typ.n, typ)
+    if typ.n != nil:
+      if typ.sym != nil and sfImportc in typ.sym.flags:
+        # imported C struct, nimZeroMem
+        p.s(cpsStmts).addCallStmt(cgsymValue(p.module, "nimZeroMem"),
+          cCast(ptrType(CPointer), cAddr(accessor)),
+          cSizeof(getTypeDesc(p.module, typ)))
+      else:
+        specializeResetN(p, accessor, typ.n, typ)
   of tyTuple:
     let typ = getUniqueType(typ)
     for i, a in typ.ikids:

--- a/tests/stdlib/tlocks.nim
+++ b/tests/stdlib/tlocks.nim
@@ -9,3 +9,30 @@ import std/assertions
 
 var m = createMyType[int]()
 doAssert m.use() == 3
+
+
+import std/locks
+
+type
+  S = object
+    r: proc()
+
+  B = object
+    d: Lock
+    w: S
+
+proc v(x: ptr B) {.exportc.} = reset(x[])
+
+type
+  Test = object
+    path: string # Removing this makes both cases work.
+    lock: Lock
+
+# A: This is not fine.
+var a = Test()
+
+proc main(): void =
+  # B: This is fine.
+  var b = Test()
+
+main()


### PR DESCRIPTION
fixes #25205
fixes #14873


```nim
  type
    SysLockObj {.importc: "pthread_mutex_t", pure, final,
               header: """#include <sys/types.h>
                          #include <pthread.h>""", byref.} = object
      when defined(linux) and defined(amd64):
        abi: array[40 div sizeof(clong), clong]
```

Before this PR, in refc, `resetLoc` generates field assignments for each fields of `importc` object. But the field `abi` is not a genuine field, which doesn't exits in the struct. We could use `zeroMem` to reset the memory if not leave it alone