### PR TITLE
fixes nightlies due to UB errors; increase `maxCPU` hard limits

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -6,7 +6,7 @@ Name: "Nim"
 Version: "$version"
 Platforms: """
   windows: i386;amd64
-  linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64;loongarch64;s390x
+  linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;s390x;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64;loongarch64
   macosx: i386;amd64;powerpc64;arm64
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64;powerpc64;arm;arm64;riscv64;sparc64;mips;mipsel;mips64;mips64el;powerpc;powerpc64el

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -210,8 +210,8 @@ type
     cpuNone, cpuI386, cpuM68k, cpuAlpha, cpuPowerpc, cpuPowerpc64,
     cpuPowerpc64el, cpuSparc, cpuVm, cpuHppa, cpuIa64, cpuAmd64, cpuMips,
     cpuMipsel, cpuArm, cpuArm64, cpuJS, cpuNimVM, cpuAVR, cpuMSP430,
-    cpuSparc64, cpuMips64, cpuMips64el, cpuRiscV32, cpuRiscV64,
-    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64, cpuS390x
+    cpuSparc64, cpuS390x, cpuMips64, cpuMips64el, cpuRiscV32, cpuRiscV64,
+    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64
 
 type
   TInfoCPU* = tuple[name: string, intSize: int, endian: Endianness,
@@ -241,6 +241,7 @@ const
     (name: "avr", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "msp430", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "sparc64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
+    (name: "s390x", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
     (name: "mips64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
     (name: "mips64el", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
     (name: "riscv32", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
@@ -248,8 +249,7 @@ const
     (name: "esp", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "wasm32", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "e2k", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
-    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
-    (name: "s390x", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64)]
+    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
 
 type
   Target* = object

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -20,7 +20,7 @@ when not defined(nimHasEffectsOf):
 
 const
   maxOS = 20 # max number of OSes
-  maxCPU = 20 # max number of CPUs
+  maxCPU = 30 # max number of CPUs
   buildShFile = "build.sh"
   buildBatFile = "build.bat"
   buildBatFile32 = "build32.bat"


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/25217

The issues is actually that there is a hard limit for max cpus in niminst: https://github.com/nim-lang/Nim/pull/25219, which set to 20 while there is a 21 cpus now