### PR TITLE
Fix a few ImplicitRangeConversion warnings

### DIFF
--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -123,7 +123,7 @@ proc rawInsert[T](c: var CritBitTree[T], key: string): Node[T] =
     var inner: Node[T]
     new inner
     result = Node[T](isLeaf: true, key: key)
-    inner.otherBits = chr(newOtherBits)
+    inner.otherBits = char(newOtherBits)
     inner.byte = newByte
     inner.child[1 - dir] = result
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -527,7 +527,7 @@ proc sample*[T, U](r: var Rand; a: openArray[T]; cdf: openArray[U]): T =
   assert(float(cdf[^1]) > 0.0)
   # While we could check cdf[i-1] <= cdf[i] for i in 1..cdf.len, that could get
   # awfully expensive even in debugging modes.
-  let u = r.rand(float(cdf[^1]))
+  let u = r.rand(range[0.0 .. high(float)](cdf[^1]))
   a[cdf.upperBound(U(u))]
 
 proc sample*[T, U](a: openArray[T]; cdf: openArray[U]): T =

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -521,7 +521,7 @@ proc formatValue*[T: SomeInteger](result: var string; value: T;
 proc formatFloat(
     result: var string, value: SomeFloat, fmode: FloatFormatMode,
     spec: StandardFormatSpecifier) =
-  var f = formatBiggestFloat(value, fmode, spec.precision)
+  var f = formatBiggestFloat(value, fmode, range[-1..32](spec.precision))
   var sign = false
   if value >= 0.0:
     if spec.sign != '-':


### PR DESCRIPTION
This just makes 3 cases slightly less implicit which silences the warning.