### PR TITLE
Fix `getTypeImpl` not returning defaults

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -62,7 +62,10 @@ proc objectNode(cache: IdentCache; n: PNode; idgen: IdGenerator): PNode =
     result = newNodeI(nkIdentDefs, n.info)
     result.add n  # name
     result.add mapTypeToAstX(cache, n.sym.typ, n.info, idgen, true, false)  # type
-    result.add newNodeI(nkEmpty, n.info)  # no assigned value
+    if n.sym.ast != nil:
+      result.add copyTree(n.sym.ast)
+    else:
+      result.add newNodeI(nkEmpty, n.info)  # no assigned value
   else:
     result = copyNode(n)
     for i in 0..<n.safeLen:
@@ -87,7 +90,10 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     var id = newNodeX(nkIdentDefs)
     id.add n  # name
     id.add mapTypeToAst(t, info)  # type
-    id.add newNodeI(nkEmpty, info)  # no assigned value
+    if n.sym.ast != nil:
+      id.add copyTree(n.sym.ast)
+    else:
+      id.add newNodeI(nkEmpty, n.info)  # no assigned value
     id
   template newIdentDefs(s): untyped = newIdentDefs(s, s.typ)
 

--- a/tests/macros/tgettypeimpl_defaults.nim
+++ b/tests/macros/tgettypeimpl_defaults.nim
@@ -1,0 +1,39 @@
+discard """
+nimout: '''
+ObjectTy
+  Empty
+  Empty
+  RecList
+    IdentDefs
+      Sym "noDefault"
+      Sym "int"
+      Empty
+    IdentDefs
+      Sym "withDefault"
+      Sym "string"
+      StrLit "Hello World"
+ProcTy
+  FormalParams
+    Sym "bool"
+    IdentDefs
+      Sym "foo"
+      Sym "string"
+      StrLit "Proc default"
+  Empty
+'''
+"""
+
+import std/macros
+
+type
+  FooBar = object
+    noDefault: int
+    withDefault = "Hello World"
+
+  SomeProc = proc (foo = "Proc default"): bool
+
+macro dumpBodies() =
+  echo bindSym("FooBar").getTypeImpl().treeRepr
+  echo bindSym("SomeProc").getTypeImpl().treeRepr
+
+dumpBodies()


### PR DESCRIPTION
`getTypeImpl` and friends were always putting `nkEmpty` in the default value field which meant the default values couldn't be introspected. This copies the default AST so it can be seen in the returned object