### PR TITLE
Nimsuggest: Operators in symbol outline

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1018,7 +1018,7 @@ proc outlineNode(graph: ModuleGraph, n: PNode, endInfo: TLineInfo, infoPairs: Su
   if n.kind == nkSym and n.sym.checkSymbol(n.info):
     graph.suggestResult(n.sym, n.sym.info, ideOutline, endInfo.line, endInfo.col)
     return true
-  elif n.kind == nkIdent:
+  elif n.kind in {nkIdent, nkAccQuoted}:
     let symData = findByTLineInfo(n.info, infoPairs)
     if symData != nil and symData.sym.checkSymbol(symData.info):
        let sym = symData.sym
@@ -1028,7 +1028,7 @@ proc outlineNode(graph: ModuleGraph, n: PNode, endInfo: TLineInfo, infoPairs: Su
 proc handleIdentOrSym(graph: ModuleGraph, n: PNode, endInfo: TLineInfo, infoPairs: SuggestFileSymbolDatabase): bool =
   result = false
   for child in n:
-    if child.kind in {nkIdent, nkSym}:
+    if child.kind in {nkIdent, nkAccQuoted, nkSym}:
       if graph.outlineNode(child, endInfo, infoPairs):
         return true
     elif child.kind == nkPostfix:


### PR DESCRIPTION
So the problem is that Nim Language Server won't show procs like \`+\` and \`==\` in the Document Symbols or Workspace Symbols lists. Which is really annoying given they are regular procs just named a bit differently.

Initially, I thought the problem was with nim-lang/langserver and opened an issue there: https://github.com/nim-lang/langserver/issues/380

But after an investigation, it turned out the issue is fixed on the nimsuggest side.

Strangely enough, calling `outline foo.nim:0:0` in nimsuggest manually does show \`+\` as well as regular procs (e.g. `foo`) but when nimsuggest is invoked from lsp only `foo` would be there.

Anyway, with this fix all procs appear on the symbol lists.