### PR TITLE
fixes #25306; Dangling pointers in stack traces with `-d:nimStackTraceOverride`

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -554,7 +554,7 @@ type
     ## Abstract class for all exceptions that are catchable.
 
 when defined(nimStackTraceOverride):
-  proc `=copy`*(x: StackTraceEntry) {.error.}
+  proc `=copy`*(x: var StackTraceEntry, y: StackTraceEntry) {.error.}
 
 when defined(nimIcIntegrityChecks):
   include "system/exceptions"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -553,6 +553,9 @@ type
   CatchableError* = object of Exception ## \
     ## Abstract class for all exceptions that are catchable.
 
+when defined(nimStackTraceOverride):
+  proc `=copy`*(x: StackTraceEntry) {.error.}
+
 when defined(nimIcIntegrityChecks):
   include "system/exceptions"
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -553,9 +553,6 @@ type
   CatchableError* = object of Exception ## \
     ## Abstract class for all exceptions that are catchable.
 
-when defined(nimStackTraceOverride):
-  proc `=copy`*(x: var StackTraceEntry, y: StackTraceEntry) {.error.}
-
 when defined(nimIcIntegrityChecks):
   include "system/exceptions"
 

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -80,6 +80,11 @@ when defined(nimStackTraceOverride):
     result.procname = result.procnameStr.cstring
     result.filename = result.filenameStr.cstring
 
+  proc copyStackTraceEntrySeq(result: var seq[StackTraceEntry]; s: seq[StackTraceEntry]) =
+    for i in 0..<s.len:
+      let entry = addr s[i]
+      result.add(copyStackTraceEntry entry)
+
   # We may have more stack trace lines in the output, due to inlined procedures.
   proc addDebuggingInfo*(s: seq[StackTraceEntry]): seq[StackTraceEntry] =
     var programCounters: seq[cuintptr_t]
@@ -90,10 +95,10 @@ when defined(nimStackTraceOverride):
       if entry.procname.isNil and entry.programCounter != 0:
         programCounters.add(cast[cuintptr_t](entry.programCounter))
       elif entry.procname.isNil and (entry.line == reraisedFromBegin or entry.line == reraisedFromEnd):
-        result.add(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
+        result.copyStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
         programCounters = @[]
         result.add(copyStackTraceEntry entry)
       else:
         result.add(copyStackTraceEntry entry)
     if programCounters.len > 0:
-      result.add(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
+      result.copyStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -74,6 +74,9 @@ when defined(nimStackTraceOverride):
     )
     when NimStackTraceMsgs:
       result.frameMsg = x.frameMsg
+
+    # points `procname`, `filename` to its own corresponding fields
+    # to avoid dangling pointers # bug #25306 18039
     result.procname = result.procnameStr.cstring
     result.filename = result.filenameStr.cstring
 

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -68,22 +68,14 @@ when defined(nimStackTraceOverride):
     for i in 0..<programCounters.len:
       s.add(StackTraceEntry(programCounter: cast[uint](programCounters[i])))
 
-  proc copyStackTraceEntry(x: ptr StackTraceEntry): StackTraceEntry =
-    result = StackTraceEntry(line: x.line, programCounter: x.programCounter,
-                             procnameStr: x.procnameStr, filenameStr: x.filenameStr
-    )
-    when NimStackTraceMsgs:
-      result.frameMsg = x.frameMsg
+  proc patchStackTraceEntry(x: var StackTraceEntry) =
+    x.procname = x.procnameStr.cstring
+    x.filename = x.filenameStr.cstring
 
-    # points `procname`, `filename` to its own corresponding fields
-    # to avoid dangling pointers # bug #25306 18039
-    result.procname = result.procnameStr.cstring
-    result.filename = result.filenameStr.cstring
-
-  proc copyStackTraceEntrySeq(result: var seq[StackTraceEntry]; s: seq[StackTraceEntry]) =
+  proc addStackTraceEntrySeq(result: var seq[StackTraceEntry]; s: seq[StackTraceEntry]) =
     for i in 0..<s.len:
-      let entry = addr s[i]
-      result.add(copyStackTraceEntry entry)
+      result.add(s[i])
+      patchStackTraceEntry(result[result.high])
 
   # We may have more stack trace lines in the output, due to inlined procedures.
   proc addDebuggingInfo*(s: seq[StackTraceEntry]): seq[StackTraceEntry] =
@@ -95,10 +87,12 @@ when defined(nimStackTraceOverride):
       if entry.procname.isNil and entry.programCounter != 0:
         programCounters.add(cast[cuintptr_t](entry.programCounter))
       elif entry.procname.isNil and (entry.line == reraisedFromBegin or entry.line == reraisedFromEnd):
-        result.copyStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
+        result.addStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
         programCounters = @[]
-        result.add(copyStackTraceEntry entry)
+        result.add(entry[])
+        patchStackTraceEntry(result[result.high])
       else:
-        result.add(copyStackTraceEntry entry)
+        result.add(entry[])
+        patchStackTraceEntry(result[result.high])
     if programCounters.len > 0:
-      result.copyStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
+      result.addStackTraceEntrySeq(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -30,7 +30,6 @@ when defined(nimStackTraceOverride):
         nimcall, gcsafe, raises: [], tags: [], noinline.}
 
 
-  const NimStackTraceMsgs = compileOption("stacktraceMsgs")
 
   # Default procedures (not normally used, because people opting in on this
   # override are supposed to register their own versions).

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -29,6 +29,9 @@ when defined(nimStackTraceOverride):
       proc (programCounters: seq[cuintptr_t], maxLength: cint): seq[StackTraceEntry] {.
         nimcall, gcsafe, raises: [], tags: [], noinline.}
 
+
+  const NimStackTraceMsgs = compileOption("stacktraceMsgs")
+
   # Default procedures (not normally used, because people opting in on this
   # override are supposed to register their own versions).
   var
@@ -65,6 +68,15 @@ when defined(nimStackTraceOverride):
     for i in 0..<programCounters.len:
       s.add(StackTraceEntry(programCounter: cast[uint](programCounters[i])))
 
+  proc copyStackTraceEntry(x: ptr StackTraceEntry): StackTraceEntry =
+    result = StackTraceEntry(line: x.line, programCounter: x.programCounter,
+                             procnameStr: x.procnameStr, filenameStr: x.filenameStr
+    )
+    when NimStackTraceMsgs:
+      result.frameMsg = x.frameMsg
+    result.procname = result.procnameStr.cstring
+    result.filename = result.filenameStr.cstring
+
   # We may have more stack trace lines in the output, due to inlined procedures.
   proc addDebuggingInfo*(s: seq[StackTraceEntry]): seq[StackTraceEntry] =
     var programCounters: seq[cuintptr_t]
@@ -77,8 +89,8 @@ when defined(nimStackTraceOverride):
       elif entry.procname.isNil and (entry.line == reraisedFromBegin or entry.line == reraisedFromEnd):
         result.add(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))
         programCounters = @[]
-        result.add(entry[])
+        result.add(copyStackTraceEntry entry)
       else:
-        result.add(entry[])
+        result.add(copyStackTraceEntry entry)
     if programCounters.len > 0:
       result.add(stackTraceOverrideGetDebuggingInfo(programCounters, maxStackTraceLines))


### PR DESCRIPTION
fixes #25306

```nim
type
  StackTraceEntry* = object ## In debug mode exceptions store the stack trace that led
                            ## to them. A `StackTraceEntry` is a single entry of the
                            ## stack trace.
    procname*: cstring      ## Name of the proc that is currently executing.
    line*: int              ## Line number of the proc that is currently executing.
    filename*: cstring      ## Filename of the proc that is currently executing.
    when NimStackTraceMsgs:
      frameMsg*: string     ## When a stacktrace is generated in a given frame and
                            ## rendered at a later time, we should ensure the stacktrace
                            ## data isn't invalidated; any pointer into PFrame is
                            ## subject to being invalidated so shouldn't be stored.
    when defined(nimStackTraceOverride):
      programCounter*: uint ## Program counter - will be used to get the rest of the info,
                            ## when `$` is called on this type. We can't use
                            ## "cuintptr_t" in here.
      procnameStr*, filenameStr*: string ## GC-ed alternatives to "procname" and "filename"
```