### PR TITLE
Fix Bisect

### DIFF
--- a/.github/workflows/bisects.yml
+++ b/.github/workflows/bisects.yml
@@ -15,9 +15,16 @@ jobs:
     name: ${{ matrix.platform }}-bisects
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: jiro4989/setup-nim-action@v1
+      - name: Install OpenSSL (Windows)
+        if: |
+          runner.os == 'Windows'
+        run: choco install openssl.light --version=1.1.1.0  # OpenSSL 3.x removed SSL_library_init
+        shell: 'powershell'
+
+      # v2 wont work here, because uses "hardcoded" nim versions, action "dynamically" finds version with bug.
+      - uses: jiro4989/setup-nim-action@v1  
         with:
           nim-version: 'devel'
 


### PR DESCRIPTION
- Nim requires `SSL_library_init`, OpenSSL 3.x removed `SSL_library_init`, Windows defaults to OpenSSL 3.x, then install  OpenSSL 1.x on Windows.
- Keep `jiro4989/setup-nim-action` at `v1`, because `v2` uses a YAML "hardcoded" matrix of Nim versions, but this Bisect "dynamically" finds the Nim version with a bug, therefore we cant hardcode Nim versions in the YAML, the Bisect programmatically installs required Nim versions as it goes bisecting commit-by-commit.
- Update `actions/checkout` from `v4` to `v5`.
- Add support for Nim `2.2.4`.

@ringabout 
