### PR TITLE
properly codegen structs on deref [backport:2.2]

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -922,7 +922,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
     else:
       a = initLocExprSingleUse(p, e[0])
 
-    if e.typ != nil and e.typ.kind == tyObject:
+    if e.typ != nil and e.typ.skipTypes(abstractInstOwned).kind == tyObject:
       # bug #23453 #25265
       discard getTypeDesc(p.module, e.typ)
     if d.k == locNone:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -922,9 +922,8 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
     else:
       a = initLocExprSingleUse(p, e[0])
 
-    if e.typ != nil and e.typ.skipTypes(abstractInstOwned).kind == tyObject:
-      # bug #23453 #25265
-      discard getTypeDesc(p.module, e.typ)
+    # bug #23453 #25265
+    discard getTypeDesc(p.module, e.typ)
     if d.k == locNone:
       # dest = *a;  <-- We do not know that 'dest' is on the heap!
       # It is completely wrong to set 'd.storage' here, unless it's not yet

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -923,7 +923,8 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
       a = initLocExprSingleUse(p, e[0])
 
     # bug #23453 #25265
-    discard getTypeDesc(p.module, e.typ)
+    if e.typ != nil and e.typ.skipTypes(abstractInst).kind == tyObject:
+      discard getTypeDesc(p.module, e.typ)
     if d.k == locNone:
       # dest = *a;  <-- We do not know that 'dest' is on the heap!
       # It is completely wrong to set 'd.storage' here, unless it's not yet


### PR DESCRIPTION
Follows up #25269, refs #25265. 

I hit the same bug as #25265 for my own project but #25269 does not fix it, I think because the type in my case is a `tyGenericInst` which does not trigger the generation here. First I thought of skipping abstract type kinds instead of checking for a raw `tyObject`, which fixes my problem. But in general this could maybe also be encountered for `tyTuple` and `tySequence` etc. So I figured it might just be safest to not filter on specific type kinds, ~~which is done now~~ (edit: broke CI). Maybe this has a slight cost on codegen performance though.

Edit: Allowing all types failed CI for some reason as commented below, trying skipped type version again.