### PR TITLE
fixes #21281; proc f(x: static[auto]) doesn't treat x as static

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1203,7 +1203,15 @@ proc addImplicitGeneric(c: PContext; typeClass: PType, typId: PIdent;
   # is this a bindOnce type class already present in the param list?
   for i in 0..<genericParams.len:
     if genericParams[i].sym.name.id == finalTypId.id:
-      return genericParams[i].typ
+      if typeClass.kind == tyStatic and genericParams[i].typ.kind != tyStatic:
+        # The base type (e.g. from `auto`) was already added as a generic param,
+        # but `static[auto]` requires upgrading it to a `tyStatic` wrapper so
+        # it is instantiated as a compile-time value (`skConst`).
+        genericParams[i].sym.linkTo(typeClass)
+        typeClass.incl tfImplicitTypeParam
+        return typeClass
+      else:
+        return genericParams[i].typ
 
   let owner = if typeClass.sym != nil: typeClass.sym
               else: getCurrOwner(c)

--- a/tests/vm/t21281.nim
+++ b/tests/vm/t21281.nim
@@ -1,0 +1,13 @@
+discard """
+  nimout: '''
+3
+3
+'''
+"""
+
+proc f(x: static[auto]) =  # doesn't work
+  static: echo x
+proc g[T](x: static[T]) =  # works
+  static: echo x
+f(3)
+g(3)


### PR DESCRIPTION
fixes #21281