### PR TITLE
Support size pragma with generic type parameters

### DIFF
--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -14,7 +14,7 @@ from std / strutils import startsWith
 from std / os import fileExists
 import astdef, idents, msgs, options
 import lineinfos as astli
-import pathutils #, modulegraphs
+import pathutils, typeext
 import "../dist/nimony/src/lib" / [bitabs, nifstreams, nifcursors, lineinfos,
   nifindexes, nifreader]
 import "../dist/nimony/src/gear2" / modnames
@@ -148,6 +148,8 @@ let
   sdefTag = registerTag(symDefTagName)
   tdefTag = registerTag(typeDefTagName)
   hiddenTypeTag = registerTag(hiddenTypeTagName)
+  typeExtensionsTag = registerTag("type_extensions")
+  extTag = registerTag("ext")
 
 type
   Writer = object
@@ -160,6 +162,8 @@ type
     #writtenTypes: seq[PType]  # types written in this module, to be unloaded later
     #writtenSyms: seq[PSym]    # symbols written in this module, to be unloaded later
     writtenPackages: HashSet[string]
+    # Type extension side-table (passed from ModuleGraph)
+    typeExtensions: ptr Table[ItemId, seq[TypeExtension]]
 
 const
   # Symbol kinds that are always local to a proc and should never have module suffix
@@ -249,6 +253,30 @@ proc writeLoc(w: var Writer; dest: var TokenBuf; loc: TLoc) =
   writeFlags(dest, loc.flags)  # TLocFlags
   dest.addStrLit loc.snippet
 
+proc typeExtKindToStr(kind: TypeExtKind): string =
+  case kind
+  of extDeferredSize: "deferred_size"
+  of extDeferredAlign: "deferred_align"
+
+proc writeTypeExtensions(w: var Writer; dest: var TokenBuf; typ: PType) =
+  ## Serialize type extensions as NIF for persistence.
+  ## Format: (type_extensions (ext "kind" <expr>) ...)
+  ## If no extensions, writes DotToken (empty).
+  if w.typeExtensions == nil or not w.typeExtensions[].hasKey(typ.itemId):
+    dest.addDotToken()
+    return
+
+  let extensions = w.typeExtensions[][typ.itemId]
+  if extensions.len == 0:
+    dest.addDotToken()
+    return
+
+  dest.buildTree typeExtensionsTag:
+    for ext in extensions:
+      dest.buildTree extTag:
+        dest.addStrLit typeExtKindToStr(ext.kind)
+        writeNode(w, dest, ext.expr)
+
 proc writeTypeDef(w: var Writer; dest: var TokenBuf; typ: PType) =
   dest.buildTree tdefTag:
     dest.addSymDef pool.syms.getOrIncl(typeToNifSym(typ, w.infos.config)), NoLineInfo
@@ -271,6 +299,8 @@ proc writeTypeDef(w: var Writer; dest: var TokenBuf; typ: PType) =
 
     # Write TLoc structure
     writeLoc w, dest, typ.locImpl
+    # Write type extensions (deferred pragmas)
+    writeTypeExtensions w, dest, typ
     # we store the type's elements here at the end so that
     # it is not ambiguous and saves space:
     for ch in typ.sonsImpl:
@@ -706,8 +736,10 @@ proc writeOp(w: var Writer; content: var TokenBuf; op: LogEntry) =
 
 proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
                      opsLog: seq[LogEntry];
-                     replayActions: seq[PNode] = @[]) =
-  var w = Writer(infos: LineInfoWriter(config: config), currentModule: thisModule)
+                     replayActions: seq[PNode] = @[];
+                     typeExtensions: ptr Table[ItemId, seq[TypeExtension]] = nil) =
+  var w = Writer(infos: LineInfoWriter(config: config), currentModule: thisModule,
+                 typeExtensions: typeExtensions)
   var content = createTokenBuf(300)
 
   let rootInfo = trLineInfo(w, n.info)
@@ -825,10 +857,18 @@ type
     syms: Table[string, (PSym, NifIndexEntry)]
     mods: Table[FileIndex, NifModule]
     cache: IdentCache
+    # Type extension side-table (set via setTypeExtensions after ModuleGraph is created)
+    typeExtensions*: ptr Table[ItemId, seq[TypeExtension]]
 
 proc createDecodeContext*(config: ConfigRef; cache: IdentCache): DecodeContext =
   ## Supposed to be a global variable
   result = DecodeContext(infos: LineInfoWriter(config: config), cache: cache)
+
+proc setTypeExtensions*(c: var DecodeContext;
+                        typeExtensions: ptr Table[ItemId, seq[TypeExtension]]) =
+  ## Sets the type extension table for loading.
+  ## Must be called after createDecodeContext and after ModuleGraph is created.
+  c.typeExtensions = typeExtensions
 
 proc cursorFromIndexEntry(c: var DecodeContext; module: FileIndex; entry: NifIndexEntry;
                           buf: var TokenBuf): Cursor =
@@ -1078,6 +1118,48 @@ proc loadLoc(c: var DecodeContext; n: var Cursor; loc: var TLoc) =
   loadField loc.flags
   loadField loc.snippet
 
+proc strToTypeExtKind(s: string): TypeExtKind =
+  case s
+  of "deferred_size": extDeferredSize
+  of "deferred_align": extDeferredAlign
+  else: extDeferredSize  # fallback, shouldn't happen
+
+proc loadTypeExtensions(c: var DecodeContext; n: var Cursor; t: PType;
+                        thisModule: string; localSyms: var Table[string, PSym]) =
+  ## Load type extensions from NIF into side-table.
+  ## Handles backwards compatibility: if no extensions present (old format), skips gracefully.
+  ## Format: (type_extensions (ext "kind" <expr>) ...) or DotToken
+  if n.kind == DotToken:
+    # No extensions (or old format that didn't have this slot)
+    inc n
+    return
+
+  if n.kind == ParLe and n.tagId == typeExtensionsTag:
+    inc n  # skip (type_extensions
+    while n.kind != ParRi:
+      if n.kind == ParLe and n.tagId == extTag:
+        inc n  # skip (ext
+        if n.kind == StringLit:
+          let kindStr = pool.strings[n.litId]
+          inc n
+          let expr = loadNode(c, n, thisModule, localSyms)
+          if c.typeExtensions != nil and expr != nil:
+            let kind = strToTypeExtKind(kindStr)
+            if not c.typeExtensions[].hasKey(t.itemId):
+              c.typeExtensions[][t.itemId] = @[]
+            c.typeExtensions[][t.itemId].add(TypeExtension(kind: kind, expr: expr))
+        else:
+          skip n  # skip malformed extension
+        if n.kind == ParRi:
+          inc n  # skip ) of ext
+      else:
+        inc n  # skip unexpected content
+    if n.kind == ParRi:
+      inc n  # skip ) of type_extensions
+  elif n.kind != ParRi:
+    # Old format without extensions slot - this position is a type son, don't consume
+    return
+
 proc loadTypeFromCursor(c: var DecodeContext; n: var Cursor; t: PType; localSyms: var Table[string, PSym]) =
   expect n, ParLe
   if n.tagId != tdefTag:
@@ -1106,6 +1188,8 @@ proc loadTypeFromCursor(c: var DecodeContext; n: var Cursor; t: PType; localSyms
   t.ownerFieldImpl = loadSymStub(c, n, typesModule, localSyms)
   t.symImpl = loadSymStub(c, n, typesModule, localSyms)
   loadLoc c, n, t.locImpl
+  # Load type extensions (deferred pragmas) from NIF pragmas
+  loadTypeExtensions c, n, t, typesModule, localSyms
 
   while n.kind != ParRi:
     t.sonsImpl.add loadTypeStub(c, n, localSyms)

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -14,6 +14,8 @@
 import std/[intsets, tables, hashes, strtabs, os, strutils, parseutils]
 import ../dist/checksums/src/checksums/md5
 import ast, astalgo, options, lineinfos,idents, btrees, ropes, msgs, pathutils, packages, suggestsymdb
+import typeext
+export typeext
 
 when not defined(nimKochBootstrap):
   import ast2nif
@@ -95,6 +97,11 @@ type
     objectTree*: Table[ItemId, seq[tuple[depth: int, value: PType]]]
     methodsPerType*: Table[ItemId, seq[PSym]]
     dispatchers*: seq[PSym]
+
+    # Type extension side-table (sparse metadata storage)
+    typeExtensions*: Table[ItemId, seq[TypeExtension]]
+      ## Generic type extensions that couldn't be stored on PType directly.
+      ## Used for deferred pragmas, future metadata, etc.
 
     systemModule*: PSym
     sysTypes*: array[TTypeKind, PType]
@@ -538,6 +545,8 @@ proc initModuleGraphFields(result: ModuleGraph) =
   result.emittedTypeInfo = initTable[string, FileIndex]()
   result.cachedFiles = newStringTable()
   result.cachedMods = initIntSet()
+  # Type extension side-table
+  result.typeExtensions = initTable[ItemId, seq[TypeExtension]]()
 
 proc newModuleGraph*(cache: IdentCache; config: ConfigRef): ModuleGraph =
   result = ModuleGraph()
@@ -545,6 +554,9 @@ proc newModuleGraph*(cache: IdentCache; config: ConfigRef): ModuleGraph =
   result.cache = cache
   initModuleGraphFields(result)
   ast.setupProgram(config, cache)
+  when not defined(nimKochBootstrap):
+    # Set type extension table pointer on DecodeContext for NIF loading
+    setTypeExtensions(ast.program, addr result.typeExtensions)
 
 proc resetAllModules*(g: ModuleGraph) =
   g.packageSyms = initStrTable()

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -1,7 +1,7 @@
 import sem, cgen, modulegraphs, ast, llstream, parser, msgs,
        lineinfos, reorder, options, semdata, cgendata, modules, pathutils,
        packages, syntaxes, depends, vm, pragmas, idents, lookups, wordrecg,
-       liftdestructors, nifgen
+       liftdestructors, nifgen, types
 
 when not defined(nimKochBootstrap):
   import vmdef
@@ -259,7 +259,8 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
           if m == module:
             replayActions.add n
 
-      writeNifModule(graph.config, module.position.int32, topLevelStmts, graph.opsLog, replayActions)
+      writeNifModule(graph.config, module.position.int32, topLevelStmts, graph.opsLog, replayActions,
+                     addr graph.typeExtensions)
 
   result = true
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -118,10 +118,13 @@ const
   errStringLiteralExpected = "string literal expected"
   errIntLiteralExpected = "integer literal expected"
 
-proc containsGenericParam(n: PNode): bool =
+proc containsGenericParam(c: PContext; n: PNode): bool =
   ## Check if AST node contains any unresolved generic type parameter.
-  ## Also returns true for unresolved identifiers (nkIdent) which may be
-  ## generic params not yet resolved during early pragma processing.
+  ## Returns true for:
+  ## - Symbols that are generic params (skGenericParam or tyGenericParam)
+  ## - Identifiers that resolve to generic params
+  ## - Identifiers that don't resolve to anything (likely generic params not yet in scope)
+  ##   BUT only if they also don't resolve to a known type like `cint`
   if n == nil: return false
   case n.kind
   of nkSym:
@@ -130,12 +133,26 @@ proc containsGenericParam(n: PNode): bool =
   of nkType:
     result = n.typ != nil and n.typ.kind == tyGenericParam
   of nkIdent:
-    # Unresolved identifier - could be a generic param not yet resolved.
-    # Defer evaluation to be safe.
-    result = true
+    # Try to look up the identifier in current scope
+    var ambiguous = false
+    let sym = searchInScopes(c, n.ident, ambiguous)
+    if sym == nil:
+      # Unresolved identifier - likely a generic param not yet fully in scope
+      result = true
+    elif sym.kind == skGenericParam:
+      result = true
+    elif sym.kind == skType and sym.typ != nil and sym.typ.kind == tyGenericParam:
+      result = true
+    else:
+      # Resolves to a known type (like cint) - not a generic param
+      result = false
+  of nkEmpty, nkNilLit, nkCharLit..nkUInt64Lit, nkFloatLit..nkFloat128Lit,
+     nkStrLit..nkTripleStrLit:
+    # Leaf nodes that are never generic params
+    result = false
   else:
     for child in n:
-      if containsGenericParam(child):
+      if containsGenericParam(c, child):
         return true
     result = false
 
@@ -964,7 +981,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         processImportObjC(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wSize:
         if sym.typ == nil: invalidPragma(c, it)
-        elif it.kind in nkPragmaCallKinds and it.len == 2 and containsGenericParam(it[1]):
+        elif it.kind in nkPragmaCallKinds and it.len == 2 and containsGenericParam(c, it[1]):
           # Defer evaluation until generic type is instantiated
           if sfImportc notin sym.flags:
             localError(c.config, it.info,

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -12,7 +12,8 @@
 import
   condsyms, ast, astalgo, idents, semdata, msgs, renderer,
   wordrecg, ropes, options, extccomp, magicsys, trees,
-  types, lookups, lineinfos, pathutils, linter, modulepaths
+  types, lookups, lineinfos, pathutils, linter, modulepaths,
+  modulegraphs
 
 from sigmatch import trySuggestPragmas
 
@@ -116,6 +117,27 @@ proc recordPragma(c: PContext; n: PNode; args: varargs[string]) =
 const
   errStringLiteralExpected = "string literal expected"
   errIntLiteralExpected = "integer literal expected"
+
+proc containsGenericParam(n: PNode): bool =
+  ## Check if AST node contains any unresolved generic type parameter.
+  ## Also returns true for unresolved identifiers (nkIdent) which may be
+  ## generic params not yet resolved during early pragma processing.
+  if n == nil: return false
+  case n.kind
+  of nkSym:
+    result = n.sym.kind == skGenericParam or
+             (n.sym.kind == skType and n.sym.typ != nil and n.sym.typ.kind == tyGenericParam)
+  of nkType:
+    result = n.typ != nil and n.typ.kind == tyGenericParam
+  of nkIdent:
+    # Unresolved identifier - could be a generic param not yet resolved.
+    # Defer evaluation to be safe.
+    result = true
+  else:
+    for child in n:
+      if containsGenericParam(child):
+        return true
+    result = false
 
 proc invalidPragma*(c: PContext; n: PNode) =
   localError(c.config, n.info, "invalid pragma: " & renderTree(n, {renderNoComments}))
@@ -942,20 +964,28 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         processImportObjC(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wSize:
         if sym.typ == nil: invalidPragma(c, it)
-        var size = expectIntLit(c, it)
-        if sfImportc in sym.flags:
-          # no restrictions on size for imported types
-          setImportedTypeSize(c.config, sym.typ, size)
-        else:
-          case size
-          of 1, 2, 4:
-            sym.typ.size = size
-            sym.typ.align = int16 size
-          of 8:
-            sym.typ.size = 8
-            sym.typ.align = floatInt64Align(c.config)
+        elif it.kind in nkPragmaCallKinds and it.len == 2 and containsGenericParam(it[1]):
+          # Defer evaluation until generic type is instantiated
+          if sfImportc notin sym.flags:
+            localError(c.config, it.info,
+              "deferred size expressions only supported for imported types")
           else:
-            localError(c.config, it.info, "size may only be 1, 2, 4 or 8")
+            c.graph.addTypeExtension(sym.typ, extDeferredSize, it[1])
+        else:
+          var size = expectIntLit(c, it)
+          if sfImportc in sym.flags:
+            # no restrictions on size for imported types
+            setImportedTypeSize(c.config, sym.typ, size)
+          else:
+            case size
+            of 1, 2, 4:
+              sym.typ.size = size
+              sym.typ.align = int16 size
+            of 8:
+              sym.typ.size = 8
+              sym.typ.align = floatInt64Align(c.config)
+            else:
+              localError(c.config, it.info, "size may only be 1, 2, 4 or 8")
       of wAlign:
         let alignment = expectIntLit(c, it)
         if isPowerOfTwo(alignment) and alignment > 0:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -31,6 +31,48 @@ proc checkConstructedType*(conf: ConfigRef; info: TLineInfo, typ: PType) =
   elif computeSize(conf, t) == szIllegalRecursion or isRecursiveStructuralType(t):
     localError(conf, info, "illegal recursion in type '" & typeToString(t) & "'")
 
+proc substituteTypeParams(n: PNode; body, inst: PType): PNode =
+  ## Substitute generic parameter references with instantiated types.
+  ## body is the generic body type, inst is the tyGenericInst.
+  if n == nil: return nil
+  case n.kind
+  of nkSym:
+    if n.sym.kind == skGenericParam or
+       (n.sym.kind == skType and n.sym.typ != nil and n.sym.typ.kind == tyGenericParam):
+      # Find which parameter this is by matching against body's params
+      for i in 0..<body.kidsLen - 1:
+        if body[i].sym == n.sym or sameTypeOrNil(body[i], n.sym.typ):
+          # inst[0] is the generic body, inst[1..] are the type arguments
+          return newNodeIT(nkType, n.info, inst[i + 1])
+      return n
+    else:
+      return n
+  of nkType:
+    if n.typ != nil and n.typ.kind == tyGenericParam:
+      for i in 0..<body.kidsLen - 1:
+        if sameTypeOrNil(body[i], n.typ):
+          return newNodeIT(nkType, n.info, inst[i + 1])
+      return n
+    else:
+      return n
+  else:
+    result = shallowCopy(n)
+    for i in 0..<n.len:
+      result[i] = substituteTypeParams(n[i], body, inst)
+
+proc evaluateTypeExtension*(c: PContext; instType, body: PType;
+                             ext: TypeExtension): BiggestInt =
+  ## Evaluates a type extension expression after type instantiation.
+  ## Returns the evaluated integer value, or szUnknownSize on error.
+  var expr = copyTree(ext.expr)
+  expr = substituteTypeParams(expr, body, instType)
+  let evaluated = c.semConstExpr(c, expr)
+  if evaluated.kind in {nkCharLit..nkUInt64Lit}:
+    result = evaluated.intVal
+  else:
+    localError(c.config, ext.expr.info, "type extension must evaluate to integer constant")
+    result = szUnknownSize
+
 proc searchInstTypes*(g: ModuleGraph; key: PType): PType =
   result = nil
   let genericTyp = key[0]
@@ -511,6 +553,27 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
 
   rawAddSon(result, newbody)
   checkPartialConstructedType(cl.c.config, cl.info, newbody)
+
+  # Evaluate type extensions (e.g., size: sizeof(T) on generic imported types)
+  if cl.c.graph.hasTypeExtensions(body):
+    for ext in cl.c.graph.typeExtensions(body):
+      let val = evaluateTypeExtension(cl.c, result, body, ext)
+      if val != szUnknownSize:
+        case ext.kind
+        of extDeferredSize:
+          newbody.size = val
+          # Set alignment based on size for imported types
+          if val <= 1:
+            newbody.align = 1
+          elif val <= 2:
+            newbody.align = 2
+          elif val <= 4:
+            newbody.align = 4
+          else:
+            newbody.align = int16 floatInt64Align(cl.c.config)
+        of extDeferredAlign:
+          newbody.align = int16 val
+
   if not cl.allowMetaTypes:
     let dc = cl.c.graph.getAttachedOp(newbody, attachedDeepCopy)
     if dc != nil and sfFromGeneric notin dc.flags:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -70,12 +70,62 @@ proc substituteTypeParams(n: PNode; body, inst: PType): PNode =
     for i in 0..<n.len:
       result[i] = substituteTypeParams(n[i], body, inst)
 
+proc containsUnresolvedGenericType(n: PNode): bool =
+  ## Check if the substituted expression still contains unresolved generic types.
+  ## This happens when Atomic[T] is instantiated with T being another generic param.
+  ## 
+  ## After substituteTypeParams, generic params that were successfully substituted
+  ## become nkType nodes with concrete types. Unresolved generic params remain as
+  ## nkType nodes with tyGenericParam types.
+  ## 
+  ## nkIdent nodes for things like `sizeof` or type names like `int8` are NOT
+  ## unresolved generic types - they're regular identifiers that will be resolved
+  ## during semantic analysis.
+  if n == nil: return false
+  case n.kind
+  of nkType:
+    # After substitution, generic params become nkType nodes
+    # Check if the type is still a generic param
+    if n.typ != nil and n.typ.kind == tyGenericParam:
+      return true
+    # Also check for generic invocations with unresolved params
+    if n.typ != nil and n.typ.containsGenericType:
+      return true
+  of nkSym:
+    if n.sym.kind == skGenericParam:
+      return true
+    if n.sym.kind == skType and n.sym.typ != nil and n.sym.typ.kind == tyGenericParam:
+      return true
+  of nkIdent:
+    # nkIdent nodes are regular identifiers (like `sizeof`, `int8`, etc.)
+    # They are NOT unresolved generic types - they will be resolved during semExpr.
+    # If a generic param wasn't substituted, it would remain as nkIdent, but
+    # substituteTypeParams handles that by matching against body's params.
+    # If it didn't match, it's a regular identifier, not a generic param.
+    return false
+  of nkEmpty, nkNilLit, nkCharLit..nkUInt64Lit, nkFloatLit..nkFloat128Lit,
+     nkStrLit..nkTripleStrLit:
+    return false
+  else:
+    for child in n:
+      if containsUnresolvedGenericType(child):
+        return true
+  return false
+
 proc evaluateTypeExtension*(c: PContext; instType, body: PType;
                              ext: TypeExtension): BiggestInt =
   ## Evaluates a type extension expression after type instantiation.
   ## Returns the evaluated integer value, or szUnknownSize on error.
+  ## Returns szUnknownSize without error if the expression still contains
+  ## unresolved generic types (will be evaluated on further instantiation).
   var expr = copyTree(ext.expr)
   expr = substituteTypeParams(expr, body, instType)
+  
+  # If the substituted expression still contains generic types, defer evaluation.
+  # This happens when e.g. Atomic[T] is used inside a generic proc like store[T].
+  if containsUnresolvedGenericType(expr):
+    return szUnknownSize
+  
   let evaluated = c.semConstExpr(c, expr)
   if evaluated.kind in {nkCharLit..nkUInt64Lit}:
     result = evaluated.intVal

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -55,6 +55,16 @@ proc substituteTypeParams(n: PNode; body, inst: PType): PNode =
       return n
     else:
       return n
+  of nkIdent:
+    # Try to match identifier against generic param names
+    for i in 0..<body.kidsLen - 1:
+      if body[i].sym != nil and body[i].sym.name.id == n.ident.id:
+        return newNodeIT(nkType, n.info, inst[i + 1])
+    return n
+  of nkEmpty, nkNilLit, nkCharLit..nkUInt64Lit, nkFloatLit..nkFloat128Lit,
+     nkStrLit..nkTripleStrLit:
+    # Leaf nodes - return as-is
+    return n
   else:
     result = shallowCopy(n)
     for i in 0..<n.len:

--- a/compiler/typeext.nim
+++ b/compiler/typeext.nim
@@ -1,0 +1,26 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2025 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Type extension definitions for sparse metadata storage.
+## Separated to avoid circular imports between modulegraphs and ast2nif.
+
+import ast
+
+type
+  TypeExtKind* = enum
+    ## Kinds of type extensions stored in side-tables.
+    ## Extensible for future type metadata needs.
+    extDeferredSize     ## size pragma with generic parameter
+    extDeferredAlign    ## align pragma with generic parameter
+
+  TypeExtension* = object
+    ## Generic type extension for sparse metadata storage.
+    ## Avoids adding fields to PType for rarely-used features.
+    kind*: TypeExtKind
+    expr*: PNode        ## The original pragma/extension expression AST

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -13,7 +13,7 @@ import
   ast, astalgo, trees, msgs, platform, renderer, options,
   lineinfos, int128, modulegraphs, astmsgs, wordrecg
 
-import std/[intsets, strutils]
+import std/[intsets, strutils, tables]
 
 when defined(nimPreviewSlimSystem):
   import std/[assertions, formatfloat]
@@ -1165,6 +1165,31 @@ proc getAlign*(conf: ConfigRef; typ: PType): BiggestInt =
 proc getSize*(conf: ConfigRef; typ: PType): BiggestInt =
   computeSizeAlign(conf, typ)
   result = typ.size
+
+proc typeExtensions*(g: ModuleGraph; t: PType): seq[TypeExtension] =
+  ## Returns type extensions, or empty seq if none.
+  if g.typeExtensions.hasKey(t.itemId):
+    result = g.typeExtensions[t.itemId]
+  else:
+    result = @[]
+
+proc addTypeExtension*(g: ModuleGraph; t: PType; kind: TypeExtKind; expr: PNode) =
+  ## Adds a type extension.
+  if not g.typeExtensions.hasKey(t.itemId):
+    g.typeExtensions[t.itemId] = @[]
+  g.typeExtensions[t.itemId].add(TypeExtension(kind: kind, expr: expr))
+
+proc hasTypeExtensions*(g: ModuleGraph; t: PType): bool =
+  ## Returns true if type has any extensions.
+  g.typeExtensions.hasKey(t.itemId)
+
+proc hasTypeExtension*(g: ModuleGraph; t: PType; kind: TypeExtKind): bool =
+  ## Returns true if type has a specific extension kind.
+  if g.typeExtensions.hasKey(t.itemId):
+    for ext in g.typeExtensions[t.itemId]:
+      if ext.kind == kind:
+        return true
+  false
 
 proc setImportedTypeSize*(conf: ConfigRef, t: PType, size: int) =
   t.size = size

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -91,9 +91,8 @@ when (defined(cpp) and defined(nimUseCppAtomics)) or defined(nimdoc):
         ## with other moSequentiallyConsistent operations.
 
   type
-    Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
+    Atomic*[T] {.importcpp: "std::atomic", size: sizeof(T), completeStruct.} = object
       ## An atomic object with underlying type `T`.
-      raw: T
 
     AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object
       ## An atomic boolean state.

--- a/tests/pragmas/tdeferred_size_pragma.nim
+++ b/tests/pragmas/tdeferred_size_pragma.nim
@@ -1,0 +1,118 @@
+discard """
+  targets: "c cpp"
+"""
+## Test: Deferred `size` pragma with generic type parameters
+##
+## Coverage:
+## - Single generic param: sizeof(T)
+## - Multiple generic params: sizeof(A), sizeof(B), sizeof(A)+sizeof(B)
+## - Complex expressions: sizeof(T)+N, sizeof(T)*N
+## - C++ templates (cpp backend only)
+##
+## Note: The `size` pragma is ONLY valid on:
+## - Enum types
+## - Imported types (types with {.importc.} or {.importcpp.})
+## It is NOT valid on fields or variables.
+
+# -----------------------------------------------------------------------------
+# Single generic parameter
+# -----------------------------------------------------------------------------
+
+type Single[T] {.importc, size: sizeof(T), completeStruct.} = object
+
+static:
+  doAssert sizeof(Single[int8]) == 1
+  doAssert sizeof(Single[int16]) == 2
+  doAssert sizeof(Single[int32]) == 4
+  doAssert sizeof(Single[int64]) == 8
+
+  # Prove different instantiations have different sizes (feature actually works):
+  doAssert sizeof(Single[int8]) != sizeof(Single[int64])
+  doAssert sizeof(Single[int16]) != sizeof(Single[int32])
+
+  # Prove size comes from pragma expression, not natural size:
+  # If pragma were broken, compiler would use natural object size (1 byte on most archs)
+  doAssert sizeof(Single[int64]) == 8  # Would be 1 if pragma didn't work
+
+# -----------------------------------------------------------------------------
+# Multiple generic parameters
+# -----------------------------------------------------------------------------
+
+type FirstParam[A, B] {.importc, size: sizeof(A), completeStruct.} = object
+
+static:
+  doAssert sizeof(FirstParam[int8, int64]) == 1
+  doAssert sizeof(FirstParam[int64, int8]) == 8
+
+type SecondParam[A, B] {.importc, size: sizeof(B), completeStruct.} = object
+
+static:
+  doAssert sizeof(SecondParam[int8, int64]) == 8
+  doAssert sizeof(SecondParam[int64, int8]) == 1
+
+type BothParams[A, B] {.importc, size: sizeof(A) + sizeof(B), completeStruct.} = object
+
+static:
+  doAssert sizeof(BothParams[int8, int8]) == 2
+  doAssert sizeof(BothParams[int32, int64]) == 12
+
+  # Verify expression uses BOTH params (would fail if only one was used):
+  doAssert sizeof(BothParams[int8, int64]) == 9   # 1 + 8
+  doAssert sizeof(BothParams[int64, int8]) == 9   # 8 + 1
+  doAssert sizeof(BothParams[int32, int32]) == 8  # 4 + 4
+
+# -----------------------------------------------------------------------------
+# Complex expressions
+# -----------------------------------------------------------------------------
+
+type PlusConst[T] {.importc, size: sizeof(T) + 4, completeStruct.} = object
+
+static:
+  doAssert sizeof(PlusConst[int8]) == 5
+  doAssert sizeof(PlusConst[int32]) == 8
+
+type TimesConst[T] {.importc, size: sizeof(T) * 2, completeStruct.} = object
+
+static:
+  doAssert sizeof(TimesConst[int8]) == 2
+  doAssert sizeof(TimesConst[int32]) == 8
+
+type ComplexExpr[T] {.importc, size: sizeof(T) * 2 + 4, completeStruct.} = object
+
+static:
+  doAssert sizeof(ComplexExpr[int8]) == 6
+  doAssert sizeof(ComplexExpr[int32]) == 12
+
+# -----------------------------------------------------------------------------
+# Non-generic (regression test: ensure fixed sizes still work)
+# -----------------------------------------------------------------------------
+
+type FixedSize {.importc, size: 16, completeStruct.} = object
+
+static:
+  doAssert sizeof(FixedSize) == 16
+
+# -----------------------------------------------------------------------------
+# Edge case: size expression with multiple operations
+# -----------------------------------------------------------------------------
+
+type MultiOpSize[T] {.importc, size: (sizeof(T) * 3 + 7) div 8 * 8, completeStruct.} = object
+
+static:
+  # Rounds up to nearest multiple of 8
+  doAssert sizeof(MultiOpSize[int8]) == 8   # (1*3+7)/8*8 = 8
+  doAssert sizeof(MultiOpSize[int16]) == 8  # (2*3+7)/8*8 = 8
+  doAssert sizeof(MultiOpSize[int32]) == 16 # (4*3+7)/8*8 = 16
+
+# -----------------------------------------------------------------------------
+# C++ templates
+# -----------------------------------------------------------------------------
+
+when defined(cpp):
+  type CppAtomic[T] {.importcpp: "std::atomic", header: "<atomic>",
+                      size: sizeof(T), completeStruct.} = object
+
+  static:
+    doAssert sizeof(CppAtomic[int8]) == 1
+    doAssert sizeof(CppAtomic[int32]) == 4
+    doAssert sizeof(CppAtomic[int64]) == 8

--- a/tests/pragmas/tdeferred_size_reject_noimport.nim
+++ b/tests/pragmas/tdeferred_size_reject_noimport.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "deferred size expressions only supported for imported types"
+  line: 7
+"""
+## Reject test: deferred size pragma requires importc/importcpp
+
+type NonImported[T] {.size: sizeof(T).} = object
+  x: int

--- a/tests/pragmas/tsize_invalid_value.nim
+++ b/tests/pragmas/tsize_invalid_value.nim
@@ -1,0 +1,7 @@
+discard """
+  errormsg: "size may only be 1, 2, 4 or 8"
+  line: 7
+"""
+## Reject test: size pragma only accepts 1, 2, 4, or 8 for non-imported types
+
+type InvalidSize {.size: 3.} = enum a, b, c


### PR DESCRIPTION
Allows imported types to use `size: sizeof(T)` where `T` is a generic type parameter, with evaluation deferred until instantiation.

```nim
type Atomic[T] {.importcpp: "std::atomic", size: sizeof(T).} = object
```

When instantiated as `Atomic[int64]`, the size pragma evaluates to 8.

### Implementation

- Uses a sparse side-table (`typeExtensions` in `ModuleGraph`) rather than adding fields to `PType`/`PSym`, avoiding per-type memory overhead. 
- Includes an attempt at NIF serialization.

### Changes

- compiler/typeext.nim - new module for TypeExtKind/TypeExtension types
- compiler/modulegraphs.nim - typeExtensions side-table
- compiler/pragmas.nim - defer size pragma when expr contains generic params
- compiler/semtypinst.nim - evaluate deferred extensions at instantiation
- compiler/ast2nif.nim - NIF serialization/deserialization
- lib/pure/concurrency/atomics.nim - use deferred size, remove dummy field

Supersedes #25403 per feedback from Araq.