### PR TITLE
fixes #25222; cast[char](i) not trunc on JS

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2879,6 +2879,8 @@ proc genCast(p: PProc, n: PNode, r: var TCompRes) =
   elif dest.kind in tyFloat..tyFloat64:
     if src.kind in {tyInt64, tyUInt64} and optJsBigInt64 in p.config.globalOptions:
       r.res = "Number($1)" % [r.res]
+  elif dest.kind == tyChar and (fromInt or fromUint):
+    r.res = "($1 & 255)" % [r.res]
   elif (src.kind == tyPtr and mapType(p, src) == etyObject) and dest.kind == tyPointer:
     r.address = r.res
     r.res = "null"

--- a/tests/cast/tcast.nim
+++ b/tests/cast/tcast.nim
@@ -17,5 +17,9 @@ proc main() =
 
   doAssert cast[int8](int16.high) == -1
 
+  block: # bug #25222
+    let ovf = 2 + int high char
+    doAssert cast[char](ovf) == '\1'
+
 static: main()
 main()


### PR DESCRIPTION
fixes #25222