### PR TITLE
fixes 25610; ignores skTemplate and skMacro symbols in cgen

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3597,6 +3597,10 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         # echo renderTree(p.prc.ast, {renderIds})
         internalError(p.config, n.info, "expr: param not init " & sym.name.s & "_" & $sym.id)
       putLocIntoDest(p, d, sym.loc)
+    of skTemplate, skMacro:
+      # it is possible to get these kind of symbols if cgen was called from nifbackend.nim
+      # as symbols are lazily loaded including symbol kinds, cannot exclude them when loading Nif files
+      discard
     else: internalError(p.config, n.info, "expr(" & $sym.kind & "); unknown symbol")
   of nkNilLit:
     if not isEmptyType(n.typ):

--- a/tests/ic/mmacros.nim
+++ b/tests/ic/mmacros.nim
@@ -1,0 +1,1 @@
+macro exportedMacro*(x: untyped): untyped = x

--- a/tests/ic/tmacros_import.nim
+++ b/tests/ic/tmacros_import.nim
@@ -1,0 +1,7 @@
+# test imported macros
+import mmacros
+
+block:
+  exportedMacro:
+    let x = 123
+  assert x == 123

--- a/tests/ic/tmacros_local.nim
+++ b/tests/ic/tmacros_local.nim
@@ -1,0 +1,20 @@
+# test macros without import
+macro test0(x: untyped): untyped = x
+
+block:
+  var x = 0
+  test0:
+    x = 123
+  assert x == 123
+
+# issue # 25610
+block:
+  macro foo(u: untyped): untyped =
+    discard
+
+  macro bar(x: untyped): untyped = x
+
+  bar:
+    let x = 111
+
+  assert x == 111


### PR DESCRIPTION
also adds simple macro tests to tests/ic.