### PR TITLE
fixes #25635; registers module suffix correctly

### DIFF
--- a/compiler/nifbackend.nim
+++ b/compiler/nifbackend.nim
@@ -44,14 +44,16 @@ proc loadModuleDependencies(g: ModuleGraph; mainFileIdx: FileIndex): seq[Precomp
     let suffix = stack.pop()
 
     if not visited.containsOrIncl(suffix.string):
-      let nifFile = toGeneratedFile(g.config, AbsoluteFile(suffix.string), ".nif")
-      let fileIdx = msgs.fileInfoIdx(g.config, nifFile)
+      var isKnownFile = false
+      let fileIdx = g.config.registerNifSuffix(suffix.string, isKnownFile)
       let precomp = moduleFromNifFile(g, fileIdx, {LoadFullAst})
       if precomp.module != nil:
         result.add precomp
         for dep in precomp.deps:
           if not visited.contains(dep.string):
             stack.add dep
+      else:
+        assert false, "Recompiling module is not implemented."
 
   if mainModule.module != nil:
     result.add mainModule


### PR DESCRIPTION
`toNifFilename` proc doesn't return correct Nif file path because module suffix is registered with wrong proc.
So `moduleFromNifFile` doesn't load the Nif file.