### PR TITLE
windows: prefer 64-bit time_t

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -264,7 +264,11 @@ elif defined(windows):
       tm_yday*: cint  ## Day of year [0,365].
       tm_isdst*: cint ## Daylight Savings flag.
 
-  proc localtime(a1: var CTime): ptr Tm {.importc, header: "<time.h>", sideEffect.}
+  # Prefer 64-bit version always - time_t might be 32 or 64 bit depending on
+  # the setting of _USE_32BIT_TIME_T and we have no way of detecting which
+  # version is actually used by default:
+  # https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64
+  proc localtime(a1: var CTime): ptr Tm {.importc: "_localtime64", header: "<time.h>", sideEffect.}
 
 type
   Month* = enum ## Represents a month. Note that the enum starts at `1`,

--- a/lib/std/time_t.nim
+++ b/lib/std/time_t.nim
@@ -13,11 +13,11 @@ when defined(nimdoc):
     Time* = Impl ## \
       ## Wrapper for `time_t`. On posix, this is an alias to `posix.Time`.
 elif defined(windows):
-  when defined(i386) and defined(gcc):
-    type Time* {.importc: "time_t", header: "<time.h>".} = distinct clong
-  else:
-    # newest version of Visual C++ defines time_t to be of 64 bits
-    type Time* {.importc: "time_t", header: "<time.h>".} = distinct int64
+  # Unless _USE_32BIT_TIME_T is defined, time_t is a 64-bit value on both 32
+  # and 64-bit versions of windows:
+  # https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/time-time32-time64
+  # For the avoidance of doubt, always use 64-bit version
+  type Time* {.importc: "__time64_t", header: "<time.h>".} = distinct clonglong
 elif defined(posix):
   import std/posix
   export posix.Time


### PR DESCRIPTION
time_t should be a 64-bit type on all relevant windows CRT versions including mingw-w64 - MSDN recommends against using the 32-bit version which only is happens when `_USE_32BIT_TIME_T` is explicitly defined - instead of guessing (and guessing wrong, as happens with recent mingw versions), we can simply use the 64-bit version always.