### PR TITLE
fixes #15797; allows calling generic procs even if the proc name is surrounded with parentheses

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1105,7 +1105,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType
     let t = n[0].typ
     if t != nil and t.kind in {tyVar, tyLent}:
       n[0] = newDeref(n[0])
-    elif isSymChoice(n[0]) and nfDotField notin n.flags:
+    elif (isSymChoice(n[0]) or (n[0].kind == nkSym and isGenericRoutineStrict(n[0].sym))) and nfDotField notin n.flags:
       # overloaded generic procs e.g. newSeq[int] can end up here
       return semDirectOp(c, n, flags, expectedType)
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1078,7 +1078,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
   if tracked.c.matchedConcept == nil and a.kind == nkSym:
-    if a.sym.isGenericRoutineStrict() and a.sym.magic notin {mSizeOf, mZeroDefault}:
+    if a.sym.isGenericRoutineStrict() and a.sym.magic notin {mSizeOf, mZeroDefault, mTypeOf}:
       # this error is likely a compiler bug
 
       # it is not instantiated if there is an error

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1078,7 +1078,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
   if a.kind == nkSym:
-    if a.sym.isGenericRoutineStrict():
+    if a.sym.isGenericRoutineStrict() and a.sym.magic != mZeroDefault:
       # this error is likely a compiler bug
       localError(tracked.config, a.info, "calling generic procedure without instantiation: $1" % a.sym.name.s)
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1077,7 +1077,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
   if n.typ != nil:
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
-  if a.kind == nkSym:
+  if tracked.c.matchedConcept == nil and a.kind == nkSym:
     if a.sym.isGenericRoutineStrict() and a.sym.magic notin {mSizeOf, mZeroDefault}:
       # this error is likely a compiler bug
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1078,7 +1078,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
   if a.kind == nkSym:
-    if a.sym.isGenericRoutineStrict() and a.sym.magic != mZeroDefault:
+    if a.sym.isGenericRoutineStrict() and a.sym.magic notin {mSizeOf, mZeroDefault}:
       # this error is likely a compiler bug
       localError(tracked.config, a.info, "calling generic procedure without instantiation: $1" % a.sym.name.s)
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1080,7 +1080,16 @@ proc trackCall(tracked: PEffects; n: PNode) =
   if a.kind == nkSym:
     if a.sym.isGenericRoutineStrict() and a.sym.magic notin {mSizeOf, mZeroDefault}:
       # this error is likely a compiler bug
-      localError(tracked.config, a.info, "calling generic procedure without instantiation: $1" % a.sym.name.s)
+
+      # it is not instantiated if there is an error
+      var hasErrorType = false
+      for i in 1..<n.len:
+        let nt = n[i].typ
+        if nt.kind == tyError:
+          hasErrorType = true
+          break
+      if not hasErrorType:
+        localError(tracked.config, a.info, "calling generic procedure without instantiation: $1" % a.sym.name.s)
 
   when defined(nimsuggest):
     var actualLoc = a.info

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1077,6 +1077,10 @@ proc trackCall(tracked: PEffects; n: PNode) =
   if n.typ != nil:
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
+  if a.kind == nkSym:
+    if a.sym.isGenericRoutineStrict():
+      # this error is likely a compiler bug
+      localError(tracked.config, a.info, "calling generic procedure without instantiation: $1" % a.sym.name.s)
 
   when defined(nimsuggest):
     var actualLoc = a.info


### PR DESCRIPTION
Also adds check code to sempass2.nim that can detect a bug like this issue.
It prints an error if a generic proc is called without instantiation.
