### PR TITLE
fixes #25620; typekey skips incorrectly the base type of `seqs` etc. types for `nim ic`

### DIFF
--- a/compiler/typekeys.nim
+++ b/compiler/typekeys.nim
@@ -274,7 +274,7 @@ proc typeKey(c: var Context; t: PType; flags: set[ConsiderFlag]; conf: ConfigRef
       c.typeKey(t.sonsImpl[0], flags-{CoIgnoreRange}, conf)
   else:
     withTree c.m, toNifTag(t.kind):
-      for i in 1..<t.sonsImpl.len:
+      for i in 0..<t.sonsImpl.len:
         c.typeKey t.sonsImpl[i], flags, conf
       if tfNotNil in t.flagsImpl and CoType notin flags:
         c.m.addIdent "´notnil"

--- a/tests/ic/tmiscs.nim
+++ b/tests/ic/tmiscs.nim
@@ -1,6 +1,8 @@
 discard """
-  disabled: "linux"
-  output: "42"
+  output: '''
+42
+5
+'''
 """
 
 # Object variant / case object
@@ -20,3 +22,14 @@ proc newInt(v: int): ref Node =
 
 let n = newInt(42)
 echo n.intVal
+
+# Sink and move semantics
+type
+  BigObj = object
+    data: seq[int]
+
+proc consume(x: sink BigObj) =
+  echo x.data.len
+
+var b = BigObj(data: @[1, 2, 3, 4, 5])
+consume(move b)


### PR DESCRIPTION
fixes #25620

This pull request includes a fix to the type key generation logic in the compiler and updates to a test file to cover additional language features. The most important changes are summarized below:

### Compiler logic fix

* In `compiler/typekeys.nim`, the `typeKey` procedure was updated to iterate over all elements in `t.sonsImpl` starting from index 0 instead of 1, ensuring that all type sons are considered during type key generation.

### Test suite improvements

* The test file `tests/ic/tenum.nim` was renamed to `tests/ic/tmiscs.nim`, and its output expectations were updated to reflect the new test cases.
* Added new test cases to `tests/ic/tmiscs.nim` to cover sink and move semantics, including the definition of a `BigObj` type and a `consume` procedure that demonstrates moving and consuming large objects.

```nim
# Sink and move semantics
type
  BigObj = object
    data: seq[int]

proc consume(x: sink BigObj) =
  echo x.data.len

var b = BigObj(data: @[1, 2, 3, 4, 5])
consume(move b)
```

gives

```
error: passing 'tySequence__qwqHTkRvwhrRyENtudHQ7g' (aka 'struct tySequence__qwqHTkRvwhrRyENtudHQ7g') to parameter of incompatible type 'tySequence__cTyVHeHOWk5jStsToosJ8Q' (aka 'struct tySequence__cTyVHeHOWk5jStsToosJ8Q')
   84 |         eqdestroy___sysma2dyk_u75((*dest_p0).data);
```

follows up https://github.com/nim-lang/Nim/pull/25614