### PR TITLE
fix: double check inputIndex in base64.decode

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -257,7 +257,7 @@ proc decode*(s: string): string =
       inc inputIndex
     # double check inputIndex as it can be incremented due to whitespace
     if inputIndex > inputEnds:
-      continue
+      break
     inputChar(a)
     inputChar(b)
     inputChar(c)

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -255,6 +255,9 @@ proc decode*(s: string): string =
   while inputIndex <= inputEnds:
     while s[inputIndex] in {'\n', '\r', ' '}:
       inc inputIndex
+    # double check inputIndex as it can be incremented due to whitespace
+    if inputIndex > inputEnds:
+      continue
     inputChar(a)
     inputChar(b)
     inputChar(c)


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/25530

this double checks the index to make sure whitespace related index increments cannot cause index defect error