### PR TITLE
fixes empty tag for `nim ic`

### DIFF
--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -523,9 +523,7 @@ proc writeNode(w: var Writer; dest: var TokenBuf; n: PNode; forAst = false) =
     of nkEmpty:
       if n.typField != nil:
         w.withNode dest, n:
-          let info = trLineInfo(w, n.info)
-          dest.addParLe pool.tags.getOrIncl(toNifTag(n.kind)), info
-          dest.addParRi
+          discard
       else:
         let info = trLineInfo(w, n.info)
         dest.addParLe pool.tags.getOrIncl(toNifTag(n.kind)), info

--- a/tests/ic/tconverter.nim
+++ b/tests/ic/tconverter.nim
@@ -1,3 +1,8 @@
+discard """
+output:
+ok
+"""
+
 type
   Meters = distinct float
   Feet = distinct float
@@ -6,6 +11,7 @@ converter toMeters(f: Feet): Meters =
   Meters(float(f) * 0.3048)
 
 proc showMeters(m: Meters) =
-  echo float(m)
+  doAssert float(m) == 3.048
+  echo "ok"
 
 showMeters(Feet(10.0))

--- a/tests/ic/tconverter.nim
+++ b/tests/ic/tconverter.nim
@@ -1,0 +1,11 @@
+type
+  Meters = distinct float
+  Feet = distinct float
+
+converter toMeters(f: Feet): Meters =
+  Meters(float(f) * 0.3048)
+
+proc showMeters(m: Meters) =
+  echo float(m)
+
+showMeters(Feet(10.0))


### PR DESCRIPTION
`writeNode` writes `(empty flags type (empty))`, but it should have been `(empty flags type)` instead

```nim
type
  Meters = distinct float
  Feet = distinct float

converter toMeters(f: Feet): Meters =
  Meters(float(f) * 0.3048)

proc showMeters(m: Meters) =
  echo float(m)

showMeters(Feet(10.0))
```
gives `[NIF decoder] expected: {ParRi} but got: ParLe14,152,/Users/blue/.choosenim/toolchains/nim-\23devel/lib/std/private/dragonbox.nim(empty)`