### PR TITLE
fixes #25008; Compiler internal error with static overload

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -346,6 +346,19 @@ proc fixupTypeAfterEval(c: PContext, evaluated, eOrig: PNode; producedClosure: v
          isArrayConstr(arg):
         arg.typ = eOrig.typ
 
+proc resetEvalPosition(n: PNode) =
+  # resets the eval position of variables because `tryConstExpr` may be
+  # called multiple times on the same node
+  case n.kind
+  of {nkNone..nkNilLit}-{nkSym}:
+    discard
+  of nkSym:
+    if n.sym.kind in {skVar, skLet} and sfGlobal notin n.sym.flags:
+      n.sym.position = 0
+  else:
+    for i in 0..<n.safeLen:
+      resetEvalPosition(n[i])
+
 proc tryConstExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   var e = semExprWithType(c, n, expectedType = expectedType)
   if e == nil: return
@@ -381,6 +394,8 @@ proc tryConstExpr(c: PContext, n: PNode; expectedType: PType = nil): PNode =
   when defined(nimsuggest):
     # Restore the error hook
     c.graph.config.structuredErrorHook = tempHook
+
+  resetEvalPosition(n)
 
   c.config.errorCounter = oldErrorCount
   c.config.errorMax = oldErrorMax

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -813,3 +813,9 @@ static:
   conf = defaultConf  # removing this results in the expected output
   conf.val = 2
   foo2323(defaultConf)
+
+
+proc g1314(_: static bool) = discard
+proc g1314(_: int) = discard
+proc y1314() = g1314((; let k = 0; k))
+y1314()


### PR DESCRIPTION
fixes #25008

It seems that `semOverloadedCall` evaluates the same node twice using `tryConstExpr` in order for `efExplain` to print all the diagnostic output. The problem is that `tryConstExpr` has side effects, i.e., it changes the slot index of variables after VM execution.