### PR TITLE
fixes compiling `newSeq` call with `nim ic` generates compile error

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1270,7 +1270,8 @@ template transitionSymKindCommon*(k: TSymKind) =
   s[] = TSym(kindImpl: k, itemId: obj.itemId, magicImpl: obj.magicImpl, typImpl: obj.typImpl, name: obj.name,
              infoImpl: obj.infoImpl, ownerFieldImpl: obj.ownerFieldImpl, flagsImpl: obj.flagsImpl, astImpl: obj.astImpl,
              optionsImpl: obj.optionsImpl, positionImpl: obj.positionImpl, offsetImpl: obj.offsetImpl,
-             locImpl: obj.locImpl, annexImpl: obj.annexImpl, constraintImpl: obj.constraintImpl)
+             disamb: obj.disamb, locImpl: obj.locImpl, annexImpl: obj.annexImpl, constraintImpl: obj.constraintImpl,
+             instantiatedFromImpl: obj.instantiatedFromImpl)
   when hasFFI:
     s.cnameImpl = obj.cnameImpl
   when defined(nimsuggest):

--- a/compiler/astdef.nim
+++ b/compiler/astdef.nim
@@ -701,6 +701,7 @@ type
 
   PLib* = ref TLib
   TSym* {.acyclic.} = object # Keep in sync with ast2nif.nim
+                             # Check `transitionSymKindCommon` in ast.nim when add a new field.
     itemId*: ItemId
     # proc and type instantiations are cached in the generic symbol
     state*: ItemState


### PR DESCRIPTION
Compiling following code with `nim ic test.nim` or `nim m test.nim` generated compile errors.
```nim
var s: seq[int]
newSeq(s, 1)
```
This PR fixes above bug.

This bug was caused by wrong PType/PSym tree generated by `ast2nif.loadSym` proc because generic param symbols in NIF files have all `0`.

`TSym.instantiatedFromImpl` is not related to the bug but it seems all field of `TSym` should be copied in `transitionSymKindCommon` template.