### PR TITLE
fixes #25226; VM repr raises RangeDefect for long string under refc

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -30,7 +30,7 @@ type
   TRenderFlags* = set[TRenderFlag]
   TRenderTok* = object
     kind*: TokType
-    length*: int16
+    length*: int32
     sym*: PSym
 
   Section = enum
@@ -154,7 +154,7 @@ proc initSrcGen(renderFlags: TRenderFlags; config: ConfigRef): TSrcGen =
                    )
 
 proc addTok(g: var TSrcGen, kind: TokType, s: string; sym: PSym = nil) =
-  g.tokens.add TRenderTok(kind: kind, length: int16(s.len), sym: sym)
+  g.tokens.add TRenderTok(kind: kind, length: int32(s.len), sym: sym)
   g.buf.add(s)
   if kind != tkSpaces:
     inc g.col, s.len

--- a/tests/vm/tmisc_vm.nim
+++ b/tests/vm/tmisc_vm.nim
@@ -479,3 +479,10 @@ static:
 
 xxx()
 
+
+static:
+  var foo: string
+  for _ in 0 ..< 100_000:
+    foo.add 'a'
+  doAssert repr(foo).len == 100_002
+


### PR DESCRIPTION
fixes #25226

`int16` seems to be too small for a reasonable VM program