### PR TITLE
fixes #25324; Channel incorrectly takes a sink argument in refc

### DIFF
--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -367,23 +367,35 @@ proc sendImpl(q: PRawChannel, typ: PNimType, msg: pointer, noBlock: bool): bool 
   releaseSys(q.lock)
   result = true
 
-proc send*[TMsg](c: var Channel[TMsg], msg: sink TMsg) {.inline.} =
-  ## Sends a message to a thread. `msg` is deeply copied.
-  discard sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), false)
-  when defined(gcDestructors):
+when defined(gcDestructors):
+  proc send*[TMsg](c: var Channel[TMsg], msg: sink TMsg) {.inline.} =
+    ## Sends a message to a thread. `msg` is deeply copied.
+    discard sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), false)
     wasMoved(msg)
 
-proc trySend*[TMsg](c: var Channel[TMsg], msg: sink TMsg): bool {.inline.} =
-  ## Tries to send a message to a thread.
-  ##
-  ## `msg` is deeply copied. Doesn't block.
-  ##
-  ## Returns `false` if the message was not sent because number of pending items
-  ## in the channel exceeded `maxItems`.
-  result = sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), true)
-  when defined(gcDestructors):
+  proc trySend*[TMsg](c: var Channel[TMsg], msg: sink TMsg): bool {.inline.} =
+    ## Tries to send a message to a thread.
+    ##
+    ## `msg` is deeply copied. Doesn't block.
+    ##
+    ## Returns `false` if the message was not sent because number of pending items
+    ## in the channel exceeded `maxItems`.
+    result = sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), true)
     if result:
       wasMoved(msg)
+else:
+  proc send*[TMsg](c: var Channel[TMsg], msg: TMsg) {.inline.} =
+    ## Sends a message to a thread. `msg` is deeply copied.
+    discard sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), false)
+
+  proc trySend*[TMsg](c: var Channel[TMsg], msg: TMsg): bool {.inline.} =
+    ## Tries to send a message to a thread.
+    ##
+    ## `msg` is deeply copied. Doesn't block.
+    ##
+    ## Returns `false` if the message was not sent because number of pending items
+    ## in the channel exceeded `maxItems`.
+    result = sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), true)
 
 proc llRecv(q: PRawChannel, res: pointer, typ: PNimType) =
   q.ready = true

--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -369,14 +369,14 @@ proc sendImpl(q: PRawChannel, typ: PNimType, msg: pointer, noBlock: bool): bool 
 
 when defined(gcDestructors):
   proc send*[TMsg](c: var Channel[TMsg], msg: sink TMsg) {.inline.} =
-    ## Sends a message to a thread. `msg` is deeply copied.
+    ## Sends a message to a thread.
     discard sendImpl(cast[PRawChannel](addr c), cast[PNimType](getTypeInfo(msg)), unsafeAddr(msg), false)
     wasMoved(msg)
 
   proc trySend*[TMsg](c: var Channel[TMsg], msg: sink TMsg): bool {.inline.} =
     ## Tries to send a message to a thread.
     ##
-    ## `msg` is deeply copied. Doesn't block.
+    ## Doesn't block.
     ##
     ## Returns `false` if the message was not sent because number of pending items
     ## in the channel exceeded `maxItems`.


### PR DESCRIPTION
… it performs a deep copy internally

fixes #25324

notes that
> Enabling `-d:nimPreviewSlimSystem` removes the import of `channels_builtin` in
  in the `system` module, which is replaced by [threading/channels](https://github.com/nim-lang/threading/blob/master/threading/channels.nim).