### PR TITLE
fixes #25284; `.global` initialization inside method hoisted to preInitProc

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2449,7 +2449,10 @@ proc handleProcGlobals(m: BModule) =
 
     # fixes recursive calls #24997
     swap stmts, m.preInitProc.s(cpsStmts)
-    genStmts(m.preInitProc, procGlobals[i])
+    var transformedN = procGlobals[i]
+    if sfInjectDestructors in m.module.flags:
+      transformedN = injectDestructorCalls(m.g.graph, m.idgen, m.module, transformedN)
+    genStmts(m.preInitProc, transformedN)
     swap stmts, m.preInitProc.s(cpsStmts)
 
     handleProcGlobals(m)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -968,10 +968,10 @@ proc p(n: PNode; c: var Con; s: var Scope; mode: ProcessMode; tmpFlags = {sfSing
                       {sfPure, sfGlobal} <= v.sym.flags and
                       isInProc
 
-              let value = moveOrCopy(v, ri, c, s, if v.kind == nkSym: {IsDecl} else: {})
               if isGlobalPragma:
-                c.graph.procGlobals.add value
+                c.graph.procGlobals.add n
               else:
+                let value = moveOrCopy(v, ri, c, s, if v.kind == nkSym: {IsDecl} else: {})
                 result.add value
             elif ri.kind == nkEmpty and c.inLoop > 0:
               let skipInit = v.kind == nkDotExpr and # Closure var

--- a/tests/global/tglobal3.nim
+++ b/tests/global/tglobal3.nim
@@ -55,3 +55,10 @@ block: # bug #24997
       doAssert not isNil(u(typeof(B.j)))
     R()
   discard u(B)
+
+proc f2(str: string): string = str
+proc m2()  =
+  let v {.global, used.}: string = f2(f2("123"))
+  assert v == "123"
+
+m2()


### PR DESCRIPTION
fixes #25284

```nim
proc m2()  =
  let v {.global, used.}: string = f2(f2("123"))
```

transform lifted `.global`statements in the top level scope