### PR TITLE
fix `@` for openarray on nimscript [backport:2.2]

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1469,7 +1469,7 @@ when defined(nimHasTopDownInference):
     ## This is not as efficient as turning a fixed length array into a sequence
     ## as it always copies every element of `a`.
     let sz = a.len
-    when supportsCopyMem(T) and not defined(js):
+    when supportsCopyMem(T) and not defined(js) and not defined(nimscript):
       result = newSeqUninit[T](sz)
       when nimvm:
         for i in 0..sz-1: result[i] = a[i]

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -143,3 +143,7 @@ proc discardableCall(cmd: string): int {.discardable.} =
   result = 123
 
 discardableCall "echo hi"
+
+block:
+  let a = "abc"
+  doAssert @a == @['a', 'b', 'c']


### PR DESCRIPTION
Even on nimscript, the `else` branch of the `when nimvm` below compiles and gives an "undeclared identifier: copyMem" error. Regression since #25064.