### PR TITLE
nimdoc: CSS: tighter on mobile; fix h1 print page break

### DIFF
--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -200,6 +200,8 @@ body {
   body {
     font-size: 1em;
     line-height: 1.35;
+    margin-left: 0.35em;
+    margin-right: 0.35em;
   }
 }
 
@@ -358,6 +360,10 @@ img {
 
   h1.title {
     page-break-before: avoid; }
+	
+  .nine.columns h1:first-of-type {
+    page-break-before: avoid;
+  }
 
   p, h2, h3 {
     orphans: 3;
@@ -425,6 +431,22 @@ h5 {
 h6 {
   font-size: 1.1em; }
 
+@media screen and (max-width: 860px) {
+  h1.title {
+    font-size: 2em;
+  }
+  h1 {
+    font-size: 1.5em;
+    margin-top: 1.5em;
+    margin-bottom: 0.75em;
+  }
+  h2 {
+    margin-top: 1.3em;
+  }
+  h3 {
+    margin-top: 1.2em;
+  }
+}
 
 ul, ol {
   padding: 0;
@@ -606,6 +628,15 @@ pre {
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
+}
+
+@media screen and (max-width: 860px) {
+  pre {
+    font-stretch: semi-condensed;
+    letter-spacing: -0.25px;
+    line-height: 1.25;
+    padding: 0.33em;
+  }
 }
 
 .copyToClipBoardBtn {

--- a/nimdoc/testproject/expected/nimdoc.out.css
+++ b/nimdoc/testproject/expected/nimdoc.out.css
@@ -200,6 +200,8 @@ body {
   body {
     font-size: 1em;
     line-height: 1.35;
+    margin-left: 0.35em;
+    margin-right: 0.35em;
   }
 }
 
@@ -358,6 +360,10 @@ img {
 
   h1.title {
     page-break-before: avoid; }
+	
+  .nine.columns h1:first-of-type {
+    page-break-before: avoid;
+  }
 
   p, h2, h3 {
     orphans: 3;
@@ -425,6 +431,22 @@ h5 {
 h6 {
   font-size: 1.1em; }
 
+@media screen and (max-width: 860px) {
+  h1.title {
+    font-size: 2em;
+  }
+  h1 {
+    font-size: 1.5em;
+    margin-top: 1.5em;
+    margin-bottom: 0.75em;
+  }
+  h2 {
+    margin-top: 1.3em;
+  }
+  h3 {
+    margin-top: 1.2em;
+  }
+}
 
 ul, ol {
   padding: 0;
@@ -606,6 +628,15 @@ pre {
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
+}
+
+@media screen and (max-width: 860px) {
+  pre {
+    font-stretch: semi-condensed;
+    letter-spacing: -0.25px;
+    line-height: 1.25;
+    padding: 0.33em;
+  }
 }
 
 .copyToClipBoardBtn {


### PR DESCRIPTION
- Small optimizations for mobile, makes code render slightly tighter.
- `font-stretch: semi-condensed;` for pre works if the user's font provides such a face, shouldn’t change the rendering with the default.
- Removes an excessive page break after the page header when printing.