### PR TITLE
fixes #22305; Combination of generic destructor and closure fails in certain cases

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -380,6 +380,10 @@ proc requiresDestructor(c: TLiftCtx; t: PType): bool {.inline.} =
 proc instantiateGeneric(c: var TLiftCtx; op: PSym; t, typeInst: PType): PSym =
   if c.c != nil and typeInst != nil:
     result = c.c.instTypeBoundOp(c.c, op, typeInst, c.info, attachedAsgn, 1)
+  elif typeInst != nil and getAttachedOp(c.g, typeInst, c.kind) != nil:
+    # c.c == nil in lambdalifting
+    # hooks are already insted
+    result = getAttachedOp(c.g, typeInst, c.kind)
   else:
     localError(c.g.config, c.info,
       "cannot generate destructor for generic type: " & typeToString(t))

--- a/tests/generics/t22305.nim
+++ b/tests/generics/t22305.nim
@@ -1,0 +1,57 @@
+discard """
+  joinable: false
+"""
+
+import asyncdispatch, options
+
+proc recv*[T](tc: ptr Channel[T]): Future[T] {.async.} =
+  discard
+
+type SharedBuf = object
+
+type WorkProc[A, B] = proc(a: A): Option[B] {.nimcall.}
+
+proc worker[TArg](p: TArg) {.thread, nimcall.} =
+  discard
+
+proc readFilesThread() =
+  type TArg[A, B] =
+    tuple[r: ptr Channel[Option[A]], w: ptr Channel[Option[B]], p: WorkProc[A, B]]
+
+  var readThread: Thread[TArg[int, SharedBuf]]
+
+proc readFilesAd() {.async.} =
+  var readChan: Channel[Option[int]]
+
+  type TArg[A, B] =
+    tuple[r: ptr Channel[Option[A]], w: ptr Channel[Option[B]], p: WorkProc[A, B]]
+
+  var readThread: Thread[TArg[int, SharedBuf]]
+  let test = await (addr readChan).recv()
+
+  joinThread(readThread)
+
+waitFor readFilesAd()
+
+type
+  SharedPtr[T] = object
+    p: ptr T
+
+proc `=destroy`[T](self: var SharedPtr[T]) =
+  discard
+
+type
+  SomethingObj[T] = object
+  Something[T] = SharedPtr[SomethingObj[T]]
+
+proc useSomething() =
+  # discard Something[int]() # When you uncomment this line, it will compile successfully.
+  discard Something[float]()
+
+proc fn() =
+  let thing = Something[int]()
+  proc closure() =
+    discard thing
+  closure()
+
+fn()


### PR DESCRIPTION
fixes #22305

It seems that the generic type is cached somehow so that no hooks are instantiated for the generic type. There are only hooks for the instantiated type. When `lambdalifting` tries to create type bounds for the generic type, it cannot either find the instantiated hooks or instantiate the generic hooks since it lacks `SemContext`. It can use hooks for the instantiated type in this case