### PR TITLE
nightlies regressions: CPU order matters for C sources?

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -6,7 +6,7 @@ Name: "Nim"
 Version: "$version"
 Platforms: """
   windows: i386;amd64
-  linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;s390x;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64;loongarch64
+  linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64;loongarch64;s390x
   macosx: i386;amd64;powerpc64;arm64
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64;powerpc64;arm;arm64;riscv64;sparc64;mips;mipsel;mips64;mips64el;powerpc;powerpc64el

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -210,8 +210,8 @@ type
     cpuNone, cpuI386, cpuM68k, cpuAlpha, cpuPowerpc, cpuPowerpc64,
     cpuPowerpc64el, cpuSparc, cpuVm, cpuHppa, cpuIa64, cpuAmd64, cpuMips,
     cpuMipsel, cpuArm, cpuArm64, cpuJS, cpuNimVM, cpuAVR, cpuMSP430,
-    cpuSparc64, cpuS390x, cpuMips64, cpuMips64el, cpuRiscV32, cpuRiscV64,
-    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64
+    cpuSparc64, cpuMips64, cpuMips64el, cpuRiscV32, cpuRiscV64,
+    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64, cpuS390x
 
 type
   TInfoCPU* = tuple[name: string, intSize: int, endian: Endianness,
@@ -241,7 +241,6 @@ const
     (name: "avr", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "msp430", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "sparc64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
-    (name: "s390x", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
     (name: "mips64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
     (name: "mips64el", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
     (name: "riscv32", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
@@ -249,7 +248,8 @@ const
     (name: "esp", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "wasm32", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "e2k", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
-    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
+    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
+    (name: "s390x", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64)]
 
 type
   Target* = object


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/25056

https://github.com/nim-lang/nightlies/actions/runs/18053288396/job/51378922406#step:12:1572

```
bin/nim compile -f --incremental:off --compileonly --gen_mapping --cc:gcc --skipUserCfg --os:windows --cpu:loongarch64 -d:danger -d:gitHash:f4497c61584dca8acd489ceb7ba862b150f5cf55 compiler/nim.nim
```

`loongarch64` is applied to all the platforms wrongly. Presumably it was caused by the order?