### PR TITLE
fixes #25387; `embedsrc` breaks with Line Continuation

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -337,7 +337,7 @@ proc genLineDir(p: BProc, t: PNode) =
   let line = t.info.safeLineNm
 
   if optEmbedOrigSrc in p.config.globalOptions:
-    p.s(cpsStmts).add("//" & sourceLine(p.config, t.info) & "\L")
+    p.s(cpsStmts).add("/* " & sourceLine(p.config, t.info) & " */" & "\L")
   let lastFileIndex = p.lastLineInfo.fileIndex
   let freshLine = freshLineInfo(p, t.info)
   if freshLine:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -337,7 +337,10 @@ proc genLineDir(p: BProc, t: PNode) =
   let line = t.info.safeLineNm
 
   if optEmbedOrigSrc in p.config.globalOptions:
-    p.s(cpsStmts).add("/* " & sourceLine(p.config, t.info) & " */" & "\L")
+    var code = sourceLine(p.config, t.info)
+    if code.endsWith('\\'):
+      code.add "#"
+    p.s(cpsStmts).add("// " & code & "\L")
   let lastFileIndex = p.lastLineInfo.fileIndex
   let freshLine = freshLineInfo(p, t.info)
   if freshLine:

--- a/tests/ccgbugs/t25387.nim
+++ b/tests/ccgbugs/t25387.nim
@@ -1,0 +1,8 @@
+discard """
+  matrix: "--embedsrc=on"
+"""
+
+proc trim() =
+  let s = 10
+  let x = s + 5 # user entered literal \
+trim()


### PR DESCRIPTION
fixes #25387

https://stackoverflow.com/questions/30286253/how-to-escape-backslash-in-comment

- adding a whitespace or `\t` after `\` breaks the `goto` block
- `\* *\` doesn't support nesting, causing problems for using it in the Nim comments

