### PR TITLE
fixes #25262; proc v[T: typedesc]() = discard / v[0]() compiles with values

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -160,7 +160,9 @@ proc matchGenericParam(m: var TCandidate, formal: PType, n: PNode) =
       arg = newTypeS(tyStatic, m.c, son = evaluated.typ)
       arg.n = evaluated
   elif formalBase.kind == tyTypeDesc:
-    if arg.kind != tyTypeDesc:
+    if arg.kind != tyTypeDesc and
+        n.kind == nkSym and n.sym.kind == skType:
+      # make sure we have a type here
       arg = makeTypeDesc(m.c, arg)
   else:
     arg = arg.skipTypes({tyTypeDesc})

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -160,10 +160,7 @@ proc matchGenericParam(m: var TCandidate, formal: PType, n: PNode) =
       arg = newTypeS(tyStatic, m.c, son = evaluated.typ)
       arg.n = evaluated
   elif formalBase.kind == tyTypeDesc:
-    if arg.kind != tyTypeDesc and
-        n.kind == nkSym and n.sym.kind == skType:
-      # make sure we have a type here
-      arg = makeTypeDesc(m.c, arg)
+    discard
   else:
     arg = arg.skipTypes({tyTypeDesc})
   let tm = typeRel(m, formal, arg)

--- a/tests/errmsgs/t25262.nim
+++ b/tests/errmsgs/t25262.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: '''type mismatch: got <>'''
+"""
+
+proc v[T: typedesc]() = discard
+v[0]()


### PR DESCRIPTION
fixes #25262

It's a half regression, gives `cannot instantiate: 'v[0]'` before 