### PR TITLE
fixes #25464; gives a deprecated warning when  `=dup` is not provided while  there being a custom `=copy`

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -558,14 +558,18 @@ proc declareTempOf(c: var TLiftCtx; body: PNode; value: PNode): PNode =
   v.addVar(result, value)
   body.add v
 
-proc warnDupCustomCopy(c: var TLiftCtx; t: PType) {.inline.} =
+proc warnDupCustomCopy(c: var TLiftCtx; t: PType; useError: bool) {.inline.} =
   ## Emit a warning when generating `=dup` code and a custom `=copy` hook
   ## exists
   if c.kind == attachedDup:
     let op2 = getAttachedOp(c.g, t, attachedAsgn)
     if op2 != nil and sfOverridden in op2.flags:
-      message(c.g.config, c.info, warnDeprecated,
-        "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
+      if useError:
+        localError(c.g.config, c.info,
+          "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
+      else:
+        message(c.g.config, c.info, warnDeprecated,
+          "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
 
 proc addIncStmt(c: var TLiftCtx; body, i: PNode) =
   let incCall = genBuiltin(c, mInc, "inc", i)
@@ -1066,7 +1070,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
           var op2 = getAttachedOp(c.g, t, attachedAsgn)
           if op2 != nil and sfOverridden in op2.flags:
             # warn if a custom '=copy' exists but no '=dup' is provided
-            warnDupCustomCopy(c, t)
+            warnDupCustomCopy(c, t, false)
             #markUsed(c.g.config, c.info, op, c.g.usageSym)
             onUse(c.info, op2)
             body.add newHookCall(c, t.assignment, x, y)
@@ -1076,7 +1080,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
           fillBodyObjT(c, t, body, x, y)
   of tyDistinct:
     if not considerUserDefinedOp(c, t, body, x, y):
-      warnDupCustomCopy(c, t)
+      warnDupCustomCopy(c, t, true)
       fillBody(c, t.elementType, body, x, y)
   of tyTuple:
     fillBodyTup(c, t, body, x, y)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -558,18 +558,14 @@ proc declareTempOf(c: var TLiftCtx; body: PNode; value: PNode): PNode =
   v.addVar(result, value)
   body.add v
 
-proc warnDupCustomCopy(c: var TLiftCtx; t: PType; useError: bool) {.inline.} =
-  ## Emit a warning when generating `=dup` code and a custom `=copy` hook
+proc errorDupCustomCopy(c: var TLiftCtx; t: PType) {.inline.} =
+  ## Emit an error when generating `=dup` code and a custom `=copy` hook
   ## exists
   if c.kind == attachedDup:
     let op2 = getAttachedOp(c.g, t, attachedAsgn)
     if op2 != nil and sfOverridden in op2.flags:
-      if useError:
-        localError(c.g.config, c.info,
-          "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
-      else:
-        message(c.g.config, c.info, warnDeprecated,
-          "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
+      localError(c.g.config, c.info,
+        "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'")
 
 proc addIncStmt(c: var TLiftCtx; body, i: PNode) =
   let incCall = genBuiltin(c, mInc, "inc", i)
@@ -1070,7 +1066,8 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
           var op2 = getAttachedOp(c.g, t, attachedAsgn)
           if op2 != nil and sfOverridden in op2.flags:
             # warn if a custom '=copy' exists but no '=dup' is provided
-            warnDupCustomCopy(c, t, false)
+            message(c.g.config, c.info, warnDeprecated,
+              "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
             #markUsed(c.g.config, c.info, op, c.g.usageSym)
             onUse(c.info, op2)
             body.add newHookCall(c, t.assignment, x, y)
@@ -1080,7 +1077,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
           fillBodyObjT(c, t, body, x, y)
   of tyDistinct:
     if not considerUserDefinedOp(c, t, body, x, y):
-      warnDupCustomCopy(c, t, true)
+      errorDupCustomCopy(c, t)
       fillBody(c, t.elementType, body, x, y)
   of tyTuple:
     fillBodyTup(c, t, body, x, y)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -558,6 +558,15 @@ proc declareTempOf(c: var TLiftCtx; body: PNode; value: PNode): PNode =
   v.addVar(result, value)
   body.add v
 
+proc warnDupCustomCopy(c: var TLiftCtx; t: PType) {.inline.} =
+  ## Emit a warning when generating `=dup` code and a custom `=copy` hook
+  ## exists
+  if c.kind == attachedDup:
+    let op2 = getAttachedOp(c.g, t, attachedAsgn)
+    if op2 != nil and sfOverridden in op2.flags:
+      message(c.g.config, c.info, warnDeprecated,
+        "'=dup' is not provided while a custom '=copy' is defined for type '" & typeToString(t) & "'; this will become a compile time error in the future")
+
 proc addIncStmt(c: var TLiftCtx; body, i: PNode) =
   let incCall = genBuiltin(c, mInc, "inc", i)
   incCall.add lowerings.newIntLit(c.g, c.info, 1)
@@ -1056,6 +1065,8 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         if c.kind == attachedDup:
           var op2 = getAttachedOp(c.g, t, attachedAsgn)
           if op2 != nil and sfOverridden in op2.flags:
+            # warn if a custom '=copy' exists but no '=dup' is provided
+            warnDupCustomCopy(c, t)
             #markUsed(c.g.config, c.info, op, c.g.usageSym)
             onUse(c.info, op2)
             body.add newHookCall(c, t.assignment, x, y)
@@ -1065,6 +1076,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
           fillBodyObjT(c, t, body, x, y)
   of tyDistinct:
     if not considerUserDefinedOp(c, t, body, x, y):
+      warnDupCustomCopy(c, t)
       fillBody(c, t.elementType, body, x, y)
   of tyTuple:
     fillBodyTup(c, t, body, x, y)

--- a/tests/destructor/tdup_from_copy.nim
+++ b/tests/destructor/tdup_from_copy.nim
@@ -1,0 +1,40 @@
+discard """
+  matrix: "--warningaserror:deprecated"
+  errormsg: "'=dup' is not provided while a custom '=copy' is defined for type 'Foo'; this will become a compile time error in the future"
+"""
+
+type Foo = distinct int
+
+var counter = 0
+
+proc `=destroy`(pkt: var Foo) =
+  if cast[int](pkt) != 0:
+    echo cast[int](pkt)
+
+proc `=copy`(a: var Foo, b: Foo) =
+  if cast[int](a) == cast[int](b):
+    return
+
+  `=destroy`(a)
+  if cast[int](b) == 0:
+    zeroMem(addr a, sizeof(Foo))
+  else:
+    counter += 1
+    copyMem(addr a, addr counter, sizeof(Foo))
+    echo "copy!"
+
+proc makeFoo(): Foo =
+  counter += 1
+  cast[Foo](counter)
+
+
+type Bar = object
+  val: Foo
+
+
+proc consume(x: sink Bar) =
+  discard
+
+let x = Bar(val: makeFoo())
+consume(x)
+discard x

--- a/tests/destructor/tdup_from_copy.nim
+++ b/tests/destructor/tdup_from_copy.nim
@@ -1,6 +1,5 @@
 discard """
-  matrix: "--warningaserror:deprecated"
-  errormsg: "'=dup' is not provided while a custom '=copy' is defined for type 'Foo'; this will become a compile time error in the future"
+  errormsg: "'=dup' is not provided while a custom '=copy' is defined for type 'Foo'"
 """
 
 type Foo = distinct int


### PR DESCRIPTION
Gives a deprecated warning to keep backwards compatibility

fixes #25464