### PR TITLE
removes `cppDefines` and `extraCmds` fields from `ConfigRef`

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -1109,9 +1109,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     of "goto": conf.exc = excGoto
     else: localError(conf, info, errInvalidExceptionSystem % arg)
   of "cppdefine":
-    expectArg(conf, switch, arg, pass, info)
-    if conf != nil:
-      conf.cppDefine(arg)
+    warningDeprecated(conf, info, "cppdefine is deprecated and ignored")
   of "newruntime":
     warningDeprecated(conf, info, "newruntime is deprecated, use arc/orc instead!")
     expectNoArg(conf, switch, arg, pass, info)

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -51,8 +51,6 @@ proc replayStateChanges*(module: PSym; g: ModuleGraph) =
         extccomp.addCompileOption(g.config, n[1].strVal)
       of "localpassc":
         extccomp.addLocalCompileOption(g.config, n[1].strVal, toFullPathConsiderDirty(g.config, module.info.fileIndex))
-      of "cppdefine":
-        options.cppDefine(g.config, n[1].strVal)
       of "inc":
         let destKey = n[1].strVal
         let by = n[2].intVal

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -368,7 +368,6 @@ type
     symbolFiles*: SymbolFilesOption
     spellSuggestMax*: int # max number of spelling suggestions for typos
 
-    cppDefines*: HashSet[string] # (*)
     headerFile*: string
     nimbasePattern*: string # pattern to find nimbase.h
     features*: set[Feature]
@@ -415,7 +414,6 @@ type
     command*: string # the main command (e.g. cc, check, scan, etc)
     commandArgs*: seq[string] # any arguments after the main command
     commandLine*: string
-    extraCmds*: seq[string] # for writeJsonBuildInstructions
     implicitImports*: seq[string] # modules that are to be implicitly imported
     implicitIncludes*: seq[string] # modules that are to be implicitly included
     docSeeSrcUrl*: string # if empty, no seeSrc will be generated. \
@@ -567,7 +565,6 @@ proc newConfigRef*(): ConfigRef =
     macrosToExpand: newStringTable(modeStyleInsensitive),
     arcToExpand: newStringTable(modeStyleInsensitive),
     m: initMsgConfig(),
-    cppDefines: initHashSet[string](),
     headerFile: "", features: {}, legacyFeatures: {},
     configVars: newStringTable(modeStyleInsensitive),
     symbols: newStringTable(modeStyleInsensitive),
@@ -627,9 +624,6 @@ proc newPartialConfigRef*(): ConfigRef =
   else:
     result = ConfigRef()
     initConfigRefCommon(result)
-
-proc cppDefine*(c: ConfigRef; define: string) =
-  c.cppDefines.incl define
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool =
   if conf.symbols.hasKey(symbol):

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -911,13 +911,9 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         incl(sym.flagsImpl, sfUsed) # avoid wrong hints
       of wImportc:
         let name = getOptionalStr(c, it, "$1")
-        cppDefine(c.config, name)
-        recordPragma(c, it, "cppdefine", name)
         makeExternImport(c, sym, name, it.info)
       of wImportCompilerProc:
         let name = getOptionalStr(c, it, "$1")
-        cppDefine(c.config, name)
-        recordPragma(c, it, "cppdefine", name)
         processImportCompilerProc(c, sym, name, it.info)
       of wExtern: setExternName(c, sym, expectStrLit(c, it), it.info)
       of wDirty:
@@ -1048,8 +1044,6 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         processDynLib(c, it, sym)
       of wCompilerProc, wCore:
         noVal(c, it)           # compilerproc may not get a string!
-        cppDefine(c.graph.config, sym.name.s)
-        recordPragma(c, it, "cppdefine", sym.name.s)
         if sfFromGeneric notin sym.flags: markCompilerProc(c, sym)
       of wNonReloadable:
         sym.incl sfNonReloadable

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -12,7 +12,7 @@
 
 import
   ast, modules, idents, condsyms,
-  options, llstream, vm, vmdef, commands,
+  options, msgs, llstream, vm, vmdef, commands,
   wordrecg, modulegraphs,
   pathutils, pipelines
 
@@ -181,7 +181,7 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   cbconf selfExe:
     setResult(a, os.getAppFilename())
   cbconf cppDefine:
-    options.cppDefine(conf, a.getString(0))
+    echo graph.config.toFileLineCol(a.currentLineInfo), " cppDefine is deprecated and no longer need to call"
   cbexc stdinReadLine, EOFError:
     if defined(nimsuggest) or graph.config.cmd == cmdCheck:
       setResult(a, "")

--- a/config/config.nims
+++ b/config/config.nims
@@ -1,13 +1,5 @@
 # this config.nims also needs to exist to prevent future regressions, see #9990
 
-cppDefine "errno"
-cppDefine "unix"
-
-# mangle the macro names in nimbase.h
-cppDefine "NAN_INFINITY"
-cppDefine "INF"
-cppDefine "NAN"
-
 when defined(nimStrictMode):
   # xxx add more flags here, and use `-d:nimStrictMode` in more contexts in CI.
 

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -365,7 +365,7 @@ proc writeTask(name, desc: string) =
     for i in 0 ..< 20 - name.len: spaces.add ' '
     echo name, spaces, desc
 
-proc cppDefine*(define: string) =
+proc cppDefine*(define: string) {.deprecated: "No longer need to call".} =
   ## tell Nim that `define` is a C preprocessor `#define` and so always
   ## needs to be mangled.
   builtin


### PR DESCRIPTION
These fields are not used.