### PR TITLE
`memfiles.nim` resizeFile fallback logic bug

### DIFF
--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -58,6 +58,7 @@ proc setFileSize(fh: FileHandle, newFileSize = -1, oldSize = -1): OSErrorCode =
         while (e = posix_fallocate(fh, 0, newFileSize); e == EINTR):
           discard
       if (e == EINVAL or e == EOPNOTSUPP or e == ENOSYS) and ftruncate(fh, newFileSize) != -1:
+        # fallback arguable; Most portable BUT allows SEGV
         discard
       elif e != 0:
         result = osLastError()

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -57,11 +57,8 @@ proc setFileSize(fh: FileHandle, newFileSize = -1, oldSize = -1): OSErrorCode =
       when declared(posix_fallocate):
         while (e = posix_fallocate(fh, 0, newFileSize); e == EINTR):
           discard
-      if e == EINVAL or e == EOPNOTSUPP or e == ENOSYS:
-        if ftruncate(fh, newFileSize) == -1:
-          result = osLastError() # fallback arguable; Most portable BUT allows SEGV
-        else:
-          discard
+      if (e == EINVAL or e == EOPNOTSUPP or e == ENOSYS) and ftruncate(fh, newFileSize) != -1:
+        discard
       elif e != 0:
         result = osLastError()
     else: # shrink the file

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -57,9 +57,12 @@ proc setFileSize(fh: FileHandle, newFileSize = -1, oldSize = -1): OSErrorCode =
       when declared(posix_fallocate):
         while (e = posix_fallocate(fh, 0, newFileSize); e == EINTR):
           discard
-      if (e == EINVAL or e == EOPNOTSUPP or e == ENOSYS) and ftruncate(fh, newFileSize) != -1:
+      if e == EINVAL or e == EOPNOTSUPP or e == ENOSYS:
         # fallback arguable; Most portable BUT allows SEGV
-        discard
+        if ftruncate(fh, newFileSize) == -1:
+          result = osLastError()
+        else:
+          discard
       elif e != 0:
         result = osLastError()
     else: # shrink the file

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -57,8 +57,11 @@ proc setFileSize(fh: FileHandle, newFileSize = -1, oldSize = -1): OSErrorCode =
       when declared(posix_fallocate):
         while (e = posix_fallocate(fh, 0, newFileSize); e == EINTR):
           discard
-      if (e == EINVAL or e == EOPNOTSUPP) and ftruncate(fh, newFileSize) == -1:
-        result = osLastError() # fallback arguable; Most portable BUT allows SEGV
+      if e == EINVAL or e == EOPNOTSUPP or e == ENOSYS:
+        if ftruncate(fh, newFileSize) == -1:
+          result = osLastError() # fallback arguable; Most portable BUT allows SEGV
+        else:
+          discard
       elif e != 0:
         result = osLastError()
     else: # shrink the file


### PR DESCRIPTION
`e` is not cleared when falling back to `ftruncate`