### PR TITLE
`compiler/cmdlinehelper` fix

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -33,14 +33,14 @@ type
   NimProg* = ref object
     suggestMode*: bool
     supportsStdinFile*: bool
-    processCmdLine*: proc(pass: TCmdLinePass, cmd: string; config: ConfigRef)
+    processCmdLine*: proc(pass: TCmdLinePass; config: ConfigRef)
 
 proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   condsyms.initDefines(conf.symbols)
   defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
-  self.processCmdLine(passCmd1, "", conf)
+  self.processCmdLine(passCmd1, conf)
   if conf.projectIsCmd and conf.projectName in ["-", ""]:
     handleCmdInput(conf)
   elif self.supportsStdinFile and conf.projectName == "-":
@@ -73,7 +73,7 @@ proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: Confi
   # command line can overwrite the config file's settings
   if conf.backend != backendJs: # bug #19059
     extccomp.initVars(conf)
-  self.processCmdLine(passCmd2, "", conf)
+  self.processCmdLine(passCmd2, conf)
   if conf.cmd == cmdNone:
     rawMessage(conf, errGenerated, "command missing")
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -47,8 +47,8 @@ proc nimbleLockExists(config: ConfigRef): bool =
         return true
   return fileExists(pd.string / nimbleLock)
 
-proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+proc processCmdLine(pass: TCmdLinePass; config: ConfigRef) =
+  var p = parseopt.initOptParser()
   var argsCount = 0
 
   config.commandLine.setLen 0

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1207,8 +1207,8 @@ proc mainCommand(graph: ModuleGraph) =
   if conf.errorCounter == 0:
     genSuccessX(graph.config)
 
-proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+proc processCmdLine(pass: TCmdLinePass; config: ConfigRef) =
+  var p = parseopt.initOptParser()
   var argsCount = 1
 
   config.commandLine.setLen 0

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -667,8 +667,8 @@ proc mainCommand(graph: ModuleGraph) =
   close(requests)
   close(results)
 
-proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
-  var p = parseopt.initOptParser(cmd)
+proc processCmdLine*(pass: TCmdLinePass; conf: ConfigRef) =
+  var p = parseopt.initOptParser()
   var findProject = false
   while true:
     parseopt.next(p)
@@ -1334,7 +1334,7 @@ else:
       compileProject(graph)
 
 
-    proc mockCmdLine(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
+    proc mockCmdLine(pass: TCmdLinePass; conf: ConfigRef) =
       conf.suggestVersion = 0
       let a = unixToNativePath(project)
       if dirExists(a) and not fileExists(a.addFileExt("nim")):


### PR DESCRIPTION
Removes an unused parameter from the callback stored in `NimProg` object. It's confusing and was ever
only called with an empty string to signal "read argv".

Any mock/testing procs just ignore this parameter.

This is a preparation to #25571 or whatever replaces it. After this change the tools should be prepared to every reasonable API change to parseopt, whatever it's going to be.

Nimony repo also relies on `cmdlinehelper` so a companion PR is following.