### PR TITLE
clean up imports in system

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -18,7 +18,7 @@ when not compileOption("threads") and not defined(nimdoc):
   when false: # fix #12330
     {.error: "Locks requires --threads:on option.".}
 
-import std/private/syslocks
+include std/private/syslocks
 
 type
   Lock* = SysLock ## Nim lock; whether this is re-entrant

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -16,7 +16,7 @@ when not compileOption("threads") and not defined(nimdoc):
     # so they can replace each other seamlessly.
     {.error: "Rlocks requires --threads:on option.".}
 
-import std/private/syslocks
+include std/private/syslocks
 
 type
   RLock* = SysLock ## Nim lock, re-entrant

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -27,7 +27,7 @@
 
 import std/macros
 import std/private/since
-from std/private/bitops_utils import forwardImpl, castToUnsigned
+include std/private/bitops_utils
 
 func bitnot*[T: SomeInteger](x: T): T {.magic: "BitnotI".}
   ## Computes the `bitwise complement` of the integer `x`.

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -491,7 +491,7 @@ func countSetBits*(x: SomeInteger): int {.inline.} =
     doAssert countSetBits(0b0000_0011'u8) == 2
     doAssert countSetBits(0b1010_1010'u8) == 4
 
-  result = countSetBitsImpl(x)
+  result = countSetBitsSysimpl(x)
 
 func popcount*(x: SomeInteger): int {.inline.} =
   ## Alias for `countSetBits <#countSetBits,SomeInteger>`_ (Hamming weight).

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -21,7 +21,7 @@
 ##
 ## Unstable API.
 
-import system/coro_detection
+include system/coro_detection
 
 when not nimCoroutines and not defined(nimdoc):
   when defined(noNimCoroutines):

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -58,7 +58,6 @@ import std/private/since
                        # of the standard library!
 
 import std/[bitops, fenv]
-import system/countbits_impl
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -1302,7 +1301,7 @@ func gcd*[T](x, y: T): T =
     swap x, y
   abs x
 
-when useBuiltins:
+when not defined(noIntrinsicsBitOpts):
   ## this func uses bitwise comparisons from C compilers, which are not always available.
   func gcd*(x, y: SomeInteger): SomeInteger =
     ## Computes the greatest common (positive) divisor of `x` and `y`,

--- a/lib/std/formatfloat.nim
+++ b/lib/std/formatfloat.nim
@@ -21,7 +21,9 @@ proc addCstringN(result: var string, buf: cstring; buflen: int) =
   result.setLen newLen
   c_memcpy(result[oldLen].addr, buf, buflen.csize_t)
 
-import std/private/digitsutils
+
+when not declared(ThisIsSystem):
+  include std/private/digitsutils
 
 include private/dragonbox
 include private/schubfach

--- a/lib/std/formatfloat.nim
+++ b/lib/std/formatfloat.nim
@@ -21,7 +21,10 @@ proc addCstringN(result: var string, buf: cstring; buflen: int) =
   result.setLen newLen
   c_memcpy(result[oldLen].addr, buf, buflen.csize_t)
 
-import std/private/[dragonbox, schubfach]
+import std/private/digitsutils
+
+include private/dragonbox
+include private/schubfach
 
 proc writeFloatToBufferRoundtrip*(buf: var array[65, char]; value: BiggestFloat): int =
   ## This is the implementation to format floats.

--- a/lib/std/private/bitops_utils.nim
+++ b/lib/std/private/bitops_utils.nim
@@ -1,4 +1,4 @@
-template forwardImpl*(impl, arg) {.dirty.} =
+template forwardImpl(impl, arg) {.dirty.} =
   when sizeof(x) <= 4:
     when x is SomeSignedInt:
       impl(cast[uint32](x.int32))
@@ -14,9 +14,9 @@ template forwardImpl*(impl, arg) {.dirty.} =
 # import std/typetraits
 # template castToUnsigned*(x: SomeInteger): auto = cast[toUnsigned(typeof(x))](x)
 
-template castToUnsigned*(x: int8): uint8 = cast[uint8](x)
-template castToUnsigned*(x: int16): uint16 = cast[uint16](x)
-template castToUnsigned*(x: int32): uint32 = cast[uint32](x)
-template castToUnsigned*(x: int64): uint64 = cast[uint64](x)
-template castToUnsigned*(x: int): uint = cast[uint](x)
-template castToUnsigned*[T: SomeUnsignedInt](x: T): T = x
+template castToUnsigned(x: int8): uint8 = cast[uint8](x)
+template castToUnsigned(x: int16): uint16 = cast[uint16](x)
+template castToUnsigned(x: int32): uint32 = cast[uint32](x)
+template castToUnsigned(x: int64): uint64 = cast[uint64](x)
+template castToUnsigned(x: int): uint = cast[uint](x)
+template castToUnsigned[T: SomeUnsignedInt](x: T): T = x

--- a/lib/std/private/bitops_utils.nim
+++ b/lib/std/private/bitops_utils.nim
@@ -4,6 +4,7 @@ const useGCC_builtins = (defined(gcc) or defined(llvm_gcc) or
                          defined(clang)) and useBuiltins
 const useICC_builtins = defined(icc) and useBuiltins
 const useVCC_builtins = defined(vcc) and useBuiltins
+const arch64 = sizeof(int) == 8
 
 template forwardImpl(impl, arg) {.dirty.} =
   when sizeof(x) <= 4:

--- a/lib/std/private/bitops_utils.nim
+++ b/lib/std/private/bitops_utils.nim
@@ -1,3 +1,10 @@
+const useBuiltins = not defined(noIntrinsicsBitOpts)
+const noUndefined = defined(noUndefinedBitOpts)
+const useGCC_builtins = (defined(gcc) or defined(llvm_gcc) or
+                         defined(clang)) and useBuiltins
+const useICC_builtins = defined(icc) and useBuiltins
+const useVCC_builtins = defined(vcc) and useBuiltins
+
 template forwardImpl(impl, arg) {.dirty.} =
   when sizeof(x) <= 4:
     when x is SomeSignedInt:

--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -34,12 +34,12 @@ const
 when not defined(nimHasEnforceNoRaises):
   {.pragma: enforceNoRaises.}
 
-proc utoa2Digits*(buf: var openArray[char]; pos: int; digits: uint32) {.inline, enforceNoRaises.} =
+proc utoa2Digits(buf: var openArray[char]; pos: int; digits: uint32) {.inline, enforceNoRaises.} =
   buf[pos] = digits100[2 * digits]
   buf[pos+1] = digits100[2 * digits + 1]
   #copyMem(buf, unsafeAddr(digits100[2 * digits]), 2 * sizeof((char)))
 
-proc trailingZeros2Digits*(digits: uint32): int {.inline, enforceNoRaises.} =
+proc trailingZeros2Digits(digits: uint32): int {.inline, enforceNoRaises.} =
   trailingZeros100[digits]
 
 when defined(js):
@@ -85,14 +85,14 @@ func addIntImpl(result: var string, x: uint64) {.inline, enforceNoRaises.} =
   addChars(result, tmp, next, tmp.len - next)
 
 
-func addInt*(result: var string, x: uint64) {.enforceNoRaises.} =
+func addInt(result: var string, x: uint64) {.enforceNoRaises.} =
   when nimvm: addIntImpl(result, x)
   else:
     when not defined(js): addIntImpl(result, x)
     else:
       addChars(result, numToString(x))
 
-proc addInt*(result: var string; x: int64) {.enforceNoRaises.} =
+proc addInt(result: var string; x: int64) {.enforceNoRaises.} =
   ## Converts integer to its string representation and appends it to `result`.
   runnableExamples:
     var s = "foo"
@@ -115,7 +115,10 @@ proc addInt*(result: var string; x: int64) {.enforceNoRaises.} =
       addChars(result, numToString(x))
     else: impl()
 
-proc addInt*(result: var string; x: int) {.inline, enforceNoRaises.} =
+proc addInt(result: var string; x: int) {.inline, enforceNoRaises.} =
   addInt(result, int64(x))
+
+proc addIntSysimpl*(result: var string; x: int) {.inline, enforceNoRaises.} =
+  addInt(result, x)
 
 {.pop.}

--- a/lib/std/private/dragonbox.nim
+++ b/lib/std/private/dragonbox.nim
@@ -22,13 +22,8 @@
 ##  This function may temporarily write up to DtoaMinBufferLength characters into the buffer.
 
 
-import std/private/digitsutils
-
-when defined(nimPreviewSlimSystem):
-  import std/assertions
-
 const
-  dtoaMinBufferLength*: cint = 64
+  dtoaMinBufferLengthDr: cint = 64
 
 ##  This file contains an implementation of Junekey Jeon's Dragonbox algorithm.
 ##
@@ -38,7 +33,7 @@ const
 ##  The reference implementation also works with single-precision floating-point numbers and
 ##  has options to configure the rounding mode.
 
-template dragonbox_Assert*(x: untyped): untyped =
+template dragonbox_Assert(x: untyped): untyped =
   assert(x)
 
 # ==================================================================================================
@@ -46,63 +41,63 @@ template dragonbox_Assert*(x: untyped): untyped =
 # ==================================================================================================
 
 type
-  ValueType* = float
-  BitsType* = uint64
+  ValueTypeDr = float
+  BitsTypeDr = uint64
 
 type
-  Double* = object
-    bits*: BitsType
+  DoubleDr = object
+    bits: BitsTypeDr
 
 const                         ##  = p   (includes the hidden bit)
-  significandSize*: int32 = 53
+  significandSizeDr: int32 = 53
 
 const ##   static constexpr int32_t   MaxExponent     = 1024 - 1 - (SignificandSize - 1);
      ##   static constexpr int32_t   MinExponent     = std::numeric_limits<value_type>::min_exponent - 1 - (SignificandSize - 1);
-  exponentBias*: int32 = 1024 - 1 + (significandSize - 1)
+  exponentBiasDr: int32 = 1024 - 1 + (significandSizeDr - 1)
 
 const
-  maxIeeeExponent*: BitsType = BitsType(2 * 1024 - 1)
+  maxIeeeExponentDr: BitsTypeDr = BitsTypeDr(2 * 1024 - 1)
 
 const                         ##  = 2^(p-1)
-  hiddenBit*: BitsType = BitsType(1) shl (significandSize - 1)
+  hiddenBitDr: BitsTypeDr = BitsTypeDr(1) shl (significandSizeDr - 1)
 
 const                         ##  = 2^(p-1) - 1
-  significandMask*: BitsType = hiddenBit - 1
+  significandMaskDr: BitsTypeDr = hiddenBitDr - 1
 
 const
-  exponentMask*: BitsType = maxIeeeExponent shl (significandSize - 1)
+  exponentMaskDr: BitsTypeDr = maxIeeeExponentDr shl (significandSizeDr - 1)
 
 const
-  signMask*: BitsType = not (not BitsType(0) shr 1)
+  signMaskDr: BitsTypeDr = not (not BitsTypeDr(0) shr 1)
 
-proc constructDouble*(bits: BitsType): Double =
-  result = Double(bits: bits)
+proc constructDoubleDr(bits: BitsTypeDr): DoubleDr =
+  result = DoubleDr(bits: bits)
 
-proc constructDouble*(value: ValueType): Double =
-  result = Double(bits: cast[typeof(result.bits)](value))
+proc constructDoubleDr(value: ValueTypeDr): DoubleDr =
+  result = DoubleDr(bits: cast[typeof(result.bits)](value))
 
-proc physicalSignificand*(this: Double): BitsType {.noSideEffect.} =
-  return this.bits and significandMask
+proc physicalSignificandDr(this: DoubleDr): BitsTypeDr {.noSideEffect.} =
+  return this.bits and significandMaskDr
 
-proc physicalExponent*(this: Double): BitsType {.noSideEffect.} =
-  return (this.bits and exponentMask) shr (significandSize - 1)
+proc physicalExponentDr(this: DoubleDr): BitsTypeDr {.noSideEffect.} =
+  return (this.bits and exponentMaskDr) shr (significandSizeDr - 1)
 
-proc isFinite*(this: Double): bool {.noSideEffect.} =
-  return (this.bits and exponentMask) != exponentMask
+proc isFiniteDr(this: DoubleDr): bool {.noSideEffect.} =
+  return (this.bits and exponentMaskDr) != exponentMaskDr
 
-proc isInf*(this: Double): bool {.noSideEffect.} =
-  return (this.bits and exponentMask) == exponentMask and
-      (this.bits and significandMask) == 0
+proc isInfDr(this: DoubleDr): bool {.noSideEffect.} =
+  return (this.bits and exponentMaskDr) == exponentMaskDr and
+      (this.bits and significandMaskDr) == 0
 
-proc isNaN*(this: Double): bool {.noSideEffect.} =
-  return (this.bits and exponentMask) == exponentMask and
-      (this.bits and significandMask) != 0
+proc isNaNDr(this: DoubleDr): bool {.noSideEffect.} =
+  return (this.bits and exponentMaskDr) == exponentMaskDr and
+      (this.bits and significandMaskDr) != 0
 
-proc isZero*(this: Double): bool {.noSideEffect.} =
-  return (this.bits and not signMask) == 0
+proc isZeroDr(this: DoubleDr): bool {.noSideEffect.} =
+  return (this.bits and not signMaskDr) == 0
 
-proc signBit*(this: Double): int {.noSideEffect.} =
-  return ord((this.bits and signMask) != 0)
+proc signBitDr(this: DoubleDr): int {.noSideEffect.} =
+  return ord((this.bits and signMaskDr) != 0)
 
 
 # ==================================================================================================
@@ -114,35 +109,35 @@ proc signBit*(this: Double): int {.noSideEffect.} =
 ##  Technically, right-shift of negative integers is implementation defined...
 ##  Should easily be optimized into SAR (or equivalent) instruction.
 
-proc floorDivPow2*(x: int32; n: int32): int32 {.inline.} =
+proc floorDivPow2Dr(x: int32; n: int32): int32 {.inline.} =
   return x shr n
 
-proc floorLog2Pow10*(e: int32): int32 {.inline.} =
+proc floorLog2Pow10Dr(e: int32): int32 {.inline.} =
   dragonbox_Assert(e >= -1233)
   dragonbox_Assert(e <= 1233)
-  return floorDivPow2(e * 1741647, 19)
+  return floorDivPow2Dr(e * 1741647, 19)
 
-proc floorLog10Pow2*(e: int32): int32 {.inline.} =
+proc floorLog10Pow2Dr(e: int32): int32 {.inline.} =
   dragonbox_Assert(e >= -1500)
   dragonbox_Assert(e <= 1500)
-  return floorDivPow2(e * 1262611, 22)
+  return floorDivPow2Dr(e * 1262611, 22)
 
-proc floorLog10ThreeQuartersPow2*(e: int32): int32 {.inline.} =
+proc floorLog10ThreeQuartersPow2Dr(e: int32): int32 {.inline.} =
   dragonbox_Assert(e >= -1500)
   dragonbox_Assert(e <= 1500)
-  return floorDivPow2(e * 1262611 - 524031, 22)
+  return floorDivPow2Dr(e * 1262611 - 524031, 22)
 
 # ==================================================================================================
 #
 # ==================================================================================================
 
 type
-  uint64x2* {.bycopy.} = object
-    hi*: uint64
-    lo*: uint64
+  uint64x2 {.bycopy.} = object
+    hi: uint64
+    lo: uint64
 
 
-proc computePow10*(k: int32): uint64x2 {.inline.} =
+proc computePow10Dr(k: int32): uint64x2 {.inline.} =
   const
     kMin: int32 = -292
   const
@@ -774,13 +769,13 @@ proc computePow10*(k: int32): uint64x2 {.inline.} =
 
 ##  Returns whether value is divisible by 2^e2
 
-proc multipleOfPow2*(value: uint64; e2: int32): bool {.inline.} =
+proc multipleOfPow2Dr(value: uint64; e2: int32): bool {.inline.} =
   dragonbox_Assert(e2 >= 0)
   return e2 < 64 and (value and ((uint64(1) shl e2) - 1)) == 0
 
 ##  Returns whether value is divisible by 5^e5
 
-proc multipleOfPow5*(value: uint64; e5: int32): bool {.inline.} =
+proc multipleOfPow5Dr(value: uint64; e5: int32): bool {.inline.} =
   type
     MulCmp {.bycopy.} = object
       mul: uint64
@@ -818,22 +813,22 @@ proc multipleOfPow5*(value: uint64; e5: int32): bool {.inline.} =
   return value * m5.mul <= m5.cmp
 
 type
-  FloatingDecimal64* {.bycopy.} = object
-    significand*: uint64
-    exponent*: int32
+  FloatingDecimal64 {.bycopy.} = object
+    significand: uint64
+    exponent: int32
 
 
-proc toDecimal64AsymmetricInterval*(e2: int32): FloatingDecimal64 {.inline.} =
+proc toDecimal64AsymmetricIntervalDr(e2: int32): FloatingDecimal64 {.inline.} =
   ##  NB:
   ##  accept_lower_endpoint = true
   ##  accept_upper_endpoint = true
   const
-    P: int32 = significandSize
+    P: int32 = significandSizeDr
   ##  Compute k and beta
-  let minusK: int32 = floorLog10ThreeQuartersPow2(e2)
-  let betaMinus1: int32 = e2 + floorLog2Pow10(-minusK)
+  let minusK: int32 = floorLog10ThreeQuartersPow2Dr(e2)
+  let betaMinus1: int32 = e2 + floorLog2Pow10Dr(-minusK)
   ##  Compute xi and zi
-  let pow10: uint64x2 = computePow10(-minusK)
+  let pow10: uint64x2 = computePow10Dr(-minusK)
   let lowerEndpoint: uint64 = (pow10.hi - (pow10.hi shr (P + 1))) shr
       (64 - P - betaMinus1)
   let upperEndpoint: uint64 = (pow10.hi + (pow10.hi shr (P + 0))) shr
@@ -856,13 +851,13 @@ proc toDecimal64AsymmetricInterval*(e2: int32): FloatingDecimal64 {.inline.} =
     inc(q, ord(q < xi))
   return FloatingDecimal64(significand: q, exponent: minusK)
 
-proc computeDelta*(pow10: uint64x2; betaMinus1: int32): uint32 {.inline.} =
+proc computeDeltaDr(pow10: uint64x2; betaMinus1: int32): uint32 {.inline.} =
   dragonbox_Assert(betaMinus1 >= 0)
   dragonbox_Assert(betaMinus1 <= 63)
   return cast[uint32](pow10.hi shr (64 - 1 - betaMinus1))
 
 when defined(sizeof_Int128):
-  proc mul128*(x: uint64; y: uint64): uint64x2 {.inline.} =
+  proc mul128Dr(x: uint64; y: uint64): uint64x2 {.inline.} =
     ##  1 mulx
     type
       uint128T = uint128
@@ -872,69 +867,69 @@ when defined(sizeof_Int128):
     return (hi, lo)
 
 elif defined(vcc) and defined(cpu64):
-  proc umul128(x, y: uint64, z: ptr uint64): uint64 {.importc: "_umul128", header: "<intrin.h>".}
-  proc mul128*(x: uint64; y: uint64): uint64x2 {.inline.} =
+  proc umul128Dr(x, y: uint64, z: ptr uint64): uint64 {.importc: "_umul128", header: "<intrin.h>".}
+  proc mul128Dr(x: uint64; y: uint64): uint64x2 {.inline.} =
     var hi: uint64 = 0
-    var lo: uint64 = umul128(x, y, addr(hi))
+    var lo: uint64 = umul128Dr(x, y, addr(hi))
     return uint64x2(hi: hi, lo: lo)
 
 else:
-  proc lo32*(x: uint64): uint32 {.inline.} =
+  proc lo32Dr(x: uint64): uint32 {.inline.} =
     return cast[uint32](x)
 
-  proc hi32*(x: uint64): uint32 {.inline.} =
+  proc hi32Dr(x: uint64): uint32 {.inline.} =
     return cast[uint32](x shr 32)
 
-  proc mul128*(a: uint64; b: uint64): uint64x2 {.inline.} =
-    let b00: uint64 = uint64(lo32(a)) * lo32(b)
-    let b01: uint64 = uint64(lo32(a)) * hi32(b)
-    let b10: uint64 = uint64(hi32(a)) * lo32(b)
-    let b11: uint64 = uint64(hi32(a)) * hi32(b)
-    let mid1: uint64 = b10 + hi32(b00)
-    let mid2: uint64 = b01 + lo32(mid1)
-    let hi: uint64 = b11 + hi32(mid1) + hi32(mid2)
-    let lo: uint64 = lo32(b00) or uint64(lo32(mid2)) shl 32
+  proc mul128Dr(a: uint64; b: uint64): uint64x2 {.inline.} =
+    let b00: uint64 = uint64(lo32Dr(a)) * lo32Dr(b)
+    let b01: uint64 = uint64(lo32Dr(a)) * hi32Dr(b)
+    let b10: uint64 = uint64(hi32Dr(a)) * lo32Dr(b)
+    let b11: uint64 = uint64(hi32Dr(a)) * hi32Dr(b)
+    let mid1: uint64 = b10 + hi32Dr(b00)
+    let mid2: uint64 = b01 + lo32Dr(mid1)
+    let hi: uint64 = b11 + hi32Dr(mid1) + hi32Dr(mid2)
+    let lo: uint64 = lo32Dr(b00) or uint64(lo32Dr(mid2)) shl 32
     return uint64x2(hi: hi, lo: lo)
 
 ##  Returns (x * y) / 2^128
 
-proc mulShift*(x: uint64; y: uint64x2): uint64 {.inline.} =
+proc mulShiftDr(x: uint64; y: uint64x2): uint64 {.inline.} =
   ##  2 mulx
-  var p1: uint64x2 = mul128(x, y.hi)
-  var p0: uint64x2 = mul128(x, y.lo)
+  var p1: uint64x2 = mul128Dr(x, y.hi)
+  var p0: uint64x2 = mul128Dr(x, y.lo)
   p1.lo += p0.hi
   inc(p1.hi, ord(p1.lo < p0.hi))
   return p1.hi
 
-proc mulParity*(twoF: uint64; pow10: uint64x2; betaMinus1: int32): bool {.inline.} =
+proc mulParityDr(twoF: uint64; pow10: uint64x2; betaMinus1: int32): bool {.inline.} =
   ##  1 mulx, 1 mul
   dragonbox_Assert(betaMinus1 >= 1)
   dragonbox_Assert(betaMinus1 <= 63)
   let p01: uint64 = twoF * pow10.hi
-  let p10: uint64 = mul128(twoF, pow10.lo).hi
+  let p10: uint64 = mul128Dr(twoF, pow10.lo).hi
   let mid: uint64 = p01 + p10
   return (mid and (uint64(1) shl (64 - betaMinus1))) != 0
 
-proc isIntegralEndpoint*(twoF: uint64; e2: int32; minusK: int32): bool {.inline.} =
+proc isIntegralEndpointDr(twoF: uint64; e2: int32; minusK: int32): bool {.inline.} =
   if e2 < -2:
     return false
   if e2 <= 9:
     return true
   if e2 <= 86:
-    return multipleOfPow5(twoF, minusK)
+    return multipleOfPow5Dr(twoF, minusK)
   return false
 
-proc isIntegralMidpoint*(twoF: uint64; e2: int32; minusK: int32): bool {.inline.} =
+proc isIntegralMidpointDr(twoF: uint64; e2: int32; minusK: int32): bool {.inline.} =
   if e2 < -4:
-    return multipleOfPow2(twoF, minusK - e2 + 1)
+    return multipleOfPow2Dr(twoF, minusK - e2 + 1)
   if e2 <= 9:
     return true
   if e2 <= 86:
-    return multipleOfPow5(twoF, minusK)
+    return multipleOfPow5Dr(twoF, minusK)
   return false
 
-proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecimal64 {.
-    inline.} =
+proc toDecimal64Dr(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecimal64 {.
+  inline.} =
   const
     kappa: int32 = 2
   const
@@ -950,31 +945,31 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
   var m2: uint64
   var e2: int32
   if ieeeExponent != 0:
-    m2 = hiddenBit or ieeeSignificand
-    e2 = cast[int32](ieeeExponent) - exponentBias
-    if 0 <= -e2 and -e2 < significandSize and multipleOfPow2(m2, -e2):
+    m2 = hiddenBitDr or ieeeSignificand
+    e2 = cast[int32](ieeeExponent) - exponentBiasDr
+    if 0 <= -e2 and -e2 < significandSizeDr and multipleOfPow2Dr(m2, -e2):
       ##  Small integer.
       return FloatingDecimal64(significand: m2 shr -e2, exponent: 0)
     if ieeeSignificand == 0 and ieeeExponent > 1:
       ##  Shorter interval case; proceed like Schubfach.
-      return toDecimal64AsymmetricInterval(e2)
+      return toDecimal64AsymmetricIntervalDr(e2)
   else:
     ##  Subnormal case; interval is always regular.
     m2 = ieeeSignificand
-    e2 = 1 - exponentBias
+    e2 = 1 - exponentBiasDr
   let isEven: bool = (m2 mod 2 == 0)
   let acceptLower: bool = isEven
   let acceptUpper: bool = isEven
   ##  Compute k and beta.
-  let minusK: int32 = floorLog10Pow2(e2) - kappa
-  let betaMinus1: int32 = e2 + floorLog2Pow10(-minusK)
+  let minusK: int32 = floorLog10Pow2Dr(e2) - kappa
+  let betaMinus1: int32 = e2 + floorLog2Pow10Dr(-minusK)
   dragonbox_Assert(betaMinus1 >= 6)
   dragonbox_Assert(betaMinus1 <= 9)
-  let pow10: uint64x2 = computePow10(-minusK)
+  let pow10: uint64x2 = computePow10Dr(-minusK)
   ##  Compute delta
   ##  10^kappa <= delta < 10^(kappa + 1)
   ##       100 <= delta < 1000
-  let delta: uint32 = computeDelta(pow10, betaMinus1)
+  let delta: uint32 = computeDeltaDr(pow10, betaMinus1)
   dragonbox_Assert(delta >= smallDivisor)
   dragonbox_Assert(delta < bigDivisor)
   let twoFl: uint64 = 2 * m2 - 1
@@ -983,7 +978,7 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
   ##  (54 bits)
   ##  Compute zi
   ##   (54 + 9 = 63 bits)
-  let zi: uint64 = mulShift(twoFr shl betaMinus1, pow10)
+  let zi: uint64 = mulShiftDr(twoFr shl betaMinus1, pow10)
   ##  2 mulx
   ##
   ##  Step 2:
@@ -997,7 +992,7 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
   if r < delta:                  ## likely ~50% ?!
             ##  (r > deltai)
     ##  Exclude the right endpoint if necessary
-    if r != 0 or acceptUpper or not isIntegralEndpoint(twoFr, e2, minusK):
+    if r != 0 or acceptUpper or not isIntegralEndpointDr(twoFr, e2, minusK):
       return FloatingDecimal64(significand: q, exponent: minusK + kappa + 1)
     dragonbox_Assert(q != 0)
     dec(q)
@@ -1006,8 +1001,8 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
     ##  Compare fractional parts.
     ##  Check conditions in the order different from the paper
     ##  to take advantage of short-circuiting
-    if (acceptLower and isIntegralEndpoint(twoFl, e2, minusK)) or
-        mulParity(twoFl, pow10, betaMinus1):
+    if (acceptLower and isIntegralEndpointDr(twoFl, e2, minusK)) or
+      mulParityDr(twoFl, pow10, betaMinus1):
       return FloatingDecimal64(significand: q, exponent: minusK + kappa + 1)
   else:
     discard
@@ -1033,9 +1028,9 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
     ##  Since there are only 2 possibilities, we only need to care about the
     ##  parity. Also, zi and r should have the same parity since the divisor
     ##  is an even number
-    if mulParity(twoFc, pow10, betaMinus1) != approxYParity:
+    if mulParityDr(twoFc, pow10, betaMinus1) != approxYParity:
       dec(q)
-    elif q mod 2 != 0 and isIntegralMidpoint(twoFc, e2, minusK):
+    elif q mod 2 != 0 and isIntegralMidpointDr(twoFc, e2, minusK):
       dec(q)
   return FloatingDecimal64(significand: q, exponent: minusK + kappa)
 
@@ -1043,7 +1038,7 @@ proc toDecimal64*(ieeeSignificand: uint64; ieeeExponent: uint64): FloatingDecima
 #  ToChars
 # ==================================================================================================
 
-proc utoa8DigitsSkipTrailingZeros*(buf: var openArray[char]; pos: int; digits: uint32): int {.inline.} =
+proc utoa8DigitsSkipTrailingZerosDr(buf: var openArray[char]; pos: int; digits: uint32): int {.inline.} =
   dragonbox_Assert(digits >= 1)
   dragonbox_Assert(digits <= 99999999'u32)
   let q: uint32 = digits div 10000
@@ -1061,7 +1056,7 @@ proc utoa8DigitsSkipTrailingZeros*(buf: var openArray[char]; pos: int; digits: u
     utoa2Digits(buf, pos + 6, rL)
     return trailingZeros2Digits(if rL == 0: rH else: rL) + (if rL == 0: 2 else: 0)
 
-proc printDecimalDigitsBackwards*(buf: var openArray[char]; pos: int; output64: uint64): int {.inline.} =
+proc printDecimalDigitsBackwardsDr(buf: var openArray[char]; pos: int; output64: uint64): int {.inline.} =
   var pos = pos
   var output64 = output64
   var tz = 0
@@ -1075,7 +1070,7 @@ proc printDecimalDigitsBackwards*(buf: var openArray[char]; pos: int; output64: 
     output64 = q
     dec(pos, 8)
     if r != 0:
-      tz = utoa8DigitsSkipTrailingZeros(buf, pos, r)
+      tz = utoa8DigitsSkipTrailingZerosDr(buf, pos, r)
       dragonbox_Assert(tz >= 0)
       dragonbox_Assert(tz <= 7)
     else:
@@ -1137,7 +1132,7 @@ proc printDecimalDigitsBackwards*(buf: var openArray[char]; pos: int; output64: 
     buf[pos] = chr(ord('0') + q)
   return tz
 
-proc decimalLength*(v: uint64): int {.inline.} =
+proc decimalLengthDr(v: uint64): int {.inline.} =
   dragonbox_Assert(v >= 1)
   dragonbox_Assert(v <= 99999999999999999'u64)
   if cast[uint32](v shr 32) != 0:
@@ -1177,7 +1172,7 @@ proc decimalLength*(v: uint64): int {.inline.} =
     return 2
   return 1
 
-proc formatDigits*[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint64; decimalExponent: int;
+proc formatDigitsDr[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint64; decimalExponent: int;
                   forceTrailingDotZero = false): int {.inline.} =
   const
     minFixedDecimalPoint = -6
@@ -1190,7 +1185,7 @@ proc formatDigits*[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint
   dragonbox_Assert(digits <= 99999999999999999'u64)
   dragonbox_Assert(decimalExponent >= -999)
   dragonbox_Assert(decimalExponent <= 999)
-  var numDigits = decimalLength(digits)
+  var numDigits = decimalLengthDr(digits)
   let decimalPoint = numDigits + decimalExponent
   let useFixed: bool = minFixedDecimalPoint <= decimalPoint and
       decimalPoint <= maxFixedDecimalPoint
@@ -1211,7 +1206,7 @@ proc formatDigits*[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint
     ##  dE+123 or d.igitsE+123
     decimalDigitsPosition = 1
   var digitsEnd = pos + int(decimalDigitsPosition + numDigits)
-  let tz = printDecimalDigitsBackwards(buffer, digitsEnd, digits)
+  let tz = printDecimalDigitsBackwardsDr(buffer, digitsEnd, digits)
   dec(digitsEnd, tz)
   dec(numDigits, tz)
   ##   decimal_exponent += tz; // => decimal_point unchanged.
@@ -1270,20 +1265,20 @@ proc formatDigits*[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint
       inc(pos, 2)
   return pos
 
-proc toChars*(buffer: var openArray[char]; v: float; forceTrailingDotZero = false): int {.
-    inline.} =
+proc toChars(buffer: var openArray[char]; v: float; forceTrailingDotZero = false): int {.
+  inline.} =
   var pos = 0
-  let significand: uint64 = physicalSignificand(constructDouble(v))
-  let exponent: uint64 = physicalExponent(constructDouble(v))
-  if exponent != maxIeeeExponent:
+  let significand: uint64 = physicalSignificandDr(constructDoubleDr(v))
+  let exponent: uint64 = physicalExponentDr(constructDoubleDr(v))
+  if exponent != maxIeeeExponentDr:
     ##  Finite
     buffer[pos] = '-'
-    inc(pos, signBit(constructDouble(v)))
+    inc(pos, signBitDr(constructDoubleDr(v)))
     if exponent != 0 or significand != 0:
       ##  != 0
-      let dec = toDecimal64(significand, exponent)
-      return formatDigits(buffer, pos, dec.significand, dec.exponent.int,
-                         forceTrailingDotZero)
+      let dec = toDecimal64Dr(significand, exponent)
+      return formatDigitsDr(buffer, pos, dec.significand, dec.exponent.int,
+             forceTrailingDotZero)
     else:
       buffer[pos] = '0'
       buffer[pos+1] = '.'
@@ -1293,7 +1288,7 @@ proc toChars*(buffer: var openArray[char]; v: float; forceTrailingDotZero = fals
       return pos
   if significand == 0:
     buffer[pos] = '-'
-    inc(pos, signBit(constructDouble(v)))
+    inc(pos, signBitDr(constructDoubleDr(v)))
     buffer[pos] = 'i'
     buffer[pos+1] = 'n'
     buffer[pos+2] = 'f'
@@ -1307,8 +1302,8 @@ proc toChars*(buffer: var openArray[char]; v: float; forceTrailingDotZero = fals
     return pos + 3
 
 when false:
-  proc toString*(value: float): string =
-    var buffer: array[dtoaMinBufferLength, char]
+  proc toString(value: float): string =
+    var buffer: array[dtoaMinBufferLengthDr, char]
     let last = toChars(addr buffer, value)
     let L = cast[int](last) - cast[int](addr(buffer))
     result = newString(L)

--- a/lib/std/private/miscdollars.nim
+++ b/lib/std/private/miscdollars.nim
@@ -1,4 +1,4 @@
-from std/private/digitsutils import addInt
+from digitsutils import addIntSysimpl
 
 template toLocation*(result: var string, file: string | cstring, line: int, col: int) =
   ## avoids spurious allocations
@@ -13,10 +13,10 @@ template toLocation*(result: var string, file: string | cstring, line: int, col:
     result.add file
   if line > 0:
     result.add "("
-    addInt(result, line)
+    addIntSysimpl(result, line)
     if col > 0:
       result.add ", "
-      addInt(result, col)
+      addIntSysimpl(result, col)
     result.add ")"
 
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}

--- a/lib/std/private/schubfach.nim
+++ b/lib/std/private/schubfach.nim
@@ -10,10 +10,6 @@
 ##      https://drive.google.com/open?id=1luHhyQF9zKlM8yJ1nebU0OgVYhfC6CBN
 # --------------------------------------------------------------------------------------------------
 
-import std/private/digitsutils
-
-when defined(nimPreviewSlimSystem):
-  import std/assertions
 
 
 template sf_Assert(x: untyped): untyped =
@@ -400,8 +396,8 @@ proc formatDigits[T: Ordinal](buffer: var openArray[char]; pos: T; digits: uint3
       inc(pos, 2)
   return pos
 
-proc float32ToChars*(buffer: var openArray[char]; v: float32; forceTrailingDotZero = false): int {.
-    inline.} =
+proc float32ToChars(buffer: var openArray[char]; v: float32; forceTrailingDotZero = false): int {.
+  inline.} =
   let significand: uint32 = physicalSignificand(constructSingle(v))
   let exponent: uint32 = physicalExponent(constructSingle(v))
   var pos = 0

--- a/lib/std/private/syslocks.nim
+++ b/lib/std/private/syslocks.nim
@@ -15,7 +15,7 @@ when defined(windows):
   type
     Handle = int
 
-    SysLock* {.importc: "CRITICAL_SECTION",
+    SysLock {.importc: "CRITICAL_SECTION",
               header: "<windows.h>", final, pure, byref.} = object # CRITICAL_SECTION in WinApi
       DebugInfo: pointer
       LockCount: int32
@@ -24,10 +24,10 @@ when defined(windows):
       LockSemaphore: int
       SpinCount: int
 
-    SysCond* {.importc: "RTL_CONDITION_VARIABLE", header: "<windows.h>", byref.} = object
+    SysCond {.importc: "RTL_CONDITION_VARIABLE", header: "<windows.h>", byref.} = object
       thePtr {.importc: "Ptr".} : Handle
 
-  proc initSysLock*(L: var SysLock) {.importc: "InitializeCriticalSection",
+  proc initSysLock(L: var SysLock) {.importc: "InitializeCriticalSection",
                                      header: "<windows.h>".}
     ## Initializes the lock `L`.
 
@@ -35,18 +35,18 @@ when defined(windows):
                                                  header: "<windows.h>".}
     ## Tries to acquire the lock `L`.
 
-  proc tryAcquireSys*(L: var SysLock): bool {.inline.} =
+  proc tryAcquireSys(L: var SysLock): bool {.inline.} =
     result = tryAcquireSysAux(L) != 0'i32
 
-  proc acquireSys*(L: var SysLock) {.importc: "EnterCriticalSection",
+  proc acquireSys(L: var SysLock) {.importc: "EnterCriticalSection",
                                     header: "<windows.h>".}
     ## Acquires the lock `L`.
 
-  proc releaseSys*(L: var SysLock) {.importc: "LeaveCriticalSection",
+  proc releaseSys(L: var SysLock) {.importc: "LeaveCriticalSection",
                                     header: "<windows.h>".}
     ## Releases the lock `L`.
 
-  proc deinitSys*(L: SysLock) {.importc: "DeleteCriticalSection",
+  proc deinitSys(L: SysLock) {.importc: "DeleteCriticalSection",
                                    header: "<windows.h>".}
 
   proc initializeConditionVariable(
@@ -60,41 +60,41 @@ when defined(windows):
   ): int32 {.stdcall, noSideEffect, dynlib: "kernel32", importc: "SleepConditionVariableCS".}
 
 
-  proc signalSysCond*(hEvent: var SysCond) {.stdcall, noSideEffect,
+  proc signalSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
     dynlib: "kernel32", importc: "WakeConditionVariable".}
 
-  proc broadcastSysCond*(hEvent: var SysCond) {.stdcall, noSideEffect,
+  proc broadcastSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
     dynlib: "kernel32", importc: "WakeAllConditionVariable".}
 
-  proc initSysCond*(cond: var SysCond) {.inline.} =
+  proc initSysCond(cond: var SysCond) {.inline.} =
     initializeConditionVariable(cond)
-  proc deinitSysCond*(cond: SysCond) {.inline.} =
+  proc deinitSysCond(cond: SysCond) {.inline.} =
     discard
-  proc waitSysCond*(cond: var SysCond, lock: var SysLock) =
+  proc waitSysCond(cond: var SysCond, lock: var SysLock) =
     discard sleepConditionVariableCS(cond, lock, -1'i32)
 
 elif defined(genode):
   const
     Header = "genode_cpp/syslocks.h"
   type
-    SysLock* {.importcpp: "Nim::SysLock", pure, final,
+    SysLock {.importcpp: "Nim::SysLock", pure, final,
               header: Header.} = object
-    SysCond* {.importcpp: "Nim::SysCond", pure, final,
+    SysCond {.importcpp: "Nim::SysCond", pure, final,
               header: Header.} = object
 
-  proc initSysLock*(L: var SysLock) = discard
-  proc deinitSys*(L: SysLock) = discard
-  proc acquireSys*(L: var SysLock) {.noSideEffect, importcpp.}
-  proc tryAcquireSys*(L: var SysLock): bool {.noSideEffect, importcpp.}
-  proc releaseSys*(L: var SysLock) {.noSideEffect, importcpp.}
+  proc initSysLock(L: var SysLock) = discard
+  proc deinitSys(L: SysLock) = discard
+  proc acquireSys(L: var SysLock) {.noSideEffect, importcpp.}
+  proc tryAcquireSys(L: var SysLock): bool {.noSideEffect, importcpp.}
+  proc releaseSys(L: var SysLock) {.noSideEffect, importcpp.}
 
-  proc initSysCond*(L: var SysCond) = discard
-  proc deinitSysCond*(L: SysCond) = discard
-  proc waitSysCond*(cond: var SysCond, lock: var SysLock) {.
+  proc initSysCond(L: var SysCond) = discard
+  proc deinitSysCond(L: SysCond) = discard
+  proc waitSysCond(cond: var SysCond, lock: var SysLock) {.
     noSideEffect, importcpp.}
-  proc signalSysCond*(cond: var SysCond) {.
+  proc signalSysCond(cond: var SysCond) {.
     noSideEffect, importcpp.}
-  proc broadcastSysCond*(cond: var SysCond) {.
+  proc broadcastSysCond(cond: var SysCond) {.
     noSideEffect, importcpp.}
 
 else:
@@ -105,7 +105,7 @@ else:
       when defined(linux) and defined(amd64):
         abi: array[40 div sizeof(clong), clong]
 
-    SysLockAttr* {.importc: "pthread_mutexattr_t", pure, final
+    SysLockAttr {.importc: "pthread_mutexattr_t", pure, final
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
       when defined(linux) and defined(amd64):
@@ -143,8 +143,8 @@ else:
     # to prevent this once and for all, we're doing an extra malloc when
     # initializing the primitive.
     type
-      SysLock* = ptr SysLockObj
-      SysCond* = ptr SysCondObj
+      SysLock = ptr SysLockObj
+      SysCond = ptr SysCondObj
 
     when not declared(c_malloc):
       proc c_malloc(size: csize_t): pointer {.
@@ -152,42 +152,42 @@ else:
       proc c_free(p: pointer) {.
         importc: "free", header: "<stdlib.h>".}
 
-    proc initSysLock*(L: var SysLock, attr: ptr SysLockAttr = nil) =
+    proc initSysLock(L: var SysLock, attr: ptr SysLockAttr = nil) =
       L = cast[SysLock](c_malloc(csize_t(sizeof(SysLockObj))))
       initSysLockAux(L[], attr)
 
-    proc deinitSys*(L: SysLock) =
+    proc deinitSys(L: SysLock) =
       deinitSysAux(L[])
       c_free(L)
 
-    template acquireSys*(L: var SysLock) =
+    template acquireSys(L: var SysLock) =
       acquireSysAux(L[])
-    template tryAcquireSys*(L: var SysLock): bool =
+    template tryAcquireSys(L: var SysLock): bool =
       tryAcquireSysAux(L[]) == 0'i32
-    template releaseSys*(L: var SysLock) =
+    template releaseSys(L: var SysLock) =
       releaseSysAux(L[])
   else:
     type
-      SysLock* = SysLockObj
-      SysCond* = SysCondObj
+      SysLock = SysLockObj
+      SysCond = SysCondObj
 
-    template initSysLock*(L: var SysLock, attr: ptr SysLockAttr = nil) =
+    template initSysLock(L: var SysLock, attr: ptr SysLockAttr = nil) =
       initSysLockAux(L, attr)
-    template deinitSys*(L: SysLock) =
+    template deinitSys(L: SysLock) =
       deinitSysAux(L)
-    template acquireSys*(L: var SysLock) =
+    template acquireSys(L: var SysLock) =
       acquireSysAux(L)
-    template tryAcquireSys*(L: var SysLock): bool =
+    template tryAcquireSys(L: var SysLock): bool =
       tryAcquireSysAux(L) == 0'i32
-    template releaseSys*(L: var SysLock) =
+    template releaseSys(L: var SysLock) =
       releaseSysAux(L)
 
   # rlocks
-  var SysLockType_Reentrant* {.importc: "PTHREAD_MUTEX_RECURSIVE",
+  var SysLockType_Reentrant {.importc: "PTHREAD_MUTEX_RECURSIVE",
     header: "<pthread.h>".}: SysLockType
-  proc initSysLockAttr*(a: var SysLockAttr) {.
+  proc initSysLockAttr(a: var SysLockAttr) {.
     importc: "pthread_mutexattr_init", header: "<pthread.h>", noSideEffect.}
-  proc setSysLockType*(a: var SysLockAttr, t: SysLockType) {.
+  proc setSysLockType(a: var SysLockAttr, t: SysLockType) {.
     importc: "pthread_mutexattr_settype", header: "<pthread.h>", noSideEffect.}
 
   # locks
@@ -204,31 +204,31 @@ else:
     importc: "pthread_cond_broadcast", header: "<pthread.h>", noSideEffect.}
 
   when defined(ios):
-    proc initSysCond*(cond: var SysCond, cond_attr: ptr SysCondAttr = nil) =
+    proc initSysCond(cond: var SysCond, cond_attr: ptr SysCondAttr = nil) =
       cond = cast[SysCond](c_malloc(csize_t(sizeof(SysCondObj))))
       initSysCondAux(cond[], cond_attr)
 
-    proc deinitSysCond*(cond: SysCond) =
+    proc deinitSysCond(cond: SysCond) =
       deinitSysCondAux(cond[])
       c_free(cond)
 
-    template waitSysCond*(cond: var SysCond, lock: var SysLock) =
+    template waitSysCond(cond: var SysCond, lock: var SysLock) =
       discard waitSysCondAux(cond[], lock[])
-    template signalSysCond*(cond: var SysCond) =
+    template signalSysCond(cond: var SysCond) =
       signalSysCondAux(cond[])
-    template broadcastSysCond*(cond: var SysCond) =
+    template broadcastSysCond(cond: var SysCond) =
       broadcastSysCondAux(cond[])
   else:
-    template initSysCond*(cond: var SysCond, cond_attr: ptr SysCondAttr = nil) =
+    template initSysCond(cond: var SysCond, cond_attr: ptr SysCondAttr = nil) =
       initSysCondAux(cond, cond_attr)
-    template deinitSysCond*(cond: SysCond) =
+    template deinitSysCond(cond: SysCond) =
       deinitSysCondAux(cond)
 
-    template waitSysCond*(cond: var SysCond, lock: var SysLock) =
+    template waitSysCond(cond: var SysCond, lock: var SysLock) =
       discard waitSysCondAux(cond, lock)
-    template signalSysCond*(cond: var SysCond) =
+    template signalSysCond(cond: var SysCond) =
       signalSysCondAux(cond)
-    template broadcastSysCond*(cond: var SysCond) =
+    template broadcastSysCond(cond: var SysCond) =
       broadcastSysCondAux(cond)
 
 {.pop.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2012,7 +2012,7 @@ proc `<`*[T: tuple](x, y: T): bool =
   return false
 
 
-import system/coro_detection
+include system/coro_detection
 
 {.push checks: off.}
 # obviously we cannot generate checking operations here :-)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2130,6 +2130,10 @@ template unlikely*(val: bool): bool =
 include std/private/digitsutils
 export addInt
 
+import std/formatfloat
+when not defined(nimPreviewSlimSystem):
+  export addFloat
+
 import system/dollars
 export dollars
 
@@ -3032,8 +3036,7 @@ when defined(genode):
 
 
 when not defined(nimPreviewSlimSystem):
-  import std/widestrs
-  export widestrs
+  include std/widestrs
 
 when notJSnotNims:
   when defined(windows) and compileOption("threads"):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -554,7 +554,8 @@ type
     ## Abstract class for all exceptions that are catchable.
 
 
-include "system/exceptions"
+when defined(nimIcIntegrityChecks):
+  include "system/exceptions"
 
 when defined(js) or defined(nimdoc):
   type
@@ -1682,6 +1683,10 @@ when not defined(js) and defined(nimV2):
         else:
           vTable: UncheckedArray[pointer] # vtable for types
     PNimTypeV2 = ptr TNimTypeV2
+
+when not defined(nimIcIntegrityChecks):
+  import system/exceptions
+  export exceptions
 
 when notJSnotNims and defined(nimSeqsV2):
   include "system/strs_v2"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2605,8 +2605,7 @@ macro varargsLen*(x: varargs[untyped]): int {.since: (1, 1).} =
   varargsLenImpl(x)
 
 when defined(nimV2):
-  import system/repr_v2
-  export repr_v2
+  include system/repr_v2
 
 proc repr*[T, U](x: HSlice[T, U]): string =
   ## Generic `repr` operator for slices that is lifted from the components

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1660,7 +1660,7 @@ when notJSnotNims:
 {.push stackTrace: off.}
 
 when not defined(js) and hasThreadSupport and hostOS != "standalone":
-  import std/private/syslocks
+  include std/private/syslocks
   include "system/threadlocalstorage"
 
 when not defined(js) and defined(nimV2):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -553,8 +553,8 @@ type
   CatchableError* = object of Exception ## \
     ## Abstract class for all exceptions that are catchable.
 
-when defined(nimIcIntegrityChecks):
-  include "system/exceptions"
+
+include "system/exceptions"
 
 when defined(js) or defined(nimdoc):
   type
@@ -1127,8 +1127,8 @@ when not defined(js) and hostOS != "standalone":
     ## deprecated, prefer `quit` or `exitprocs.getProgramResult`, `exitprocs.setProgramResult`.
 
 import std/private/since
-import system/ctypes
-export ctypes
+
+include system/ctypes
 
 include system/ptrarith
 
@@ -1682,10 +1682,6 @@ when not defined(js) and defined(nimV2):
         else:
           vTable: UncheckedArray[pointer] # vtable for types
     PNimTypeV2 = ptr TNimTypeV2
-
-when not defined(nimIcIntegrityChecks):
-  import system/exceptions
-  export exceptions
 
 when notJSnotNims and defined(nimSeqsV2):
   include "system/strs_v2"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2127,6 +2127,9 @@ template unlikely*(val: bool): bool =
     else:
       unlikelyProc(val)
 
+include std/private/digitsutils
+export addInt
+
 import system/dollars
 export dollars
 
@@ -2456,9 +2459,6 @@ proc finished*[T: iterator {.closure.}](x: T): bool {.noSideEffect, inline, magi
     {.emit: """
     `result` = ((NI*) `x`.ClE_0)[1] < 0;
     """.}
-
-from std/private/digitsutils import addInt
-export addInt
 
 when defined(js) and not defined(nimscript):
   # nimscript can be defined if config file for js compilation

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2340,7 +2340,7 @@ when not defined(js):
 
 
 when notJSnotNims:
-  import system/countbits_impl
+  include system/countbits_impl
   include "system/sets"
 
   when defined(gogc):

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -11,7 +11,6 @@
 {.push profiler:off.}
 
 include osalloc
-import std/private/syslocks
 
 template track(op, address, size) =
   when defined(memTracker):

--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -143,8 +143,6 @@
 when not declared(ThisIsSystem):
   {.error: "You must not import this module explicitly".}
 
-import std/private/syslocks
-
 type
   pbytes = ptr UncheckedArray[byte]
   RawChannel {.pure, final.} = object ## msg queue for a thread

--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -147,10 +147,6 @@ when defined(nimV2):
   proc raiseObjectCaseTransition() {.compilerproc.} =
     sysFatal(FieldDefect, "assignment to discriminant changes object branch")
 
-import std/formatfloat
-
-when not defined(nimPreviewSlimSystem):
-  export addFloat
 
 func f2s(x: float | float32): string =
   ## Outplace version of `addFloat`.

--- a/lib/system/coro_detection.nim
+++ b/lib/system/coro_detection.nim
@@ -11,10 +11,10 @@ when defined(nimCoroutines):
   # Explicit opt-in.
   when not coroutinesSupportedPlatform():
     {.error: "Coroutines are not supported on this architecture and/or garbage collector.".}
-  const nimCoroutines* = true
+  const nimCoroutines = true
 elif defined(noNimCoroutines):
   # Explicit opt-out.
-  const nimCoroutines* = false
+  const nimCoroutines = false
 else:
   # Autodetect coroutine support.
-  const nimCoroutines* = false
+  const nimCoroutines = false

--- a/lib/system/countbits_impl.nim
+++ b/lib/system/countbits_impl.nim
@@ -11,13 +11,7 @@
 
 include std/private/bitops_utils
 
-const useBuiltins* = not defined(noIntrinsicsBitOpts)
-const noUndefined* = defined(noUndefinedBitOpts)
-const useGCC_builtins* = (defined(gcc) or defined(llvm_gcc) or
-                         defined(clang)) and useBuiltins
-const useICC_builtins* = defined(icc) and useBuiltins
-const useVCC_builtins* = defined(vcc) and useBuiltins
-const arch64* = sizeof(int) == 8
+const arch64 = sizeof(int) == 8
 
 template countBitsImpl(n: uint32): int =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -60,7 +54,7 @@ elif useICC_builtins:
       importc: "_popcnt64", header: "<immintrin.h>".}
 
 
-func countSetBitsImpl*(x: SomeInteger): int {.inline.} =
+func countSetBitsImpl(x: SomeInteger): int {.inline.} =
   ## Counts the set bits in an integer (also called `Hamming weight`:idx:).
   # TODO: figure out if ICC support _popcnt32/_popcnt64 on platform without POPCNT.
   # like GCC and MSVC
@@ -85,3 +79,6 @@ func countSetBitsImpl*(x: SomeInteger): int {.inline.} =
     else:
       when sizeof(x) <= 4: result = countBitsImpl(x.uint32)
       else: result = countBitsImpl(x.uint64)
+
+func countSetBitsSysimpl*(x: SomeInteger): int {.inline.} =
+  result = countSetBitsImpl(x)

--- a/lib/system/countbits_impl.nim
+++ b/lib/system/countbits_impl.nim
@@ -9,7 +9,7 @@
 
 ## Contains the used algorithms for counting bits.
 
-from std/private/bitops_utils import forwardImpl, castToUnsigned
+include std/private/bitops_utils
 
 const useBuiltins* = not defined(noIntrinsicsBitOpts)
 const noUndefined* = defined(noUndefinedBitOpts)

--- a/lib/system/countbits_impl.nim
+++ b/lib/system/countbits_impl.nim
@@ -11,8 +11,6 @@
 
 include std/private/bitops_utils
 
-const arch64 = sizeof(int) == 8
-
 template countBitsImpl(n: uint32): int =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint32(n)

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -7,7 +7,6 @@ import std/private/miscdollars
 
 when not defined(nimPreviewSlimSystem):
   import std/formatfloat
-  export addFloat
 
   func `$`*(x: float | float32): string =
     ## Outplace version of `addFloat`.

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -94,8 +94,7 @@ proc `$`*[T: tuple](x: T): string =
   tupleObjectDollar(result, x)
 
 when not defined(nimPreviewSlimSystem):
-  import std/objectdollar
-  export objectdollar
+  include std/objectdollar
 
 proc collectionToString[T](x: T, prefix, separator, suffix: string): string =
   result = prefix

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -3,7 +3,7 @@ runnableExamples:
   assert $0.1 == "0.1"
   assert $(-2*3) == "-6"
 
-import std/private/[digitsutils, miscdollars]
+import std/private/miscdollars
 
 when not defined(nimPreviewSlimSystem):
   import std/formatfloat

--- a/lib/system/gc_regions.nim
+++ b/lib/system/gc_regions.nim
@@ -9,7 +9,6 @@
 {.push raises: [], gcsafe.}
 
 # "Stack GC" for embedded devices or ultra performance requirements.
-import std/private/syslocks
 
 when defined(memProfiler):
   proc nimProfile(requestedSize: int) {.benign.}

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -1,5 +1,3 @@
-include system/inclrtl
-
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
   ## imported from typetraits
 

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -1,8 +1,5 @@
 include system/inclrtl
 
-when defined(nimPreviewSlimSystem):
-  import std/formatfloat
-
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
   ## imported from typetraits
 

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -8,9 +8,6 @@
 #
 # The generic ``repr`` procedure for the javascript backend.
 
-when defined(nimPreviewSlimSystem):
-  import std/formatfloat
-
 proc reprInt(x: int64): string {.compilerproc.} = $x
 proc reprInt(x: uint64): string {.compilerproc.} = $x
 proc reprInt(x: int): string {.compilerproc.} = $x

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -8,7 +8,6 @@
 #
 
 # Compilerprocs for strings that do not depend on the string implementation.
-import std/private/digitsutils as digitsutils2
 
 proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let alen = a.len

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -157,6 +157,7 @@ lib/std/sha1.nim
 lib/pure/htmlparser.nim
 lib/std/private/schubfach.nim
 lib/std/private/dragonbox.nim
+lib/std/private/syslocks.nim
 """.splitWhitespace()
 
   officialPackagesList = """

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -206,8 +206,8 @@ lib/system/iterators.nim
 lib/system/exceptions.nim
 lib/system/dollars.nim
 lib/system/ctypes.nim
-lib/system/repr_v2.nim
 """.splitWhitespace()
+# lib/system/repr_v2.nim
 
   proc follow(a: PathEntry): bool =
     result = a.path.lastPathPart notin ["nimcache", htmldocsDirname,

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -155,6 +155,8 @@ lib/posix/posix_haiku.nim
 lib/pure/md5.nim
 lib/std/sha1.nim
 lib/pure/htmlparser.nim
+lib/std/private/schubfach.nim
+lib/std/private/dragonbox.nim
 """.splitWhitespace()
 
   officialPackagesList = """


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/issues/24272

- removes all exported symbols
- adds `Dr` suffixes for most symbols in `dragonbox` because these names conflict with `schubfach` 