### PR TITLE
fixes #25046; Infinite loop with anonymous iterator

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -974,6 +974,20 @@ proc liftForLoop*(g: ModuleGraph; body: PNode; idgen: IdGenerator; owner: PSym):
       for i in 0..<op.len-1:
         result.add op[i]
 
+  elif op.kind != nkSym: # might have side effects
+    # bug #25046
+    # create a temp for the closure
+    # var :closureTemp
+    # :closureTemp = ...
+    let tempSym = newSym(skLet, getIdent(g.cache, ":closureTemp"), idgen, owner, body.info)
+    tempSym.typ = call[0].typ
+    let temp = newSymNode(tempSym)
+    var v = newNodeI(nkVarSection, body.info)
+    addVar(v, temp)
+    result.add(v)
+    result.add newAsgnStmt(temp, call[0], body.info)
+    call[0] = temp
+
   var loopBody = newNodeI(nkStmtList, body.info, 3)
   var whileLoop = newNodeI(nkWhileStmt, body.info, 2)
   whileLoop[0] = newIntTypeNode(1, getSysType(g, body.info, tyBool))

--- a/tests/closure/tnested.nim
+++ b/tests/closure/tnested.nim
@@ -213,3 +213,23 @@ block:
       discard call2()
 
   pork()
+
+# bug #25046
+proc makeiter(v: string): iterator(): string =
+  return iterator(): string =
+    yield v
+
+var flag = ""
+
+var iter = makeiter("test1")
+for c in iter():
+  flag = c
+
+assert flag == "test1"
+
+# loops
+for c in makeiter("test2")():
+  flag = c
+
+assert flag == "test2"
+


### PR DESCRIPTION
fixes #25046

```nim
proc makeiter(v: string): iterator(): string =
  return iterator(): string =
    yield v

# loops
for c in makeiter("test")():
  echo "loops ", c
```
becomes

```nim
var temp = makeiter("test")
for c in temp():
  echo "loops ", c
```
for closures that might have side effects