### PR TITLE
`distinctBase` emits weird types sometimes

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -250,7 +250,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     var arg = operand.skipTypes({tyGenericInst})
     let rec = semConstExpr(c, traitCall[2]).intVal != 0
     while arg.kind == tyDistinct:
-      arg = arg.base.skipTypes(skippedTypes + {tyGenericInst})
+      arg = arg.base.skipTypes(skippedTypes)
       if not rec: break
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
   of "rangeBase":

--- a/tests/distinct/tdistinctbaseinstparams.nim
+++ b/tests/distinct/tdistinctbaseinstparams.nim
@@ -1,0 +1,40 @@
+discard """
+  nimout: '''1
+2
+3: Protocol[system.int, system.int]
+4'''
+"""
+import std/typetraits
+
+type
+  AsCompleteFullWriter*[T] = distinct T
+  Protocol*[R; W] = object
+
+template write*[T](
+    writer: AsCompleteFullWriter[T]; data: pointer; length: int
+): int =
+  static:
+    echo "3: ", $T
+  fwrite(distinctBase writer, data, length)
+
+proc write(w: var auto, c: char): int =
+  static:
+    echo "2"
+  var a = default(array[1, byte])
+  write(w, addr a[0], 1)
+
+proc fwrite*[R;I; T](writer: var Protocol[R,I]; v: T): int {.discardable.} =
+  static:
+    echo "1"
+  write(AsCompleteFullWriter[Protocol[R,I]](writer), v)
+
+proc fwrite*[R;W](tp: var Protocol[R,W]; p: pointer; length: int): int =
+  static:
+    echo "4"
+  result = 0
+
+proc main(arg: var Protocol[int, int]) =
+  discard arg.fwrite('c')
+
+var p = Protocol[int, int]()
+main p


### PR DESCRIPTION
Seeing how the CI fairs with this. On several occasions I've seen the compiler throw object types into `typeRel` that are certainly the exact same type but `sameObjectTypes` says they are different. This leads to incorrect `csNoMatch`. I guess from this it seems one of the places they come from are under-processed generic instantiations. Why the object types are different but have the same sym? Idk.