### PR TITLE
fixes #25457; make rawAlloc support alignment 

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -478,7 +478,8 @@ iterator allObjects(m: var MemRegion): pointer {.inline.} =
             a = a +% size
         else:
           let c = cast[PBigChunk](c)
-          yield addr(c.data)
+          # Yield the aligned address that was actually returned to user
+          yield addr(c.data) +! c.alignOffset
   m.locked = false
 
 proc iterToProc*(iter: typed, envType: typedesc; procName: untyped) {.
@@ -1130,7 +1131,8 @@ when not defined(gcDestructors):
         if avlNode != nil:
           var k = cast[pointer](avlNode.key)
           var c = cast[PBigChunk](pageAddr(k))
-          sysAssert(addr(c.data) == k, " k is not the same as addr(c.data)!")
+          # k should be the aligned address (addr(c.data) + alignOffset)
+          sysAssert(addr(c.data) +! c.alignOffset == k, " k is not the aligned address!")
           if cast[ptr FreeCell](k).zeroField >% 1:
             result = k
             sysAssert isAllocatedPtr(a, result), " result wrong pointer!"

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -849,10 +849,11 @@ when defined(heaptrack):
 proc applyAlignment(basePtr: pointer, alignment: int, offset: int, c: PBigChunk): pointer {.inline.} =
   # Apply alignment if needed: align (basePtr + offset) to alignment boundary
   if alignment > MemAlign:
-    let base = basePtr +! offset
-    let alignOffset = alignment -% cast[int](cast[uint](base) and uint(alignment - 1))
-    result = base +! alignOffset
-    c.alignOffset = cast[uint16](alignOffset +% offset)
+    # Use integer modulo-safe arithmetic for addresses and ptrarith for casts
+    let alignedUserData = align(cast[int](basePtr) +% offset, alignment)
+    let finalResult = alignedUserData -% offset
+    c.alignOffset = cast[uint16](finalResult -% cast[int](basePtr))
+    result = cast[pointer](finalResult)
   else:
     c.alignOffset = 0
     result = basePtr

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -134,6 +134,7 @@ type
 
   BigChunk = object of BaseChunk # not necessarily > PageSize!
     next, prev: PBigChunk    # chunks of the same (or bigger) size
+    alignOffset: int16       # offset from data start to actual Cell (for aligned allocs)
     data {.align: MemAlign.}: UncheckedArray[byte]      # start of usable memory
 
   HeapLinks = object
@@ -967,7 +968,11 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     if alignment > MemAlign:
       let mask = alignment - 1
       let alignedUserData = (cast[int](result) + extraSize + mask) and not mask
-      result = cast[pointer](alignedUserData - extraSize)
+      let finalResult = cast[pointer](alignedUserData - extraSize)
+      c.alignOffset = cast[int16](cast[int](finalResult) - cast[int](result))
+      result = finalResult
+    else:
+      c.alignOffset = 0
 
     sysAssert((cast[int](c) and (MemAlign-1)) == 0, "rawAlloc 13")
     sysAssert((cast[int](c) and PageMask) == 0, "rawAlloc: Not aligned on a page boundary")
@@ -1079,11 +1084,9 @@ when not defined(gcDestructors):
             (cast[ptr FreeCell](p).zeroField >% 1)
         else:
           var c = cast[PBigChunk](c)
-          # For aligned allocations, p might not be exactly at c.data
-          let dataStart = cast[int](addr(c.data))
-          let dataEnd = dataStart + (c.size - bigChunkOverhead())
-          result = (cast[int](p) >= dataStart and cast[int](p) < dataEnd) and
-                   cast[ptr FreeCell](p).zeroField >% 1
+          # Use stored alignOffset to find the actual Cell location
+          let cellPtr = cast[pointer](cast[int](addr(c.data)) + c.alignOffset)
+          result = p == cellPtr and cast[ptr FreeCell](p).zeroField >% 1
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =
     a.minLargeObj = lowGauge(a.root)
@@ -1107,7 +1110,8 @@ when not defined(gcDestructors):
               sysAssert isAllocatedPtr(a, result), " result wrong pointer!"
         else:
           var c = cast[PBigChunk](c)
-          var d = addr(c.data)
+          # Use stored alignment offset to find the actual Cell location
+          var d = cast[pointer](cast[int](addr(c.data)) + c.alignOffset)
           if p >= d and cast[ptr FreeCell](d).zeroField >% 1:
             result = d
             sysAssert isAllocatedPtr(a, result), " result wrong pointer!"

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -1088,7 +1088,7 @@ when not defined(gcDestructors):
         else:
           var c = cast[PBigChunk](c)
           # Use stored alignOffset to find the actual Cell location
-          let cellPtr = cast[pointer](cast[int](addr(c.data)) + cast[int](c.alignOffset))
+          let cellPtr = addr(c.data) +! c.alignOffset
           result = p == cellPtr and cast[ptr FreeCell](p).zeroField >% 1
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =
@@ -1114,7 +1114,7 @@ when not defined(gcDestructors):
         else:
           var c = cast[PBigChunk](c)
           # Use stored alignment offset to find the actual Cell location
-          var d = cast[pointer](cast[int](addr(c.data)) + c.alignOffset)
+          var d = addr(c.data) +! c.alignOffset
           if p >= d and cast[ptr FreeCell](d).zeroField >% 1:
             result = d
             sysAssert isAllocatedPtr(a, result), " result wrong pointer!"

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -850,16 +850,10 @@ when defined(heaptrack):
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
 proc applyAlignment(basePtr: pointer, alignment: int, offset: int, c: PBigChunk): pointer {.inline.} =
-  # Apply alignment if needed: align (basePtr + offset) to alignment boundary
-  if alignment > MemAlign:
-    # Use integer modulo-safe arithmetic for addresses and ptrarith for casts
-    let alignedUserData = align(cast[int](basePtr) +% offset, alignment)
-    let finalResult = alignedUserData -% offset
-    c.alignOffset = cast[uint16](finalResult -% cast[int](basePtr))
-    result = cast[pointer](finalResult)
-  else:
-    c.alignOffset = 0
-    result = basePtr
+  let alignedUserData = align(cast[int](basePtr) +% offset, alignment)
+  let finalResult = alignedUserData -% offset
+  c.alignOffset = cast[uint16](finalResult -% cast[int](basePtr))
+  result = cast[pointer](finalResult)
 
 proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
   when defined(nimTypeNames):
@@ -979,7 +973,10 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
     sysAssert c.next == nil, "rawAlloc 11"
     result = addr(c.data)
     # Apply alignment if needed: align (result + offset) to alignment boundary
-    result = applyAlignment(result, alignment, offset, c)
+    if alignment > MemAlign:
+      result = applyAlignment(result, alignment, offset, c)
+    else:
+      c.alignOffset = 0
 
     sysAssert((cast[int](c) and (MemAlign-1)) == 0, "rawAlloc 13")
     sysAssert((cast[int](c) and PageMask) == 0, "rawAlloc: Not aligned on a page boundary")

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -850,9 +850,9 @@ proc applyAlignment(basePtr: pointer, alignment: int, offset: int, c: PBigChunk)
   # Apply alignment if needed: align (basePtr + offset) to alignment boundary
   if alignment > MemAlign:
     let base = basePtr +! offset
-    let alignOffset = alignment - (cast[int](base) and (alignment - 1))
+    let alignOffset = alignment -% cast[int](cast[uint](base) and uint(alignment - 1))
     result = base +! alignOffset
-    c.alignOffset = cast[uint16](alignOffset + offset)
+    c.alignOffset = cast[uint16](alignOffset +% offset)
   else:
     c.alignOffset = 0
     result = basePtr

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -134,7 +134,6 @@ type
 
   BigChunk = object of BaseChunk # not necessarily > PageSize!
     next, prev: PBigChunk    # chunks of the same (or bigger) size
-    alignOffset: uint16       # offset from data start to actual Cell (for aligned allocs)
     data {.align: MemAlign.}: UncheckedArray[byte]      # start of usable memory
 
   HeapLinks = object
@@ -478,8 +477,8 @@ iterator allObjects(m: var MemRegion): pointer {.inline.} =
             a = a +% size
         else:
           let c = cast[PBigChunk](c)
-          # Yield the aligned address that was actually returned to user
-          yield addr(c.data) +! c.alignOffset
+          # prev stores the aligned data pointer set during rawAlloc
+          yield cast[pointer](c.prev)
   m.locked = false
 
 proc iterToProc*(iter: typed, envType: typedesc; procName: untyped) {.
@@ -779,9 +778,10 @@ proc deallocBigChunk(a: var MemRegion, c: PBigChunk) =
   sysAssert a.occ >= 0, "rawDealloc: negative occupied memory (case B)"
   when not defined(gcDestructors):
     a.deleted = getBottom(a)
-    # Use the same address that was added during allocation (accounting for alignment)
-    let alignedDataAddr = cast[int](addr(c.data)) +% c.alignOffset.int
-    del(a, a.root, alignedDataAddr)
+    # prev stores the aligned data pointer that was added to the AVL tree during allocation
+    del(a, a.root, cast[int](c.prev))
+  # Reset prev before freeing (required by listAdd assertions in freeBigChunk)
+  c.prev = nil
   if c.size >= HugeChunkSize: freeHugeChunk(a, c)
   else: freeBigChunk(a, c)
 
@@ -849,11 +849,12 @@ when defined(heaptrack):
   proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
-proc applyAlignment(basePtr: pointer, alignment: int, offset: int, c: PBigChunk): pointer {.inline.} =
-  let alignedUserData = align(cast[int](basePtr) +% offset, alignment)
-  let finalResult = alignedUserData -% offset
-  c.alignOffset = cast[uint16](finalResult -% cast[int](basePtr))
-  result = cast[pointer](finalResult)
+proc bigChunkAlignOffset(alignment, offset: int): int {.inline.} =
+  ## Compute the alignment offset for big chunk data.
+  ## Since chunks are page-aligned and sizeof(BigChunk) is a compile-time constant,
+  ## the offset is deterministic for a given alignment and data offset.
+  if alignment <= MemAlign: 0
+  else: align(sizeof(BigChunk) + offset, alignment) - sizeof(BigChunk) - offset
 
 proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
   when defined(nimTypeNames):
@@ -962,21 +963,20 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
       if deferredFrees != nil:
         freeDeferredObjects(a, deferredFrees)
 
-    # For big chunks with custom alignment, allocate extra space for alignment adjustment
-    size = requestedSize + bigChunkOverhead()
-    if alignment > MemAlign:
-      size += alignment - 1
+    # For big chunks with custom alignment, allocate extra space.
+    # Since chunks are page-aligned, the needed padding is a compile-time
+    # deterministic value rather than a worst-case estimate.
+    let alignPad = bigChunkAlignOffset(alignment, offset)
+    size = requestedSize + bigChunkOverhead() + alignPad
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
             else: getBigChunk(a, size)
     sysAssert c.prev == nil, "rawAlloc 10"
     sysAssert c.next == nil, "rawAlloc 11"
-    result = addr(c.data)
-    # Apply alignment if needed: align (result + offset) to alignment boundary
-    if alignment > MemAlign:
-      result = applyAlignment(result, alignment, offset, c)
-    else:
-      c.alignOffset = 0
+    result = addr(c.data) +! alignPad
+    # Store the aligned data pointer in prev for deallocation and GC traversal.
+    # prev is unused while the chunk is allocated (next/prev are free-list links).
+    c.prev = cast[PBigChunk](result)
 
     sysAssert((cast[int](c) and (MemAlign-1)) == 0, "rawAlloc 13")
     sysAssert((cast[int](c) and PageMask) == 0, "rawAlloc: Not aligned on a page boundary")
@@ -1088,8 +1088,8 @@ when not defined(gcDestructors):
             (cast[ptr FreeCell](p).zeroField >% 1)
         else:
           var c = cast[PBigChunk](c)
-          # Use stored alignOffset to find the actual Cell location
-          let cellPtr = addr(c.data) +! c.alignOffset
+          # prev stores the aligned data pointer set during rawAlloc
+          let cellPtr = cast[pointer](c.prev)
           result = p == cellPtr and cast[ptr FreeCell](p).zeroField >% 1
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =
@@ -1114,8 +1114,8 @@ when not defined(gcDestructors):
               sysAssert isAllocatedPtr(a, result), " result wrong pointer!"
         else:
           var c = cast[PBigChunk](c)
-          # Use stored alignment offset to find the actual Cell location
-          var d = addr(c.data) +! c.alignOffset
+          # prev stores the aligned data pointer set during rawAlloc
+          var d = cast[pointer](c.prev)
           if p >= d and cast[ptr FreeCell](d).zeroField >% 1:
             result = d
             sysAssert isAllocatedPtr(a, result), " result wrong pointer!"
@@ -1128,8 +1128,8 @@ when not defined(gcDestructors):
         if avlNode != nil:
           var k = cast[pointer](avlNode.key)
           var c = cast[PBigChunk](pageAddr(k))
-          # k should be the aligned address (addr(c.data) + alignOffset)
-          sysAssert(addr(c.data) +! c.alignOffset == k, " k is not the aligned address!")
+          # prev stores the aligned data pointer (the AVL tree key)
+          sysAssert(cast[pointer](c.prev) == k, " k is not the aligned address!")
           if cast[ptr FreeCell](k).zeroField >% 1:
             result = k
             sysAssert isAllocatedPtr(a, result), " result wrong pointer!"

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -849,14 +849,14 @@ when defined(heaptrack):
   proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
-proc bigChunkAlignOffset(alignment, offset: int): int {.inline.} =
+proc bigChunkAlignOffset(alignment: int): int {.inline.} =
   ## Compute the alignment offset for big chunk data.
-  ## Since chunks are page-aligned and sizeof(BigChunk) is a compile-time constant,
-  ## the offset is deterministic for a given alignment and data offset.
-  if alignment <= MemAlign: 0
-  else: align(sizeof(BigChunk) + offset, alignment) - sizeof(BigChunk) - offset
+  if alignment <= MemAlign:
+    result = 0
+  else:
+    result = align(sizeof(BigChunk) + sizeof(Cell), alignment) - sizeof(BigChunk) - sizeof(Cell)
 
-proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
+proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign): pointer =
   when defined(nimTypeNames):
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
@@ -966,7 +966,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time
     # deterministic value rather than a worst-case estimate.
-    let alignPad = bigChunkAlignOffset(alignment, offset)
+    let alignPad = bigChunkAlignOffset(alignment)
     size = requestedSize + bigChunkOverhead() + alignPad
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
@@ -991,8 +991,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
 
-proc rawAlloc0(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
-  result = rawAlloc(a, requestedSize, alignment, offset)
+proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
+  result = rawAlloc(a, requestedSize)
   zeroMem(result, requestedSize)
 
 proc rawDealloc(a: var MemRegion, p: pointer) =

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -850,18 +850,13 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
   sysAssert(roundup(65, 8) == 72, "rawAlloc: roundup broken")
-  
-  # Calculate the actual size we need to allocate
-  # If alignment > MemAlign, we need extra space to ensure we can align the result
-  let alignmentOverhead = if alignment > MemAlign: alignment - 1 + extraSize else: 0
-  let totalSize = requestedSize + alignmentOverhead
-  
-  var size = roundup(totalSize, MemAlign)
+  var size = roundup(requestedSize, MemAlign)
   sysAssert(size >= sizeof(FreeCell), "rawAlloc: requested size too small")
   sysAssert(size >= requestedSize, "insufficient allocated size!")
   #c_fprintf(stdout, "alloc; size: %ld; %ld\n", requestedSize, size)
 
-  # Force big chunk allocation for aligned allocations to avoid cell boundary issues
+  # For custom alignments > MemAlign, force big chunk allocation
+  # Small chunks cannot handle arbitrary alignments due to fixed cell boundaries
   if size <= SmallChunkSize-smallChunkOverhead() and alignment <= MemAlign:
     template fetchSharedCells(tc: PSmallChunk) =
       # Consumes cells from (potentially) foreign threads from `a.sharedFreeLists[s]`
@@ -957,13 +952,23 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
       if deferredFrees != nil:
         freeDeferredObjects(a, deferredFrees)
 
-    size = requestedSize + bigChunkOverhead() #  roundup(requestedSize+bigChunkOverhead(), PageSize)
+    # For big chunks with custom alignment, allocate extra space for alignment adjustment
+    size = requestedSize + bigChunkOverhead()
+    if alignment > MemAlign:
+      size += alignment - 1 + extraSize
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
             else: getBigChunk(a, size)
     sysAssert c.prev == nil, "rawAlloc 10"
     sysAssert c.next == nil, "rawAlloc 11"
     result = addr(c.data)
+    
+    # Apply alignment if needed: align (result + extraSize) to alignment boundary
+    if alignment > MemAlign and extraSize > 0:
+      let mask = alignment - 1
+      let alignedUserData = (cast[int](result) + extraSize + mask) and not mask
+      result = cast[pointer](alignedUserData - extraSize)
+
     sysAssert((cast[int](c) and (MemAlign-1)) == 0, "rawAlloc 13")
     sysAssert((cast[int](c) and PageMask) == 0, "rawAlloc: Not aligned on a page boundary")
     when not defined(gcDestructors):
@@ -972,23 +977,13 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     inc a.occ, c.size
     trackSize(c.size)
   sysAssert(isAccessible(a, result), "rawAlloc 14")
-  
-  # Handle alignment if specified
-  if alignment > MemAlign:
-    # We need to ensure that (result + extraSize) is aligned
-    # So find the aligned address for user data, then back up by extraSize
-    let userDataAddr = cast[int](result) + extraSize
-    let alignedUserDataAddr = (userDataAddr + alignment - 1) and not (alignment - 1)
-    # The result should be extraSize bytes before the aligned user data
-    result = cast[pointer](alignedUserDataAddr - extraSize)
-  
   sysAssert(allocInv(a), "rawAlloc: end")
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
 
-proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
-  result = rawAlloc(a, requestedSize)
+proc rawAlloc0(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, extraSize: int = 0): pointer =
+  result = rawAlloc(a, requestedSize, alignment, extraSize)
   zeroMem(result, requestedSize)
 
 proc rawDealloc(a: var MemRegion, p: pointer) =
@@ -1084,12 +1079,11 @@ when not defined(gcDestructors):
             (cast[ptr FreeCell](p).zeroField >% 1)
         else:
           var c = cast[PBigChunk](c)
-          # For aligned allocations, p might be offset from addr(c.data), but should be within data bounds
-          # Note: We cannot check zeroField/refcount as it may not be initialized yet when called from rawNewObj
+          # For aligned allocations, p might not be exactly at c.data
           let dataStart = cast[int](addr(c.data))
-          let dataEnd = dataStart + c.size - bigChunkOverhead()
-          let pAddr = cast[int](p)
-          result = (pAddr >= dataStart) and (pAddr < dataEnd)
+          let dataEnd = dataStart + (c.size - bigChunkOverhead())
+          result = (cast[int](p) >= dataStart and cast[int](p) < dataEnd) and
+                   cast[ptr FreeCell](p).zeroField >% 1
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =
     a.minLargeObj = lowGauge(a.root)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -987,8 +987,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
 
-proc rawAlloc0(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, extraSize: int = 0): pointer =
-  result = rawAlloc(a, requestedSize, alignment, extraSize)
+proc rawAlloc0(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
+  result = rawAlloc(a, requestedSize, alignment, offset)
   zeroMem(result, requestedSize)
 
 proc rawDealloc(a: var MemRegion, p: pointer) =

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -846,7 +846,7 @@ when defined(heaptrack):
   proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
-proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, extraSize: int = 0): pointer =
+proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
   when defined(nimTypeNames):
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
@@ -956,7 +956,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     # For big chunks with custom alignment, allocate extra space for alignment adjustment
     size = requestedSize + bigChunkOverhead()
     if alignment > MemAlign:
-      size += alignment - 1 + extraSize
+      size += alignment - 1
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
             else: getBigChunk(a, size)
@@ -964,11 +964,11 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     sysAssert c.next == nil, "rawAlloc 11"
     result = addr(c.data)
     
-    # Apply alignment if needed: align (result + extraSize) to alignment boundary
+    # Apply alignment if needed: align (result + offset) to alignment boundary
     if alignment > MemAlign:
       let mask = alignment - 1
-      let alignedUserData = (cast[int](result) + extraSize + mask) and not mask
-      let finalResult = cast[pointer](alignedUserData - extraSize)
+      let alignedUserData = (cast[int](result) + offset + mask) and not mask
+      let finalResult = cast[pointer](alignedUserData - offset)
       c.alignOffset = cast[int16](cast[int](finalResult) - cast[int](result))
       result = finalResult
     else:

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -845,17 +845,24 @@ when defined(heaptrack):
   proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
-proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
+proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, extraSize: int = 0): pointer =
   when defined(nimTypeNames):
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
   sysAssert(roundup(65, 8) == 72, "rawAlloc: roundup broken")
-  var size = roundup(requestedSize, MemAlign)
+  
+  # Calculate the actual size we need to allocate
+  # If alignment > MemAlign, we need extra space to ensure we can align the result
+  let alignmentOverhead = if alignment > MemAlign: alignment - 1 + extraSize else: 0
+  let totalSize = requestedSize + alignmentOverhead
+  
+  var size = roundup(totalSize, MemAlign)
   sysAssert(size >= sizeof(FreeCell), "rawAlloc: requested size too small")
   sysAssert(size >= requestedSize, "insufficient allocated size!")
   #c_fprintf(stdout, "alloc; size: %ld; %ld\n", requestedSize, size)
 
-  if size <= SmallChunkSize-smallChunkOverhead():
+  # Force big chunk allocation for aligned allocations to avoid cell boundary issues
+  if size <= SmallChunkSize-smallChunkOverhead() and alignment <= MemAlign:
     template fetchSharedCells(tc: PSmallChunk) =
       # Consumes cells from (potentially) foreign threads from `a.sharedFreeLists[s]`
       when defined(gcDestructors):
@@ -965,6 +972,16 @@ proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
     inc a.occ, c.size
     trackSize(c.size)
   sysAssert(isAccessible(a, result), "rawAlloc 14")
+  
+  # Handle alignment if specified
+  if alignment > MemAlign:
+    # We need to ensure that (result + extraSize) is aligned
+    # So find the aligned address for user data, then back up by extraSize
+    let userDataAddr = cast[int](result) + extraSize
+    let alignedUserDataAddr = (userDataAddr + alignment - 1) and not (alignment - 1)
+    # The result should be extraSize bytes before the aligned user data
+    result = cast[pointer](alignedUserDataAddr - extraSize)
+  
   sysAssert(allocInv(a), "rawAlloc: end")
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
@@ -1067,7 +1084,12 @@ when not defined(gcDestructors):
             (cast[ptr FreeCell](p).zeroField >% 1)
         else:
           var c = cast[PBigChunk](c)
-          result = p == addr(c.data) and cast[ptr FreeCell](p).zeroField >% 1
+          # For aligned allocations, p might be offset from addr(c.data), but should be within data bounds
+          # Note: We cannot check zeroField/refcount as it may not be initialized yet when called from rawNewObj
+          let dataStart = cast[int](addr(c.data))
+          let dataEnd = dataStart + c.size - bigChunkOverhead()
+          let pAddr = cast[int](p)
+          result = (pAddr >= dataStart) and (pAddr < dataEnd)
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =
     a.minLargeObj = lowGauge(a.root)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -964,7 +964,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, e
     result = addr(c.data)
     
     # Apply alignment if needed: align (result + extraSize) to alignment boundary
-    if alignment > MemAlign and extraSize > 0:
+    if alignment > MemAlign:
       let mask = alignment - 1
       let alignedUserData = (cast[int](result) + extraSize + mask) and not mask
       result = cast[pointer](alignedUserData - extraSize)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -134,7 +134,7 @@ type
 
   BigChunk = object of BaseChunk # not necessarily > PageSize!
     next, prev: PBigChunk    # chunks of the same (or bigger) size
-    alignOffset: int16       # offset from data start to actual Cell (for aligned allocs)
+    alignOffset: uint16       # offset from data start to actual Cell (for aligned allocs)
     data {.align: MemAlign.}: UncheckedArray[byte]      # start of usable memory
 
   HeapLinks = object
@@ -846,6 +846,17 @@ when defined(heaptrack):
   proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
   proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
 
+proc applyAlignment(basePtr: pointer, alignment: int, offset: int, c: PBigChunk): pointer {.inline.} =
+  # Apply alignment if needed: align (basePtr + offset) to alignment boundary
+  if alignment > MemAlign:
+    let base = basePtr +! offset
+    let alignOffset = alignment - (cast[int](base) and (alignment - 1))
+    result = base +! alignOffset
+    c.alignOffset = cast[uint16](alignOffset + offset)
+  else:
+    c.alignOffset = 0
+    result = basePtr
+
 proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, offset: int = 0): pointer =
   when defined(nimTypeNames):
     inc(a.allocCounter)
@@ -963,16 +974,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = MemAlign, o
     sysAssert c.prev == nil, "rawAlloc 10"
     sysAssert c.next == nil, "rawAlloc 11"
     result = addr(c.data)
-    
     # Apply alignment if needed: align (result + offset) to alignment boundary
-    if alignment > MemAlign:
-      let mask = alignment - 1
-      let alignedUserData = (cast[int](result) + offset + mask) and not mask
-      let finalResult = cast[pointer](alignedUserData - offset)
-      c.alignOffset = cast[int16](cast[int](finalResult) - cast[int](result))
-      result = finalResult
-    else:
-      c.alignOffset = 0
+    result = applyAlignment(result, alignment, offset, c)
 
     sysAssert((cast[int](c) and (MemAlign-1)) == 0, "rawAlloc 13")
     sysAssert((cast[int](c) and PageMask) == 0, "rawAlloc: Not aligned on a page boundary")
@@ -1085,7 +1088,7 @@ when not defined(gcDestructors):
         else:
           var c = cast[PBigChunk](c)
           # Use stored alignOffset to find the actual Cell location
-          let cellPtr = cast[pointer](cast[int](addr(c.data)) + c.alignOffset)
+          let cellPtr = cast[pointer](cast[int](addr(c.data)) + cast[int](c.alignOffset))
           result = p == cellPtr and cast[ptr FreeCell](p).zeroField >% 1
 
   proc prepareForInteriorPointerChecking(a: var MemRegion) {.inline.} =

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -778,7 +778,9 @@ proc deallocBigChunk(a: var MemRegion, c: PBigChunk) =
   sysAssert a.occ >= 0, "rawDealloc: negative occupied memory (case B)"
   when not defined(gcDestructors):
     a.deleted = getBottom(a)
-    del(a, a.root, cast[int](addr(c.data)))
+    # Use the same address that was added during allocation (accounting for alignment)
+    let alignedDataAddr = cast[int](addr(c.data)) +% c.alignOffset.int
+    del(a, a.root, alignedDataAddr)
   if c.size >= HugeChunkSize: freeHugeChunk(a, c)
   else: freeBigChunk(a, c)
 

--- a/lib/system/cellsets.nim
+++ b/lib/system/cellsets.nim
@@ -49,20 +49,6 @@ when defined(gcOrc) or defined(gcArc) or defined(gcAtomicArc):
   when not declaredInScope(PageShift):
     include bitmasks
 
-else:
-  type
-    RefCount = int
-
-    Cell {.pure.} = object
-      refcount: RefCount  # the refcount and some flags
-      typ: PNimType
-      when trackAllocationSource:
-        filename: cstring
-        line: int
-      when useCellIds:
-        id: int
-
-    PCell = ptr Cell
 
 type
   PPageDesc = ptr PageDesc

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -460,7 +460,7 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   collectCT(gch)
   # Use alignment from typ.base if available, otherwise use MemAlign
   let alignment = if typ.kind == tyRef and typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment, sizeof(Cell)))
+  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment))
   #gcAssert typ.kind in {tyString, tySequence} or size >= typ.base.size, "size too small"
   # Check that the user data (after the Cell header) is properly aligned
   gcAssert((cast[int](cellToUsr(res)) and (alignment-1)) == 0, "newObj: 2")
@@ -513,7 +513,7 @@ proc newObjRC1(typ: PNimType, size: int): pointer {.compilerRtl, noinline, raise
 
   # Use alignment from typ.base if available, otherwise use MemAlign
   let alignment = if typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment, sizeof(Cell)))
+  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment))
   sysAssert(allocInv(gch.region), "newObjRC1 after rawAlloc")
   # Check that the user data (after the Cell header) is properly aligned
   sysAssert((cast[int](cellToUsr(res)) and (alignment-1)) == 0, "newObj: 2")

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -458,9 +458,12 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   sysAssert(allocInv(gch.region), "rawNewObj begin")
   gcAssert(typ.kind in {tyRef, tyString, tySequence}, "newObj: 1")
   collectCT(gch)
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  # Use alignment from typ.base if available, otherwise use MemAlign
+  let alignment = if typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
+  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment, sizeof(Cell)))
   #gcAssert typ.kind in {tyString, tySequence} or size >= typ.base.size, "size too small"
-  gcAssert((cast[int](res) and (MemAlign-1)) == 0, "newObj: 2")
+  # Check that the user data (after the Cell header) is properly aligned
+  gcAssert((cast[int](cellToUsr(res)) and (alignment-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
   res.typ = typ
   setFrameInfo(res)
@@ -508,9 +511,12 @@ proc newObjRC1(typ: PNimType, size: int): pointer {.compilerRtl, noinline, raise
   collectCT(gch)
   sysAssert(allocInv(gch.region), "newObjRC1 after collectCT")
 
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  # Use alignment from typ.base if available, otherwise use MemAlign
+  let alignment = if typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
+  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment, sizeof(Cell)))
   sysAssert(allocInv(gch.region), "newObjRC1 after rawAlloc")
-  sysAssert((cast[int](res) and (MemAlign-1)) == 0, "newObj: 2")
+  # Check that the user data (after the Cell header) is properly aligned
+  sysAssert((cast[int](cellToUsr(res)) and (alignment-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
   res.typ = typ
   setFrameInfo(res)

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -459,7 +459,7 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   gcAssert(typ.kind in {tyRef, tyString, tySequence}, "newObj: 1")
   collectCT(gch)
   # Use alignment from typ.base if available, otherwise use MemAlign
-  let alignment = if typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
+  let alignment = if typ.kind == tyRef and typ.base != nil: max(typ.base.align, MemAlign) else: MemAlign
   var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell), alignment, sizeof(Cell)))
   #gcAssert typ.kind in {tyString, tySequence} or size >= typ.base.size, "size too small"
   # Check that the user data (after the Cell header) is properly aligned

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -38,7 +38,7 @@ type
   PByte = ptr ByteArray
   PString = ptr string
 
-when not (defined(gcOrc) or defined(gcArc) or defined(gcAtomicArc)):
+when not defined(nimV2):
   type
     RefCount = int
 

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -38,6 +38,21 @@ type
   PByte = ptr ByteArray
   PString = ptr string
 
+when not (defined(gcOrc) or defined(gcArc) or defined(gcAtomicArc)):
+  type
+    RefCount = int
+
+    Cell {.pure.} = object
+      refcount: RefCount  # the refcount and some flags
+      typ: PNimType
+      when trackAllocationSource:
+        filename: cstring
+        line: int
+      when useCellIds:
+        id: int
+
+    PCell = ptr Cell
+
 when declared(IntsPerTrunk):
   discard
 else:

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -1,6 +1,6 @@
 discard """
 ccodeCheck: "\\i @'NIM_ALIGN(128) NI mylocal1' .*"
-matrix: "--mm:refc -d:useGcAssert; --mm:orc"
+matrix: "--mm:refc -d:useGcAssert -d:useSysAssert; --mm:orc"
 targets: "c cpp"
 output: "align ok"
 """

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -123,49 +123,49 @@ for q in 0..500:
     z[i].a = q
     doAssert(cast[int](z[i]) mod alignof(MyType64) == 0)
 
-# type
-#   MyType128 = object
-#     a{.align(128).}: int
+type
+  MyType128 = object
+    a{.align(128).}: int
 
-# var w: array[10, ref MyType128]
-# for q in 0..500:
-#   for i in 0..<w.len:
-#     new w[i]
-#     w[i].a = q
-#     doAssert(cast[int](w[i]) mod alignof(MyType128) == 0)
+var w: array[10, ref MyType128]
+for q in 0..500:
+  for i in 0..<w.len:
+    new w[i]
+    w[i].a = q
+    doAssert(cast[int](w[i]) mod alignof(MyType128) == 0)
 
-# # Nested aligned-object tests
-# type
-#   Inner128 = object
-#     v {.align(128).}: byte
+# Nested aligned-object tests
+type
+  Inner128 = object
+    v {.align(128).}: byte
 
-#   OuterWithInner = object
-#     prefix: int
-#     inner: Inner128
+  OuterWithInner = object
+    prefix: int
+    inner: Inner128
 
-# var outerArr: array[8, ref OuterWithInner]
-# for q in 0..200:
-#   for i in 0..<outerArr.len:
-#     new outerArr[i]
-#     # write to inner to ensure it's allocated
-#     outerArr[i].inner.v = cast[byte](q and 0xFF)
-#     doAssert(cast[uint](addr outerArr[i].inner) mod uint(alignof(Inner128)) == 0)
+var outerArr: array[8, ref OuterWithInner]
+for q in 0..200:
+  for i in 0..<outerArr.len:
+    new outerArr[i]
+    # write to inner to ensure it's allocated
+    outerArr[i].inner.v = cast[byte](q and 0xFF)
+    doAssert(cast[uint](addr outerArr[i].inner) mod uint(alignof(Inner128)) == 0)
 
-# # Nested two-level alignment
-# type
-#   DeepInner = object
-#     b {.align(128).}: int
+# Nested two-level alignment
+type
+  DeepInner = object
+    b {.align(128).}: int
 
-#   Mid = object
-#     di: DeepInner
+  Mid = object
+    di: DeepInner
 
-#   Top = object
-#     m: Mid
+  Top = object
+    m: Mid
 
-# var topArr: array[4, ref Top]
-# for q in 0..100:
-#   for i in 0..<topArr.len:
-#     new topArr[i]
-#     topArr[i].m.di.b = q
-#     doAssert(cast[uint](addr topArr[i].m.di) mod uint(alignof(DeepInner)) == 0)
+var topArr: array[4, ref Top]
+for q in 0..100:
+  for i in 0..<topArr.len:
+    new topArr[i]
+    topArr[i].m.di.b = q
+    doAssert(cast[uint](addr topArr[i].m.di) mod uint(alignof(DeepInner)) == 0)
 

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -123,49 +123,49 @@ for q in 0..500:
     z[i].a = q
     doAssert(cast[int](z[i]) mod alignof(MyType64) == 0)
 
-type
-  MyType128 = object
-    a{.align(128).}: int
+# type
+#   MyType128 = object
+#     a{.align(128).}: int
 
-var w: array[10, ref MyType128]
-for q in 0..500:
-  for i in 0..<w.len:
-    new w[i]
-    w[i].a = q
-    doAssert(cast[int](w[i]) mod alignof(MyType128) == 0)
+# var w: array[10, ref MyType128]
+# for q in 0..500:
+#   for i in 0..<w.len:
+#     new w[i]
+#     w[i].a = q
+#     doAssert(cast[int](w[i]) mod alignof(MyType128) == 0)
 
-# Nested aligned-object tests
-type
-  Inner128 = object
-    v {.align(128).}: byte
+# # Nested aligned-object tests
+# type
+#   Inner128 = object
+#     v {.align(128).}: byte
 
-  OuterWithInner = object
-    prefix: int
-    inner: Inner128
+#   OuterWithInner = object
+#     prefix: int
+#     inner: Inner128
 
-var outerArr: array[8, ref OuterWithInner]
-for q in 0..200:
-  for i in 0..<outerArr.len:
-    new outerArr[i]
-    # write to inner to ensure it's allocated
-    outerArr[i].inner.v = cast[byte](q and 0xFF)
-    doAssert(cast[uint](addr outerArr[i].inner) mod uint(alignof(Inner128)) == 0)
+# var outerArr: array[8, ref OuterWithInner]
+# for q in 0..200:
+#   for i in 0..<outerArr.len:
+#     new outerArr[i]
+#     # write to inner to ensure it's allocated
+#     outerArr[i].inner.v = cast[byte](q and 0xFF)
+#     doAssert(cast[uint](addr outerArr[i].inner) mod uint(alignof(Inner128)) == 0)
 
-# Nested two-level alignment
-type
-  DeepInner = object
-    b {.align(128).}: int
+# # Nested two-level alignment
+# type
+#   DeepInner = object
+#     b {.align(128).}: int
 
-  Mid = object
-    di: DeepInner
+#   Mid = object
+#     di: DeepInner
 
-  Top = object
-    m: Mid
+#   Top = object
+#     m: Mid
 
-var topArr: array[4, ref Top]
-for q in 0..100:
-  for i in 0..<topArr.len:
-    new topArr[i]
-    topArr[i].m.di.b = q
-    doAssert(cast[uint](addr topArr[i].m.di) mod uint(alignof(DeepInner)) == 0)
+# var topArr: array[4, ref Top]
+# for q in 0..100:
+#   for i in 0..<topArr.len:
+#     new topArr[i]
+#     topArr[i].m.di.b = q
+#     doAssert(cast[uint](addr topArr[i].m.di) mod uint(alignof(DeepInner)) == 0)
 

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -1,5 +1,6 @@
 discard """
 ccodeCheck: "\\i @'NIM_ALIGN(128) NI mylocal1' .*"
+matrix: "--mm:refc -d:useGcAssert; --mm:orc"
 targets: "c cpp"
 output: "align ok"
 """
@@ -66,4 +67,47 @@ block: # bug #22419
       doAssert value mod 16 == 0
 
   f()()
+
+
+type Xxx = object
+  v {.align: 128.}: byte
+
+type Yyy = object
+  v: byte
+  v2: Xxx
+
+for i in 0..<3:
+  let x = new Yyy
+  # echo "addr v2.v:", cast[uint](addr x.v2.v)
+  doAssert cast[uint](addr x.v2.v) mod 128 == 0
+
+let m = new Yyy
+m.v2.v = 42
+doAssert m.v2.v == 42
+m.v = 7
+doAssert m.v == 7
+
+
+type
+  MyType16 = object
+    a {.align(16).}: int
+
+
+var x: array[10, ref MyType16]
+for q in 0..500:
+  for i in 0..<x.len:
+    new x[i]
+    x[i].a = q
+    doAssert(cast[int](x[i]) mod alignof(MyType16) == 0)
+
+type
+  MyType32  = object
+    a{.align(32).}: int
+
+var y: array[10, ref MyType32]
+for q in 0..500:
+  for i in 0..<y.len:
+    new y[i]
+    y[i].a = q
+    doAssert(cast[int](y[i]) mod alignof(MyType32) == 0)
 

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -111,3 +111,61 @@ for q in 0..500:
     y[i].a = q
     doAssert(cast[int](y[i]) mod alignof(MyType32) == 0)
 
+# Additional tests: allocate custom aligned objects using `new`
+type
+  MyType64 = object
+    a{.align(64).}: int
+
+var z: array[10, ref MyType64]
+for q in 0..500:
+  for i in 0..<z.len:
+    new z[i]
+    z[i].a = q
+    doAssert(cast[int](z[i]) mod alignof(MyType64) == 0)
+
+type
+  MyType128 = object
+    a{.align(128).}: int
+
+var w: array[10, ref MyType128]
+for q in 0..500:
+  for i in 0..<w.len:
+    new w[i]
+    w[i].a = q
+    doAssert(cast[int](w[i]) mod alignof(MyType128) == 0)
+
+# Nested aligned-object tests
+type
+  Inner128 = object
+    v {.align(128).}: byte
+
+  OuterWithInner = object
+    prefix: int
+    inner: Inner128
+
+var outerArr: array[8, ref OuterWithInner]
+for q in 0..200:
+  for i in 0..<outerArr.len:
+    new outerArr[i]
+    # write to inner to ensure it's allocated
+    outerArr[i].inner.v = cast[byte](q and 0xFF)
+    doAssert(cast[uint](addr outerArr[i].inner) mod uint(alignof(Inner128)) == 0)
+
+# Nested two-level alignment
+type
+  DeepInner = object
+    b {.align(128).}: int
+
+  Mid = object
+    di: DeepInner
+
+  Top = object
+    m: Mid
+
+var topArr: array[4, ref Top]
+for q in 0..100:
+  for i in 0..<topArr.len:
+    new topArr[i]
+    topArr[i].m.di.b = q
+    doAssert(cast[uint](addr topArr[i].m.di) mod uint(alignof(DeepInner)) == 0)
+


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/25457

Small chunks allocate memory in fixed-size cells. Each cell is positioned at exact multiples of the cell size from the chunk's data start, which makes it much harder to support alignment

```nim
sysAssert c.size == size, "rawAlloc 6"
if c.freeList == nil:
  sysAssert(c.acc.int + smallChunkOverhead() + size <= SmallChunkSize,
            "rawAlloc 7")
  result = cast[pointer](cast[int](addr(c.data)) +% c.acc.int)
  inc(c.acc, size)
```

See also https://github.com/nim-lang/Nim/pull/12926 

While using big trunk, each allocation gets its own chunk