### PR TITLE
Missleading sentence about array indexing

### DIFF
--- a/doc/tut1.md
+++ b/doc/tut1.md
@@ -1278,9 +1278,10 @@ Arrays can be constructed using `[]`:
     echo x[i]
   ```
 
-The notation `x[i]` is used to access the i-th element of `x`.
-Array access is always bounds checked (at compile-time or at runtime). These
-checks can be disabled via pragmas or invoking the compiler with the
+The notation `x[i]` is used to access the i-th element of `x` in the example
+above but valid indexes can be defined by any subrange. Array access is
+always bounds checked (at compile-time or at runtime). These checks can be
+disabled via pragmas or invoking the compiler with the
 ``--bound_checks:off`` command line switch.
 
 Arrays are value types, like any other Nim type. The assignment operator

--- a/doc/tut1.md
+++ b/doc/tut1.md
@@ -1279,7 +1279,7 @@ Arrays can be constructed using `[]`:
   ```
 
 The notation `x[i]` is used to access the i-th element of `x` in the example
-above but valid indexes can be defined by any subrange. Array access is
+above. Valid indexes can be defined by any subrange. Array access is
 always bounds checked (at compile-time or at runtime). These checks can be
 disabled via pragmas or invoking the compiler with the
 ``--bound_checks:off`` command line switch.


### PR DESCRIPTION
I added some precision. The first time I read this sentence, I was confused. This applies to the above example, but it cannot be generalized, since every array has its own range of valid indexes.

I think this change make the documentation clearer.