### PR TITLE
fixes #25611; `t.state != Sealed`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1196,7 +1196,12 @@ proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
     let o2 = owner.skipTypes({tyGenericInst, tyAlias, tySink})
     if o2.kind in {tyTuple, tyObject, tyArray,
                    tySequence, tyString, tySet, tyDistinct}:
-      o2.incl mask
+      if o2.state == Sealed:
+        # During the original compilation, propagateToOwner set tfHasAsgn/tfHasOwned on the type before it was sealed
+        # On IC reload, the sealed type already has those flags
+        assert mask <= o2.flags, "IC bug: sealed type missing propagated flags"
+      else:
+        o2.incl mask
       owner.incl mask
 
   if owner.kind notin {tyProc, tyGenericInst, tyGenericBody,


### PR DESCRIPTION
fixes #25611

This pull request updates the `propagateToOwner` procedure in `compiler/ast.nim` to handle sealed types more robustly during incremental compilation (IC) reloads. The main change is the addition of an assertion to ensure that sealed types already have the necessary propagated flags, preventing incorrect state during IC reloads.

Handling of sealed types and propagated flags:

* Added a check for `Sealed` state on `o2` (the owner type), and included an assertion to verify that sealed types already have the required propagated flags (`tfHasAsgn`/`tfHasOwned`) during IC reloads, instead of redundantly setting them.