### PR TITLE
fixes #25632; errors incompatibility between {.error.} and {.exportc} pragmas in semProcAux

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2552,6 +2552,9 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if not hasProto:
     implicitPragmas(c, s, n.info, validPragmas)
 
+  if sfError in s.flags and sfExportc in s.flags:
+    localError(c.config, n.info, "{.error.} and {.exportc.} pragmas are incompatible")
+
   if n[pragmasPos].kind != nkEmpty and sfBorrow notin s.flags:
     setEffectsForProcType(c.graph, s.typ, n[pragmasPos], s)
   s.typ.incl tfEffectSystemWorkaround

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2552,7 +2552,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if not hasProto:
     implicitPragmas(c, s, n.info, validPragmas)
 
-  if sfError in s.flags and sfExportc in s.flags:
+  if {sfError, sfExportc} * s.flags == {sfError, sfExportc}:
     localError(c.config, n.info, "{.error.} and {.exportc.} pragmas are incompatible")
 
   if n[pragmasPos].kind != nkEmpty and sfBorrow notin s.flags:


### PR DESCRIPTION
fixes #25632
fixes #25631
fixes #25630

This pull request introduces a compatibility check between the `{.error.}` and `{.exportc.}` pragmas in procedure declarations. Specifically, it prevents a procedure from being marked with both pragmas at the same time, as this combination is now considered invalid.

Pragma compatibility enforcement:

* Added a check in `semProcAux` (in `compiler/semstmts.nim`) to emit a local error if a procedure is declared with both `{.error.}` and `{.exportc.}` pragmas, preventing their incompatible usage.