### PR TITLE
Feat: std: parseopt parser modes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,10 @@ errors.
 
 - `system.setLenUninit` now supports refc, JS and VM backends.
 
+- `std/parseopt` now supports multiple parser modes via `-d:parseopt.mode=<int>`.
+  Modes include `Nim` (default, fully compatible) and two new experimental modes:
+  `PosixLax` and `Gnu` for different option parsing behaviors.
+
 [//]: # "Changes:"
 
 - `std/math` The `^` symbol now supports floating-point as exponent in addition to the Natural type.

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -184,7 +184,7 @@
 ##    in future releases.
 ##
 ## The parser supports several distinct rule sets that change how options are
-## interpreted. The modes are switched at compile time.
+## interpreted. The modes are controlled by `ParserMode<#ParserMode>`_ constant.
 ## Select a mode with `-d:parseopt.mode=<int>`:
 ##
 ## - `0` (`PosixLax`): Most forgiving mode, combines `Nim` with POSIX-like
@@ -267,6 +267,23 @@
 ## - In `Gnu` mode: whitespace around `=` is not allowed, so `--foo` is an
 ##   option without a value, and `=bar` is parsed as an argument
 ##
+## Custom Rule Sets
+## ================
+##
+## .. Warning:: Custom rule sets is an **experimental** feature.
+##
+## Beyond the three provided modes, you can define a custom parser behavior
+## by specifying individual `ParserCapabilities<#ParserCapabilities>`_ at
+## compile time by overriding the `ParserRulesMask<#ParserRulesMask>`_
+## bit mask with `-d:parseopt.ruleset=<int32>`.
+##
+## This is useful when you need parsing rules that don't match any standard
+## mode.
+##
+## When defined, `ParserRulesMask` value completely overrides the selected mode
+## and the `RuleSet<#RuleSet>`_ derived from it. See `RuleSet<#RuleSet>`_ for
+## details on the derivation process.
+##
 ## See also
 ## ========
 ##
@@ -290,7 +307,7 @@
 
 include "system/inclrtl"
 
-import std/strutils
+import std/[strutils, bitops]
 import std/os
 
 type
@@ -309,7 +326,7 @@ type
           ## - No notion of optional/mandatory arguments.
 
 type
-  ParserCapabilities = enum
+  ParserCapabilities* = enum
     ## Feature flags used to assemble parser behavior for a given mode.
     pcSepAllowDelimBefore,       ## Allow whitespace before a separator (':'|'=')
     pcSepAllowDelimAfter,        ## Allow whitespace after a separator (':'|'=')
@@ -321,16 +338,36 @@ type
     pcLongAllowSep,              ## Allow `--opt=val`/`--opt:val`, see `SepSet`
     pcLongValAllowNextArg,       ## Allow `--opt val` form, requires non-emty `longNoVal`
 
+func toRuleSet(mask: int32): set[ParserCapabilities] =
+  for cap in ParserCapabilities:
+    if testBit(mask, ord(cap)): result.incl(cap)
+
+func toRuleSetMask*(caps: set[ParserCapabilities]): int32 =
+  ## Helper to derive a value for a custom `ParserRulesMask<#ParserRulesMask>`_
+  ## override value from `caps`.
+  for cap in caps:
+    result.setBit(ord(cap))
+
 const
-  ParserMode* {.intdefine: "parseopt.mode".}: int = ord(rsNim)
+  ParserMode* {.intdefine: "parseopt.mode".}: int = ord(rsNim) ##|
+  ## Parser mode switch. Defined at compilation with the `-d:parseopt.mode=<int>`.
+  ## Valid integer values:
+  ## - `0`: PosixLax mode
+  ## - `1`: Nim mode (default)
+  ## - `2`: Gnu mode
+  ##
+  ## See `Parser Modes<#parser-modes>`_ for details.
+  ##
+  ## If `ParserRulesMask<#ParserRulesMask>`_ is set at compile-time, it
+  ## takes precedence and effectively overrides `ParserMode`.
   RuleMode: ParserRuleMode = static: ##|
     ## Selected parser mode controlled by `-d:parseopt.mode=<int>`.
     when ParserMode notin 0..int(ParserRuleMode.high):
       {.error: "Unknown parseopt parser mode!".}
     ParserRuleMode(ParserMode)
 
-  RuleSet: set[ParserCapabilities] = static:
-    ## Capability set derived from the selected rule mode.
+  DefaultRuleSet: set[ParserCapabilities] = static:
+    ## Default capability set derived from the selected rule mode.
     let
       Common = {
         pcShortValAllowAdjacent,
@@ -354,6 +391,62 @@ const
     elif RuleMode == rsGnu:
       Common + ShortPosix
     else: {.error: "No rule set defined for the parseopt parser mode." & $RuleMode .}
+
+  ParserRulesMask* {.intdefine: "parseopt.ruleset".}: int32 = ##|
+  ## Integer bitmask for the effective parser rule set.
+  ## Used to override the chosen mode with a granular custom set of
+  ## `ParserCapabilities<#ParserCapabilities>`_ rules.
+  ##
+  ## To enact, use the `-d:parseopt.ruleset=<N>` define at compile time.
+  ##
+  ## By default, this is derived from the active `RuleMode`.
+  ## Each bit position corresponds to a `ParserCapabilities` enum value.
+  ##
+  ## To use a custom capability set instead of a predefined mode, define
+  ## `parseopt.ruleset` at compile time in  your `config.nims`:
+  ##
+  ## ```nim
+  ## import parseopt
+  ## let myRuleSet = {
+  ##   pcShortBundle,              # Allow -abc bundling
+  ##   pcShortValAllowAdjacent,    # Allow -cval
+  ##   pcLongAllowSep,             # Allow --opt=val
+  ##   pcSepAllowDelimBefore,      # Allow --opt =val
+  ##   pcSepAllowDelimAfter        # Allow --opt= val
+  ## }
+  ## switch("define", "parseopt.ruleset=" & $toRuleSetMask(myRuleSet))
+  ## ```
+  ##
+  ## When `parseopt.ruleset` is defined, it completely bypasses the default
+  ## derivation (steps 1-3) and directly controls the final `RuleSet`.
+    toRuleSetMask(DefaultRuleSet)
+
+  RuleSet*: set[ParserCapabilities] = toRuleSet(ParserRulesMask) ##|
+  ## The final active parser capability set used throughout the module to
+  ## control parsing behavior.
+  ##
+  ## Derivation Process:
+  ##
+  ## The `RuleSet` is derived through a multi-stage compile-time process:
+  ##
+  ## 1. Mode Selection: The `ParserMode<#ParserMode>`_ selects one of the
+  ##    pre-defined parsing modes. Defaults to `Nim` mode.
+  ##
+  ## 2. Default Capabilities: Based on `RuleMode`, a default set of
+  ##    `ParserCapabilities` is assembled.
+  ##
+  ## 3. Bitmask Conversion: The derived rule set is converted to an integer
+  ##    bitmask and stored in `ParserRulesMask<#ParserRulesMask>`_.
+  ##    This step allows user override: if `-d:parseopt.ruleset=<int32>` is
+  ##    used as a compilation switch, it replaces the value.
+  ##
+  ## 4. Final Rule Set: `ParserRulesMask` is converted back
+  ##    to the final value of `RuleSet` used by the parser.
+  ##
+  ## **See Also:**
+  ## - `ParserCapabilities<#ParserCapabilities>`_ for individual capability meanings
+  ## - `ParserMode<#ParserMode>`_ for mode selection
+  ## - `ParserRulesMask<#ParserRulesMask>`_ for custom override mechanism
 
   SepSet = if RuleMode == rsGnu: {'='} else: {':', '='} ##|
   ## Allowed separators for long/short option values.

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -14,6 +14,11 @@
 ## Supported Syntax
 ## ================
 ##
+## The parser supports multiple `parsing modes<#parser-modes>`_ that affect how
+## options are interpreted. The syntax described here applies to the default
+## `Nim` mode. See `Parser Modes<#parser-modes>`_ for details on alternative
+## modes and their differences.
+##
 ## The following syntax is supported when arguments for the `shortNoVal` and
 ## `longNoVal` parameters, which are
 ## `described later<#nimshortnoval-and-nimlongnoval>`_, are not provided:
@@ -30,7 +35,8 @@
 ##
 ## The `--` option, commonly used to denote that every token that follows is
 ## an argument, is interpreted as a long option, and its name is the empty
-## string.
+## string. Trailing arguments can be accessed with `remainingArgs<#remainingArgs,OptParser>`_
+## or `cmdLineRest<#cmdLineRest,OptParser>`_.
 ##
 ## Parsing
 ## =======
@@ -107,16 +113,29 @@
 ## specifying which short and long options do not accept values.
 ##
 ## When `shortNoVal` is non-empty, users are not required to separate short
-## options and their values with a ':' or '=' since the parser knows which
+## options and their values with a `:` or `=` since the parser knows which
 ## options accept values and which ones do not. This behavior also applies for
-## long options if `longNoVal` is non-empty. For short options, `-j4`
-## becomes supported syntax, and for long options, `--foo bar` becomes
-## supported. This is in addition to the `previously mentioned
-## syntax<#supported-syntax>`_. Users can still separate options and their
-## values with ':' or '=', but that becomes optional.
+## long options if `longNoVal` is non-empty.
+##
+## For short options, `-j4` becomes supported syntax (parsed as option `j` with
+## value `4` instead of two separate options `j` and `4`). For long options,
+## `--foo bar` becomes supported syntax in all modes. In `PosixLax` and `Gnu`
+## modes, short options can also take values from the next argument (e.g.,
+## `-c val`), but this does **not** work in the default `Nim` mode.
+##
+## This is in addition to the `previously mentioned syntax<#supported-syntax>`_.
+## Users can still separate options and their values with `:` or `=`, but that
+## becomes optional.
 ##
 ## As more options which do not accept values are added to your program,
 ## remember to amend `shortNoVal` and `longNoVal` accordingly.
+##
+##
+## .. Important::
+##   Next-argument value-taking for short/long options is only enabled when
+##   `shortNoVal`/`longNoVal` are non-empty. If your program has *no* options
+##   that take no value, you still must pass a non-empty placeholder (for example,
+##   `shortNoVal = {'\0'}` and/or `longNoVal = @[""]`) to enable this form.
 ##
 ## The following example illustrates the difference between having an empty
 ## `shortNoVal` and `longNoVal`, which is the default, and providing
@@ -158,6 +177,96 @@
 ##   # Option and value: first, bar
 ##   ```
 ##
+## Parser Modes
+## ============
+##
+## .. Warning:: Modes other than the default (`Nim`) are **experimental** and may change
+##    in future releases.
+##
+## The parser supports several distinct rule sets that change how options are
+## interpreted. The modes are switched at compile time.
+## Select a mode with `-d:parseopt.mode=<int>`:
+##
+## - `0` (`PosixLax`): Most forgiving mode, combines `Nim` with POSIX-like
+##    short option handling. Tries to follow the POSIX_ guidelines where possible.
+## - `1` (`Nim`): Standard Nim parsing rules (default).
+## - `2` (`Gnu`): GNU-inspired parsing (e.g. `=` as the only delimiter).
+##   Puts some restrictions, following some of the GNU_ conventions.
+##
+## Modes are numbered from most relaxed (0) to strictest (2). The names were
+## chosen to set general user expectations and full compliance is neither
+## achieved nor planned.
+##
+## Mode Differences
+## ----------------
+##
+## **Nim** (mode 1, default):
+##
+## - Short options require adjacent values or explicit delimiters: `-cval`, `-c:val`, `-c=val`
+## - Next-argument value taking (`-c val`) is **not** supported by default
+## - Supports both `:` and `=` as delimiters
+## - Allows whitespace around delimiters
+## - Values starting with `-` are interpreted as new options
+##
+## **PosixLax** (mode 0):
+##
+## - Essentially the Nim mode with a key relaxation for short options
+## - Allows short options to take values from the next argument: `-c val`
+## - Supports bundled short options with trailing value: `-abc val`
+## - Values starting with `-` can be consumed as option arguments
+##
+## **Gnu** (mode 2):
+##
+## - Only `=` is treated as a delimiter (`:` is not a delimiter)
+## - No whitespace allowed around `=`
+## - Short options can take next-argument values: `-c val`
+## - Values starting with `-` can be consumed as option arguments
+##
+## Mode-Specific Behavior
+## ======================
+##
+## The parser's behavior varies significantly between modes, particularly
+## around how options consume their values:
+##
+## **Short Options**
+##
+## Consider `-c val`:
+##
+## - In `Nim` mode: `-c` is parsed as an option without a value, and `val` is
+##   parsed as an argument (unless `shortNoVal` is non-empty and `c` is not in it)
+## - In `PosixLax` mode: same as `Nim`, but if `shortNoVal` is non-empty and
+##   `c` is not in it, `val` is consumed as the value of `-c`
+## - In `Gnu` mode: if `shortNoVal` is non-empty and `c` is not in it, `val` is
+##   consumed as the value of `-c`
+##
+## Consider `-c-10`:
+##
+## - In `Nim` mode: `-c` is an option, `-10` is interpreted as two bundled
+##   short options `-1` and `-0`
+## - In `PosixLax` mode: same as `Nim`, unless `shortNoVal` is non-empty and
+##   `c` is not in it, in which case `-10` is consumed as the value of `-c`
+##   (allowing negative numbers)
+## - In `Gnu` mode: if `shortNoVal` is non-empty and `c` is not in it, `-10` is
+##   consumed as the value of `-c` (allowing negative numbers)
+##
+## **Long Options**
+##
+## Consider `--foo:bar`:
+##
+## - In `Nim` mode: `:` is a valid delimiter, so `bar` is the value of `--foo`
+## - In `PosixLax` mode: same as `Nim`
+## - In `Gnu` mode: only `=` is a delimiter, so this parses as an option named
+##   `foo:bar` without a value (unless `longNoVal` is non-empty and allows
+##   next-argument consumption)
+##
+## Consider `--foo =bar`:
+##
+## - In `Nim` mode: whitespace around delimiters is allowed, so `=bar` is the
+##   value of `--foo`
+## - In `PosixLax` mode: same as `Nim`
+## - In `Gnu` mode: whitespace around `=` is not allowed, so `--foo` is an
+##   option without a value, and `=bar` is parsed as an argument
+##
 ## See also
 ## ========
 ##
@@ -171,6 +280,11 @@
 ##   parser
 ## * `parsexml module<parsexml.html>`_ for a XML / HTML parser
 ## * `other parsers<lib.html#pure-libraries-parsers>`_ for more parsers
+## * POSIX_ - The Open Group Base Specifications Issue 8. Utility Conventions
+## * GNU_ - GNU C Library reference manual. 26.1.1 Program Argument Syntax Conventions
+##
+## .. _GNU: https://sourceware.org/glibc/manual/latest/html_node/Argument-Syntax.html
+## .. _POSIX: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html
 
 {.push debugger: off.}
 
@@ -178,6 +292,72 @@ include "system/inclrtl"
 
 import std/strutils
 import std/os
+
+type
+  ParserRuleMode = enum
+    ## Parser behavior profiles used to select capability sets at compile time.
+    rsPosixLax, ## The mose forgiving mode. Combines Nim-style parser with
+                ## POSIX-like handling of short options, allowing passing
+                ## whitespace-delimited arguments.
+    rsNim,      ## Nim parsing rules (default).
+    rsGnu ## GNU-style parsing:
+          ## - Short options follow POSIX-style bundling and value handling.
+          ## - Only '=' is a long/short delimiter (':' not treated as a delimiter).
+          ## - Whitespace around '=' is disallowed.
+          ##
+          ## Known discrepancies:
+          ## - No notion of optional/mandatory arguments.
+
+type
+  ParserCapabilities = enum
+    ## Feature flags used to assemble parser behavior for a given mode.
+    pcSepAllowDelimBefore,       ## Allow whitespace before a separator (':'|'=')
+    pcSepAllowDelimAfter,        ## Allow whitespace after a separator (':'|'=')
+    pcShortAllowSep,             ## Allow `-c:val`/`-c=val` forms, see `SepSet`
+    pcShortBundle,               ## Allow bundling short options behind one '-'
+    pcShortValAllowAdjacent,     ## Allow adjacent short option values: `-cval`
+    pcShortValAllowNextArg,      ## Allow next-argv short option values: `-c val`
+    pcShortValAllowDashLeading,  ## Allow values that start with '-' to be taken
+    pcLongAllowSep,              ## Allow `--opt=val`/`--opt:val`, see `SepSet`
+    pcLongValAllowNextArg,       ## Allow `--opt val` form, requires non-emty `longNoVal`
+
+const
+  ParserMode* {.intdefine: "parseopt.mode".}: int = ord(rsNim)
+  RuleMode: ParserRuleMode = static: ##|
+    ## Selected parser mode controlled by `-d:parseopt.mode=<int>`.
+    when ParserMode notin 0..int(ParserRuleMode.high):
+      {.error: "Unknown parseopt parser mode!".}
+    ParserRuleMode(ParserMode)
+
+  RuleSet: set[ParserCapabilities] = static:
+    ## Capability set derived from the selected rule mode.
+    let
+      Common = {
+        pcShortValAllowAdjacent,
+        pcShortBundle,
+        pcLongValAllowNextArg,
+        pcLongAllowSep,
+      }
+      Lax = {
+        pcSepAllowDelimBefore,
+        pcSepAllowDelimAfter,
+        pcShortAllowSep,
+      }
+      ShortPosix = {
+        pcShortValAllowNextArg,
+        pcShortValAllowDashLeading,
+      }
+    when RuleMode == rsPosixLax:
+      Common + Lax + ShortPosix
+    elif RuleMode == rsNim:
+      Common + Lax
+    elif RuleMode == rsGnu:
+      Common + ShortPosix
+    else: {.error: "No rule set defined for the parseopt parser mode." & $RuleMode .}
+
+  SepSet = if RuleMode == rsGnu: {'='} else: {':', '='} ##|
+  ## Allowed separators for long/short option values.
+  DelimSet = {'\t', ' '} ## Allowed delimiters between tokens
 
 type
   CmdLineKind* = enum ## The detected command line token.
@@ -203,7 +383,7 @@ type
                                  ## the option was given a value
 
 proc parseWord(s: string, i: int, w: var string,
-               delim: set[char] = {'\t', ' '}): int =
+               delim: set[char] = DelimSet): int =
   result = i
   if result < s.len and s[result] == '\"':
     inc(result)
@@ -223,12 +403,22 @@ proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
                     allowWhitespaceAfterColon = true): OptParser =
   ## Initializes the command line parser.
   ##
-  ## If `cmdline.len == 0`, the real command line as provided by the
-  ## `os` module is retrieved instead if it is available. If the
-  ## command line is not available, a `ValueError` will be raised.
-  ## Behavior of the other parameters remains the same as in
-  ## `initOptParser(string, ...)
-  ## <#initOptParser,string,set[char],seq[string]>`_.
+  ## **Parameters:**
+  ##
+  ## - `cmdline`: Sequence of command line arguments to parse. If empty, the
+  ##   real command line as provided by the `os` module is retrieved instead.
+  ##   If the command line is not available, an assertion will be raised.
+  ## - `shortNoVal`: Set of short option characters that do not accept values.
+  ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
+  ## - `longNoVal`: Sequence of long option names that do not accept values.
+  ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
+  ## - `allowWhitespaceAfterColon`: When `true` (default), allows forms like
+  ##   `--option: value` or `--option= value` where the value is in the next
+  ##   command line argument after the delimiter. When `false`, the value must
+  ##   be in the same argument as the delimiter.
+  ##
+  ## **Note:** The parser's behavior depends on the selected `parser mode
+  ## <#parser-modes>`_, which is set at compile time with `-d:parseopt.mode=<int>`.
   ##
   ## See also:
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
@@ -273,18 +463,27 @@ proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
 proc initOptParser*(cmdline = "", shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon = true): OptParser =
-  ## Initializes the command line parser.
+  ## Initializes the command line parser from a command line string.
   ##
-  ## If `cmdline == ""`, the real command line as provided by the
-  ## `os` module is retrieved instead if it is available. If the
-  ## command line is not available, a `ValueError` will be raised.
+  ## The `cmdline` string is parsed into tokens using shell-like quoting rules.
   ##
-  ## `shortNoVal` and `longNoVal` are used to specify which options
-  ## do not take values. See the `documentation about these
-  ## parameters<#nimshortnoval-and-nimlongnoval>`_ for more information on
-  ## how this affects parsing.
+  ## **Parameters:**
   ##
-  ## This does not provide a way of passing default values to arguments.
+  ## - `cmdline`: Command line string to parse. If empty, the real command line
+  ##   as provided by the `os` module is retrieved instead. If the command line
+  ##   is not available, an assertion will be raised.
+  ## - `shortNoVal`: Set of short option characters that do not accept values.
+  ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
+  ## - `longNoVal`: Sequence of long option names that do not accept values.
+  ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
+  ## - `allowWhitespaceAfterColon`: When `true` (default), allows forms like
+  ##   `--option: value` or `--option= value` where the value is in the next
+  ##   token after the delimiter. When `false`, the value must be in the same
+  ##   token as the delimiter.
+  ##
+  ## **Note:** This does not provide a way of passing default values to arguments.
+  ## The parser's behavior depends on the selected `parser mode<#parser-modes>`_,
+  ## which is set at compile time with `-d:parseopt.mode=<int>`.
   ##
   ## See also:
   ## * `getopt iterator<#getopt.i,OptParser>`_
@@ -303,18 +502,63 @@ proc handleShortOption(p: var OptParser; cmd: string) =
     add(p.key, cmd[i])
     inc(i)
   p.inShortState = true
-  while i < cmd.len and cmd[i] in {'\t', ' '}:
+  when pcSepAllowDelimBefore in RuleSet:
+    while i < cmd.len and cmd[i] in DelimSet:
+      inc(i)
+      p.inShortState = false
+  let canTakeVal = card(p.shortNoVal) > 0 and p.key[0] notin p.shortNoVal
+
+  template consumeDelims() =
+      while i < cmd.len and cmd[i] in DelimSet: inc(i)
+
+  template consumeSepValue() =
     inc(i)
     p.inShortState = false
-  if i < cmd.len and (cmd[i] in {':', '='} or
-      card(p.shortNoVal) > 0 and p.key[0] notin p.shortNoVal):
-    if i < cmd.len and cmd[i] in {':', '='}:
-      inc(i)
-    p.inShortState = false
-    while i < cmd.len and cmd[i] in {'\t', ' '}: inc(i)
+    when pcSepAllowDelimAfter in RuleSet:
+      consumeDelims()
     p.val = substr(cmd, i)
     p.pos = 0
     inc p.idx
+
+  template consumeAdjacentValue() =
+    p.inShortState = false
+    when pcSepAllowDelimBefore in RuleSet:
+      consumeDelims()
+    p.val = substr(cmd, i)
+    p.pos = 0
+    inc p.idx
+
+  template canConsumeNextArg(): bool =
+    when pcShortValAllowNextArg in RuleSet:
+      if canTakeVal and i >= cmd.len and p.idx + 1 < p.cmds.len:
+        when pcShortValAllowDashLeading in RuleSet:
+          true
+        else:
+          p.cmds[p.idx + 1].len == 0 or p.cmds[p.idx + 1][0] != '-'
+      else:
+        false
+    else:
+      false
+
+  template sepAllowedAndFound(): bool =
+    when pcShortAllowSep in RuleSet:
+      i < cmd.len and cmd[i] in SepSet
+    else:
+      false
+
+  if sepAllowedAndFound():
+    consumeSepValue()
+  elif canTakeVal and i < cmd.len:
+    when pcShortValAllowAdjacent in RuleSet:
+      consumeAdjacentValue()
+    else:
+      p.pos = i
+  elif canConsumeNextArg():
+    p.inShortState = false
+    p.val = p.cmds[p.idx + 1]
+    p.pos = 0
+    inc p.idx, 2
+    return
   else:
     p.pos = i
   if i >= cmd.len:
@@ -343,14 +587,17 @@ proc next*(p: var OptParser) {.rtl, extern: "npo$1".} =
     return
 
   var i = p.pos
-  while i < p.cmds[p.idx].len and p.cmds[p.idx][i] in {'\t', ' '}: inc(i)
+  template consumeDelims() =
+    while i < p.cmds[p.idx].len and p.cmds[p.idx][i] in DelimSet: inc(i)
+
+  consumeDelims()
   p.pos = i
   setLen(p.key, 0)
   setLen(p.val, 0)
   if p.inShortState:
     p.inShortState = false
     if i >= p.cmds[p.idx].len:
-      inc(p.idx)
+      inc p.idx
       p.pos = 0
       if p.idx >= p.cmds.len:
         p.kind = cmdEnd
@@ -364,24 +611,52 @@ proc next*(p: var OptParser) {.rtl, extern: "npo$1".} =
     if i < p.cmds[p.idx].len and p.cmds[p.idx][i] == '-':
       p.kind = cmdLongOption
       inc(i)
-      i = parseWord(p.cmds[p.idx], i, p.key, {' ', '\t', ':', '='})
-      while i < p.cmds[p.idx].len and p.cmds[p.idx][i] in {'\t', ' '}: inc(i)
-      if i < p.cmds[p.idx].len and p.cmds[p.idx][i] in {':', '='}:
-        inc(i)
-        while i < p.cmds[p.idx].len and p.cmds[p.idx][i] in {'\t', ' '}: inc(i)
+      var foundSep = false
+
+      template sepFoundAndAllowed(): bool =
+        when pcLongAllowSep in RuleSet:
+          if i < p.cmds[p.idx].len and p.cmds[p.idx][i] in SepSet:
+            foundSep = true
+            inc(i)
+            when pcSepAllowDelimAfter in RuleSet:
+              consumeDelims()
+            true
+          else:
+            false
+        else:
+          false
+
+      template canConsumeNextArg(): bool =
+        when pcLongValAllowNextArg in RuleSet:
+          len(p.longNoVal) > 0 and p.key notin p.longNoVal and p.idx+1 < p.cmds.len
+        else:
+          false
+
+      i = parseWord(p.cmds[p.idx], i, p.key,
+            DelimSet + (when pcLongAllowSep in RuleSet: SepSet else: {}))
+      when pcSepAllowDelimBefore in RuleSet:
+        consumeDelims()
+      if sepFoundAndAllowed():
         # if we're at the end, use the next command line option:
-        if i >= p.cmds[p.idx].len and p.idx < p.cmds.len and
-            p.allowWhitespaceAfterColon:
+        if i >= p.cmds[p.idx].len and p.idx < p.cmds.len and p.allowWhitespaceAfterColon:
           inc p.idx
           i = 0
         if p.idx < p.cmds.len:
           p.val = p.cmds[p.idx].substr(i)
-      elif len(p.longNoVal) > 0 and p.key notin p.longNoVal and p.idx+1 < p.cmds.len:
-        p.val = p.cmds[p.idx+1]
+        else:
+          p.val = ""
         inc p.idx
+      elif canConsumeNextArg():
+        p.val = p.cmds[p.idx+1]
+        inc p.idx, 2
       else:
         p.val = ""
-      inc p.idx
+        if not foundSep and i < p.cmds[p.idx].len:
+          # Leave remainder of the current token to be parsed as an argument.
+          consumeDelims()
+          p.cmds[p.idx] = p.cmds[p.idx].substr(i)
+        else:
+          inc p.idx
       p.pos = 0
     else:
       p.pos = i

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -233,39 +233,37 @@
 ## Consider `-c val`:
 ##
 ## - In `Nim` mode: `-c` is parsed as an option without a value, and `val` is
-##   parsed as an argument (unless `shortNoVal` is non-empty and `c` is not in it)
-## - In `PosixLax` mode: same as `Nim`, but if `shortNoVal` is non-empty and
-##   `c` is not in it, `val` is consumed as the value of `-c`
-## - In `Gnu` mode: if `shortNoVal` is non-empty and `c` is not in it, `val` is
-##   consumed as the value of `-c`
+##   parsed as an argument, regardless of `shortNoVal` being empty or not.
+## - In `PosixLax` and `Gnu` modes: same as `Nim` when `shortNoVal` is
+##   empty and `c` is not in it, when it's not, `val` is consumed as the value.
 ##
 ## Consider `-c-10`:
 ##
-## - In `Nim` mode: `-c` is an option, `-10` is interpreted as two bundled
-##   short options `-1` and `-0`
-## - In `PosixLax` mode: same as `Nim`, unless `shortNoVal` is non-empty and
-##   `c` is not in it, in which case `-10` is consumed as the value of `-c`
-##   (allowing negative numbers)
-## - In `Gnu` mode: if `shortNoVal` is non-empty and `c` is not in it, `-10` is
-##   consumed as the value of `-c` (allowing negative numbers)
+## - If `shortNoVal` value is empty, all three modes parse thre separate short
+##   options: `c`, `1` and `0`.
+## - Otherwise, if `-c` is not in `shortNoVal`:
+##   + `Nim`: `-c` is an option without an argument. `-10` is interpreted as a
+##      an option `-1` with the `0` argument.
+##   + `PosixLax` and `Gnu`: `-10` is consumed as the value of `-c`
+##     (allowing negative number values).
 ##
 ## **Long Options**
 ##
 ## Consider `--foo:bar`:
 ##
-## - In `Nim` mode: `:` is a valid delimiter, so `bar` is the value of `--foo`
-## - In `PosixLax` mode: same as `Nim`
-## - In `Gnu` mode: only `=` is a delimiter, so this parses as an option named
+## - `Nim`: `:` is a valid delimiter, so `bar` is the value of `--foo`.
+## - `PosixLax`: same as `Nim`.
+## - `Gnu`: only `=` is a delimiter, so this parses as an option named
 ##   `foo:bar` without a value (unless `longNoVal` is non-empty and allows
-##   next-argument consumption)
+##   next-argument consumption).
 ##
 ## Consider `--foo =bar`:
 ##
-## - In `Nim` mode: whitespace around delimiters is allowed, so `=bar` is the
-##   value of `--foo`
-## - In `PosixLax` mode: same as `Nim`
-## - In `Gnu` mode: whitespace around `=` is not allowed, so `--foo` is an
-##   option without a value, and `=bar` is parsed as an argument
+## - `Nim`: whitespace around delimiters is allowed, so `=bar` is the
+##   value of `--foo`.
+## - `PosixLax`: same as `Nim`.
+## - `Gnu`: whitespace around `=` is not allowed, so `--foo` is an
+##   option without a value, and `=bar` is parsed as an argument.
 ##
 ## Custom Rule Sets
 ## ================
@@ -493,7 +491,7 @@ proc parseWord(s: string, i: int, w: var string,
 
 proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
-                    allowWhitespaceAfterColon = true): OptParser =
+                    allowWhitespaceAfterColon = pcSepAllowDelimAfter in RuleSet): OptParser =
   ## Initializes the command line parser.
   ##
   ## **Parameters:**
@@ -555,7 +553,7 @@ proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
 
 proc initOptParser*(cmdline = "", shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
-                    allowWhitespaceAfterColon = true): OptParser =
+                    allowWhitespaceAfterColon = pcSepAllowDelimAfter in RuleSet): OptParser =
   ## Initializes the command line parser from a command line string.
   ##
   ## The `cmdline` string is parsed into tokens using shell-like quoting rules.

--- a/tests/misc/tparseoptmodes.nim
+++ b/tests/misc/tparseoptmodes.nim
@@ -8,7 +8,7 @@ from std/sequtils import toSeq
 
 
 type Opt = tuple[kind: CmdLineKind, key, val: string]
-proc `$`(opt: Opt): string = $opt[0] & "\t'" & opt[1] & "'\t'" & opt[2] & "'"
+proc `$`(opt: Opt): string = "(" & $opt[0] & ", \"" & opt[1] & "\", \"" & opt[2] & "\")"
 
 proc check(name: string; got, expected: openArray[Opt]) =
   doAssert got == expected, "- " & name & ":\n" & $got
@@ -34,6 +34,12 @@ block:
     of rsNim:      @[(cmdShortOption, "c", ""), (cmdArgument, "4", "")]
     of rsGnu:      @[(cmdShortOption, "c", "4")]
   check("short whitespace value", res, expected)
+
+block:
+  # No opt-arg knowledge: whitespace does not bind to short option.
+  let res = collectNoVal(@["-c", "4"])
+  let expected = [(cmdShortOption, "c", ""), (cmdArgument, "4", "")]
+  check("short no-val whitespace value", res, expected)
 
 block:
   # pcShortBundle + pcShortValAllowNextArg: grouped shorts with one opt-arg.
@@ -117,12 +123,6 @@ block:
     of rsNim:      @[(cmdShortOption, "c", ""), (cmdArgument, "foo bar", "")]
     of rsGnu:      @[(cmdShortOption, "c", "foo bar")]
   check("short whitespace quoted value", res, expected)
-
-block:
-  # No opt-arg knowledge: whitespace does not bind to short option.
-  let res = collectNoVal(@["-c", "4"])
-  let expected = [(cmdShortOption, "c", ""), (cmdArgument, "4", "")]
-  check("short no-val whitespace", res, expected)
 
 block:
   # pcShortValAllowNextArg + pcShortValAllowDashLeading: negative numbers as opt-args.
@@ -279,3 +279,44 @@ block:
   let res = collect(@["--", "rest"])
   let expected = @[(cmdLongOption, "", ""), (cmdArgument, "rest", "")]
   check("double-dash marker", res, expected)
+
+block issue9619:
+  let res = collect(@["--option=", "", "--anotherOption", "tree"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdLongOption, "option", ""),
+                     (cmdLongOption, "anotherOption", ""),
+                     (cmdArgument, "tree", "")]
+    of rsNim:      @[(cmdLongOption, "option", ""),
+                     (cmdLongOption, "anotherOption", ""),
+                     (cmdArgument, "tree", "")]
+    of rsGnu:      @[(cmdLongOption, "option", ""),
+                     (cmdArgument, "", ""),
+                     (cmdLongOption, "anotherOption", ""),
+                     (cmdArgument, "tree", "")]
+  check("issue #9619, whitespace after separator", res, expected)
+
+
+block issue22736:
+  let res = collect(@["--long", "", "-h", "--long:", "-h", "--long=", "-h", "arg"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdLongOption, "long", ""),
+                     (cmdArgument, "", ""),
+                     (cmdShortOption, "h", ""),
+                     (cmdLongOption, "long", "-h"),
+                     (cmdLongOption, "long", "-h"),
+                     (cmdArgument, "arg", "")]
+    of rsNim:      @[(cmdLongOption, "long", ""),
+                     (cmdArgument, "", ""),
+                     (cmdShortOption, "h", ""),
+                     (cmdLongOption, "long", "-h"),
+                     (cmdLongOption, "long", "-h"),
+                     (cmdArgument, "arg", "")]
+    of rsGnu:      @[(cmdLongOption, "long", ""),
+                     (cmdArgument, "", ""),
+                     (cmdShortOption, "h", ""),
+                     (cmdLongOption, "long:", ""),
+                     (cmdShortOption, "h", ""),
+                     (cmdLongOption, "long", ""),
+                     (cmdShortOption, "h", ""),
+                     (cmdArgument, "arg", "")]
+  check("issue #22736, whitespace after separator, colon separator", res, expected)

--- a/tests/misc/tparseoptmodes.nim
+++ b/tests/misc/tparseoptmodes.nim
@@ -1,0 +1,281 @@
+discard """
+  action: run
+  matrix: "-d:parseopt.mode=0; -d:parseopt.mode=1; -d:parseopt.mode=2"
+"""
+
+import parseopt {.all.}
+from std/sequtils import toSeq
+
+
+type Opt = tuple[kind: CmdLineKind, key, val: string]
+proc `$`(opt: Opt): string = $opt[0] & "\t'" & opt[1] & "'\t'" & opt[2] & "'"
+
+proc check(name: string; got, expected: openArray[Opt]) =
+  doAssert got == expected, "- " & name & ":\n" & $got
+
+proc collect(args: seq[string]; shortNoVal: set[char] = {}; longNoVal: seq[string] = @[]): seq[Opt] =
+  var p = parseopt.initOptParser(args, shortNoVal = shortNoVal, longNoVal = longNoVal)
+  toSeq(parseopt.getopt(p))
+
+proc collectStr(cmdline: string; shortNoVal: set[char] = {}; longNoVal: seq[string] = @[]): seq[Opt] =
+  var p = parseopt.initOptParser(cmdline, shortNoVal = shortNoVal, longNoVal = longNoVal)
+  toSeq(parseopt.getopt(p))
+
+proc collectNoVal(args: seq[string]): seq[Opt] =
+  var p = parseopt.initOptParser(args, shortNoVal = {}, longNoVal = @[])
+  toSeq(parseopt.getopt(p))
+
+
+block:
+  # pcShortValAllowNextArg: separate option-argument for mandatory opt-arg.
+  let res = collect(@["-c", "4"], shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "c", "4")]
+    of rsNim:      @[(cmdShortOption, "c", ""), (cmdArgument, "4", "")]
+    of rsGnu:      @[(cmdShortOption, "c", "4")]
+  check("short whitespace value", res, expected)
+
+block:
+  # pcShortBundle + pcShortValAllowNextArg: grouped shorts with one opt-arg.
+  let res = collect(@["-abc", "4"], shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "b", ""),
+                     (cmdShortOption, "c", "4")]
+
+    of rsNim:      @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "b", ""),
+                     (cmdShortOption, "c", ""),
+                     (cmdArgument, "4", "")]
+
+    of rsGnu:      @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "b", ""),
+                     (cmdShortOption, "c", "4")]
+  check("short bundle with trailing value", res, expected)
+
+block:
+  # pcShortValAllowAdjacent: option+argument in same token (dash-led value).
+  let res = collect(@["-c-x"], shortNoVal = {'a', 'b'})
+  let expected = @[(cmdShortOption, "c", "-x")]
+  check("short adjacent dash-led", res, expected)
+
+block:
+  # pcShortBundle + pcShortValAllowAdjacent (dash-led value).
+  let res = collect(@["-abc-10"], shortNoVal = {'a', 'b'})
+  let expected = @[
+    (cmdShortOption, "a", ""),
+    (cmdShortOption, "b", ""),
+    (cmdShortOption, "c", "-10")
+  ]
+  check("short bundle with adjacent negative", res, expected)
+
+block:
+  # pcShortValAllowNextArg: option and option-argument can be separate args.
+  let res = collect(@["-c", ":"], shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "c", ":")]
+    of rsNim:      @[(cmdShortOption, "c", ""), (cmdArgument, ":", "")]
+    of rsGnu:      @[(cmdShortOption, "c", ":")]
+  check("short whitespace colon value", res, expected)
+
+block:
+  # pcShortValAllowAdjacent: combined option+argument without blanks.
+  let res = collect(@["-abc4"], shortNoVal = {'a', 'b'})
+  let expected = [
+    (cmdShortOption, "a", ""),
+    (cmdShortOption, "b", ""),
+    (cmdShortOption, "c", "4")
+  ]
+  check("short bundle adjacent value", res, expected)
+
+block:
+  # pcShortBundle: bundle of no-arg shorts should split into options.
+  let res = collect(@["-ab"], shortNoVal = {'a', 'b'})
+  let expected = [(cmdShortOption, "a", ""), (cmdShortOption, "b", "")]
+  check("short bundle no-arg", res, expected)
+
+block:
+  # pcShortBundle + pcShortValAllowNextArg: a no-arg short followed by one with arg.
+  let res = collect(@["-ac", "4"], shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "c", "4")]
+
+    of rsNim:      @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "c", ""),
+                     (cmdArgument, "4", "")]
+
+    of rsGnu:      @[(cmdShortOption, "a", ""),
+                     (cmdShortOption, "c", "4")]
+  check("short bundle trailing value", res, expected)
+
+block:
+  # pcShortValAllowNextArg + cmdline parsing: whitespace-separated opt-arg.
+  let res = collectStr("-c \"foo bar\"", shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "c", "foo bar")]
+    of rsNim:      @[(cmdShortOption, "c", ""), (cmdArgument, "foo bar", "")]
+    of rsGnu:      @[(cmdShortOption, "c", "foo bar")]
+  check("short whitespace quoted value", res, expected)
+
+block:
+  # No opt-arg knowledge: whitespace does not bind to short option.
+  let res = collectNoVal(@["-c", "4"])
+  let expected = [(cmdShortOption, "c", ""), (cmdArgument, "4", "")]
+  check("short no-val whitespace", res, expected)
+
+block:
+  # pcShortValAllowNextArg + pcShortValAllowDashLeading: negative numbers as opt-args.
+  let res = collect(@["-n", "-10"], shortNoVal = {'a', 'b', 'c'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "n", "-10")]
+    of rsNim:      @[(cmdShortOption, "n", ""), (cmdShortOption, "1", "0")]
+    of rsGnu:      @[(cmdShortOption, "n", "-10")]
+  check("short negative value, shortNoVal used", res, expected)
+
+block:
+  # pcShortValAllowNextArg + pcShortValAllowDashLeading: negative numbers as opt-args.
+  let res = collectNoVal(@["-n", "-10"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "n", ""),
+                     (cmdShortOption, "1", ""),
+                     (cmdShortOption, "0", "")]
+    of rsNim:      @[(cmdShortOption, "n", ""),
+                     (cmdShortOption, "1", ""),
+                     (cmdShortOption, "0", "")]
+    of rsGnu:      @[(cmdShortOption, "n", ""),
+                     (cmdShortOption, "1", ""),
+                     (cmdShortOption, "0", "")]
+  check("short negative value, shortNoVal empty", res, expected)
+
+block:
+  # pcShortValAllowNextArg: repeated option-argument pairs are interpreted in order.
+  let res = collect(@["-c", "1", "-c", "2"], shortNoVal = {'a', 'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "c", "1"),
+                     (cmdShortOption, "c", "2")]
+    of rsNim:      @[(cmdShortOption, "c", ""),
+                     (cmdArgument, "1", ""),
+                     (cmdShortOption, "c", ""),
+                     (cmdArgument, "2", "")]
+    of rsGnu:      @[(cmdShortOption, "c", "1"),
+                     (cmdShortOption, "c", "2")]
+  check("short repeat whitespace values", res, expected)
+
+block:
+  # pcShortValAllowAdjacent: adjacent opt-args preserve order for repeats.
+  let res = collect(@["-c1", "-c2"], shortNoVal = {'a', 'b'})
+  let expected = @[(cmdShortOption, "c", "1"), (cmdShortOption, "c", "2")]
+  check("short repeat adjacent values", res, expected)
+
+block:
+  # pcShortValAllowDashLeading: value starting with '-' is consumed as opt-arg.
+  # Divergence from POSIX Guideline 14 when enabled.
+  let res = collect(@["-c", "-a"], shortNoVal = {'b'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdShortOption, "c", "-a")]
+    of rsNim:      @[(cmdShortOption, "c", ""), (cmdShortOption, "a", "")]
+    of rsGnu:      @[(cmdShortOption, "c", "-a")]
+  check("short dash-led value", res, expected)
+
+block:
+  # pcLongAllowSep, mixed long/short parsing.
+  # Option-arguments may include ':'/'=' chars.
+  let args = @[
+    "foo bar",
+    "--path:/i like space/projects",
+    "--aa:bar=a",
+    "--a=c:d",
+    "--ab",
+    "-c",
+    "--a[baz]:doo"
+  ]
+  let res = collect(args, shortNoVal = {'c'})
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[
+      (cmdArgument, "foo bar", ""),
+      (cmdLongOption, "path", "/i like space/projects"),
+      (cmdLongOption, "aa", "bar=a"),
+      (cmdLongOption, "a", "c:d"),
+      (cmdLongOption, "ab", ""),
+      (cmdShortOption, "c", ""),
+      (cmdLongOption, "a[baz]", "doo")]
+    of rsNim: @[
+      (cmdArgument, "foo bar", ""),
+      (cmdLongOption, "path", "/i like space/projects"),
+      (cmdLongOption, "aa", "bar=a"),
+      (cmdLongOption, "a", "c:d"),
+      (cmdLongOption, "ab", ""),
+      (cmdShortOption, "c", ""),
+      (cmdLongOption, "a[baz]", "doo")]
+    of rsGnu: @[
+      (cmdArgument, "foo bar", ""),
+      (cmdLongOption, "path:/i", ""), # longNoVal is empty so can't take arg here
+      (cmdArgument, "like space/projects", ""),
+      (cmdLongOption, "aa:bar", "a"),
+      (cmdLongOption, "a", "c:d"),
+      (cmdLongOption, "ab", ""),
+      (cmdShortOption, "c", ""),
+      (cmdLongOption, "a[baz]:doo", "")]
+  check("mixed long/short argv tokens", res, expected)
+
+
+block:
+  # pcLongAllowSep + SepSet: long option separator handling.
+  let res = collect(@["--foo:bar"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdLongOption, "foo", "bar")]
+    of rsNim:      @[(cmdLongOption, "foo", "bar")]
+    of rsGnu:      @[(cmdLongOption, "foo:bar", "")]
+  check("long option colon separator", res, expected)
+
+block:
+  # pcLongAllowSep + SepSet: long option separator handling.
+  let res = collect(@["--foo= bar"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdLongOption, "foo", "bar")]
+    of rsNim:      @[(cmdLongOption, "foo", "bar")]
+    of rsGnu:      @[(cmdLongOption, "foo", " bar")]
+  check("long option whitespace around separators", res, expected)
+
+block:
+  let res = collect(@["--foo =bar"])
+  let expected = case parseopt.RuleMode
+    of rsPosixLax: @[(cmdLongOption, "foo", "bar")]
+    of rsNim:      @[(cmdLongOption, "foo", "bar")]
+    of rsGnu:      @[(cmdLongOption, "foo", ""), (cmdArgument, "=bar", "")]
+  check("long option whitespace around separators", res, expected)
+
+block:
+  let res = collectStr("--foo =bar", longNoVal = @[""])
+  let expected = [(cmdLongOption, "foo", "=bar")]
+  check("long option argument delimited with whitespace, val allowed", res, expected)
+
+block:
+  let res = collectStr("--foo =bar")
+  let expected = [(cmdLongOption, "foo", ""), (cmdArgument, "=bar", "")]
+  check("long option argument delimited with whitespace, val not allowed", res, expected)
+
+block:
+  # pcLongAllowSep: '=' separator
+  let res = collect(@["--foo=bar"])
+  let expected = @[(cmdLongOption, "foo", "bar")]
+  check("long option equals separator", res, expected)
+
+block:
+  # pcLongValAllowNextArg: long option value can be next argument.
+  let res = collect(@["--foo", "bar"], longNoVal = @[""])
+  let expected = @[(cmdLongOption, "foo", "bar")]
+  check("long option next-arg value", res, expected)
+
+block:
+  # longNoVal disables next-arg value consumption.
+  let res = collect(@["--foo", "bar"], longNoVal = @["foo"])
+  let expected = @[(cmdLongOption, "foo", ""), (cmdArgument, "bar", "")]
+  check("long option longNoVal disables argument taking", res, expected)
+
+block:
+  # "--" is parsed as a long option with an empty key.
+  let res = collect(@["--", "rest"])
+  let expected = @[(cmdLongOption, "", ""), (cmdArgument, "rest", "")]
+  check("double-dash marker", res, expected)


### PR DESCRIPTION
Adds parser mode support to parseopt module via a CT define.
Initially solved the issue of not being able to pass arguments to short options, as you do habitually with most of the everyday terminal stuff. But the chosen solution lends itself nicely for different modes so I did two new.

`std/parseopt` now supports multiple parser modes via `-d:parseopt.mode=<int>`.
  Modes include `Nim` (default, fully compatible) and two new experimental modes:  `PosixLax` and `Gnu` for different option parsing behaviours. With `ParserRulesMask` controllable by another intdefine (`parseopt.rules`), it's also possible to define a custom set of rules for the parser.

This is all optional and not exactly at the front of the module docs, so I hope the damage potential is very small. Most parser changes that employ branching are encapsulated within `when` blocks so should not affect parser performance (which I don't think is ever a problem, being a mostly launch-once system).

- Default mode is `Nim`, which should preserve existing behavior fully
- New modes are opt-in via compile-time flag
- Marked as experimental
- Tests included
- Changelogged

This also shows a viable technique for providing *module features*. As const defines are limited by just three types (bool/int/str), it's not as easy as writing a .toml config, but thanks to nims, almost as convenient. The main limitation is the module controlled should be importable by nimscript, which parseopts is.

Working on the parser modes exposed a few quirks of the parser that I find unconventional even by Nim standards. Namely:

1. **Parser behaviour is controlled by an emptiness of two containers**. This is an interesting approach. It's also made more interesting because the `shortNoVal`/`longNoVal` control both the namesakes, but *and also how their opposites (value-taking opts) work*.
2. `allowWhitespaceAfterColon` in `initOptParser`. It's the only option controlled. Why does it need to exist and why only it? GH search shows almost no use in the wild besides all the argparsing library attempt boneyard. I'd remove this feature, especially if this PR gets merged, as it can replace it. For now it's untouched, of course (though the default depends on the effective `Mode`/`RuleSet`)

---
Edit:

@c-blake reminded me of `{.define.}`'s existence that ~~allows configuring this module right in you code, without resorting to nimscript, which is great.~~ But that pragma itself is undocumented, so I hesitate to mention using it in this parseopt doc's until this is changed.