### PR TITLE
Fix data race in Channel.trySend/tryRecv (issue #23174)

### DIFF
--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -349,9 +349,11 @@ template lockChannel(q, action): untyped =
   releaseSys(q.lock)
 
 proc sendImpl(q: PRawChannel, typ: PNimType, msg: pointer, noBlock: bool): bool =
-  if q.mask == ChannelDeadMask:
-    sysFatal(DeadThreadDefect, "cannot send message; thread died")
   acquireSys(q.lock)
+  # Check mask inside the lock to avoid data race
+  if q.mask == ChannelDeadMask:
+    releaseSys(q.lock)
+    sysFatal(DeadThreadDefect, "cannot send message; thread died")
   if q.maxItems > 0:
     # Wait until count is less than maxItems
     if noBlock and q.count >= q.maxItems:
@@ -430,12 +432,12 @@ proc tryRecv*[TMsg](c: var Channel[TMsg]): tuple[dataAvailable: bool,
   ## returns `(true, msg)`.
   result = default(tuple[dataAvailable: bool, msg: TMsg])
   var q = cast[PRawChannel](addr(c))
-  if q.mask != ChannelDeadMask:
-    if tryAcquireSys(q.lock):
-      if q.count > 0:
-        llRecv(q, addr(result.msg), cast[PNimType](getTypeInfo(result.msg)))
-        result.dataAvailable = true
-      releaseSys(q.lock)
+  if tryAcquireSys(q.lock):
+    # Check mask inside the lock to avoid data race
+    if q.mask != ChannelDeadMask and q.count > 0:
+      llRecv(q, addr(result.msg), cast[PNimType](getTypeInfo(result.msg)))
+      result.dataAvailable = true
+    releaseSys(q.lock)
 
 proc peek*[TMsg](c: var Channel[TMsg]): int =
   ## Returns the current number of messages in the channel `c`.


### PR DESCRIPTION
The channel implementation had unsafe unsynchronized access to the `mask` field across threads:

1. tryRecv() checked `q.mask != ChannelDeadMask` BEFORE acquiring the lock
2. sendImpl() checked `q.mask == ChannelDeadMask` BEFORE acquiring the lock
3. rawSend() modified `q.mask` WHILE HOLDING the lock

This created a race condition detected by ThreadSanitizer where one thread reads the mask while another thread modifies it under lock protection.

The fix moves both mask checks inside their respective critical sections:
- tryRecv: Now acquires lock first, then checks mask
- sendImpl: Now acquires lock first, then checks mask (releasing before fatal)

This ensures all accesses to the shared `mask` field are properly synchronized.

Fixes nim-lang/Nim#23174