### PR TITLE
Fix a few typos

### DIFF
--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -2127,7 +2127,7 @@ can be used in an `isolate` context:
     `=destroy`(dest.value)
   ```
 
-The `.sendable` pragma itself is an experimenal, unchecked, unsafe annotation. It is
+The `.sendable` pragma itself is an experimental, unchecked, unsafe annotation. It is
 currently only used by `Isolated[T]`.
 
 Virtual pragma

--- a/doc/markdown_rst.md
+++ b/doc/markdown_rst.md
@@ -276,9 +276,9 @@ This parser has 2 modes for inline markup:
 
 2) Compatibility mode which is RST rules.
 
-.. Note:: in both modes the parser interpretes text between single
+.. Note:: in both modes the parser interprets text between single
      backticks (code) identically:
-     backslash does not escape; the only exception: ``\`` folowed by `
+     backslash does not escape; the only exception: ``\`` followed by `
      does escape so that we can always input a single backtick ` in
      inline code. However that makes impossible to input code with
      ``\`` at the end in *single* backticks, one must use *double*

--- a/doc/nimgrep_cmdline.txt
+++ b/doc/nimgrep_cmdline.txt
@@ -52,7 +52,7 @@ Options:
                           nimgrep --filenames               # In current dir
                           nimgrep --filenames "" DIRECTORY
                            # Note empty pattern "", lists all files in DIRECTORY
-* Interprete patterns:
+* Interpret patterns:
   --peg               PATTERN and PAT are Peg
   --re                PATTERN and PAT are regular expressions (default)
   --rex, -x           use the "extended" syntax for the regular expression

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -27,7 +27,7 @@ Nim runs on a wide variety of platforms. Support on amd64 and i386 is tested reg
 - ppc64el (aka ppc64le)
 - riscv64
 
-The following platforms are seldomly tested:
+The following platforms are seldom tested:
 
 - alpha
 - hppa

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -27,7 +27,7 @@ Nim runs on a wide variety of platforms. Support on amd64 and i386 is tested reg
 - ppc64el (aka ppc64le)
 - riscv64
 
-The following platforms are seldom tested:
+The following platforms are rarely tested:
 
 - alpha
 - hppa


### PR DESCRIPTION
While fixing a few things in the tutorial, I found a few other typos lingering in the `doc/` directory.