### PR TITLE
`std/cmdline.commandLineParams` NimScript fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,9 @@ errors.
 parameter and result types, not just their source-level shape. Use
 `--legacy:procParamTypeBackendAliases` to restore the older behavior.
 
+- `std/cmdline.commandLineParams()` for NimScript now consistently returns only the script arguments (excluding the `nim` executable and its flags), fixing inconsistency between `std/cmdline` and `std/parseopt`.
+
+
 ## Standard library additions and changes
 
 [//]: # "Additions:"

--- a/lib/std/cmdline.nim
+++ b/lib/std/cmdline.nim
@@ -279,8 +279,14 @@ when declared(paramCount) or defined(nimdoc):
   proc commandLineParams*(): seq[string] =
     ## Convenience proc which returns the command line parameters.
     ##
-    ## This returns **only** the parameters. If you want to get the application
+    ## Unlike `paramStr proc`_, returns **only** the parameters.
+    ## If you want to get the application
     ## executable filename, call `getAppFilename() <os.html#getAppFilename>`_.
+    ##
+    ## When used from NimScript, arguments preceding and including the first
+    ## `.nims` file are excluded, returning only the arguments intended for the
+    ## script. If no token ending with `.nims` (case-insensitive) is present
+    ## in the command line, this returns an empty sequence.
     ##
     ## **Availability**: On Posix there is no portable way to get the command
     ## line from a DLL and thus the proc isn't defined in this environment. You
@@ -303,8 +309,23 @@ when declared(paramCount) or defined(nimdoc):
     ##     # Do something else!
     ##   ```
     result = @[]
-    for i in 1..paramCount():
-      result.add(paramStr(i))
+    when defined(nimscript):
+      func isNimScriptExt(s: openArray[char]): bool =
+        let L = s.len
+        (L >= 5 and s[L-5] == '.' and (
+          (s[L-4] in {'n', 'N'}) and
+          (s[L-3] in {'i', 'I'}) and
+          (s[L-2] in {'m', 'M'}) and
+          (s[L-1] in {'s', 'S'})))
+      var firstNimsFound = false
+      for i in 0..paramCount(): # nimscript needs to check index 0
+        if firstNimsFound:
+          result.add(paramStr(i))
+        elif isNimScriptExt(paramStr(i)):
+          firstNimsFound = true
+    else:
+      for i in 1..paramCount():
+        result.add(paramStr(i))
 else:
   proc commandLineParams*(): seq[string] {.error:
   "commandLineParams() unsupported by dynamic libraries".} =

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -57,11 +57,19 @@ proc warningImpl(arg, orig: string) = discard
 proc hintImpl(arg, orig: string) = discard
 
 proc paramStr*(i: int): string =
-  ## Retrieves the `i`'th command line parameter.
+  ## Retrieves the `i`'th raw command line parameter seen by the Nim
+  ## compiler or script host.
+  ##
+  ## Use `commandLineParams proc <cmdline.html#commandLineParams>`_ for the
+  ## stripped arguments intended for the current script.
   builtin
 
 proc paramCount*(): int =
-  ## Retrieves the number of command line parameters.
+  ## Retrieves the number of raw command line parameters seen by the Nim
+  ## compiler or script host.
+  ##
+  ## Use `commandLineParams proc <cmdline.html#commandLineParams>`_ for the
+  ## stripped arguments intended for the current script.
   builtin
 
 proc switch*(key: string, val="") =

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -311,6 +311,22 @@ tests/newconfig/bar/mfoo.nims""".splitLines
       expected.add &"Hint: used config file '{b}' [Conf]\n"
     doAssert outp.endsWith expected, outp & "\n" & expected
 
+  block: # commandLineParams vs paramCount/paramStr in config.nies
+    let implicitCmd = fmt"{nim} check --hints:off tests/newconfig/cmdline/_/test.nim"
+    const implicitExp = """nims cmdline test:
+  scriptArgs=[]; (paramCount > 0)==true; rawHasNims=false; rawHasMain=true;
+  parseopt got args: 0
+"""
+    check execCmdEx(implicitCmd) == (implicitExp, 0)
+
+    let explicitCmd =
+      fmt"""{nim} e --hints:off tests/newconfig/cmdline/tcmdline.nims arg1 "arg2""""
+    const explicitExp = """nims cmdline test:
+  scriptArgs=[arg1, arg2]; (paramCount > 0)==true; rawHasNims=true; rawHasMain=false;
+  parseopt got args: 2
+"""
+    check execCmdEx(explicitCmd) == (explicitExp, 0)
+
   block: # bug #8219
     let file = "tests/newconfig/mconfigcheck.nims"
     let cmd = fmt"{nim} check --hints:off {file}"

--- a/tests/newconfig/cmdline/_/config.nims
+++ b/tests/newconfig/cmdline/_/config.nims
@@ -1,0 +1,1 @@
+include ".."/"tcmdline.nims"

--- a/tests/newconfig/cmdline/_/test.nim
+++ b/tests/newconfig/cmdline/_/test.nim
@@ -1,0 +1,1 @@
+discard

--- a/tests/newconfig/cmdline/tcmdline.nims
+++ b/tests/newconfig/cmdline/tcmdline.nims
@@ -1,0 +1,24 @@
+from std/strutils import endsWith, join
+from std/os import commandLineParams
+import std/parseopt
+
+let cmdParams = commandLineParams().join(", ")
+var
+ rawHasNims = false
+ rawHasMain = false
+ parsed: seq[string]
+
+for i in 1..paramCount():
+  let arg = paramStr(i)
+  rawHasNims = rawHasNims or arg.endsWith(".nims")
+  rawHasMain = rawHasMain or arg.endsWith("test.nim")
+
+# parseopt follows commandLineParams for NimScript.
+var p = initOptParser()
+for _, key, val in p.getopt():
+  parsed.add key
+
+echo "nims cmdline test:\n",
+  "  scriptArgs=[", cmdParams, "]; (paramCount > 0)==", paramCount() > 0,
+  "; rawHasNims=", rawHasNims, "; rawHasMain=", rawHasMain, ";\n",
+  "  parseopt got args: ", parsed.len

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -134,8 +134,16 @@ block:  # cpDir, cpFile, dirExists, fileExists, mkDir, mvDir, mvFile, rmDir, rmF
   rmDir(dname)
 
 block:
-  # check parseopt can get command line:
-  discard initOptParser()
+  # parsing live input tested in misc/trunner
+  let cmdParams = commandLineParams()
+  doAssert cmdParams.len == 0, "commandLineParams should strip compiler args"
+  var parsed: seq[string]
+  var p = initOptParser()
+  for _, key, val  in p.getopt():
+    parsed.add key
+    parsed.add val
+  doAssert parsed.len == 0, "initOptParser should strip compiler args"
+  doAssert parsed == cmdParams, "initOptParser.getopt != commandLineParams"
 
 # issue #24780:
 


### PR DESCRIPTION
`cmdline.commandLineParams()` now returns only the script arguments, skipping compiler arguments.

Closes #23554

The logic is extracted from `parseopt.initOptParser` and is now duplicated. Though there it triggers only when there are no arguments provided so double reads are an edge case:

Read `commandLineParams()` from a NimScript and get none -> pass them explicitly to `initOptParser` -> Whole argv reread again and stripped.

Should be fixed if #25571 or an alternative is merged.