### PR TITLE
`std/parseopt`: fixes `initOptParser` fallback logic, moves NimScript logic to `os.cmdline`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,14 @@ errors.
 
 - Adds a new warning `--warning:ImplicitRangeConversion` that detects downsizing implicit conversions to range types (e.g., `int -> range[0..255]` or `range[1..256] -> range[0..255]`) that could cause runtime panics. Safe conversions like `range[0..255] -> range[0..65535]` and explicit casts do not trigger warnings. `int` to `Natural` and `Positive` conversions do not trigger warnings, which can be enabled with `--warning:systemRangeConversion`.
 
+
+- `std/parseopt`: `initOptParser` and `getopt` no longer fall back to `commandLineParams()` when given empty input (`""` or `@[]`). An explicit empty string or sequence now produces an empty parser. Code that relied on `""` or `@[]` values to implicitly re-parse the OS command line must be updated to call `initOptParser()` with the `cmdline` argument omitted instead.
+  The `cmdline = ""` default was removed from the string overload of `initOptParser`. The no-argument form now unambiguously resolves to the `seq[string]` overload with `commandLineParams()` as its default.
+
+
+- `std/cmdline.commandLineParams()` for NimScript now consistently returns only the script arguments (excluding the `nim` executable and its flags), fixing inconsistency between `std/cmdline` and `std/parseopt`.
+
+
 ## Standard library additions and changes
 
 [//]: # "Additions:"

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -48,7 +48,8 @@ proc nimbleLockExists(config: ConfigRef): bool =
   return fileExists(pd.string / nimbleLock)
 
 proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+  var p = if cmd.len == 0: parseopt.initOptParser()
+          else: parseopt.initOptParser(cmd)
   var argsCount = 0
 
   config.commandLine.setLen 0

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1208,7 +1208,8 @@ proc mainCommand(graph: ModuleGraph) =
     genSuccessX(graph.config)
 
 proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+  var p = if cmd.len == 0: parseopt.initOptParser()
+          else: parseopt.initOptParser(cmd)
   var argsCount = 1
 
   config.commandLine.setLen 0

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -450,39 +450,18 @@ proc initOptParser(cmdline: openArray[string];
                     )
   if prSepAllowEq    in rules: result.separators.incl('=')
   if prSepAllowColon in rules: result.separators.incl(':')
-  if cmdline.len == 0:
-    when declared(paramCount):
-      when defined(nimscript):
-        var ctr = 0
-        var firstNimsFound = false
-        for i in countup(0, paramCount()):
-          if firstNimsFound: 
-            result.cmds[ctr] = paramStr(i)
-            inc ctr, 1
-          if paramStr(i).toLowerAscii().endsWith(".nims") and not firstNimsFound:
-            firstNimsFound = true 
-            result.cmds = newSeq[string](paramCount()-i)
-      else:
-        result.cmds = newSeq[string](paramCount())
-        for i in countup(1, paramCount()):
-          result.cmds[i-1] = paramStr(i)
-    else:
-      # we cannot provide this for NimRtl creation on Posix, because we can't
-      # access the command line arguments then!
-      raiseAssert "empty command line given but" &
-        " real command line is not accessible"
 
-proc initOptParser*(cmdline: seq[string];
+proc initOptParser*(cmdline: seq[string] = commandLineParams();
                     shortNoVal: set[char] = {};
                     longNoVal: seq[string] = @[];
                     mode: CliMode = NimMode): OptParser =
-  ## Initializes the command line parser.
+  ## Initializes the command line parser from a sequence of arguments.
   ##
   ## **Parameters:**
   ##
-  ## - `cmdline`: Sequence of command line arguments to parse. If empty, the
-  ##   real command line as provided by the `os` module is retrieved instead.
-  ##   If the command line is not available, an assertion will be raised.
+  ## - `cmdline`: Sequence of arguments to parse. Defaults to
+  ##   `os.commandLineParams()`, which retrieves the actual command line arguments
+  ##   at the call site. Empty value means no arguments and has no side-effects.
   ## - `shortNoVal`: Set of short option characters that do not accept values.
   ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
   ## - `longNoVal`: Sequence of long option names that do not accept values.
@@ -499,8 +478,8 @@ proc initOptParser*(cmdline: seq[string];
                       shortNoVal = {'l'}, longNoVal = @["left"])
   initOptParser(cmdline, shortNoVal, longNoVal, toRules(mode))
 
-proc initOptParser*(cmdline: seq[string],
-                    shortNoVal: set[char] = {},
+proc initOptParser*(cmdline: seq[string] = commandLineParams();
+                    shortNoVal: set[char] = {};
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon: bool): OptParser {.deprecated:
       "`allowWhitespaceAfterColon` is deprecated, use parser modes instead".} =
@@ -517,19 +496,22 @@ proc initOptParser*(cmdline: seq[string],
   if allowWhitespaceAfterColon == false: nimrules.excl prSepAllowDelimAfter
   initOptParser(cmdline, shortNoVal, longNoVal, nimrules)
 
-proc initOptParser*(cmdline = "";
+proc initOptParser*(cmdline: string;
                     shortNoVal: set[char] = {};
                     longNoVal: seq[string] = @[];
                     mode: CliMode = NimMode): OptParser =
   ## Initializes the command line parser from a command line string.
   ##
-  ## The `cmdline` string is parsed into tokens using shell-like quoting rules.
+  ## The `cmdline` string is split into tokens with `parseCmdLine proc`_
+  ## using shell-like quoting rules.
   ##
   ## **Parameters:**
   ##
-  ## - `cmdline`: Command line string to parse. If empty, the real command line
-  ##   as provided by the `os` module is retrieved instead. If the command line
-  ##   is not available, an assertion will be raised.
+  ## - `cmdline`: Command line string to parse. Empty value means no arguments
+  ##   and has no side-effects. To parse the actual OS command line arguments,
+  ##   use the `initOptParser(seq[string], seq[char], seq[string], NimMode)`,
+  ##   or just omit this parameter, which the compiler will resolve to that
+  ##   overload automatically.
   ## - `shortNoVal`: Set of short option characters that do not accept values.
   ##   See `shortNoVal and longNoVal<#nimshortnoval-and-nimlongnoval>`_ for details.
   ## - `longNoVal`: Sequence of long option names that do not accept values.
@@ -548,7 +530,7 @@ proc initOptParser*(cmdline = "";
                       shortNoVal = {'l'}, longNoVal = @["left"])
   initOptParser(parseCmdLine(cmdline), shortNoVal, longNoVal, toRules(mode))
 
-proc initOptParser*(cmdline = "";
+proc initOptParser*(cmdline: string;
                     shortNoVal: set[char] = {};
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon: bool): OptParser {.deprecated:
@@ -585,10 +567,10 @@ proc handleShortOption(p: var OptParser; cmd: string) =
     p.inShortState = false
     p.pos = 0
     inc p.idx, n
-    
+
   template next(): untyped = p.cmds[p.idx + 1]
 
-  let canTakeVal = card(p.shortNoVal) > 0 and p.key[0] notin p.shortNoVal 
+  let canTakeVal = card(p.shortNoVal) > 0 and p.key[0] notin p.shortNoVal
   if i < cmd.len and cmd[i] in p.separators:
     # separator case
     if prShortAllowSep in p.rules:
@@ -779,16 +761,18 @@ iterator getopt*(p: var OptParser): tuple[kind: CmdLineKind, key,
     if p.kind == cmdEnd: break
     yield (p.kind, p.key, p.val)
 
-iterator getopt*(cmdline: seq[string] = @[];
+iterator getopt*(cmdline: seq[string] = commandLineParams();
                   shortNoVal: set[char] = {};
                   longNoVal: seq[string] = @[];
                   mode: CliMode = NimMode):
             tuple[kind: CmdLineKind, key, val: string] =
   ## Convenience iterator for iterating over command line arguments.
   ##
-  ## This creates a new `OptParser<#OptParser>`_. If no command line
-  ## arguments are provided, the real command line as provided by the
-  ## `os` module is retrieved instead.
+  ## This creates a new `OptParser<#OptParser>`_.
+  ##
+  ## `cmdline` is a sequence of arguments to parse. Defaults to
+  ## `os.commandLineParams()`, which retrieves the actual command line arguments
+  ## at the call site. Empty value means no arguments and has no side-effects.
   ##
   ## `shortNoVal` and `longNoVal` are used to specify which options
   ## do not take values. See the `documentation about these

--- a/lib/std/cmdline.nim
+++ b/lib/std/cmdline.nim
@@ -279,8 +279,13 @@ when declared(paramCount) or defined(nimdoc):
   proc commandLineParams*(): seq[string] =
     ## Convenience proc which returns the command line parameters.
     ##
-    ## This returns **only** the parameters. If you want to get the application
+    ## Unlike `paramStr proc`_, returns **only** the parameters.
+    ## If you want to get the application
     ## executable filename, call `getAppFilename() <os.html#getAppFilename>`_.
+    ##
+    ## When used from NimScript, arguments preceding and including the `.nims`
+    ## file are also excluded, returning only the arguments intended for the
+    ## script.
     ##
     ## **Availability**: On Posix there is no portable way to get the command
     ## line from a DLL and thus the proc isn't defined in this environment. You
@@ -303,8 +308,23 @@ when declared(paramCount) or defined(nimdoc):
     ##     # Do something else!
     ##   ```
     result = @[]
-    for i in 1..paramCount():
-      result.add(paramStr(i))
+    when defined(nimscript):
+      func isNimScriptExt(s: openArray[char]): bool =
+        let L = s.len
+        (L >= 5 and s[L-5] == '.' and (
+          (s[L-4] in {'n', 'N'}) and
+          (s[L-3] in {'i', 'I'}) and
+          (s[L-2] in {'m', 'M'}) and
+          (s[L-1] in {'s', 'S'})))
+      var firstNimsFound = false
+      for i in 0..paramCount(): # nimscript needs to check index 0
+        if firstNimsFound:
+          result.add(paramStr(i))
+        elif isNimScriptExt(paramStr(i)):
+          firstNimsFound = true
+    else:
+      for i in 1..paramCount():
+        result.add(paramStr(i))
 else:
   proc commandLineParams*(): seq[string] {.error:
   "commandLineParams() unsupported by dynamic libraries".} =

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -668,7 +668,8 @@ proc mainCommand(graph: ModuleGraph) =
   close(results)
 
 proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+  var p = if cmd.len == 0: parseopt.initOptParser()
+          else: parseopt.initOptParser(cmd)
   var findProject = false
   while true:
     parseopt.next(p)


### PR DESCRIPTION
Fixes #17018
Closes #23554
Fixes #25557

Both `initOptParser` overloads currently fall back to `commandLineParams()` when given empty input. As already pointed out in #17018, branching semantics on a valid value (`len == 0`) is a bad API decision.

The most common failure mode is subcommand delegation as described in #25557.

The same issue affects calls like:

```nim
commandLineParams().filterIt(...).initOptParser()
```

If the filter produces an empty sequence, the parser unexpectedly falls back to the full OS argv.

Separately, in NimScript, `commandLineParams()` returns the compiler invocation flags, not just script arguments. `std/parseopt` contained CT-defined logic to slice those out, but `std/cmdline` itself did not. This split responsibility was inconsistent.

# Changes:

1. Moved the NimScript stripping logic from `std/parseopt` into `std/cmdline.commandLineParams()` where it belongs. Closes #23554.

2. Removed the `cmdline.len == 0` fallback from the core (private) parser implementation.

3. Set the default value for initOptParser and changed for getopt: 

   ```nim
   proc initOptParser*(cmdline: seq[string] = commandLineParams(); ...)
   iterator getopt*(cmdline: seq[string] = commandLineParams(); ...) # was `= @[]`
   ```

4. Removed the `cmdline = ""` default from the string overload so the "omit" case resolves to the _now-main_ seq-taking overload.

5. Removed the assertion raise from initOptParser. Because the new default `commandLineParams()` is evaluated at the call site, calling `initOptParser()` in a dynamic library now should trigger the `{.error.}` pragma in `cmdline` at *compile-time*, rather than crashing with a `raiseAssert` at runtime.

The parser now strictly respects the input given. Implicit fetching OS arguments reduced to no-parameters from previous two cases (omitted/empty).

## Breakage

This breaks the code that used explicit empty values to trigger OS fallback. Well, this is a silly approach and, hopefully, no one relied on it.

**However:**

 `initOptParser()` (`cmdline` omitted) continues to fetch OS arguments via the default `commandLineParams()` value, so the idiomatic  usage remains unaffected. The routine this call resolves to changed, though, now it's  **the seq-taking `initOptParser`** which is really the first-class one anyway, as the string overload splits cmdline to seq[string] with `parseCmdLine` under the hood (btw, this proc itself recommends using `parseopt` instead which is a bit circular).

## Another bug/quirk fixed/worth mentioning

Under the old implementation, a whitespace-only string such as `initOptParser(" ")` was first routed through `parseCmdLine`, which consumes whitespace as delimiters and produces `@[]`, this would then trigger the fallback and silently re-parse the real OS command line.

In other words, a **non-empty string argument could unexpectedly produce a parser over the process argv**. With the fallback removed, this improves naturally and produces a parser over an empty seq (`parseCmdLine(" ") == @[]`).

However, this still diverges with `initOptParser(@[" "])`. Here the parser receives exactly one whitespace argument. No tokenization step collapses it to empty. So, although the sentinel fallback is gone, the two overloads are not fully equivalent for inputs that *feel* empty. The string overload has a wider "empty surface", so to speak.

## Examples

```nim
# old behavour
var p1 = initOptParser()    # Fetches OS arguments
var p2 = initOptParser("")  # Fetches OS arguments - ambiguity
var p3 = initOptParser(" ") # Fetches OS arguments - buggy
var p4 = initOptParser(@[]) # Fetches OS arguments - ambiguity

# new behavour
var p1 = initOptParser()    # Fetches OS arguments. No breakage for idiomatic usage
var p2 = initOptParser("")  # Parses 0 arguments, allows sub-parsing
var p3 = initOptParser(" ") # Parses 0 arguments, resolves to call below
var p4 = initOptParser(@[]) # Parses 0 arguments, allows sub-parsing
```

For NimsScript:

```nim
# nim -f test.nims foo
let c = commandLineParams()

# old behaviour
assert c == @["-f", "test.nims", "foo"]
# new behaviour
assert c ==  @["foo"]
```

----

Overall, this removes the sentinel-based branching, restores predictable semantics, and fixes the NimScript layering issue at the same time. I say, wins all around.