### PR TITLE
std: sysatomics: fix use of atomicCompareExchangeN for MSVC

### DIFF
--- a/lib/std/sysatomics.nim
+++ b/lib/std/sysatomics.nim
@@ -230,11 +230,11 @@ elif someVcc:
   proc atomicCompareExchangeN*[T: ptr](p, expected: ptr T, desired: T,
     weak: bool, success_memmodel: AtomMemModel, failure_memmodel: AtomMemModel): bool =
     when sizeof(T) == 8:
-      interlockedCompareExchange64(p, cast[int64](desired), cast[int64](expected)) ==
-        cast[int64](expected)
+      interlockedCompareExchange64(p, cast[int64](desired), cast[int64](expected[])) ==
+        cast[int64](expected[])
     elif sizeof(T) == 4:
-      interlockedCompareExchange32(p, cast[int32](desired), cast[int32](expected)) ==
-        cast[int32](expected)
+      interlockedCompareExchange32(p, cast[int32](desired), cast[int32](expected[])) ==
+        cast[int32](expected[])
 
   proc atomicExchangeN*[T: ptr](p: ptr T, val: T, mem: AtomMemModel): T =
     when sizeof(T) == 8:


### PR DESCRIPTION
`InterlockedCompareExchange64 `(winnt.h) is used instead of gcc atomics when compiling with MSVC on Windows, but the function signatures are `InterlockedCompareExchange64(ptr int64, int64, int64)` and `InterlockedCompareExchange32(ptr int32, int32, int32)` as opposed to `(ptr T, ptr T, T)` for `__atomic_compare_exchange_n`.

Passing a pointer to the expected value (parameter two) instead of the value itself causes the comparison to unconditionally fail, with stalls in threaded code using atomic comparisons.

Fix the function signature for MSVC.