### PR TITLE
Fix memory leak in asyncdispatch.withTimeout by clearing losing callbacks

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1946,9 +1946,14 @@ proc withTimeout*[T](fut: Future[T], timeout: int): owned(Future[bool]) =
           retFuture.fail(fut.error)
         else:
           retFuture.complete(true)
+        # Timeout side lost; drop its callback to avoid retaining closures/futures.
+        timeoutFuture.clearCallbacks()
   timeoutFuture.callback =
     proc () =
-      if not retFuture.finished: retFuture.complete(false)
+      if not retFuture.finished:
+        retFuture.complete(false)
+        # Wrapped future side lost; drop its callback to avoid retaining closures/futures.
+        fut.clearCallbacks()
   return retFuture
 
 proc accept*(socket: AsyncFD,


### PR DESCRIPTION
withTimeout currently leaves the “losing” callback installed:

  - when fut finishes first, timeout callback remains until timer fires,
  - when timeout fires first, fut callback remains on the wrapped future.

Under high-throughput use with large future payloads, this retains closures/future references longer than needed and causes large transient RSS growth.
This patch clears the opposite callback immediately once outcome is decided, reducing retention without changing API behavior.