### PR TITLE
enables dfa for refc strings

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -165,11 +165,11 @@ proc isLastReadImpl(n: PNode; c: var Con; scope: var Scope): bool =
 
 template hasDestructorOrAsgn(c: var Con, typ: PType): bool =
   # bug #23354; an object type could have a non-trivial assignements when it is passed to a sink parameter
-  hasDestructor(c, typ) or (c.graph.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
+  hasDestructor(c, typ) or (c.graph.config.selectedGC == gcRefc and typ.kind == tyString) or (c.graph.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
         typ.kind == tyObject and not isTrivial(getAttachedOp(c.graph, typ, attachedAsgn)))
 
 proc isLastRead(n: PNode; c: var Con; s: var Scope): bool =
-  if not hasDestructorOrAsgn(c, n.typ): return true
+  if not hasDestructorOrAsgn(c, n.typ.skipTypes({tyGenericInst, tyAlias, tySink})): return true
 
   let m = skipConvDfa(n)
   result = isLastReadImpl(n, c, s)
@@ -286,7 +286,9 @@ proc deepAliases(dest, ri: PNode): bool =
     return aliases(dest, ri) != no
 
 proc genSink(c: var Con; s: var Scope; dest, ri: PNode; flags: set[MoveOrCopyFlag] = {}): PNode =
-  if (c.inLoopCond == 0 and (isFullyUnpackedTuple(dest) or IsDecl in flags or
+  if c.graph.config.selectedGC == gcRefc and dest.typ.skipTypes({tyGenericInst, tyAlias, tySink}).kind == tyString:
+    result = newFastAsgnStmt(dest, callCodegenProc(c.graph, "moveString", dest.info, ri))
+  elif (c.inLoopCond == 0 and (isFullyUnpackedTuple(dest) or IsDecl in flags or
       (isAnalysableFieldAccess(dest, c.owner) and isFirstWrite(dest, c)))) or
       isNoInit(dest) or IsReturn in flags:
     # optimize sink call into a bitwise memcopy

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -354,6 +354,9 @@ proc genCopyNoCheck(c: var Con; dest, ri: PNode; a: TTypeAttachedOp): PNode =
   assert ri.typ != nil
 
 proc genCopy(c: var Con; dest, ri: PNode; flags: set[MoveOrCopyFlag]): PNode =
+  if c.graph.config.selectedGC == gcRefc and dest.typ.skipTypes({tyGenericInst, tyAlias, tySink}).kind == tyString:
+    result = newAsgnStmt(dest, ri)
+    return
   if c.inEnsureMove > 0:
     localError(c.graph.config, ri.info, errFailedMove, "cannot move '" & $ri &
                                                       "', which introduces an implicit copy")

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -1036,6 +1036,8 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of tyString:
     if useNoGc(c, t):
       useSeqOrStrOp(c, t, body, x, y)
+    elif c.g.config.selectedGC == gcRefc:
+      defaultOp(c, t, body, x, y)
     elif tfHasAsgn in t.flags:
       discard considerUserDefinedOp(c, t, body, x, y)
     else:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2430,7 +2430,7 @@ proc processMagicType(c: PContext, m: PSym) =
   of mString:
     setMagicType(c.config, m, tyString, szUncomputedSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
-    if optSeqDestructors in c.config.globalOptions:
+    if optSeqDestructors in c.config.globalOptions or c.config.selectedGC == gcRefc:
       incl m.typ, tfHasAsgn
   of mCstring:
     setMagicIntegral(c.config, m, tyCstring, c.config.target.ptrSize)

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -115,10 +115,13 @@ proc cstrToNimstr(str: cstring): NimString {.compilerRtl.} =
   else: toNimStr(str, str.len)
 
 proc moveString(src: NimString): NimString {.compilerRtl.} =
-  if (src.reserved and strlitFlag) != 0:
-    result = toOwnedCopy(src)
-  else:
+  if src == nil:
     result = src
+  else:
+    if (src.reserved and strlitFlag) != 0:
+      result = toOwnedCopy(src)
+    else:
+      result = src
 
 proc copyString(src: NimString): NimString {.compilerRtl.} =
   ## Expects `src` to be initialized (len and terminating zero set)

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -114,6 +114,12 @@ proc cstrToNimstr(str: cstring): NimString {.compilerRtl.} =
   if str == nil: NimString(nil)
   else: toNimStr(str, str.len)
 
+proc moveString(src: NimString): NimString {.compilerRtl.} =
+  if (src.reserved and strlitFlag) != 0:
+    result = toOwnedCopy(src)
+  else:
+    result = src
+
 proc copyString(src: NimString): NimString {.compilerRtl.} =
   ## Expects `src` to be initialized (len and terminating zero set)
   if src != nil:


### PR DESCRIPTION
- [ ] inline `=copy` since the hook is not really needed

```nim
proc makeiter(v: sink string): string =
  result = v

var iter = makeiter("foo")
echo iter
```
It seems that we need to handle string literals either by copying it when it is passed to the call or when moving it to the target