### PR TITLE
fixes #25626; Fix injection variable declaration in sequtils.nim

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1092,7 +1092,7 @@ template mapIt*(s: typed, op: untyped): untyped =
 
   type OutType = typeof((
     block:
-      var it{.inject.}: typeof(items(s), typeOfIter);
+      var it{.inject, used.}: typeof(items(s), typeOfIter);
       op), typeOfProc)
   when OutType is not (proc):
     # Here, we avoid to create closures in loops.


### PR DESCRIPTION
fixes #25626

This pull request introduces a small change to the `mapIt` template in `sequtils.nim`. The update adds the `used` pragma to the injected `it` variable, which can help suppress unused variable warnings in certain cases.

- Added the `used` pragma to the injected `it` variable in the `mapIt` template to prevent unused variable warnings.

or it should give a better warning or something if `it` is not used