### PR TITLE
fixes #25210; VM error when passing object field ref to proc(var T): var T

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1586,7 +1586,11 @@ proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
     of nkObjDownConv:
       gen(p, n[0], r)
     of nkHiddenDeref, nkDerefExpr:
-      gen(p, n[0], r)
+      if n.kind in {nkAddr, nkHiddenAddr}:
+        # addr ( deref ( x )) --> x
+        gen(p, n[0][0], r)
+      else:
+        gen(p, n[0], r)
     of nkHiddenAddr:
       gen(p, n[0], r)
     of nkConv:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -519,8 +519,7 @@ proc transformAddrDeref(c: PTransf, n: PNode, kinds: TNodeKinds, isAddr = false)
           n.typ.kind == tyVar and
           n.typ.skipTypes(abstractVar).kind == tyOpenArray and
           n[0][0].typ.skipTypes(abstractVar).kind == tyString) and
-          not (isAddr and n.typ.kind == tyVar and n[0][0].typ.kind == tyRef and
-              n[0][0].kind == nkObjConstr)
+          not (isAddr and n.typ.kind == tyVar and n[0][0].typ.kind == tyRef)
         : # elimination is harmful to `for tuple unpack` because of newTupleAccess
           # it is also harmful to openArrayLoc (var openArray) for strings
       # addr ( deref ( x )) --> x

--- a/tests/vm/tmisc_vm.nim
+++ b/tests/vm/tmisc_vm.nim
@@ -457,3 +457,25 @@ proc publish*(): void {.transform.} =
   map["k"].incl "d"
 
 publish()
+
+
+iterator it(x: var int): var int =
+  yield x
+
+proc it(x: var int): var int =
+  x
+
+proc xxx() =
+  type Obj = object
+    field: ref int
+  var obj = Obj(field: new(int))
+  obj.field[] = 123
+  assert it(obj.field[]) == 123 # fails
+  for x in it(obj.field[]): # fails
+    assert x == 123
+
+static:
+  xxx()
+
+xxx()
+


### PR DESCRIPTION
fixes #25210
no longer transform `addr(obj.field[])` into `obj.field` to keep the addressing needed for VM
