### PR TITLE
fixes #25446; [FieldDefect] with static: discard cast[pointer](default(pointer))

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -663,7 +663,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       of rkNode:
         if regs[rb].node.typ.kind notin PtrLikeKinds:
           stackTrace(c, tos, pc, "opcCastIntToPtr: regs[rb].node.typ: " & $regs[rb].node.typ.kind)
-        node2.intVal = regs[rb].node.intVal
+        if regs[rb].node.kind == nkNilLit:
+          node2.intVal = 0
+        else:
+          node2.intVal = regs[rb].node.intVal
       else: stackTrace(c, tos, pc, "opcCastIntToPtr: regs[rb].kind: " & $regs[rb].kind)
       regs[ra].node = node2
     of opcAsgnComplex:

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -814,6 +814,8 @@ static:
   conf.val = 2
   foo2323(defaultConf)
 
+  discard cast[pointer](default(pointer)) # bug #25446
+
 
 proc g1314(_: static bool) = discard
 proc g1314(_: int) = discard


### PR DESCRIPTION
fixes #25446

supports this since `static: discard cast[pointer](nil)` works