### PR TITLE
Improve error messages with Rust-style formatting and error codes

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -11,7 +11,7 @@
 ## `TLineInfo` object.
 
 import ropes, pathutils
-import std/[hashes, tables]
+import std/[hashes, tables, strutils]
 
 const
   explanationsBaseUrl* = "https://nim-lang.github.io/Nim"
@@ -252,6 +252,22 @@ const
   hintMax* = high(TMsgKind)
   rstWarnings* = {warnRstRedefinitionOfLabel..warnRstStyle}
 
+proc errorCode*(msg: TMsgKind): string =
+  ## Returns the error code for a message kind (similar to Rust's E0001 format)
+  ## Errors use E prefix, Warnings use W prefix, Hints use H prefix
+  case msg
+  of errMin..errMax:
+    # Fatal and regular errors: E0001-E0999
+    result = "E" & align($ord(msg), 4, '0')
+  of warnMin..warnMax:
+    # Warnings: W0001-W0999
+    let idx = ord(msg) - ord(warnMin) + 1
+    result = "W" & align($idx, 4, '0')
+  of hintMin..hintMax:
+    # Hints: H0001-H0999
+    let idx = ord(msg) - ord(hintMin) + 1
+    result = "H" & align($idx, 4, '0')
+
 type
   TNoteKind* = range[warnMin..hintMax] # "notes" are warnings or hints
   TNoteKinds* = set[TNoteKind]
@@ -312,6 +328,30 @@ type
     eStdErr
 
   TErrorOutputs* = set[TErrorOutput]
+
+  TDiagnosticLabel* = object
+    ## A label annotation for a span of code in an error message
+    info*: TLineInfo
+    endInfo*: TLineInfo  # for multi-character spans
+    message*: string     # optional label text (e.g., "expected type here")
+
+  TDiagnosticNote* = object
+    ## Additional context note for an error
+    info*: TLineInfo     # can be unknownLineInfo for general notes
+    message*: string
+
+  TDiagnosticHelp* = object
+    ## Suggestion for how to fix the error
+    message*: string
+
+  TStructuredDiagnostic* = object
+    ## A complete structured diagnostic in Rust style
+    msg*: TMsgKind
+    info*: TLineInfo
+    arg*: string
+    labels*: seq[TDiagnosticLabel]
+    notes*: seq[TDiagnosticNote]
+    help*: seq[TDiagnosticHelp]
 
   ERecoverableError* = object of ValueError
   ESuggestDone* = object of ValueError

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -501,12 +501,50 @@ proc sourceLine*(conf: ConfigRef; i: TLineInfo): string =
 
   result = conf.m.fileInfos[i.fileIndex.int32].lines[i.line.int-1]
 
+proc formatRustStyleLocation(conf: ConfigRef; info: TLineInfo): string =
+  ## Format location in Rust style:  --> file.nim:12:5
+  if info == unknownLineInfo:
+    return ""
+  result = " --> " & conf.toFileLineCol(info)
+
+proc formatRustStyleSourceContext(conf: ConfigRef; info: TLineInfo;
+                                   labels: seq[TDiagnosticLabel] = @[]): string =
+  ## Format source context with line numbers and annotations (Rust style)
+  if info == unknownLineInfo or not conf.hasHint(hintSource):
+    return ""
+
+  let line = sourceLine(conf, info)
+  if line == "":
+    return ""
+
+  # Calculate the gutter width (line number width)
+  let lineNum = $info.line
+  let gutterWidth = max(lineNum.len, 3)
+  let gutter = align(lineNum, gutterWidth)
+  let emptyGutter = spaces(gutterWidth)
+
+  result = "\n"
+  result.add emptyGutter & " |\n"
+  result.add gutter & " | " & line & "\n"
+  result.add emptyGutter & " | "
+
+  # Add carets/underlines for the error location
+  if info.col >= 0:
+    result.add spaces(info.col) & "^"
+
+    # Add label annotations if provided
+    if labels.len > 0:
+      for label in labels:
+        if label.info.line == info.line and label.message.len > 0:
+          result.add " " & label.message
+          break
+
+  result.add "\n"
+
 proc getSurroundingSrc(conf: ConfigRef; info: TLineInfo): string =
+  ## Legacy function - now uses Rust-style formatting
   if conf.hasHint(hintSource) and info != unknownLineInfo:
-    const indent = "  "
-    result = "\n" & indent & $sourceLine(conf, info)
-    if info.col >= 0:
-      result.add "\n" & indent & spaces(info.col) & '^'
+    result = formatRustStyleSourceContext(conf, info)
   else:
     result = ""
 
@@ -568,6 +606,8 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
 
   let s = if isRaw: arg else: getMessageStr(msg, arg)
   if not ignoreMsg:
+    # Rust-style error code formatting
+    let errCode = errorCode(msg)
     let loc = if info != unknownLineInfo: conf.toFileLineCol(info) & " " else: ""
     # we could also show `conf.cmdInput` here for `projectIsCmd`
     var kindmsg = if kind.len > 0: KindFormat % kind else: ""
@@ -577,7 +617,10 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
       if msg == hintProcessing and conf.hintProcessingDots:
         msgWrite(conf, ".")
       else:
-        styledMsgWriteln(styleBright, loc, resetStyle, color, title, resetStyle, s, KindColor, kindmsg,
+        # Rust-style format: error[E0001]: message text
+        let titleWithCode = title.strip() & "[" & errCode & "]"
+        styledMsgWriteln(color, titleWithCode, resetStyle, ": ", s,
+                         resetStyle, formatRustStyleLocation(conf, info),
                          resetStyle, conf.getSurroundingSrc(info), conf.unitSep)
         if hintMsgOrigin in conf.mainPackageNotes:
           # xxx needs a bit of refactoring to honor `conf.filenameOption`
@@ -645,6 +688,38 @@ template internalAssert*(conf: ConfigRef, e: bool) =
     const info2 = instLoc()
     let arg = info2.toFileLineCol
     internalErrorImpl(conf, unknownLineInfo, arg, info2)
+
+proc addDiagnosticNote*(conf: ConfigRef; info: TLineInfo; note: string) =
+  ## Add a note to provide additional context for an error (Rust-style)
+  ## Notes are shown in blue/cyan
+  if not ignoreMsgBecauseOfIdeTools(conf, hintUser):
+    let noteLine = if info != unknownLineInfo:
+      formatRustStyleLocation(conf, info) & "\n"
+    else:
+      ""
+    styledMsgWriteln(fgCyan, "note", resetStyle, ": ", note,
+                     resetStyle, noteLine, conf.unitSep)
+
+proc addDiagnosticHelp*(conf: ConfigRef; help: string) =
+  ## Add a help message to suggest how to fix an error (Rust-style)
+  ## Help messages are shown in green
+  if not ignoreMsgBecauseOfIdeTools(conf, hintUser):
+    styledMsgWriteln(fgGreen, "help", resetStyle, ": ", help,
+                     resetStyle, "\n", conf.unitSep)
+
+proc emitStructuredDiagnostic*(conf: ConfigRef; diag: TStructuredDiagnostic;
+                                eh: TErrorHandling = doNothing) =
+  ## Emit a complete structured diagnostic with notes and help (Rust-style)
+  # First emit the main error message
+  liMessage(conf, diag.info, diag.msg, diag.arg, eh, instLoc())
+
+  # Then emit any notes
+  for note in diag.notes:
+    addDiagnosticNote(conf, note.info, note.message)
+
+  # Finally emit any help messages
+  for helpMsg in diag.help:
+    addDiagnosticHelp(conf, helpMsg.message)
 
 template lintReport*(conf: ConfigRef; info: TLineInfo, beau, got: string, extraMsg = "") =
   let m = "'$1' should be: '$2'$3" % [got, beau, extraMsg]

--- a/demo_enhanced_errors.nim
+++ b/demo_enhanced_errors.nim
@@ -1,0 +1,36 @@
+# Demo file showing how to use enhanced error reporting in the compiler
+# This demonstrates the new Rust-style error messages with notes and help
+
+import compiler/[msgs, lineinfos, options, idents]
+
+# Example: How to emit a structured diagnostic with notes and help
+proc exampleStructuredError*(conf: ConfigRef; info: TLineInfo) =
+  var diag = TStructuredDiagnostic(
+    msg: errGenerated,
+    info: info,
+    arg: "type mismatch: expected 'int' but got 'string'"
+  )
+
+  # Add a note for additional context
+  diag.notes.add TDiagnosticNote(
+    info: unknownLineInfo,
+    message: "integers and strings cannot be implicitly converted"
+  )
+
+  # Add help suggesting a fix
+  diag.help.add TDiagnosticHelp(
+    message: "consider using '$' to convert the string to int, or change the type"
+  )
+
+  conf.emitStructuredDiagnostic(diag, doNothing)
+
+# Example: How to add a simple note to an existing error
+proc exampleSimpleNote*(conf: ConfigRef; info: TLineInfo) =
+  # First emit the main error
+  conf.localError(info, "cannot call proc with these arguments")
+
+  # Then add a note with additional context
+  conf.addDiagnosticNote(unknownLineInfo, "proc expects 2 arguments but 3 were provided")
+
+  # Add a help message
+  conf.addDiagnosticHelp("check the proc signature to see required parameter types")

--- a/test_errors.nim
+++ b/test_errors.nim
@@ -1,0 +1,14 @@
+# Test file to demonstrate improved error messages
+
+proc example() =
+  # Test 1: Undeclared identifier
+  echo undeclaredVar
+
+  # Test 2: Type mismatch
+  var x: int = "hello"
+
+  # Test 3: Wrong number of arguments
+  let y = max(1, 2, 3, 4)
+
+# Test 4: Using undefined proc
+unknown_proc()


### PR DESCRIPTION
This commit significantly improves the Nim compiler's error messages to be more clear and helpful, similar to Rust's excellent error reporting system.

Key improvements:
- Add error codes (E0001-style for errors, W0001 for warnings, H0001 for hints)
- Implement Rust-style formatting with ` --> file.nim:line:col` location display
- Enhanced source context with line numbers and caret indicators
- Add structured diagnostic types (TDiagnosticLabel, TDiagnosticNote, TDiagnosticHelp)
- New helper functions for emitting notes and help messages:
  - addDiagnosticNote() for additional context
  - addDiagnosticHelp() for fix suggestions
  - emitStructuredDiagnostic() for complete diagnostics

Example output:
  Error:[E0017]: undeclared identifier: 'foo'
   --> file.nim(5, 8)
      |
    5 |   echo foo
      |        ^

Files changed:
- compiler/lineinfos.nim: Add errorCode() function and diagnostic types
- compiler/msgs.nim: Implement Rust-style formatting and helper functions
- demo_enhanced_errors.nim: Example usage of new diagnostic features
- test_errors.nim: Test file for verifying error messages