### PR TITLE
fixes #25204; Uninitialized variable usage in resize__system_u... in @psystem.nim.c in ORC

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1241,6 +1241,7 @@ proc allPathsAsgnResult(p: BProc; n: PNode): InitResultEnum =
     elif n[0].kind == nkSym and
         n[0].sym.magic in {mUnaryMinusI..mAbsI, mAddI..mPred} and
           optOverflowCheck in p.config.options:
+      # arithmetic operations may raise exceptions
       result = InitRequired
     else:
       for i in 0..<n.safeLen:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1238,6 +1238,10 @@ proc allPathsAsgnResult(p: BProc; n: PNode): InitResultEnum =
         (n[0].kind == nkSym and sfNoReturn in n[0].sym.flags):
       # requires initializations when encountering unreachable code
       result = InitRequired
+    elif n[0].kind == nkSym and
+        n[0].sym.magic in {mUnaryMinusI..mAbsI, mAddI..mPred} and
+          optOverflowCheck in p.config.options:
+      result = InitRequired
     else:
       for i in 0..<n.safeLen:
         allPathsInBranch(n[i])


### PR DESCRIPTION
fixes #25204

```nim
  of mUnaryMinusI..mAbsI: unaryArithOverflow(p, e, d, op)
  of mAddI..mPred: binaryArithOverflow(p, e, d, op)
```
Arithmetic operations may raise exceptions. So we cannot entrust the optimizer to skip `result` initialization in this situation, as complained righteously by `gcc` and `clang`: `warning: ‘result’ may be used uninitialized [-Wmaybe-uninitialize]`.

With this PR, `clang -c -Wuninitialized -O1 @psystem.nim.c` no longer gives warnings

