### PR TITLE
Fix `tupleLen` not skipping aliases

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -243,7 +243,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     let cond = operand.kind == tyTuple and operand.n != nil
     result = newIntNodeT(toInt128(ord(cond)), traitCall, c.idgen, c.graph)
   of "tupleLen":
-    var operand = operand.skipTypes({tyGenericInst})
+    var operand = operand.skipTypes({tyGenericInst, tyAlias})
     assert operand.kind == tyTuple, $operand.kind
     result = newIntNodeT(toInt128(operand.len), traitCall, c.idgen, c.graph)
   of "distinctBase":

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -194,6 +194,11 @@ block: # tupleLen
     MyGenericTuple2Alias2 =   MyGenericTuple2Alias[float]
   static: doAssert MyGenericTuple2Alias2.tupleLen == 3
 
+  type
+    MyGenericTuple3[T] = T
+    MyGenericTuple3Alias = MyGenericTuple3[(string, int)]
+  static: doAssert MyGenericTuple3Alias.tupleLen == 2
+
   static: doAssert (int, float).tupleLen == 2
   static: doAssert (1, ).tupleLen == 1
   static: doAssert ().tupleLen == 0


### PR DESCRIPTION
This code was failing to compile with `Error: unhandled exception: semmagic.nim(247, 5) operand.kind == tyTuple tyAlias [AssertionDefect]`
```nim
import std/typetraits

type
  Bar[T] = T 
  Foo = Bar[tuple[a: int]]

echo Foo.tupleLen
```

Fix was just making `tupleLen` skip alias types also