### PR TITLE
Fix warning admonition in `std/streams`

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -16,9 +16,9 @@
 ## stream interface.
 ##
 ## .. warning:: Due to the use of `pointer`, the `readData`, `peekData` and
-## `writeData` interfaces are not available on the compile-time VM, and must
-## be cast from a `ptr string` on the JS backend. However, `readDataStr` is
-## available generally in place of `readData`.
+##   `writeData` interfaces are not available on the compile-time VM, and must
+##   be cast from a `ptr string` on the JS backend. However, `readDataStr` is
+##   available generally in place of `readData`.
 ##
 ## Basic usage
 ## ===========


### PR DESCRIPTION
The rest of the body must be indented in order to fall under the warning admonition. Right now, only the first part of the warning is inside the admonition, see [std/streams](https://nim-lang.org/docs/streams.html).
