### PR TITLE
fixes transf cannot handle bare sym for `nim ic`

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -1190,6 +1190,13 @@ proc transform(c: PTransf, n: PNode, noConstFold = false): PNode =
     # no need to transform type sections:
     return n
   of nkVarSection, nkLetSection:
+    # NIF loads let/var sections with bare nkSym children instead of nkIdentDefs.
+    # Expand them so transformSons reaches the value expression (e.g. for-loop).
+    for i in 0 ..< n.len:
+      if n[i].kind == nkSym:
+        let impl = n[i].sym.ast  # triggers lazy load if Partial
+        if impl != nil and impl.kind == nkIdentDefs:
+          n[i] = impl
     if c.inlining > 0:
       # we need to copy the variables for multiple yield statements:
       result = transformVarSection(c, n)

--- a/tests/ic/tmiscs.nim
+++ b/tests/ic/tmiscs.nim
@@ -69,14 +69,13 @@ m[1, 1] = 2.0
 echo m[0, 0]
 echo m[1, 1]
 
-block:
-  template compute(body: untyped): int =
-    block:
-      body
-  let x = compute:
-    var sum = 0
-    for i in 1..10: sum += i
-    sum
+template compute(body: untyped): int =
+  block:
+    body
+let x = compute:
+  var sum = 0
+  for i in 1..10: sum += i
+  sum
 
-  echo x
+echo x
 

--- a/tests/ic/tmiscs.nim
+++ b/tests/ic/tmiscs.nim
@@ -6,6 +6,7 @@ discard """
 2
 1.0
 2.0
+55
 '''
 """
 
@@ -67,3 +68,15 @@ m[0, 0] = 1.0
 m[1, 1] = 2.0
 echo m[0, 0]
 echo m[1, 1]
+
+block:
+  template compute(body: untyped): int =
+    block:
+      body
+  let x = compute:
+    var sum = 0
+    for i in 1..10: sum += i
+    sum
+
+  echo x
+


### PR DESCRIPTION
```nim
template compute(body: untyped): int =
  block:
    body
let x = compute:
  var sum = 0
  for i in 1..10: sum += i
  sum
echo x
```

supersedes https://github.com/nim-lang/Nim/pull/25653

which in https://github.com/nim-lang/Nim/commit/02893e2f4c2bca4cb107ce7673c615362a91e33f 

```nim
of nkSym:
    genSingleVar(p, it.sym, newSymNode(it.sym), it.sym.astdef)
```

A new branch for `nkSym` is added, though more changes might be needed if `nkSym` is handled specifically