### PR TITLE
fixes #25352; warn when trying to isolate reference types in refc

### DIFF
--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -11,9 +11,9 @@
 ## https://github.com/nim-lang/RFCs/issues/244 for more details.
 
 import
-  ast, types, renderer
+  ast, types, renderer, options, msgs, lineinfos
 
-import std/intsets
+import std/[intsets, strutils]
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -163,7 +163,10 @@ proc containsVariable(n: PNode): bool =
       if containsVariable(ch): return true
     result = false
 
-proc checkIsolate*(n: PNode): bool =
+proc checkIsolate*(conf: ConfigRef, n: PNode): bool =
+  if conf.selectedGC notin {gcArc, gcAtomicArc, gcOrc} and
+      containsGarbageCollectedRef(n.typ):
+    message(conf, n.info, warnGcIsolated, "Garbage-collected types '$#' cannot be isolated in refc" % [$n.typ])
   if types.containsTyRef(n.typ):
     # XXX Maybe require that 'n.typ' is acyclic. This is not much
     # worse than the already existing inheritance and closure restrictions.
@@ -177,7 +180,7 @@ proc checkIsolate*(n: PNode): bool =
       if tfNoSideEffect notin n[0].typ.flags:
         return false
       for i in 1..<n.len:
-        if checkIsolate(n[i]):
+        if checkIsolate(conf, n[i]):
           discard "fine, it is isolated already"
         else:
           let argType = n[i].typ
@@ -192,30 +195,30 @@ proc checkIsolate*(n: PNode): bool =
     of nkIfStmt, nkIfExpr:
       result = false
       for it in n:
-        result = checkIsolate(it.lastSon)
+        result = checkIsolate(conf, it.lastSon)
         if not result: break
     of nkCaseStmt:
       result = false
       for i in 1..<n.len:
-        result = checkIsolate(n[i].lastSon)
+        result = checkIsolate(conf, n[i].lastSon)
         if not result: break
     of nkObjConstr:
       result = true
       for i in 1..<n.len:
-        result = checkIsolate(n[i].lastSon)
+        result = checkIsolate(conf, n[i].lastSon)
         if not result: break
     of nkBracket, nkTupleConstr, nkPar:
       result = false
       for it in n:
-        result = checkIsolate(it)
+        result = checkIsolate(conf, it)
         if not result: break
     of nkHiddenStdConv, nkHiddenSubConv, nkCast, nkConv:
-      result = checkIsolate(n[1])
+      result = checkIsolate(conf, n[1])
     of nkObjUpConv, nkObjDownConv, nkDotExpr:
-      result = checkIsolate(n[0])
+      result = checkIsolate(conf, n[0])
     of nkStmtList, nkStmtListExpr:
       if n.len > 0:
-        result = checkIsolate(n[^1])
+        result = checkIsolate(conf, n[^1])
       else:
         result = false
     of nkSym:

--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -166,7 +166,7 @@ proc containsVariable(n: PNode): bool =
 proc checkIsolate*(conf: ConfigRef, n: PNode): bool =
   if conf.selectedGC notin {gcArc, gcAtomicArc, gcOrc} and
       containsGarbageCollectedRef(n.typ):
-    message(conf, n.info, warnGcIsolated, "Garbage-collected types '$#' cannot be isolated in refc" % [$n.typ])
+    message(conf, n.info, warnGcIsolated, "'$#' containing garbage-collected types cannot be isolated in refc" % [$n.typ])
   if types.containsTyRef(n.typ):
     # XXX Maybe require that 'n.typ' is acyclic. This is not much
     # worse than the already existing inheritance and closure restrictions.

--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -165,7 +165,7 @@ proc containsVariable(n: PNode): bool =
 
 proc checkIsolate*(conf: ConfigRef, n: PNode): bool =
   if conf.selectedGC notin {gcArc, gcAtomicArc, gcOrc} and
-      containsGarbageCollectedRef(n.typ):
+      containsGarbageCollectedRefRecursive(n.typ):
     message(conf, n.info, warnGcIsolated, "'$#' containing garbage-collected types cannot be isolated in refc" % [$n.typ])
   if types.containsTyRef(n.typ):
     # XXX Maybe require that 'n.typ' is acyclic. This is not much

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -93,8 +93,9 @@ type
     warnBareExcept = "BareExcept",
     warnImplicitDefaultValue = "ImplicitDefaultValue",
     warnIgnoredSymbolInjection = "IgnoredSymbolInjection",
-    warnStdPrefix = "StdPrefix"
-    warnUnknownNotes = "UnknownNotes"
+    warnStdPrefix = "StdPrefix",
+    warnUnknownNotes = "UnknownNotes",
+    warnGcIsolated = "GcIsolated",
     warnUser = "User",
     warnGlobalVarConstructorTemporary = "GlobalVarConstructorTemporary",
     # hints
@@ -202,6 +203,7 @@ const
     warnIgnoredSymbolInjection: "$1",
     warnStdPrefix: "$1 needs the 'std' prefix",
     warnUnknownNotes: "$1",
+    warnGcIsolated: "$1",
     warnUser: "$1",
     warnGlobalVarConstructorTemporary: "global variable '$1' initialization requires a temporary variable",
     hintSuccess: "operation successful: $#",

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -683,7 +683,7 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mZeroDefault:
     result = checkDefault(c, n)
   of mIsolate:
-    if not checkIsolate(n[1]):
+    if not checkIsolate(c.config, n[1]):
       localError(c.config, n.info, "expression cannot be isolated: " & $n[1])
     result = n
   of mPrivateAccess:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -252,32 +252,32 @@ proc iterOverType(t: PType, iter: TTypeIter, closure: RootRef): bool =
   result = iterOverTypeAux(marker, t, iter, closure)
 
 proc searchTypeForAux(t: PType, predicate: TTypePredicate,
-                      marker: var IntSet): bool
+                      marker: var IntSet; recursive: bool = false): bool
 
 proc searchTypeNodeForAux(n: PNode, p: TTypePredicate,
-                          marker: var IntSet): bool =
+                          marker: var IntSet; recursive: bool = false): bool =
   result = false
   case n.kind
   of nkRecList:
     for i in 0..<n.len:
-      result = searchTypeNodeForAux(n[i], p, marker)
+      result = searchTypeNodeForAux(n[i], p, marker, recursive)
       if result: return
   of nkRecCase:
     assert(n[0].kind == nkSym)
-    result = searchTypeNodeForAux(n[0], p, marker)
+    result = searchTypeNodeForAux(n[0], p, marker, recursive)
     if result: return
     for i in 1..<n.len:
       case n[i].kind
       of nkOfBranch, nkElse:
-        result = searchTypeNodeForAux(lastSon(n[i]), p, marker)
+        result = searchTypeNodeForAux(lastSon(n[i]), p, marker, recursive)
         if result: return
       else: discard
   of nkSym:
-    result = searchTypeForAux(n.sym.typ, p, marker)
+    result = searchTypeForAux(n.sym.typ, p, marker, recursive)
   else: discard
 
 proc searchTypeForAux(t: PType, predicate: TTypePredicate,
-                      marker: var IntSet): bool =
+                      marker: var IntSet; recursive: bool = false): bool =
   # iterates over VALUE types!
   result = false
   if t == nil: return
@@ -287,20 +287,23 @@ proc searchTypeForAux(t: PType, predicate: TTypePredicate,
   case t.kind
   of tyObject:
     if t.baseClass != nil:
-      result = searchTypeForAux(t.baseClass.skipTypes(skipPtrs), predicate, marker)
-    if not result: result = searchTypeNodeForAux(t.n, predicate, marker)
+      result = searchTypeForAux(t.baseClass.skipTypes(skipPtrs), predicate, marker, recursive)
+    if not result: result = searchTypeNodeForAux(t.n, predicate, marker, recursive)
   of tyGenericInst, tyDistinct, tyAlias, tySink:
-    result = searchTypeForAux(skipModifier(t), predicate, marker)
+    result = searchTypeForAux(skipModifier(t), predicate, marker, recursive)
   of tyArray, tySet, tyTuple:
     for a in t.kids:
-      result = searchTypeForAux(a, predicate, marker)
+      result = searchTypeForAux(a, predicate, marker, recursive)
       if result: return
+  of tyRef, tyPtr, tyUncheckedArray, tyOpenArray, tyVarargs:
+    if recursive:
+      result = searchTypeForAux(t.elementType, predicate, marker, recursive)
   else:
     discard
 
 proc searchTypeFor*(t: PType, predicate: TTypePredicate): bool =
   var marker = initIntSet()
-  result = searchTypeForAux(t, predicate, marker)
+  result = searchTypeForAux(t, predicate, marker, recursive = false)
 
 proc isObjectPredicate(t: PType): bool =
   result = t.kind == tyObject
@@ -363,6 +366,12 @@ proc containsGarbageCollectedRef*(typ: PType): bool =
   # returns true if typ contains a reference, sequence or string (all the
   # things that are garbage-collected)
   result = searchTypeFor(typ, isGCRef)
+
+proc containsGarbageCollectedRefRecursive*(typ: PType): bool =
+  # returns true if typ contains a reference, sequence or string (all the
+  # things that are garbage-collected). It checks recursively
+  var marker = initIntSet()
+  result = searchTypeForAux(typ, isGCRef, marker, recursive = true)
 
 proc isManagedMemory(t: PType): bool =
   result = t.kind in GcTypeKinds or

--- a/tests/isolate/tisolaterefc.nim
+++ b/tests/isolate/tisolaterefc.nim
@@ -1,0 +1,29 @@
+discard """
+  nimout: '''
+tisolaterefc.nim(20, 20) Warning: 'string' containing garbage-collected types cannot be isolated in refc [GcIsolated]
+tisolaterefc.nim(21, 25) Warning: 'ptr string' containing garbage-collected types cannot be isolated in refc [GcIsolated]
+tisolaterefc.nim(22, 20) Warning: 'Foo' containing garbage-collected types cannot be isolated in refc [GcIsolated]
+tisolaterefc.nim(23, 25) Warning: 'ptr Foo' containing garbage-collected types cannot be isolated in refc [GcIsolated]
+'''
+  matrix: "--mm:refc"
+"""
+
+import std/isolation
+type
+  Foo = object
+    id: ptr string
+
+proc foo() =
+  var x = Foo()
+
+  var m = "24e"
+  var s1 = isolate(m)
+  var s2 = isolate(addr m)
+  var s3 = isolate(x)
+  var s4 = isolate(addr x)
+  discard s1
+  discard s2
+  discard s3
+  discard s4
+
+foo()


### PR DESCRIPTION
fixes #25352

- [x] applys to recursively `ptr/uncheckedArray/openarray/varargs` types ?