### PR TITLE
flush `stdout` when prompting for password

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -909,6 +909,7 @@ when defined(windows):
     ## `true` otherwise.
     password.setLen(0)
     stdout.write(prompt)
+    stdout.flushFile()
     let hi = createFileA("CONIN$",
       GENERIC_READ or GENERIC_WRITE, 0, nil, OPEN_EXISTING, 0, 0)
     var mode = DWORD 0
@@ -936,6 +937,7 @@ else:
     cur.c_lflag = cur.c_lflag and not Cflag(ECHO)
     discard fd.tcSetAttr(TCSADRAIN, cur.addr)
     stdout.write prompt
+    stdout.flushFile()
     result = stdin.readLine(password)
     stdout.write "\n"
     discard fd.tcSetAttr(TCSADRAIN, old.addr)


### PR DESCRIPTION
Saw this misbehave on Linux. It was fine in Windows when I checked, but I figured it can't hurt.