### PR TITLE
fixes #25005; new doesn't work with ref object

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2049,6 +2049,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         # proc signature for example
         if c.inGenericInst > 0:
           let bound = result.typ.elementType.sym
+          # the symbol may still point to the uninstantiated generic body type 
           if bound != nil and bound.typ == result.typ.elementType:
             return bound
           return result

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -2049,7 +2049,8 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         # proc signature for example
         if c.inGenericInst > 0:
           let bound = result.typ.elementType.sym
-          if bound != nil: return bound
+          if bound != nil and bound.typ == result.typ.elementType:
+            return bound
           return result
         if result.typ.sym == nil:
           localError(c.config, n.info, errTypeExpected)

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -902,3 +902,15 @@ block: # issue #25494
       a, b, c
 
   foo[MyEnum]()
+
+block: # issue #25005
+  type
+    RpcResponse[T] = ref object
+      result: T
+
+  func testit[T](p: var ref T) =
+    p = new(T)
+
+  var v: RpcResponse[string]
+  testit(v)
+


### PR DESCRIPTION
fixes #25005

 In `semTypeIdent`, when resolving a typedesc parameter inside a generic instantiation, the code took a shortcut: it returned the symbol of the element type (`bound = result.typ.elementType.sym`). However, for generic types like `RpcResponse[T] = ref object`, the instantiated object type (e.g., `RpcResponse:ObjectType[string]`) is a copy with a new type ID but still points to the same symbol as the uninstantiated generic body type. That symbol's .typ refers to the original uninstantiated type, which still contains unresolved generic params `T`