### PR TITLE
use `nimKochBootstrap` for niminst

### DIFF
--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -544,7 +544,7 @@ proc srcdist(c: var ConfigData) =
       var dir = getOutputDir(c) / buildDir(osA, cpuA)
       if dirExists(dir): removeDir(dir)
       createDir(dir)
-      var cmd = ("$# compile -f --incremental:off --compileonly " &
+      var cmd = ("$# compile -f --incremental:off --d:nimKochBootstrap --compileonly " &
                  "--gen_mapping --cc:gcc --skipUserCfg" &
                  " --os:$# --cpu:$# $# $#") %
                  [findNim(), osname, cpuname, c.nimArgs, c.mainfile]


### PR DESCRIPTION
so that `nimony` won't be required for nightlies. It's annoying to build `nimony` on each platform, e.g. `std/memfiles` which is used by `nimony` is not supported by `nintendoswitch`

```
bin/nim compile -f --incremental:off --compileonly --gen_mapping --cc:gcc --skipUserCfg --os:nintendoswitch --cpu:arm64 -d:danger -d:gitHash:cd69f37f3a4fb46468b77b84ccf6aa3225c8895e compiler/nim.nim
```

```
/home/runner/work/nightlies/nightlies/nim/lib/pure/memfiles.nim(107, 40) Error: undeclared identifier: 'MAP_SHARED'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (4, 5): 'freeShared'
```