### PR TITLE
Scan until next special char (", \, \0, \c, \L) and append that slice once.

### DIFF
--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -205,6 +205,7 @@ proc parseString(my: var JsonParser): TokKind =
   while true:
     case my.buf[pos]
     of '\0':
+      my.err = errInvalidToken
       addSpan(my.a, my.buf, spanStart, pos)
       result = tkError
       break
@@ -247,16 +248,19 @@ proc parseString(my: var JsonParser): TokKind =
         var pos2 = pos
         var r = parseEscapedUTF16(cstring(my.buf), pos)
         if r < 0:
+          my.err = errInvalidToken
           break
         # Deal with surrogates
         if (r and 0xfc00) == 0xd800:
           if my.buf[pos] != '\\' or my.buf[pos+1] != 'u':
+            my.err = errInvalidToken
             break
           inc(pos, 2)
           var s = parseEscapedUTF16(cstring(my.buf), pos)
           if (s and 0xfc00) == 0xdc00 and s > 0:
             r = 0x10000 + (((r - 0xd800) shl 10) or (s - 0xdc00))
           else:
+            my.err = errInvalidToken
             break
         if my.rawStringLiterals:
           let length = pos - pos2

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -175,23 +175,34 @@ proc parseEscapedUTF16*(buf: cstring, pos: var int): int =
     else:
       return -1
 
+proc addSpan(dst: var string; src: string; startPos, endPos: int) {.inline.} =
+  let n = endPos - startPos
+  if n <= 0:
+    return
+  let oldLen = dst.len
+  setLen(dst, oldLen + n)
+  copyMem(addr dst[oldLen], addr src[startPos], n)
+
 proc parseString(my: var JsonParser): TokKind =
   result = tkString
   var pos = my.bufpos + 1
+  var spanStart = pos
   if my.rawStringLiterals:
     add(my.a, '"')
   while true:
     case my.buf[pos]
     of '\0':
-      my.err = errQuoteExpected
+      addSpan(my.a, my.buf, spanStart, pos)
       result = tkError
       break
     of '"':
+      addSpan(my.a, my.buf, spanStart, pos)
       if my.rawStringLiterals:
         add(my.a, '"')
       inc(pos)
       break
     of '\\':
+      addSpan(my.a, my.buf, spanStart, pos)
       if my.rawStringLiterals:
         add(my.a, '\\')
       case my.buf[pos+1]
@@ -223,19 +234,16 @@ proc parseString(my: var JsonParser): TokKind =
         var pos2 = pos
         var r = parseEscapedUTF16(cstring(my.buf), pos)
         if r < 0:
-          my.err = errInvalidToken
           break
         # Deal with surrogates
         if (r and 0xfc00) == 0xd800:
           if my.buf[pos] != '\\' or my.buf[pos+1] != 'u':
-            my.err = errInvalidToken
             break
           inc(pos, 2)
           var s = parseEscapedUTF16(cstring(my.buf), pos)
           if (s and 0xfc00) == 0xdc00 and s > 0:
             r = 0x10000 + (((r - 0xd800) shl 10) or (s - 0xdc00))
           else:
-            my.err = errInvalidToken
             break
         if my.rawStringLiterals:
           let length = pos - pos2
@@ -251,14 +259,18 @@ proc parseString(my: var JsonParser): TokKind =
         # don't bother with the error
         add(my.a, my.buf[pos])
         inc(pos)
+      spanStart = pos
     of '\c':
+      addSpan(my.a, my.buf, spanStart, pos)
       pos = lexbase.handleCR(my, pos)
       add(my.a, '\c')
+      spanStart = pos
     of '\L':
+      addSpan(my.a, my.buf, spanStart, pos)
       pos = lexbase.handleLF(my, pos)
       add(my.a, '\L')
+      spanStart = pos
     else:
-      add(my.a, my.buf[pos])
       inc(pos)
   my.bufpos = pos # store back
 

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -179,9 +179,22 @@ proc addSpan(dst: var string; src: string; startPos, endPos: int) {.inline.} =
   let n = endPos - startPos
   if n <= 0:
     return
-  let oldLen = dst.len
-  setLen(dst, oldLen + n)
-  copyMem(addr dst[oldLen], addr src[startPos], n)
+
+  let old = dst.len
+  dst.setLen old + n
+
+  template impl =
+    for i in 0..<n:
+      dst[old + i] = src[startPos + i]
+
+  when nimvm:
+    impl
+  else:
+    when defined(js) or defined(nimscript):
+      impl
+    else:
+      {.noSideEffect.}:
+        copyMem dst[old].addr, src[startPos].unsafeAddr, n
 
 proc parseString(my: var JsonParser): TokKind =
   result = tkString


### PR DESCRIPTION
Benchmark comparison (-d:danger --mm:arc --debugger:native -d:useMalloc,
  OpenAI file benchmark, 5 runs):

  - Before: 0.196674934, 0.189423191, 0.198763300, 0.197125584, 0.205015032
  - After: 0.182827130, 0.183330852, 0.174878542, 0.174360811, 0.181704921
  - Median before: 0.197125584s
  - Median after: 0.181704921s
  - Improvement: 7.82% faster

  Callgrind comparison (same build flags):

  - Total Ir before: 3,219,477,120
  - Total Ir after: 2,449,556,167
  - Total Ir reduction: 23.91%

  parseString hotspot:

  - Before: 1,343,343,723 Ir
  - After: 573,423,735 Ir
  - Reduction: 57.31%