### PR TITLE
fixes  #25048; Closure environment wrongly marked as cyclic

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -150,6 +150,7 @@ template isIterator*(owner: PSym): bool =
 
 proc createEnvObj(g: ModuleGraph; idgen: IdGenerator; owner: PSym; info: TLineInfo): PType =
   result = createObj(g, idgen, owner, info, final=false)
+  result.flags.incl tfFinal
   if owner.isIterator:
     rawAddField(result, createStateField(g, owner, idgen))
 


### PR DESCRIPTION
fixes  #25048

```nim
proc canFormAcycleAux =
  of tyObject:
    # Inheritance can introduce cyclic types, however this is not relevant
    # as the type that is passed to 'new' is statically known!
    # er but we use it also for the write barrier ...
    if tfFinal notin t.flags:
      # damn inheritance may introduce cycles:
      result = true
```

It seems that all objects without `tfFinal` in their flags are registering cycles. It doesn't seem that `Env` can be a cyclic type because of inheritance since it is not going to be inherited after all by another `Env` object type