### PR TITLE
fixes #25475; incompatible types errors for array types with different index types

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -41,7 +41,7 @@ type
     CoType
     CoOwnerSig
     CoIgnoreRange
-    CoIgnoreRangeInarray
+    CoIgnoreRangeInArray
     CoConsiderOwned
     CoDistinct
     CoHashTypeInsideNode
@@ -221,14 +221,14 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
     else:
       for a in t.kids: c.hashType a, flags+{CoIgnoreRange}, conf
   of tyRange:
-    if {CoIgnoreRange, CoIgnoreRangeInarray} * flags == {}:
+    if {CoIgnoreRange, CoIgnoreRangeInArray} * flags == {}:
       c &= char(t.kind)
       c.hashTree(t.n, {}, conf)
       c.hashType(t.elementType, flags, conf)
-    elif CoIgnoreRangeInarray in flags:
+    elif CoIgnoreRangeInArray in flags:
       # include only the length of the range (not its specific bounds)
       c &= char(t.kind)
-      let l = lastOrd(conf, t) - firstOrd(conf, t) + 1
+      let l = lengthOrd(conf, t)
       lowlevel l
     else:
       c.hashType(t.elementType, flags, conf)
@@ -261,7 +261,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
     if tfVarargs in t.flags: c &= ".varargs"
   of tyArray:
     c &= char(t.kind)
-    c.hashType(t.indexType, flags-{CoIgnoreRange}+{CoIgnoreRangeInarray}, conf)
+    c.hashType(t.indexType, flags-{CoIgnoreRange}+{CoIgnoreRangeInArray}, conf)
     c.hashType(t.elementType, flags-{CoIgnoreRange}, conf)
   else:
     c &= char(t.kind)

--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -41,6 +41,7 @@ type
     CoType
     CoOwnerSig
     CoIgnoreRange
+    CoIgnoreRangeInarray
     CoConsiderOwned
     CoDistinct
     CoHashTypeInsideNode
@@ -220,10 +221,17 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
     else:
       for a in t.kids: c.hashType a, flags+{CoIgnoreRange}, conf
   of tyRange:
-    if CoIgnoreRange notin flags:
+    if {CoIgnoreRange, CoIgnoreRangeInarray} * flags == {}:
       c &= char(t.kind)
       c.hashTree(t.n, {}, conf)
-    c.hashType(t.elementType, flags, conf)
+      c.hashType(t.elementType, flags, conf)
+    elif CoIgnoreRangeInarray in flags:
+      # include only the length of the range (not its specific bounds)
+      c &= char(t.kind)
+      let l = lastOrd(conf, t) - firstOrd(conf, t) + 1
+      lowlevel l
+    else:
+      c.hashType(t.elementType, flags, conf)
   of tyStatic:
     c &= char(t.kind)
     c.hashTree(t.n, {}, conf)
@@ -253,7 +261,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
     if tfVarargs in t.flags: c &= ".varargs"
   of tyArray:
     c &= char(t.kind)
-    c.hashType(t.indexType, flags-{CoIgnoreRange}, conf)
+    c.hashType(t.indexType, flags-{CoIgnoreRange}+{CoIgnoreRangeInarray}, conf)
     c.hashType(t.elementType, flags-{CoIgnoreRange}, conf)
   else:
     c &= char(t.kind)

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -605,3 +605,17 @@ block t18643:
   except IndexDefect:
     caught = true
   doAssert caught, "IndexDefect not caught!"
+
+
+# bug #25475
+block:
+  type N = object
+    b: seq[array[1'u, int]]
+  doAssert N(b: @[[0]]) == N(b: @[[0]])
+
+block:
+  var x: array[5..6, int] = [0, 1]
+  var y: array[1..2, int] = [0, 1]
+
+  doAssert x == y # compiles
+  doAssert @[x] == @[y]


### PR DESCRIPTION
fixes #25475

```nim
var x: array[0..1, int] = [0, 1]
var y: array[4'u..5'u, int] = [0, 3]

echo x == y
```

sigmatch treats array compatibility by element type + length, not by the index (range) type. Perhaps backend should do the same check