### PR TITLE
See discussion at https://github.com/nim-lang/Nim/pull/25602 .

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -266,7 +266,7 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result = default(array[0..3, TNoteKinds])
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept, warnStdPrefix, warnSystemRangeConversion}
   result[2] = result[3] - {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
-  result[1] = result[2] - {warnProveField, warnProveIndex,
+  result[1] = result[2] - {warnImplicitRangeConversion, warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin, hintPerformance}
   result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,


### PR DESCRIPTION
It seems in dispute whether changes to code induced to avoid this new warning firing are worthwhile.

Until either the analyzer is better or a palatable way to adjust stdlib code not warn is found, verbosity=1 should not include the warning.

Possibly higher levels, too, but this PR is conservative and only takes it out at the 2->1 transition.