### PR TITLE
nimdoc: CSS: fix rendering of inline code spans

### DIFF
--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -123,7 +123,6 @@ Modified by Boyd Greenfield and narimiran
 }
 
 html {
-  overflow-x: hidden;
   max-width: 100%;
   box-sizing: border-box;
   font-size: 100%;
@@ -572,8 +571,8 @@ blockquote.markdown-quote {
   padding-left: 3px;
   padding-right: 3px;
   border-radius: 4px;
-  white-space: normal;
-  word-break: break-all;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 span.tok {
@@ -674,6 +673,8 @@ table {
   border-collapse: collapse;
   border-color: var(--third-background);
   border-spacing: 0;
+  display: block;
+  overflow-x: auto;
 }
 
 table:not(.line-nums-table) {

--- a/nimdoc/testproject/expected/nimdoc.out.css
+++ b/nimdoc/testproject/expected/nimdoc.out.css
@@ -123,7 +123,6 @@ Modified by Boyd Greenfield and narimiran
 }
 
 html {
-  overflow-x: hidden;
   max-width: 100%;
   box-sizing: border-box;
   font-size: 100%;
@@ -572,8 +571,8 @@ blockquote.markdown-quote {
   padding-left: 3px;
   padding-right: 3px;
   border-radius: 4px;
-  white-space: normal;
-  word-break: break-all;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 span.tok {
@@ -674,6 +673,8 @@ table {
   border-collapse: collapse;
   border-color: var(--third-background);
   border-spacing: 0;
+  display: block;
+  overflow-x: auto;
 }
 
 table:not(.line-nums-table) {


### PR DESCRIPTION
I've been wondering why the inline code was rendered wrapped with no regards to words/whitespace for a while.

Partially reverts 8b82f5 (#24927)

- `word-break: break-all;` This is seriously wrong, replaced with `overflow-wrap: break-word;`
- `white-space: normal;` -> `pre-wrap;` to preserve whitespace in code spans.
- Added `display: block;` and `overflow-x: auto;` to tables. This contains wide tables with their own scrollbars without stretching the whole doc.
- `overflow-x: hidden;` just clips content and possibly conflicts with navbar's `sticky` attribute. Removed.