### PR TITLE
uses newer Nimony

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -16,7 +16,7 @@ const
   ChecksumsStableCommit = "0b8e46379c5bc1bf73d8b3011908389c60fb9b98" # 2.0.1
   SatStableCommit = "faf1617f44d7632ee9601ebc13887644925dcc01"
 
-  NimonyStableCommit = "1dbabac403ae32e185ee4c29f006d04e04b50c6d" # unversioned \
+  NimonyStableCommit = "3660f375dc0ec25da3401d3eb28603864340dc6d" # unversioned \
     # Note that Nimony uses Nim as a git submodule but we don't want to install
     # Nimony's dependency to Nim as we are Nim. So a `git clone` without --recursive
     # is **required** here.


### PR DESCRIPTION
Old Nimony has unfixed issue https://github.com/nim-lang/nimony/issues/1313.
So https://github.com/nim-lang/Nim/pull/25243 doesn't work correctly with float literal `-0.0`.
This PR updates the Nimony that fixed the issue.