### PR TITLE
Support size pragma with generic type parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -103,6 +103,18 @@ errors.
   See the [experimental manual](https://nim-lang.github.io/Nim/manual_experimental.html#typeminusbound-overloads)
   for more information.
 
+- The `size` pragma now supports expressions involving type parameters for generic
+  imported types. The expression is evaluated when the generic type is instantiated.
+
+  ```nim
+  type
+    CppAtomic[T] {.importcpp: "std::atomic", header: "<atomic>",
+                   size: sizeof(T), completeStruct.} = object
+
+  static:
+    doAssert sizeof(CppAtomic[int32]) == 4
+  ```
+
 ## Compiler changes
 
 - Fixed a bug where `sizeof(T)` inside a `typedesc` template called from a generic type's

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -143,6 +143,36 @@ proc `alignment=`*(s: PSym, val: int) {.inline.} =
   if s.state == Partial: loadSym(s)
   s.alignmentImpl = val
 
+proc setDeferredExpr*(s: PSym, word: TSpecialWord, expr: PNode) {.inline.} =
+  ## Sets a deferred expression for a pragma word on a field symbol.
+  assert s.state != Sealed, "cannot modify sealed symbol"
+  assert s.kind in {skLet, skVar, skField, skForVar},
+    "setDeferredExpr only valid for field-like symbols"
+  if s.state == Partial: loadSym(s)
+  for i in 0..<s.deferredExprsImpl.len:
+    if s.deferredExprsImpl[i].word == word:
+      s.deferredExprsImpl[i].expr = expr
+      if expr != nil:
+        s.flagsImpl.incl sfHasDeferredPragmas
+      return
+  s.deferredExprsImpl.add DeferredPragmaExpr(word: word, expr: expr)
+  if expr != nil:
+    s.flagsImpl.incl sfHasDeferredPragmas
+
+proc clearDeferredExpr*(s: PSym, word: TSpecialWord) {.inline.} =
+  ## Clears a deferred expression for a pragma word.
+  for i in 0..<s.deferredExprsImpl.len:
+    if s.deferredExprsImpl[i].word == word:
+      s.deferredExprsImpl.delete(i)
+      break
+  if s.deferredExprsImpl.len == 0:
+    s.flagsImpl.excl sfHasDeferredPragmas
+
+iterator deferredPragmas*(s: PSym): DeferredPragmaExpr {.inline.} =
+  ## Iterates over all deferred pragma expressions on a symbol
+  for dp in s.deferredExprsImpl:
+    yield dp
+
 proc magic*(s: PSym): TMagic {.inline.} =
   if s.state == Partial: loadSym(s)
   result = s.magicImpl
@@ -377,6 +407,34 @@ proc align*(t: PType): int16 {.inline.} =
 proc `align=`*(t: PType, val: int16) {.inline.} =
   backendEnsureMutable t
   t.alignImpl = val
+
+proc setDeferredExpr*(t: PType, word: TSpecialWord, expr: PNode) {.inline.} =
+  ## Sets a deferred expression for a pragma word on a type.
+  assert t.state != Sealed
+  if t.state == Partial: loadType(t)
+  for i in 0..<t.deferredExprsImpl.len:
+    if t.deferredExprsImpl[i].word == word:
+      t.deferredExprsImpl[i].expr = expr
+      if expr != nil:
+        t.flagsImpl.incl tfHasDeferredPragmas
+      return
+  t.deferredExprsImpl.add DeferredPragmaExpr(word: word, expr: expr)
+  if expr != nil:
+    t.flagsImpl.incl tfHasDeferredPragmas
+
+proc clearDeferredExpr*(t: PType, word: TSpecialWord) {.inline.} =
+  ## Clears a deferred expression for a pragma word.
+  for i in 0..<t.deferredExprsImpl.len:
+    if t.deferredExprsImpl[i].word == word:
+      t.deferredExprsImpl.delete(i)
+      break
+  if t.deferredExprsImpl.len == 0:
+    t.flagsImpl.excl tfHasDeferredPragmas
+
+iterator deferredPragmas*(t: PType): DeferredPragmaExpr {.inline.} =
+  ## Iterates over all deferred pragma expressions on a type
+  for dp in t.deferredExprsImpl:
+    yield dp
 
 proc paddingAtEnd*(t: PType): int16 {.inline.} =
   if t.state == Partial: loadType(t)

--- a/compiler/astdef.nim
+++ b/compiler/astdef.nim
@@ -8,7 +8,7 @@
 #
 
 import
-  lineinfos, options, ropes, idents, int128
+  lineinfos, options, ropes, idents, int128, wordrecg
 
 import std/[tables, hashes]
 
@@ -125,6 +125,8 @@ type
     sfCodegenDecl     # type, proc, global or proc param is marked as codegenDecl
     sfWasGenSym       # symbol was 'gensym'ed
     sfForceLift       # variable has to be lifted into closure environment
+
+    sfHasDeferredPragmas  # field has one or more deferred pragma expressions
 
     sfDirty           # template is not hygienic (old styled template) module,
                       # compiled from a dirty-buffer
@@ -397,6 +399,7 @@ type
     tfIsOutParam
     tfSendable
     tfImplicitStatic
+    tfHasDeferredPragmas  # type has one or more deferred pragma expressions
 
   TTypeFlags* = set[TTypeFlag]
 
@@ -589,6 +592,13 @@ type
   TNodeSeq* = seq[PNode]
   PType* = ref TType
   PSym* = ref TSym
+
+  DeferredPragmaExpr* = object
+    ## A pragma expression that needs evaluation during generic instantiation.
+    ## Used for pragmas like size that can reference generic params.
+    word*: TSpecialWord   ## which pragma (wSize, etc.)
+    expr*: PNode          ## the deferred expression containing generic params
+
   TNode*{.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
     when defined(useNodeIds):
       id*: int
@@ -709,6 +719,7 @@ type
       guardImpl*: PSym
       bitsizeImpl*: int
       alignmentImpl*: int # for alignment
+      deferredExprsImpl*: seq[DeferredPragmaExpr]  # deferred pragma expressions (nil = none)
     else: nil
     magicImpl*: TMagic
     typImpl*: PType
@@ -796,6 +807,7 @@ type
                               # -1 means that the size is unknown
     alignImpl*: int16             # the type's alignment requirements
     paddingAtEndImpl*: int16      #
+    deferredExprsImpl*: seq[DeferredPragmaExpr]  # deferred pragma expressions (nil = none)
     locImpl*: TLoc
     typeInstImpl*: PType          # for generic instantiations the tyGenericInst that led to this
                               # type.

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -174,4 +174,5 @@ proc initDefines*(symbols: StringTableRef) =
 
   defineSymbol("nimHasSetLengthSeqUninitMagic")
   defineSymbol("nimHasPreviewDuplicateModuleError")
+  defineSymbol("nimHasDeferredPragmas")
 

--- a/compiler/ic/enum2nif.nim
+++ b/compiler/ic/enum2nif.nim
@@ -1266,6 +1266,7 @@ proc genFlags*(s: set[TSymFlag]; dest: var string) =
     of sfAnon: dest.add "a0"
     of sfAllUntyped: dest.add "a1"
     of sfTemplateRedefinition: dest.add "t1"
+    of sfHasDeferredPragmas: dest.add "h"
 
 
 proc parse*(t: typedesc[TSymFlag]; s: string): set[TSymFlag] =
@@ -1362,6 +1363,7 @@ proc parse*(t: typedesc[TSymFlag]; s: string): set[TSymFlag] =
         result.incl sfGoto
         inc i
       else: result.incl sfGlobal
+    of 'h': result.incl sfHasDeferredPragmas
     of 'i':
       if i+1 < s.len and s[i+1] == '0':
         result.incl sfInfixCall
@@ -1588,6 +1590,7 @@ proc genFlags*(s: set[TTypeFlag]; dest: var string) =
     of tfIsOutParam: dest.add "i5"
     of tfSendable: dest.add "s0"
     of tfImplicitStatic: dest.add "i6"
+    of tfHasDeferredPragmas: dest.add "h2"
 
 
 proc parse*(t: typedesc[TTypeFlag]; s: string): set[TTypeFlag] =
@@ -1646,6 +1649,9 @@ proc parse*(t: typedesc[TTypeFlag]; s: string): set[TTypeFlag] =
         inc i
       elif i+1 < s.len and s[i+1] == '1':
         result.incl tfHasStatic
+        inc i
+      elif i+1 < s.len and s[i+1] == '2':
+        result.incl tfHasDeferredPragmas
         inc i
       else: result.incl tfHasOwned
     of 'i':

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -97,6 +97,32 @@ const
   allRoutinePragmas* = methodPragmas + iteratorPragmas + lambdaPragmas
   enumFieldPragmas* = {wDeprecated}
 
+proc isGenericParamSym(sym: PSym): bool {.inline.} =
+  ## Returns true if sym represents a generic parameter.
+  if sym == nil: return false
+  if sym.kind == skGenericParam: return true
+  if sym.kind == skType and sym.typ != nil and sym.typ.kind == tyGenericParam:
+    return true
+  return false
+
+proc containsUnresolvedIdent(c: PContext, n: PNode): bool =
+  ## Returns true if n contains any identifiers that cannot be resolved in scope.
+  ## Unresolved identifiers indicate potential generic params that haven't been
+  ## added to scope yet (pragmas are processed before generic params in typeDefLeftSidePass).
+  if n == nil: return false
+  case n.kind
+  of nkIdent:
+    var ambiguous = false
+    let sym = searchInScopes(c, n.ident, ambiguous)
+    return sym == nil or isGenericParamSym(sym)
+  of nkSym:
+    return isGenericParamSym(n.sym)
+  else:
+    for child in n:
+      if containsUnresolvedIdent(c, child):
+        return true
+    return false
+
 proc getPragmaVal*(procAst: PNode; name: TSpecialWord): PNode =
   result = nil
   let p = procAst[pragmasPos]
@@ -118,6 +144,48 @@ proc recordPragma(c: PContext; n: PNode; args: varargs[string]) =
 const
   errStringLiteralExpected = "string literal expected"
   errIntLiteralExpected = "integer literal expected"
+  errPragmaRequiresArgument = "$1 pragma requires an argument"
+  errDeferredOnlyForImported = "deferred $1 expressions only supported for imported types"
+  errMustBeConstantInteger = "$1 must be a compile-time constant integer"
+
+proc deferOrEvaluate(c: PContext, sym: PSym, it: PNode,
+                     word: TSpecialWord, requireImportc: bool): bool =
+  ## Generic helper: decides whether to defer or evaluate a pragma expression.
+  ## Returns true if expression was deferred, false if it should be evaluated immediately.
+  ## Handles nil checks, validation, and error reporting.
+  ##
+  ## Args:
+  ##   c: Semantic context
+  ##   sym: Symbol being processed (must have .typ for types, or be a field symbol)
+  ##   it: The pragma node
+  ##   word: Pragma word (wSize, wAlign, etc.)
+  ##   requireImportc: If true, deferred expressions require sfImportc flag
+  ##
+  ## Returns:
+  ##   true = expression was deferred (caller should return)
+  ##   false = expression is ready for immediate evaluation (caller continues)
+  let expr = if it.kind in nkPragmaCallKinds and it.len == 2: it[1] else: nil
+  if expr == nil:
+    localError(c.config, it.info, errPragmaRequiresArgument % $word)
+    return true
+
+  if containsUnresolvedIdent(c, expr):
+    if requireImportc:
+      let hasImportc = if sym.kind in {skLet, skVar, skField, skForVar}:
+                         false
+                       else:
+                         sfImportc in sym.flags
+      if not hasImportc:
+        localError(c.config, it.info, errDeferredOnlyForImported % $word)
+        return true
+
+    if sym.kind in {skLet, skVar, skField, skForVar}:
+      sym.setDeferredExpr(word, expr)
+    else:
+      sym.typ.setDeferredExpr(word, expr)
+    return true
+
+  return false
 
 proc invalidPragma*(c: PContext; n: PNode) =
   localError(c.config, n.info, "invalid pragma: " & renderTree(n, {renderNoComments}))
@@ -232,9 +300,35 @@ proc expectIntLit(c: PContext, n: PNode): int =
     of nkIntLit..nkInt64Lit: result = int(n[1].intVal)
     else: localError(c.config, n.info, errIntLiteralExpected)
 
+template expectInt(c: PContext, n: PNode, info: TLineInfo,
+                   pragmaName: string): int =
+  ## Validates that n is an integer constant. Returns value or 0 on error.
+  var resultVal = 0
+  if n.kind in nkIntLit..nkInt64Lit:
+    resultVal = int(n.intVal)
+  else:
+    localError(c.config, info, errMustBeConstantInteger % pragmaName)
+  resultVal
+
 proc getOptionalStr(c: PContext, n: PNode, defaultStr: string): string =
   if n.kind in nkPragmaCallKinds: result = expectStrLit(c, n)
   else: result = defaultStr
+
+proc applySize(c: PContext, typ: PType, size: int, isImported: bool, info: TLineInfo) =
+  ## Applies size pragma to a type. Validates size for non-imported types.
+  if size <= 0: return
+  if isImported:
+    setImportedTypeSize(c.config, typ, size)
+  else:
+    case size
+    of 1, 2, 4:
+      typ.size = size
+      typ.align = int16 size
+    of 8:
+      typ.size = 8
+      typ.align = floatInt64Align(c.config)
+    else:
+      localError(c.config, info, "size may only be 1, 2, 4 or 8")
 
 proc processVirtual(c: PContext, n: PNode, s: PSym, flag: TSymFlag) =
   s.constraint = newEmptyStrNode(c, n, getOptionalStr(c, n, "$1"))
@@ -946,20 +1040,15 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         processImportObjC(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wSize:
         if sym.typ == nil: invalidPragma(c, it)
-        var size = expectIntLit(c, it)
-        if sfImportc in sym.flags:
-          # no restrictions on size for imported types
-          setImportedTypeSize(c.config, sym.typ, size)
+        if sym.kind == skType:
+          if not deferOrEvaluate(c, sym, it, wSize, requireImportc = true):
+            let expr = it[1]
+            let evaluated = c.semConstExpr(c, expr.copyTree)
+            let size = expectInt(c, evaluated, it.info, "size")
+            applySize(c, sym.typ, size, sfImportc in sym.flags, it.info)
         else:
-          case size
-          of 1, 2, 4:
-            sym.typ.size = size
-            sym.typ.align = int16 size
-          of 8:
-            sym.typ.size = 8
-            sym.typ.align = floatInt64Align(c.config)
-          else:
-            localError(c.config, it.info, "size may only be 1, 2, 4 or 8")
+          let size = expectIntLit(c, it)
+          applySize(c, sym.typ, size, sfImportc in sym.flags, it.info)
       of wAlign:
         let alignment = expectIntLit(c, it)
         if isPowerOfTwo(alignment) and alignment > 0:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -12,7 +12,7 @@
 import std / tables
 
 import ast, astalgo, msgs, types, magicsys, semdata, renderer, options,
-  lineinfos, modulegraphs, layeredtable
+  lineinfos, modulegraphs, layeredtable, wordrecg
 
 when defined(nimPreviewSlimSystem):
   import std/assertions
@@ -79,6 +79,7 @@ type
     isReturnType*: bool
     owner*: PSym              # where this instantiation comes from
     recursionLimit: int
+    genericBody*: PType       # the generic body type, used for pragma evaluation
 
 proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType, isInstValue = false): PType
 proc replaceTypeVarsS(cl: var TReplTypeVars, s: PSym, t: PType): PSym
@@ -419,6 +420,104 @@ proc instCopyType*(cl: var TReplTypeVars, t: PType): PType =
       result.destructor = nil
       result.sink = nil
 
+proc resolveConcreteType(cl: var TReplTypeVars, n: PNode,
+                         concreteType: PType, hasUnresolved: var bool): PNode =
+  ## Resolves a concrete type to an AST node for pragma expression substitution.
+  ## Returns nil if type is still generic (sets hasUnresolved), otherwise
+  ## returns appropriate node (value for static, typedesc for type params).
+  if concreteType.kind == tyGenericParam:
+    hasUnresolved = true
+    return nil
+  if concreteType.kind == tyStatic:
+    if concreteType.n != nil:
+      return concreteType.n.copyTree
+    return nil
+  let typeDescType = makeTypeDesc(cl.c, concreteType)
+  return newNodeIT(nkType, n.info, typeDescType)
+
+proc tryResolveGenericParam(cl: var TReplTypeVars, n: PNode,
+                            concreteType: PType, hasUnresolved: var bool): PNode =
+  ## Attempts to resolve a generic param to a concrete node.
+  ## Returns: resolved node, original node (if unresolved), or nil (if concreteType is nil).
+  if concreteType == nil:
+    return nil
+  let resolved = resolveConcreteType(cl, n, concreteType, hasUnresolved)
+  if resolved != nil:
+    return resolved
+  if hasUnresolved:
+    return n
+  return nil
+
+proc replaceIdentsWithTypes(cl: var TReplTypeVars, n: PNode, body: PType, hasUnresolved: var bool): PNode =
+  ## Walks the expression and replaces identifier nodes with type symbols
+  ## based on the generic parameters in body and concrete types in typeMap.
+  ## Sets hasUnresolved to true if any generic param couldn't be resolved to a concrete type.
+  if n == nil: return nil
+
+  case n.kind
+  of nkIdent:
+    for i in FirstGenericParamAt..<body.kidsLen:
+      let param = body[i-1]
+      if param.sym != nil and param.sym.name.s == n.ident.s:
+        let concreteType = cl.typeMap.lookup(param)
+        let resolved = tryResolveGenericParam(cl, n, concreteType, hasUnresolved)
+        if resolved != nil:
+          return resolved
+        return
+    result = n
+  of nkSym:
+    if n.sym != nil and n.sym.typ != nil and n.sym.typ.kind == tyGenericParam:
+      let concreteType = cl.typeMap.lookup(n.sym.typ)
+      let resolved = tryResolveGenericParam(cl, n, concreteType, hasUnresolved)
+      if resolved != nil:
+        return resolved
+    result = copyNode(n)
+    result.typ = replaceTypeVarsT(cl, n.typ)
+  of nkCharLit..nkNilLit:
+    result = copyNode(n)
+  else:
+    result = copyNode(n)
+    result.typ = if n.typ != nil: replaceTypeVarsT(cl, n.typ) else: nil
+    for i in 0..<n.len:
+      result.add replaceIdentsWithTypes(cl, n[i], body, hasUnresolved)
+
+proc applyDeferredPragma(cl: var TReplTypeVars, t: PType, word: TSpecialWord,
+                         val: PNode, info: TLineInfo) =
+  ## Applies an evaluated deferred pragma to a type.
+  case word
+  of wSize:
+    var size = 0
+    if val.kind in nkIntLit..nkInt64Lit:
+      size = int(val.intVal)
+    else:
+      localError(cl.c.config, info, "size must be a compile-time constant integer")
+    if size > 0:
+      setImportedTypeSize(cl.c.config, t, size)
+  else:
+    discard
+
+proc evaluateDeferredPragmas(cl: var TReplTypeVars, t: PType, body: PType) =
+  ## Evaluates all deferred pragma expressions on a type after generic instantiation.
+  if tfHasDeferredPragmas notin t.flags:
+    return
+
+  var toClear: seq[TSpecialWord] = @[]
+  for dp in t.deferredPragmas:
+    let expr = dp.expr
+    if expr == nil: continue
+
+    var hasUnresolved = false
+    let replacedExpr = replaceIdentsWithTypes(cl, expr, body, hasUnresolved)
+    if hasUnresolved:
+      continue
+
+    let val = cl.c.semConstExpr(cl.c, replacedExpr)
+    applyDeferredPragma(cl, t, dp.word, val, expr.info)
+    toClear.add(dp.word)
+
+  for word in toClear:
+    t.clearDeferredExpr(word)
+
 proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   # tyGenericInvocation[A, tyGenericInvocation[A, B]]
   # is difficult to handle:
@@ -494,10 +593,16 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
     return
 
   let bbody = last body
+  cl.genericBody = body
   var newbody = replaceTypeVarsT(cl, bbody, isInstValue = true)
   cl.skipTypedesc = oldSkipTypedesc
   newbody.flags = newbody.flags + (t.flags + body.flags - tfInstClearedFlags)
   result.flags = result.flags + newbody.flags - tfInstClearedFlags
+
+  if tfHasDeferredPragmas in body.flags:
+    for dp in body.deferredPragmas:
+      newbody.setDeferredExpr(dp.word, dp.expr)
+  evaluateDeferredPragmas(cl, newbody, body)
 
   setToPreviousLayer(cl.typeMap)
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7873,6 +7873,30 @@ so that one can get the size of it at compile time even if it was declared witho
       echo sizeof(AtomicFlag)
   ```
 
+For generic imported types, the `size` pragma accepts expressions involving type parameters:
+
+  ```Nim
+  type
+    # Size based on generic parameter
+    CppAtomic[T] {.importcpp: "std::atomic", header: "<atomic>",
+                   size: sizeof(T), completeStruct.} = object
+
+    # Complex expressions are supported
+    PaddedWrapper[T] {.importc, size: sizeof(T) + 4, completeStruct.} = object
+
+    # Multiple type parameters
+    Pair[A, B] {.importc, size: sizeof(A) + sizeof(B), completeStruct.} = object
+
+  static:
+    doAssert sizeof(CppAtomic[int32]) == 4
+    doAssert sizeof(PaddedWrapper[int8]) == 5
+    doAssert sizeof(Pair[int32, int64]) == 12
+  ```
+
+The expression is evaluated when the generic type is instantiated. The
+`completeStruct` pragma is typically used with these declarations to enable
+compile-time size queries.
+
 
 Align pragma
 ------------

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -91,9 +91,8 @@ when (defined(cpp) and defined(nimUseCppAtomics)) or defined(nimdoc):
         ## with other moSequentiallyConsistent operations.
 
   type
-    Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
+    Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T), completeStruct.} = object
       ## An atomic object with underlying type `T`.
-      raw: T
 
     AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object
       ## An atomic boolean state.

--- a/tests/pragmas/tdeferred_size.nim
+++ b/tests/pragmas/tdeferred_size.nim
@@ -1,0 +1,118 @@
+discard """
+  targets: "c cpp"
+"""
+## Test: Deferred `size` pragma with generic type parameters
+##
+## Coverage:
+## - Single generic param: sizeof(T)
+## - Multiple generic params: sizeof(A), sizeof(B), sizeof(A)+sizeof(B)
+## - Complex expressions: sizeof(T)+N, sizeof(T)*N
+## - C++ templates (cpp backend only)
+##
+## Note: The `size` pragma is ONLY valid on:
+## - Enum types
+## - Imported types (types with {.importc.} or {.importcpp.})
+## It is NOT valid on fields or variables.
+
+# -----------------------------------------------------------------------------
+# Single generic parameter
+# -----------------------------------------------------------------------------
+
+type Single[T] {.importc, size: sizeof(T), completeStruct.} = object
+
+static:
+  doAssert sizeof(Single[int8]) == 1
+  doAssert sizeof(Single[int16]) == 2
+  doAssert sizeof(Single[int32]) == 4
+  doAssert sizeof(Single[int64]) == 8
+
+  # Prove different instantiations have different sizes (feature actually works):
+  doAssert sizeof(Single[int8]) != sizeof(Single[int64])
+  doAssert sizeof(Single[int16]) != sizeof(Single[int32])
+
+  # Prove size comes from pragma expression, not natural size:
+  # If pragma were broken, compiler would use natural object size (1 byte on most archs)
+  doAssert sizeof(Single[int64]) == 8  # Would be 1 if pragma didn't work
+
+# -----------------------------------------------------------------------------
+# Multiple generic parameters
+# -----------------------------------------------------------------------------
+
+type FirstParam[A, B] {.importc, size: sizeof(A), completeStruct.} = object
+
+static:
+  doAssert sizeof(FirstParam[int8, int64]) == 1
+  doAssert sizeof(FirstParam[int64, int8]) == 8
+
+type SecondParam[A, B] {.importc, size: sizeof(B), completeStruct.} = object
+
+static:
+  doAssert sizeof(SecondParam[int8, int64]) == 8
+  doAssert sizeof(SecondParam[int64, int8]) == 1
+
+type BothParams[A, B] {.importc, size: sizeof(A) + sizeof(B), completeStruct.} = object
+
+static:
+  doAssert sizeof(BothParams[int8, int8]) == 2
+  doAssert sizeof(BothParams[int32, int64]) == 12
+
+  # Verify expression uses BOTH params (would fail if only one was used):
+  doAssert sizeof(BothParams[int8, int64]) == 9   # 1 + 8
+  doAssert sizeof(BothParams[int64, int8]) == 9   # 8 + 1
+  doAssert sizeof(BothParams[int32, int32]) == 8  # 4 + 4
+
+# -----------------------------------------------------------------------------
+# Complex expressions
+# -----------------------------------------------------------------------------
+
+type PlusConst[T] {.importc, size: sizeof(T) + 4, completeStruct.} = object
+
+static:
+  doAssert sizeof(PlusConst[int8]) == 5
+  doAssert sizeof(PlusConst[int32]) == 8
+
+type TimesConst[T] {.importc, size: sizeof(T) * 2, completeStruct.} = object
+
+static:
+  doAssert sizeof(TimesConst[int8]) == 2
+  doAssert sizeof(TimesConst[int32]) == 8
+
+type ComplexExpr[T] {.importc, size: sizeof(T) * 2 + 4, completeStruct.} = object
+
+static:
+  doAssert sizeof(ComplexExpr[int8]) == 6
+  doAssert sizeof(ComplexExpr[int32]) == 12
+
+# -----------------------------------------------------------------------------
+# Non-generic (regression test: ensure fixed sizes still work)
+# -----------------------------------------------------------------------------
+
+type FixedSize {.importc, size: 16, completeStruct.} = object
+
+static:
+  doAssert sizeof(FixedSize) == 16
+
+# -----------------------------------------------------------------------------
+# Edge case: size expression with multiple operations
+# -----------------------------------------------------------------------------
+
+type MultiOpSize[T] {.importc, size: (sizeof(T) * 3 + 7) div 8 * 8, completeStruct.} = object
+
+static:
+  # Rounds up to nearest multiple of 8
+  doAssert sizeof(MultiOpSize[int8]) == 8   # (1*3+7)/8*8 = 8
+  doAssert sizeof(MultiOpSize[int16]) == 8  # (2*3+7)/8*8 = 8
+  doAssert sizeof(MultiOpSize[int32]) == 16 # (4*3+7)/8*8 = 16
+
+# -----------------------------------------------------------------------------
+# C++ templates
+# -----------------------------------------------------------------------------
+
+when defined(cpp):
+  type CppAtomic[T] {.importcpp: "std::atomic", header: "<atomic>",
+                      size: sizeof(T), completeStruct.} = object
+
+  static:
+    doAssert sizeof(CppAtomic[int8]) == 1
+    doAssert sizeof(CppAtomic[int32]) == 4
+    doAssert sizeof(CppAtomic[int64]) == 8


### PR DESCRIPTION
This PR implements deferred pragma expressions for the `size` pragma, and establishes infrastructure for deferred evaluation of expressions for other pragmas in generic types.

## Summary

1. **Deferred evaluation infrastructure**: New `DeferredPragmaExpr` type and accessors for storing pragma expressions that reference generic type parameters
2. **Size pragma enhancement**: The `size` pragma now accepts expressions like `sizeof(T)` that are evaluated during generic instantiation
3. **Feature detection**: Use `defined(nimHasDeferredPragmas)` to check for this feature

## Use Cases

### Proper C++ Template Type Wrapping

The primary motivation: correctly wrapping C++ template types whose size depends on template parameters.

```nim
# Before:
type
  Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
    raw: T  # Fake field as workaround

# After: 
type
  Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T), completeStruct.} = object
```

### Platform-Independent FFI

Cross-platform bindings where size may vary by architecture:

```nim
type
  PlatformInt {.importc: "intptr_t", size: sizeof(pointer), completeStruct.} = object
```

## Implementation

**AST extensions** (`astdef.nim`, `ast.nim`):
- `DeferredPragmaExpr` type pairs pragma word with unevaluated expression
- `deferredExprsImpl` field on `TType` and `TSym`
- `sfHasDeferredPragmas` / `tfHasDeferredPragmas` flags
- Accessor procs: `setDeferredExpr`, `clearDeferredExpr`, `deferredPragmas` iterator

**Pragma processing** (`pragmas.nim`):
- `containsUnresolvedIdent`: Detects expressions with unresolved generic identifiers
- `deferOrEvaluate`: Generic helper for defer-or-evaluate decision
- Modified `wSize` handler to defer when expression contains generic params

**Instantiation** (`semtypinst.nim`):
- `replaceIdentsWithTypes`: Substitutes generic param names with concrete types
- `applyDeferredPragma`: Evaluates deferred pragmas after instantiation
- `evaluateDeferredPragmas`: Orchestrates evaluation of all deferred type pragmas

**IC serialization** (`ic/enum2nif.nim`):
- Added serialization for new `sfHasDeferredPragmas` and `tfHasDeferredPragmas` flags

## Tests

- `tests/pragmas/tdeferred_size.nim` - Size pragma with `sizeof(T)` expressions

## Prior Art

[PR #24204](https://github.com/nim-lang/Nim/pull/24204) addresses the same problem for the `size` pragma. Key differences in our approach:

| Aspect | PR #24204 | This PR |
|--------|-----------|---------|
| **Scope** | `size` pragma | `size` pragma (with extensible infrastructure) |
| **Storage** | Retrieves from symbol's pragma AST | Dedicated `deferredExprsImpl` field with typed accessors |
| **Detection** | `tfHasMeta` flag | Scope lookup via `containsUnresolvedIdent` |
| **Extensibility** | Single pragma | Generic system designed for additional pragmas |

This PR uses a dedicated storage mechanism rather than mining symbol AST (which the #24204 author noted "seems dubious"). The `DeferredPragmaExpr` type and accessor API make it straightforward to add deferred support to additional pragmas in follow-up PRs.

## Related Work

I have submtited a follow-up PRs to support`align` pragma with generic expressions (#25404).

If the changeset is accepted, I also have branches ready for PR to support:  
- `importc`/`importcpp` pragmas with generic expressions
- `header` pragma with generic expressions