### PR TITLE
fixes #25265; fixes #23453; Unable to build Nim 2.2.6 tools from source

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -919,6 +919,10 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
       return
     else:
       a = initLocExprSingleUse(p, e[0])
+
+    if e.typ.kind == tyObject:
+      # bug #23453 #25265
+      discard getTypeDesc(p.module, e.typ)
     if d.k == locNone:
       # dest = *a;  <-- We do not know that 'dest' is on the heap!
       # It is completely wrong to set 'd.storage' here, unless it's not yet

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -920,7 +920,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
     else:
       a = initLocExprSingleUse(p, e[0])
 
-    if e.typ.kind == tyObject:
+    if e.typ != nil and e.typ.kind == tyObject:
       # bug #23453 #25265
       discard getTypeDesc(p.module, e.typ)
     if d.k == locNone:


### PR DESCRIPTION
fixes #25265;
fixes #23453

`(addr deref (ptr object))` generated weak typedesc before, which causes problems for old GCC versions. As a bonus, by generating a typedesc for `deref (ptr object)`, it also fixes #23453