### PR TITLE
silence mass dump of `BareExcept` when using `unittest`

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -394,7 +394,7 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil)
       elif a.len == 1:
         # count number of ``except: body`` blocks
         inc catchAllExcepts
-        if noPanicOnExcept notin c.graph.config.legacyFeatures:
+        if noPanicOnExcept in c.graph.config.legacyFeatures:
           message(c.config, a.info, warnBareExcept,
                     "The bare except clause is deprecated; use `except CatchableError:` instead")
       else:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -394,8 +394,9 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil)
       elif a.len == 1:
         # count number of ``except: body`` blocks
         inc catchAllExcepts
-        message(c.config, a.info, warnBareExcept,
-                  "The bare except clause is deprecated; use `except CatchableError:` instead")
+        if noPanicOnExcept notin c.graph.config.legacyFeatures:
+          message(c.config, a.info, warnBareExcept,
+                    "The bare except clause is deprecated; use `except CatchableError:` instead")
       else:
         # support ``except KeyError, ValueError, ... : body``
         if catchAllExcepts > 0:

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -28,7 +28,6 @@ type
 template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
   bind finished
   {.push stackTrace: off.}
-  {.push warning[BareExcept]: off.}
   proc identName(fut: Future[futTyp], it: ClosureIt[futTyp]) {.effectsOf: it.} =
     try:
       if not it.finished:
@@ -47,8 +46,7 @@ template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
           {.gcsafe.}:
             next.addCallback(cast[proc() {.closure, gcsafe.}](proc =
               identName(fut, it)))
-    except Exception:
-      {.pop.}
+    except CatchableError, Defect:
       futureVarCompletions
       if fut.finished:
         # Take a look at tasyncexceptions for the bug which this fixes.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -48,6 +48,7 @@ template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
             next.addCallback(cast[proc() {.closure, gcsafe.}](proc =
               identName(fut, it)))
     except Exception:
+      {.pop.}
       futureVarCompletions
       if fut.finished:
         # Take a look at tasyncexceptions for the bug which this fixes.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -46,7 +46,7 @@ template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
           {.gcsafe.}:
             next.addCallback(cast[proc() {.closure, gcsafe.}](proc =
               identName(fut, it)))
-    except CatchableError, Defect:
+    except Exception:
       futureVarCompletions
       if fut.finished:
         # Take a look at tasyncexceptions for the bug which this fixes.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -28,6 +28,7 @@ type
 template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
   bind finished
   {.push stackTrace: off.}
+  {.push warning[BareExcept]: off.}
   proc identName(fut: Future[futTyp], it: ClosureIt[futTyp]) {.effectsOf: it.} =
     try:
       if not it.finished:

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -547,14 +547,11 @@ template test*(name, body) {.dirty.} =
     for formatter in formatters:
       formatter.testStarted(name)
 
-    {.push warning[BareExcept]:off.}
     try:
       when declared(testSetupIMPLFlag): testSetupIMPL()
       when declared(testTeardownIMPLFlag):
         defer: testTeardownIMPL()
-      {.push warning[BareExcept]:on.}
       body
-      {.pop.}
 
     except Exception:
       let e = getCurrentException()
@@ -577,7 +574,6 @@ template test*(name, body) {.dirty.} =
       )
       testEnded(testResult)
       checkpoints = @[]
-    {.pop.}
 
 proc checkpoint*(msg: string) =
   ## Set a checkpoint identified by `msg`. Upon test failure all
@@ -801,11 +797,8 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
       discard
 
   template expectBody(errorTypes, lineInfoLit, body): NimNode {.dirty.} =
-    {.push warning[BareExcept]:off.}
     try:
-      {.push warning[BareExcept]:on.}
       body
-      {.pop.}
       checkpoint(lineInfoLit & ": Expect Failed, no exception was thrown.")
       fail()
     except errorTypes:
@@ -814,8 +807,6 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
       let err = getCurrentException()
       checkpoint(lineInfoLit & ": Expect Failed, " & $err.name & " was thrown.")
       fail()
-    {.pop.}
-
   var errorTypes = newNimNode(nnkBracket)
   var hasException = false
   for exp in exceptions:


### PR DESCRIPTION
Seems better to change it to `CatchableError` instead?