### PR TITLE
Support cyclic imports without forward declarations and fix ORC async leaks

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1580,6 +1580,7 @@ proc genProc(m: BModule, prc: PSym) =
   if sfForward in prc.flags:
     addForwardedProc(m, prc)
     fillProcLoc(m, prc.ast[namePos])
+    genProcPrototype(m, prc)
   else:
     genProcLvl2(m, prc)
     if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} and

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -280,7 +280,7 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
     let recursion = c.graph.importStack.find(f)
     c.graph.importStack.add f
     #echo "adding ", toFullPath(f), " at ", L+1
-    if recursion >= 0:
+    if recursion >= 0 and codeReordering notin c.features and codeReordering notin c.graph.config.features:
       var err = ""
       for i in recursion..<L:
         if i > recursion: err.add "\n"

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -25,6 +25,9 @@ when defined(nimPreviewSlimSystem):
   import std/assertions
 
 type
+  ModuleCompileState* = enum
+    mcsNone, mcsCollectingInterface, mcsInterfaceReady, mcsSemchecking, mcsDone
+
   SigHash* = distinct MD5Digest
 
   Iface* = object       ## data we don't want to store directly in the
@@ -80,6 +83,11 @@ type
                                             # first module that included it
     importStack*: seq[FileIndex]  # The current import stack. Used for detecting recursive
                                   # module dependencies.
+    compileStates*: seq[ModuleCompileState]
+    interfaceImportMode*: int
+    interfaceCallableStubs*: IntSet
+    semcheckStack*: seq[FileIndex]
+    pendingSemchecks*: seq[FileIndex]
     backend*: RootRef # minor hack so that a backend can extend this easily
     config*: ConfigRef
     cache*: IdentCache
@@ -154,6 +162,10 @@ proc resetForBackend*(g: ModuleGraph) =
   for a in mitems(g.loadedOps):
     a.clear()
   g.opsLog.setLen(0)
+
+proc ensureCompileStateSlot*(g: ModuleGraph; fileIdx: FileIndex) =
+  if fileIdx.int >= g.compileStates.len:
+    g.compileStates.setLen(fileIdx.int + 1)
 
 const
   cb64 = [
@@ -525,6 +537,9 @@ proc initModuleGraphFields(result: ModuleGraph) =
   result.importDeps = initTable[FileIndex, seq[FileIndex]]()
   result.ifaces = @[]
   result.importStack = @[]
+  result.interfaceCallableStubs = initIntSet()
+  result.semcheckStack = @[]
+  result.pendingSemchecks = @[]
   result.inclToMod = initTable[FileIndex, FileIndex]()
   result.owners = @[]
   result.suggestSymbols = initTable[FileIndex, SuggestFileSymbolDatabase]()

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -111,6 +111,72 @@ proc prePass*(c: PContext; n: PNode) =
         else:
           discard
 
+proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags; fromModule: PSym = nil): PSym
+
+proc enqueuePendingSemcheck(graph: ModuleGraph; fileIdx: FileIndex) =
+  for it in graph.pendingSemchecks:
+    if it == fileIdx:
+      return
+  graph.pendingSemchecks.add fileIdx
+
+proc drainPendingSemchecks(graph: ModuleGraph) =
+  while graph.pendingSemchecks.len > 0:
+    let fileIdx = graph.pendingSemchecks[0]
+    graph.pendingSemchecks.delete(0)
+    if fileIdx.int < graph.compileStates.len and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      let m = graph.getModule(fileIdx)
+      if m != nil:
+        discard compilePipelineModule(graph, fileIdx, m.flags)
+
+proc wantsInterfaceCollection(c: PContext): bool =
+  sfSystemModule notin c.module.flags and
+    (codeReordering in c.features or sfReorder in c.module.flags)
+
+proc parseModuleTopLevel(graph: ModuleGraph; module: PSym): PNode =
+  result = syntaxes.parseFile(module.fileIdx, graph.cache, graph.config)
+
+proc collectPipelineModuleInterface(graph: ModuleGraph; module: PSym; idgen: IdGenerator): bool =
+  let fileIdx = module.fileIdx
+  ensureCompileStateSlot(graph, fileIdx)
+  case graph.compileStates[fileIdx.int]
+  of mcsCollectingInterface, mcsInterfaceReady, mcsSemchecking, mcsDone:
+    return graph.compileStates[fileIdx.int] != mcsNone
+  of mcsNone:
+    discard
+
+  let oldSymbolFiles = graph.config.symbolFiles
+  graph.compileStates[fileIdx.int] = mcsCollectingInterface
+  graph.config.symbolFiles = disabledSf
+  var ctx: PContext = nil
+  try:
+    let sl = parseModuleTopLevel(graph, module)
+    ctx = preparePContext(graph, module, idgen)
+    prePass(ctx, sl)
+    if not wantsInterfaceCollection(ctx):
+      graph.compileStates[fileIdx.int] = mcsNone
+      return false
+
+    if not belongsToStdlib(graph, module) or (belongsToStdlib(graph, module) and module.name.s == "distros"):
+      if module.name.s != "nimscriptapi":
+        inc graph.interfaceImportMode
+        try:
+          processImplicitImports graph, graph.config.implicitImports, nkImportStmt, module, ctx, nil, idgen
+          processImplicitImports graph, graph.config.implicitIncludes, nkIncludeStmt, module, ctx, nil, idgen
+        finally:
+          dec graph.interfaceImportMode
+
+    inc graph.interfaceImportMode
+    try:
+      collectInterfaceWithPContext(ctx, sl)
+    finally:
+      dec graph.interfaceImportMode
+    graph.compileStates[fileIdx.int] = mcsInterfaceReady
+    result = true
+  finally:
+    graph.config.symbolFiles = oldSymbolFiles
+    if ctx != nil:
+      discardPContext(ctx)
+
 proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
                     stream: PLLStream): bool =
   if graph.stopCompile(): return true
@@ -276,6 +342,7 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
       elif graph.config.projectIsCmd: s = llStreamOpen(graph.config.cmdInput)
     discard processPipelineModule(graph, result, idGeneratorFromModule(result), s)
   if result == nil:
+    var cachedModules: seq[FileIndex] = @[]
     when not defined(nimKochBootstrap):
       # For cmdM: load imports from NIF files (but compile the main module from source)
       # Skip when withinSystem is true (compiling system.nim itself)
@@ -300,6 +367,8 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
           if result.ast != nil:
             replayStateChanges(result, graph)
           return result  # Return early, don't process from source
+    result = moduleFromRodFile(graph, fileIdx, cachedModules)
+    ensureCompileStateSlot(graph, fileIdx)
     let path = toFullPath(graph.config, fileIdx)
     let filename = AbsoluteFile path
     # it could be a stdinfile/cmdfile
@@ -309,22 +378,79 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
       result = newModule(graph, fileIdx)
       result.incl flags
       registerModule(graph, result)
+      discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+      if graph.interfaceImportMode > 0 and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+        return result
+      graph.compileStates[fileIdx.int] = mcsSemchecking
+      graph.semcheckStack.add fileIdx
       processModuleAux("import")
+      doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+      graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+      graph.compileStates[fileIdx.int] = mcsDone
+      if graph.semcheckStack.len == 0:
+        drainPendingSemchecks(graph)
     else:
       if sfSystemModule in flags:
         graph.systemModule = result
       if sfMainModule in flags and graph.config.cmd == cmdM:
         result.incl flags
         registerModule(graph, result)
+        graph.compileStates[fileIdx.int] = mcsSemchecking
+        graph.semcheckStack.add fileIdx
         processModuleAux("import")
+        doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+        graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+        graph.compileStates[fileIdx.int] = mcsDone
+        if graph.semcheckStack.len == 0:
+          drainPendingSemchecks(graph)
       partialInitModule(result, graph, fileIdx, filename)
+    for m in cachedModules:
+      registerModuleById(graph, m)
+      if sfMainModule in flags and graph.config.cmd == cmdM:
+        discard
+      else:
+        replayStateChanges(graph.packed.pm[m.int].module, graph)
+        replayGenericCacheInformation(graph, m.int)
   elif graph.isDirty(result):
     result.excl sfDirty
     # reset module fields:
     initStrTables(graph, result)
     result.ast = nil
+    ensureCompileStateSlot(graph, fileIdx)
+    graph.compileStates[fileIdx.int] = mcsNone
+    discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+    if graph.interfaceImportMode > 0 and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      return result
+    graph.compileStates[fileIdx.int] = mcsSemchecking
+    graph.semcheckStack.add fileIdx
     processModuleAux("import(dirty)")
+    doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+    graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+    graph.compileStates[fileIdx.int] = mcsDone
+    if graph.semcheckStack.len == 0:
+      drainPendingSemchecks(graph)
     graph.markClientsDirty(fileIdx)
+  else:
+    ensureCompileStateSlot(graph, fileIdx)
+    case graph.compileStates[fileIdx.int]
+    of mcsCollectingInterface, mcsSemchecking, mcsDone, mcsInterfaceReady:
+      discard
+    of mcsNone:
+      discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+    if graph.interfaceImportMode > 0:
+      return result
+    if graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      if graph.semcheckStack.len > 0:
+        enqueuePendingSemcheck(graph, fileIdx)
+        return result
+      graph.compileStates[fileIdx.int] = mcsSemchecking
+      graph.semcheckStack.add fileIdx
+      processModuleAux("import")
+      doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+      graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+      graph.compileStates[fileIdx.int] = mcsDone
+      if graph.semcheckStack.len == 0:
+        drainPendingSemchecks(graph)
 
 proc importPipelineModule(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -61,6 +61,8 @@ proc semTypeOf(c: PContext; n: PNode): PNode
 proc computeRequiresInit(c: PContext, t: PType): bool
 proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo)
 proc hasUnresolvedArgs(c: PContext, n: PNode): bool
+proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool
+proc isEmptyTree(n: PNode): bool
 proc isArrayConstr(n: PNode): bool {.inline.} =
   result = n.kind == nkBracket and
     n.typ.skipTypes(abstractInst).kind == tyArray
@@ -753,6 +755,24 @@ proc addCodeForGenerics(c: PContext, n: PNode) =
         n.add prc.ast
   c.lastGenericIdx = c.generics.len
 
+proc preloadForwardDecls(c: PContext) =
+  for s in semtabAll(c.graph, c.module).data:
+    if s != nil and sfForward in s.flags:
+      if s.kind in OverloadableSyms:
+        addOverloadableSymAt(c, c.currentScope, s)
+      else:
+        addDeclAt(c, c.currentScope, s)
+
+proc ensureTopLevelSystemImport(c: PContext; n: PNode) =
+  if c.topStmts == 0 and not isImportSystemStmt(c.graph, n):
+    if sfSystemModule notin c.module.flags and not isEmptyTree(n):
+      assert c.graph.systemModule != nil
+      c.moduleScope.addSym c.graph.systemModule
+      importAllSymbols(c, c.graph.systemModule)
+      inc c.topStmts
+  else:
+    inc c.topStmts
+
 proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PContext =
   result = newContext(graph, module)
   result.idgen = idgen
@@ -788,6 +808,109 @@ proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PCo
   if sfSystemModule in module.flags:
     graph.systemModule = module
   result.topLevelScope = openScope(result)
+  preloadForwardDecls(result)
+
+proc discardPContext*(c: PContext) =
+  rawCloseScope(c)
+  rawCloseScope(c)
+  popOwner(c)
+  popProcCon(c)
+
+proc semCallableHeader(c: PContext; n: PNode) =
+  var header = copyTree(n)
+  if bodyPos < header.len:
+    header[bodyPos] = newNodeI(nkEmpty, n.info)
+  case header.kind
+  of nkProcDef: discard semProc(c, header)
+  of nkFuncDef: discard semFunc(c, header)
+  of nkMethodDef: discard semMethod(c, header)
+  of nkIteratorDef: discard semIterator(c, header)
+  of nkConverterDef: discard semConverterDef(c, header)
+  of nkMacroDef: discard semMacroDef(c, header)
+  of nkTemplateDef: discard semTemplateDef(c, header)
+  else: discard
+  if namePos < header.len and header[namePos].kind == nkSym:
+    let s = header[namePos].sym
+    if s != nil and s.kind in {skProc, skFunc, skMethod, skIterator, skConverter} and sfForward in s.flags:
+      c.graph.interfaceCallableStubs.incl s.id
+
+proc isExportedCallableHeader(n: PNode): bool =
+  if namePos >= n.len:
+    return false
+  var name = n[namePos]
+  if name.kind == nkPragmaExpr:
+    name = name[0]
+  result = name.kind == nkPostfix
+
+proc collectTypeNames(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectTypeNames(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList, nkWhenStmt, nkElifBranch, nkElse, nkStaticStmt:
+    for i in 0..<n.len:
+      collectTypeNames(c, n[i])
+  of nkTypeSection:
+    incl n.flags, nfSem
+    inc c.inTypeContext
+    typeSectionLeftSidePass(c, n)
+    dec c.inTypeContext
+  else:
+    discard
+
+proc collectImports(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectImports(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList:
+    for i in 0..<n.len:
+      collectImports(c, n[i])
+  of nkImportStmt, nkFromStmt, nkImportExceptStmt:
+    discard semStmt(c, n, {})
+  else:
+    discard
+
+proc collectCallableHeaders(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectCallableHeaders(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList, nkWhenStmt, nkElifBranch, nkElse, nkStaticStmt:
+    for i in 0..<n.len:
+      collectCallableHeaders(c, n[i])
+  of procDefs, nkMacroDef, nkTemplateDef:
+    if isExportedCallableHeader(n):
+      semCallableHeader(c, n)
+  else:
+    discard
+
+proc collectInterfaceWithPContext*(c: PContext; n: PNode) =
+  ensureTopLevelSystemImport(c, n)
+  collectTypeNames(c, n)
+  collectImports(c, n)
+  collectCallableHeaders(c, n)
 
 proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool =
   if g.systemModule == nil: return false
@@ -823,14 +946,7 @@ proc isEmptyTree(n: PNode): bool =
   else: result = false
 
 proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
-  if c.topStmts == 0 and not isImportSystemStmt(c.graph, n):
-    if sfSystemModule notin c.module.flags and not isEmptyTree(n):
-      assert c.graph.systemModule != nil
-      c.moduleScope.addSym c.graph.systemModule # import the "System" identifier
-      importAllSymbols(c, c.graph.systemModule)
-      inc c.topStmts
-  else:
-    inc c.topStmts
+  ensureTopLevelSystemImport(c, n)
   if sfNoForward in c.module.flags:
     result = semAllTypeSections(c, n)
   else:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1470,45 +1470,57 @@ proc typeDefLeftSidePass(c: PContext, typeSection: PNode, i: int) =
         localError(c.config, name.info, typsym.name.s & " is not a type that can be forwarded")
         s = typsym
   else:
-    s = semIdentDef(c, name, skType)
-    onDef(name.info, s)
-    if s.typ != nil:
-      # name node is a symbol with a type already, probably in resem, don't touch it
-      discard
+    let existing =
+      if isTopLevel(c):
+        var typeName = name
+        if typeName.kind == nkPragmaExpr:
+          typeName = typeName[0]
+        if typeName.kind == nkPostfix:
+          typeName = typeName[1]
+        let ident = considerQuotedIdent(c, typeName)
+        strTableGet(c.currentScope.symbols, ident)
+      else:
+        nil
+    if existing != nil and existing.kind == skType and
+        sfForward in existing.flags and sfNoForward notin existing.flags:
+      s = existing
     else:
+      s = semIdentDef(c, name, skType)
+      onDef(name.info, s)
       s.typ = newTypeS(tyForward, c)
       s.typ.sym = s
-    # process pragmas:
-    if name.kind == nkPragmaExpr:
-      let rewritten = applyTypeSectionPragmas(c, name[1], typeDef)
-      if rewritten != nil:
-        case rewritten.kind
-        of nkTypeDef:
-          typeSection[i] = rewritten
-        of nkTypeSection:
-          typeSection.sons[i .. i] = rewritten.sons
-        else: illFormedAst(rewritten, c.config)
-        typeDefLeftSidePass(c, typeSection, i)
-        return
-      pragma(c, s, name[1], typePragmas)
-    if sfForward in s.flags:
-      # check if the symbol already exists:
-      let pkg = c.module.owner
-      if not isTopLevel(c) or pkg.isNil:
-        localError(c.config, name.info, "only top level types in a package can be 'package'")
-      else:
-        let typsym = c.graph.packageTypes.strTableGet(s.name)
-        if typsym != nil:
-          if sfForward notin typsym.flags or sfNoForward notin typsym.flags:
-            typeCompleted(typsym)
-            typsym.info = s.info
-          else:
-            localError(c.config, name.info, "cannot complete type '" & s.name.s & "' twice; " &
-                    "previous type completion was here: " & c.config$typsym.info)
-          s = typsym
-    # add it here, so that recursive types are possible:
-    if sfGenSym notin s.flags: addInterfaceDecl(c, s)
-    elif s.owner == nil: setOwner(s, getCurrOwner(c))
+      if c.graph.interfaceImportMode > 0 and isTopLevel(c):
+        s.flags.incl sfForward
+      if name.kind == nkPragmaExpr:
+        let rewritten = applyTypeSectionPragmas(c, name[1], typeDef)
+        if rewritten != nil:
+          case rewritten.kind
+          of nkTypeDef:
+            typeSection[i] = rewritten
+          of nkTypeSection:
+            typeSection.sons[i .. i] = rewritten.sons
+          else: illFormedAst(rewritten, c.config)
+          typeDefLeftSidePass(c, typeSection, i)
+          return
+        pragma(c, s, name[1], typePragmas)
+      if sfForward in s.flags:
+        # check if the symbol already exists:
+        let pkg = c.module.owner
+        if not isTopLevel(c) or pkg.isNil:
+          localError(c.config, name.info, "only top level types in a package can be 'package'")
+        else:
+          let typsym = c.graph.packageTypes.strTableGet(s.name)
+          if typsym != nil:
+            if sfForward notin typsym.flags or sfNoForward notin typsym.flags:
+              typeCompleted(typsym)
+              typsym.info = s.info
+            else:
+              localError(c.config, name.info, "cannot complete type '" & s.name.s & "' twice; " &
+                      "previous type completion was here: " & c.config$typsym.info)
+            s = typsym
+      # add it here, so that recursive types are possible:
+      if sfGenSym notin s.flags: addInterfaceDecl(c, s)
+      elif s.owner == nil: setOwner(s, getCurrOwner(c))
 
   if name.kind == nkPragmaExpr:
     if name[0].kind == nkPostfix:
@@ -1766,6 +1778,12 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
         obj.incl sfPure
       obj.typ = objTy
       objTy.sym = obj
+    if sfForward in s.flags and sfNoForward notin s.flags and
+        a[2].kind != nkEmpty and s.typ != nil and s.typ.kind != tyForward:
+      typeCompleted(s)
+  for sk in c.skipTypes:
+    discard semTypeNode(c, sk, nil)
+  c.skipTypes = @[]
 
 proc checkForMetaFields(c: PContext; n: PNode; hasError: var bool) =
   proc checkMeta(c: PContext; n: PNode; t: PType; hasError: var bool; parent: PType) =
@@ -2420,6 +2438,15 @@ proc semMethodPrototype(c: PContext; s: PSym; n: PNode) =
     else:
       localError(c.config, n.info, "'method' needs a parameter that has an object type")
 
+proc reownCallableHeaderSyms(n: PNode; newOwner: PSym) =
+  if n.isNil:
+    return
+  if n.kind == nkSym and n.sym != nil and
+      n.sym.kind in {skParam, skGenericParam, skResult}:
+    setOwner(n.sym, newOwner)
+  for i in 0..<n.safeLen:
+    reownCallableHeaderSyms(n[i], newOwner)
+
 proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
                 validPragmas: TSpecialWords, flags: TExprFlags = {}): PNode =
   result = semProcAnnotation(c, n, validPragmas)
@@ -2580,6 +2607,16 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if hasProto:
     if sfForward notin proto.flags and proto.magic == mNone:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)
+    if sfForward in proto.flags and proto != s and c.graph.interfaceCallableStubs.contains(proto.id):
+      reownCallableHeaderSyms(n[genericParamsPos], proto)
+      reownCallableHeaderSyms(n[paramsPos], proto)
+      if s.typ != nil and s.typ.n != nil:
+        reownCallableHeaderSyms(s.typ.n, proto)
+      proto.typ = s.typ
+      proto.ast[genericParamsPos] = n[genericParamsPos]
+      proto.ast[paramsPos] = n[paramsPos]
+      proto.ast[pragmasPos] = n[pragmasPos]
+      c.graph.interfaceCallableStubs.excl proto.id
     if not comesFromShadowScope:
       excl(proto, sfForward)
       incl(proto, sfWasForwarded)

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -128,8 +128,13 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif kind notin {skParam, skResult}:
       result = t
   of tyGenericBody, tyGenericParam, tyGenericInvocation,
-     tyNone, tyForward, tyFromExpr:
+     tyNone, tyFromExpr:
     result = t
+  of tyForward:
+    if c.graph.interfaceImportMode > 0 and kind in {skProc, skParam, skResult}:
+      result = nil
+    else:
+      result = t
   of tyNil:
     if kind != skConst and kind != skParam: result = t
   of tyString, tyBool, tyChar, tyEnum, tyInt..tyUInt64, tyCstring, tyPointer:

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -353,9 +353,19 @@ when defined(windows) or defined(nimdoc):
 
   var gDisp{.threadvar.}: owned PDispatcher ## Global dispatcher
 
+  proc close*(disp: PDispatcher) =
+    if disp.isNil: return
+    assert disp.callbacks.len == 0
+    assert disp.timers.len == 0
+    assert disp.handles.len == 0
+    if disp.ioPort != 0:
+      if closeHandle(disp.ioPort) == 0:
+        raiseOSError(osLastError())
+      disp.ioPort = 0
+
   proc setGlobalDispatcher*(disp: sink PDispatcher) =
     if not gDisp.isNil:
-      assert gDisp.callbacks.len == 0
+      close(gDisp)
     gDisp = disp
     initCallSoonProc()
 
@@ -1120,14 +1130,29 @@ when defined(windows) or defined(nimdoc):
     doAssert(ev.hWaiter != 0, "Event is not registered in the queue!")
     let p = getGlobalDispatcher()
     p.handles.excl(AsyncFD(ev.hEvent))
-    if unregisterWait(ev.hWaiter) == 0:
+    let waitFd = ev.hWaiter
+    ev.hWaiter = 0
+    if unregisterWait(waitFd) == 0:
       let err = osLastError()
       if err.int32 != ERROR_IO_PENDING:
         raiseOSError(err)
-    ev.hWaiter = 0
+    else:
+      deallocShared(cast[pointer](ev.pcd))
+      ev.pcd = nil
 
   proc close*(ev: AsyncEvent) =
     ## Closes event `ev`.
+    if ev.hWaiter != 0:
+      unregister(ev)
+      if closeHandle(ev.hEvent) == 0:
+        raiseOSError(osLastError())
+      if ev.pcd != nil:
+        # Unregistration completed asynchronously; event callback will free the
+        # registration state and then release the event object itself.
+        ev.hEvent = 0
+      else:
+        deallocShared(cast[pointer](ev))
+      return
     let res = closeHandle(ev.hEvent)
     deallocShared(cast[pointer](ev))
     if res == 0:
@@ -1146,23 +1171,40 @@ when defined(windows) or defined(nimdoc):
     proc eventcb(fd: AsyncFD, bytesCount: DWORD, errcode: OSErrorCode) =
       if ev.hWaiter != 0:
         if cb(fd):
-          # we need this check to avoid exception, if `unregister(event)` was
-          # called in callback.
-          deallocShared(cast[pointer](pcd))
           if ev.hWaiter != 0:
-            unregister(ev)
+            let waitFd = ev.hWaiter
+            ev.hWaiter = 0
+            p.handles.excl(fd)
+            if unregisterWait(waitFd) == 0:
+              let err = osLastError()
+              if err.int32 != ERROR_IO_PENDING:
+                raiseOSError(err)
+          deallocShared(cast[pointer](pcd))
+          ev.pcd = nil
+          if ev.hEvent == 0:
+            deallocShared(cast[pointer](ev))
         else:
           # if callback returned `false`, then it wants to be called again, so
           # we need to ref and protect `pcd.ovl` again, because it will be
           # unrefed and disposed in `poll()`.
-          GC_ref(pcd.ovl)
-          pcd.ovl.data.cell = system.protect(rawEnv(pcd.ovl.data.cb))
+          if ev.hWaiter != 0:
+            GC_ref(pcd.ovl)
+            pcd.ovl.data.cell = system.protect(rawEnv(pcd.ovl.data.cb))
+          else:
+            deallocShared(cast[pointer](pcd))
+            ev.pcd = nil
+            if ev.hEvent == 0:
+              deallocShared(cast[pointer](ev))
       else:
         # if ev.hWaiter == 0, then event was unregistered before `poll()` call.
         deallocShared(cast[pointer](pcd))
+        ev.pcd = nil
+        if ev.hEvent == 0:
+          deallocShared(cast[pointer](ev))
 
     registerWaitableHandle(p, hEvent, flags, pcd, INFINITE, eventcb)
     ev.hWaiter = pcd.waitFd
+    ev.pcd = pcd
 
   initAll()
 else:
@@ -1218,16 +1260,27 @@ else:
 
   when defined(nuttx):
     import std/exitprocs
+    proc close*(disp: PDispatcher)
 
     proc cleanDispatcher() {.noconv.} =
+      close(gDisp)
       gDisp = nil
 
     proc addFinalyzer() =
       addExitProc(cleanDispatcher)
 
+  proc close*(disp: PDispatcher) =
+    if disp.isNil: return
+    assert disp.callbacks.len == 0
+    assert disp.timers.len == 0
+    assert disp.selector.isNil or disp.selector.isEmpty()
+    if not disp.selector.isNil:
+      disp.selector.close()
+      disp.selector = nil
+
   proc setGlobalDispatcher*(disp: owned PDispatcher) =
     if not gDisp.isNil:
-      assert gDisp.callbacks.len == 0
+      close(gDisp)
     gDisp = disp
     initCallSoonProc()
 

--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -126,6 +126,7 @@ proc close*[T](s: Selector[T]) =
   let res2 = posix.close(s.sock)
   when hasThreadSupport:
     deinitLock(s.changesLock)
+    deallocSharedArray(s.changes)
     deallocSharedArray(s.fds)
     deallocShared(cast[pointer](s))
   if res1 != 0 or res2 != 0:

--- a/tests/async/tasyncdispatch_dispatcher_fdleak.nim
+++ b/tests/async/tasyncdispatch_dispatcher_fdleak.nim
@@ -1,0 +1,21 @@
+discard """
+  output: "closed"
+"""
+
+when defined(windows):
+  echo "closed"
+else:
+  import asyncdispatch, selectors, posix
+
+  block:
+    let disp = newDispatcher()
+    let fd = getFd(getIoHandler(disp))
+    disp.close()
+    doAssert fcntl(fd.cint, F_GETFD) == -1
+
+  block:
+    let fd = getFd(getIoHandler(getGlobalDispatcher()))
+    setGlobalDispatcher(nil)
+    doAssert fcntl(fd.cint, F_GETFD) == -1
+
+  echo "closed"

--- a/tests/async/tasyncevent_memleak.nim
+++ b/tests/async/tasyncevent_memleak.nim
@@ -1,0 +1,27 @@
+discard """
+  cmd: "nim c -r --threads:on --mm:orc $file"
+  output: "0"
+"""
+
+when defined(windows):
+  import asyncdispatch
+
+  let before = getOccupiedSharedMem()
+
+  block:
+    let ev = newAsyncEvent()
+    addEvent(ev) do (fd: AsyncFD) -> bool:
+      true
+    ev.close()
+
+  block:
+    let ev = newAsyncEvent()
+    addEvent(ev) do (fd: AsyncFD) -> bool:
+      true
+    ev.unregister()
+    ev.close()
+
+  setGlobalDispatcher(nil)
+  echo getOccupiedSharedMem() - before
+else:
+  echo 0

--- a/tests/async/tioselectors_memleak.nim
+++ b/tests/async/tioselectors_memleak.nim
@@ -1,0 +1,14 @@
+discard """
+  cmd: "nim c -r --threads:on -d:threadsafe --mm:orc $file"
+  output: "0"
+"""
+
+import selectors
+
+let before = getOccupiedSharedMem()
+
+block:
+  let selector = newSelector[int]()
+  selector.close()
+
+echo getOccupiedSharedMem() - before

--- a/tests/modules/mcyclicimports_noreorder.nim
+++ b/tests/modules/mcyclicimports_noreorder.nim
@@ -1,0 +1,4 @@
+import tcyclicimports_noreorder
+
+proc b*(x: int): int =
+  a(x - 1)

--- a/tests/modules/mcyclicimports_proc.nim
+++ b/tests/modules/mcyclicimports_proc.nim
@@ -1,0 +1,9 @@
+{.experimental: "codeReordering".}
+
+import tcyclicimports_proc
+
+proc b*(x: int): int =
+  if x <= 0:
+    0
+  else:
+    a(x - 1)

--- a/tests/modules/mcyclicimports_types.nim
+++ b/tests/modules/mcyclicimports_types.nim
@@ -1,0 +1,6 @@
+{.experimental: "codeReordering".}
+
+import tcyclicimports_types
+
+proc id*(x: tcyclicimports_types.T): tcyclicimports_types.T =
+  x

--- a/tests/modules/tcyclicimports_noreorder.nim
+++ b/tests/modules/tcyclicimports_noreorder.nim
@@ -1,0 +1,11 @@
+discard """
+  errormsg: "undeclared identifier: 'a'"
+  cmd: "nim c $file"
+"""
+
+import mcyclicimports_noreorder
+
+proc a*(x: int): int =
+  b(x)
+
+discard a(1)

--- a/tests/modules/tcyclicimports_proc.nim
+++ b/tests/modules/tcyclicimports_proc.nim
@@ -1,0 +1,16 @@
+discard """
+  output: "4"
+  cmd: "nim c -r $file"
+"""
+
+{.experimental: "codeReordering".}
+
+import mcyclicimports_proc
+
+proc a*(x: int): int =
+  if x <= 0:
+    1
+  else:
+    b(x) + 1
+
+echo a(3)

--- a/tests/modules/tcyclicimports_types.nim
+++ b/tests/modules/tcyclicimports_types.nim
@@ -1,0 +1,17 @@
+discard """
+  output: "1"
+  cmd: "nim c -r $file"
+"""
+
+{.experimental: "codeReordering".}
+
+import mcyclicimports_types
+
+type
+  T* = object
+    value*: int
+
+proc makeT(): T =
+  T(value: 1)
+
+echo id(makeT()).value


### PR DESCRIPTION
Summary

- support cyclic imports under code reordering without manual forward declarations
- add regression coverage for cyclic imports with and without code reordering
- fix ORC-related async resource leaks in asyncdispatch, AsyncEvent, and the kqueue selector backend

Testing

- ./bin/nim_cyclic_imports_test c -r tests/modules/tcyclicimports_proc.nim
- ./bin/nim_cyclic_imports_test c -r tests/modules/tcyclicimports_types.nim
- ./bin/nim_cyclic_imports_test c tests/modules/tcyclicimports_noreorder.nim
- ./bin/nim_cyclic_imports_test c -r tests/modules/trecmod2.nim
- ./bin/nim_cyclic_imports_test c tests/modules/tselfimport.nim
- ./bin/nim_cyclic_imports_test c -r --mm:orc tests/async/tasyncdispatch_dispatcher_fdleak.nim
- ./bin/nim_cyclic_imports_test c -r --threads:on -d:threadsafe --mm:orc tests/async/tioselectors_memleak.nim
- ./bin/nim_cyclic_imports_test c -r --threads:on --mm:orc tests/async/tasyncevent_memleak.nim
- ./bin/nim_cyclic_imports_test c -r tests/stdlib/tfdleak.nim
- ./bin/nim_cyclic_imports_test c -r --mm:orc -d:useMalloc tests/arc/tasyncorc.nim

This PR supersedes #25659, whose PR metadata kept the old compare range after a force-push even though the branch history was corrected.
