### PR TITLE
consider generic param type as typedesc in tuple type expressions

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3064,10 +3064,10 @@ proc semTupleConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
   var isTupleType: bool = false
   if tupexp.len > 0: # don't interpret () as type
     internalAssert c.config, tupexp.kind == nkTupleConstr
-    isTupleType = tupexp[0].typ.kind == tyTypeDesc
+    isTupleType = tupexp[0].typ.kind in {tyTypeDesc, tyGenericParam}
     # check if either everything or nothing is tyTypeDesc
     for i in 1..<tupexp.len:
-      if isTupleType != (tupexp[i].typ.kind == tyTypeDesc):
+      if isTupleType != (tupexp[i].typ.kind in {tyTypeDesc, tyGenericParam}):
         return localErrorNode(c, n, tupexp[i].info, "Mixing types and values in tuples is not allowed.")
   if isTupleType: # expressions as ``(int, string)`` are reinterpret as type expressions
     result = n

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3054,6 +3054,13 @@ proc semExport(c: PContext, n: PNode): PNode =
 
         s = nextOverloadIter(o, c, a)
 
+proc isTypeTupleField(n: PNode): bool {.inline.} =
+  result = n.typ.kind == tyTypeDesc or
+    (n.typ.kind == tyGenericParam and n.typ.sym.kind == skGenericParam)
+    # `skGenericParam` stays as `tyGenericParam` type rather than being wrapped in `tyTypeDesc`
+    # would check if `n` itself is an `skGenericParam` symbol, but these symbols semcheck to an ident
+    # maybe check if `n` is an ident to ensure this is not a value with the generic param type?
+
 proc semTupleConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   result = semTuplePositionsConstr(c, n, flags, expectedType)
   if result.typ.kind == tyFromExpr:
@@ -3064,10 +3071,10 @@ proc semTupleConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
   var isTupleType: bool = false
   if tupexp.len > 0: # don't interpret () as type
     internalAssert c.config, tupexp.kind == nkTupleConstr
-    isTupleType = tupexp[0].typ.kind in {tyTypeDesc, tyGenericParam}
+    isTupleType = isTypeTupleField(tupexp[0])
     # check if either everything or nothing is tyTypeDesc
     for i in 1..<tupexp.len:
-      if isTupleType != (tupexp[i].typ.kind in {tyTypeDesc, tyGenericParam}):
+      if isTupleType != isTypeTupleField(tupexp[i]):
         return localErrorNode(c, n, tupexp[i].info, "Mixing types and values in tuples is not allowed.")
   if isTupleType: # expressions as ``(int, string)`` are reinterpret as type expressions
     result = n

--- a/tests/tuples/tgenericparamtypetuple.nim
+++ b/tests/tuples/tgenericparamtypetuple.nim
@@ -1,0 +1,25 @@
+# issue #25312
+
+import heapqueue
+
+proc test1[T](test: (float, T)) = # Works
+    discard
+
+proc test2[T](test: seq[(float, T)]) = # Works
+    discard
+
+proc test3[T](test: HeapQueue[tuple[sqd: float, data: T]]) = # Works
+    discard
+
+proc test4(test: HeapQueue[(float, float)]) = # Works
+    discard
+
+type ExampleObj = object
+    a: string
+    b: seq[float]
+
+proc test5(test: HeapQueue[(float, ExampleObj)]) = # Works
+    discard
+
+proc failingTest[T](test: HeapQueue[(float, T)]) = # (Compile) Error: Mixing types and values in tuples is not allowed.
+    discard

--- a/tests/tuples/tgenericparamtypetuple.nim
+++ b/tests/tuples/tgenericparamtypetuple.nim
@@ -23,3 +23,12 @@ proc test5(test: HeapQueue[(float, ExampleObj)]) = # Works
 
 proc failingTest[T](test: HeapQueue[(float, T)]) = # (Compile) Error: Mixing types and values in tuples is not allowed.
     discard
+
+proc failingTest2[T](test: HeapQueue[(T, float)]) = # (Compile) Error: Mixing types and values in tuples is not allowed.
+    discard
+
+proc test6[T](test: HeapQueue[(T, T)]) = # works
+    discard
+
+proc test7[T, U](test: HeapQueue[(T, U)]) = # works
+    discard


### PR DESCRIPTION
fixes #25312

Tuple expressions `(a, b, c)` can be either types or values depending on if their elements are typedescs or values, this is checked by checking if the type of the element is `tyTypeDesc`. However when an `skGenericParam` symbol is semchecked by `semSym` it is given its own `tyGenericParam` type rather than a `tyTypeDesc` type, this seems to be necessary for signatures to allow wildcard generic params passed to static constrained generic params (tested in #25315). The reason `semSym` is called is that `semGeneric` for generic invocations calls `matches` which sems its arguments like normal expressions.

To deal with this, an expression of type `tyGenericParam` and with a `skGenericParam` sym is allowed as a type in the tuple expression. A problem is that this might consider a value with a wildcard generic param type as a type. But this is a very niche problem, and I'm not sure how to check for this. `skGenericParam` symbols stay as idents when semchecked so it can't be checked that the node is an `skGenericParam` symbol. It could be checked that it's an ident but I don't know how robust this is. And maybe there is another way to refer to a wildcard generic param type instead of just its symbol, i.e. another kind of node.

This also makes #5647 finally work but a test case for that can be added after.