### PR TITLE
fixes #25441; fixes #7355; put placeholders instead of `nil` for void args

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -830,6 +830,13 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType) =
   for i in 0 ..< flatUnbound.len():
     x.bindings.put(flatUnbound[i], flatBound[i])
 
+proc compactVoidArgs(n: PNode): PNode =
+  # deletes void args from the argument list, which are created by `setSon`
+  result = copyNode(n)
+  for i in 0..<n.len:
+    if n[i] != nil:
+      result.add n[i]
+
 proc semResolvedCall(c: PContext, x: var TCandidate,
                      n: PNode, flags: TExprFlags;
                      expectedType: PType = nil): PNode =
@@ -880,7 +887,7 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
   markUsed(c, info, finalCallee, isGenericInstance = true)
   onUse(info, finalCallee, isGenericInstance = true)
 
-  result = x.call
+  result = compactVoidArgs(x.call)
   instGenericConvertersSons(c, result, x)
   markConvertersUsed(c, result)
   result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -830,13 +830,6 @@ proc inheritBindings(c: PContext, x: var TCandidate, expectedType: PType) =
   for i in 0 ..< flatUnbound.len():
     x.bindings.put(flatUnbound[i], flatBound[i])
 
-proc compactVoidArgs(n: PNode): PNode =
-  # deletes void args from the argument list, which are created by `setSon`
-  result = copyNode(n)
-  for i in 0..<n.len:
-    if n[i] != nil:
-      result.add n[i]
-
 proc semResolvedCall(c: PContext, x: var TCandidate,
                      n: PNode, flags: TExprFlags;
                      expectedType: PType = nil): PNode =
@@ -887,7 +880,7 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
   markUsed(c, info, finalCallee, isGenericInstance = true)
   onUse(info, finalCallee, isGenericInstance = true)
 
-  result = compactVoidArgs(x.call)
+  result = x.call
   instGenericConvertersSons(c, result, x)
   markConvertersUsed(c, result)
   result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -832,9 +832,6 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PTyp
 proc fixAbstractType(c: PContext, n: PNode) =
   for i in 1..<n.len:
     let it = n[i]
-    if it == nil:
-      localError(c.config, n.info, "'$1' has nil child at index $2" % [renderTree(n, {renderNoComments}), $i])
-      return
     # do not get rid of nkHiddenSubConv for OpenArrays, the codegen needs it:
     if it.kind == nkHiddenSubConv and
         skipTypes(it.typ, abstractVar).kind notin {tyOpenArray, tyVarargs}:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2730,14 +2730,14 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
       echo m.c.config $ arg.info, " for ", m.calleeSym.name.s, " ", m.c.config $ m.calleeSym.info
       writeMatches(m)
 
-proc setSon(father: PNode, at: int, son: PNode) =
+proc setSon(c: PContext; father: PNode, at: int, son: PNode) =
   let oldLen = father.len
   if oldLen <= at:
     setLen(father.sons, at + 1)
   father[at] = son
   # insert potential 'void' parameters:
-  #for i in oldLen..<at:
-  #  father[i] = newNodeIT(nkEmpty, son.info, getSysType(tyVoid))
+  for i in oldLen..<at:
+    father[i] = newNodeIT(nkEmpty, son.info, getSysType(c.graph, father.info, tyVoid))
 
 # we are allowed to modify the calling node in the 'prepare*' procs:
 proc prepareOperand(c: PContext; formal: PType; a: PNode, newlyTyped: var bool): PNode =
@@ -2864,11 +2864,11 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         doAssert n[a][0].kind == nkEmpty and
                  n[a][1].kind in {nkBracket, nkArgList}
         # Steal the container and pass it along
-        setSon(m.call, formal.position + 1, n[a][1])
+        setSon(c, m.call, formal.position + 1, n[a][1])
       else:
         if container.isNil:
           container = newNodeIT(nkArgList, n[a].info, arrayConstr(c, n.info))
-          setSon(m.call, formal.position + 1, container)
+          setSon(c, m.call, formal.position + 1, container)
         else:
           incrIndexType(container.typ)
         container.add n[a]
@@ -2908,10 +2908,10 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         #assert(container == nil)
         container = newNodeIT(nkBracket, n[a].info, arrayConstr(c, arg))
         container.add arg
-        setSon(m.call, formal.position + 1, container)
+        setSon(c, m.call, formal.position + 1, container)
         if f != formalLen - 1: container = nil
       else:
-        setSon(m.call, formal.position + 1, arg)
+        setSon(c, m.call, formal.position + 1, arg)
       inc f
     else:
       # unnamed param
@@ -2967,7 +2967,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if formal.typ.isVarargsUntyped:
           if container.isNil:
             container = newNodeIT(nkArgList, n[a].info, arrayConstr(c, n.info))
-            setSon(m.call, formal.position + 1, container)
+            setSon(c, m.call, formal.position + 1, container)
           else:
             incrIndexType(container.typ)
           container.add n[a]
@@ -2984,7 +2984,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
           if formal.typ.isVarargsTyped and m.calleeSym.kind in {skTemplate, skMacro}:
             if container.isNil:
               container = newNodeIT(nkBracket, n[a].info, arrayConstr(c, n.info))
-              setSon(m.call, formal.position + 1, implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
+              setSon(c, m.call, formal.position + 1, implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
             else:
               incrIndexType(container.typ)
             container.add n[a]
@@ -2998,14 +2998,14 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
             else:
               incrIndexType(container.typ)
             container.add arg
-            setSon(m.call, formal.position + 1,
+            setSon(c, m.call, formal.position + 1,
                    implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
             #if f != formalLen - 1: container = nil
 
             # pick the formal from the end, so that 'x, y, varargs, z' works:
             f = max(f, formalLen - n.len + a + 1)
           elif formal.typ.kind != tyVarargs or container == nil:
-            setSon(m.call, formal.position + 1, arg)
+            setSon(c, m.call, formal.position + 1, arg)
             inc f
             container = nil
           else:
@@ -3059,7 +3059,7 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
           # container node kind accordingly
           let cnKind = if formal.typ.isVarargsUntyped: nkArgList else: nkBracket
           var container = newNodeIT(cnKind, n.info, arrayConstr(c, n.info))
-          setSon(m.call, formal.position + 1,
+          setSon(c, m.call, formal.position + 1,
                  implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
         else:
           # no default value
@@ -3091,7 +3091,7 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
             # see bug #11600:
             put(m, formal.typ, defaultValue.typ)
         defaultValue.flags.incl nfDefaultParam
-        setSon(m.call, formal.position + 1, defaultValue)
+        setSon(c, m.call, formal.position + 1, defaultValue)
   # forget all inferred types if the overload matching failed
   if m.state == csNoMatch:
     for t in m.inferredTypes:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2737,7 +2737,7 @@ proc setSon(c: PContext; father: PNode, at: int, son: PNode) =
   father[at] = son
   # insert potential 'void' parameters:
   for i in oldLen..<at:
-    father[i] = newNodeIT(nkEmpty, son.info, getSysType(c.graph, father.info, tyVoid))
+    father[i] = newNodeIT(nkEmpty, son.info, getSysType(c.graph, son.info, tyVoid))
 
 # we are allowed to modify the calling node in the 'prepare*' procs:
 proc prepareOperand(c: PContext; formal: PType; a: PNode, newlyTyped: var bool): PNode =

--- a/tests/generics/tvoids.nim
+++ b/tests/generics/tvoids.nim
@@ -1,0 +1,19 @@
+block: # bug #25441
+  func foo[T](x: T, y: int) =
+    discard
+
+  foo[void](10)
+
+block:
+  func foo[T: void|float](e: openArray[int], x: T, y: int) =
+    discard
+
+  var x: seq[int]
+  foo[void] x, 2
+
+block: # bug #7355
+  proc gen[A: void, T: void|int](a: A, b: T) = discard
+
+  gen[void, void]()     # Works
+  gen[void, int] 0      # Crash
+  gen[void, int](b = 0) # Crash

--- a/tests/macros/t16758.nim
+++ b/tests/macros/t16758.nim
@@ -1,7 +1,3 @@
-discard """
-errormsg: "'blk.p(a)' has nil child at index 1"
-action: reject
-"""
 import macros
 
 type BlockLiteral[T] = object


### PR DESCRIPTION
fixes #25441
fixes  #7355

During signature matching (`sigmatch.nim`) the candidate call node
  (`m.call`) is constructed using absolute slot positions (via `setSon(..., formal.position+1, ...)`),
  which can leave holes (`nil`) for erased parameters.

In this PR, it removes these nil slots from parameters. Or it can use `nkEmpty` for placeholders to be removed after sigmatch