### PR TITLE
Support cyclic imports and zero-forward-declaration semantics

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1580,6 +1580,7 @@ proc genProc(m: BModule, prc: PSym) =
   if sfForward in prc.flags:
     addForwardedProc(m, prc)
     fillProcLoc(m, prc.ast[namePos])
+    genProcPrototype(m, prc)
   else:
     genProcLvl2(m, prc)
     if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} and

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -275,12 +275,17 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
   n = transf.node
   let f = checkModuleName(c.config, n)
   if f != InvalidFileIdx:
+    if f == FileIndex(c.module.position):
+      localError(c.config, n.info, "module '$1' cannot import itself" % c.module.name.s)
     addImportFileDep(c, f)
     let L = c.graph.importStack.len
     let recursion = c.graph.importStack.find(f)
     c.graph.importStack.add f
     #echo "adding ", toFullPath(f), " at ", L+1
-    if recursion >= 0:
+    if recursion >= 0 and
+        not usesDefaultCodeReordering(c.graph, c.module) and
+        codeReordering notin c.features and
+        codeReordering notin c.graph.config.features:
       var err = ""
       for i in recursion..<L:
         if i > recursion: err.add "\n"

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -25,6 +25,9 @@ when defined(nimPreviewSlimSystem):
   import std/assertions
 
 type
+  ModuleCompileState* = enum
+    mcsNone, mcsCollectingInterface, mcsInterfaceReady, mcsSemchecking, mcsDone
+
   SigHash* = distinct MD5Digest
 
   Iface* = object       ## data we don't want to store directly in the
@@ -80,6 +83,11 @@ type
                                             # first module that included it
     importStack*: seq[FileIndex]  # The current import stack. Used for detecting recursive
                                   # module dependencies.
+    compileStates*: seq[ModuleCompileState]
+    interfaceImportMode*: int
+    interfaceCallableStubs*: IntSet
+    semcheckStack*: seq[FileIndex]
+    pendingSemchecks*: seq[FileIndex]
     backend*: RootRef # minor hack so that a backend can extend this easily
     config*: ConfigRef
     cache*: IdentCache
@@ -154,6 +162,10 @@ proc resetForBackend*(g: ModuleGraph) =
   for a in mitems(g.loadedOps):
     a.clear()
   g.opsLog.setLen(0)
+
+proc ensureCompileStateSlot*(g: ModuleGraph; fileIdx: FileIndex) =
+  if fileIdx.int >= g.compileStates.len:
+    g.compileStates.setLen(fileIdx.int + 1)
 
 const
   cb64 = [
@@ -525,6 +537,9 @@ proc initModuleGraphFields(result: ModuleGraph) =
   result.importDeps = initTable[FileIndex, seq[FileIndex]]()
   result.ifaces = @[]
   result.importStack = @[]
+  result.interfaceCallableStubs = initIntSet()
+  result.semcheckStack = @[]
+  result.pendingSemchecks = @[]
   result.inclToMod = initTable[FileIndex, FileIndex]()
   result.owners = @[]
   result.suggestSymbols = initTable[FileIndex, SuggestFileSymbolDatabase]()
@@ -731,6 +746,9 @@ proc getPackage*(graph: ModuleGraph; fileIdx: FileIndex): PSym =
 proc belongsToStdlib*(graph: ModuleGraph, sym: PSym): bool =
   ## Check if symbol belongs to the 'stdlib' package.
   sym.getPackageSymbol.getPackageId == graph.systemModule.getPackageId
+
+proc usesDefaultCodeReordering*(graph: ModuleGraph; module: PSym): bool =
+  sfSystemModule notin module.flags and not belongsToStdlib(graph, module)
 
 proc fileSymbols*(graph: ModuleGraph, fileIdx: FileIndex): SuggestFileSymbolDatabase =
   result = graph.suggestSymbols.getOrDefault(fileIdx, newSuggestFileSymbolDatabase(fileIdx, optIdeExceptionInlayHints in graph.config.globalOptions))

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -141,7 +141,8 @@ proc processModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
         var n = parseTopLevelStmt(p)
         if n.kind == nkEmpty: break
         sl.add n
-      if sfReorder in module.flags or codeReordering in graph.config.features:
+      if usesDefaultCodeReordering(graph, module) or sfReorder in module.flags or
+          codeReordering in graph.config.features:
         sl = reorder(graph, sl, module)
       discard processTopLevelStmt(graph, sl, a)
 

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -1,5 +1,6 @@
 import sem, cgen, modulegraphs, ast, llstream, parser, msgs,
        lineinfos, reorder, options, semdata, cgendata, modules, pathutils,
+       modulepaths,
        packages, syntaxes, depends, vm, pragmas, idents, lookups, wordrecg,
        liftdestructors, nifgen
 
@@ -17,7 +18,6 @@ when not defined(leanCompiler):
 
 import std/[syncio, objectdollar, assertions, tables, strutils, strtabs]
 import renderer
-import ic/replayer
 
 proc setPipeLinePass*(graph: ModuleGraph; pass: PipelinePass) =
   graph.pipelinePass = pass
@@ -111,6 +111,136 @@ proc prePass*(c: PContext; n: PNode) =
         else:
           discard
 
+proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags; fromModule: PSym = nil): PSym
+
+proc enqueuePendingSemcheck(graph: ModuleGraph; fileIdx: FileIndex) =
+  for it in graph.pendingSemchecks:
+    if it == fileIdx:
+      return
+  graph.pendingSemchecks.add fileIdx
+
+proc drainPendingSemchecks(graph: ModuleGraph) =
+  while graph.pendingSemchecks.len > 0:
+    let fileIdx = graph.pendingSemchecks[0]
+    graph.pendingSemchecks.delete(0)
+    if fileIdx.int < graph.compileStates.len and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      let m = graph.getModule(fileIdx)
+      if m != nil:
+        discard compilePipelineModule(graph, fileIdx, m.flags)
+
+proc wantsInterfaceCollection(c: PContext): bool =
+  sfSystemModule notin c.module.flags and (
+    usesDefaultCodeReordering(c.graph, c.module) or
+    codeReordering in c.features or sfReorder in c.module.flags
+  )
+
+proc importsNonStdlibModule(graph: ModuleGraph; n: PNode): bool =
+  proc isNonStdlibModuleNode(n: PNode): bool =
+    result = false
+    var n = n
+    if n.kind == nkPragmaExpr:
+      n = n[0]
+    if n.kind == nkInfix and n.len == 3 and n[0].kind == nkIdent and n[0].ident.s == "as":
+      n = n[1]
+    let f = checkModuleName(graph.config, n, false)
+    if f != InvalidFileIdx:
+      result = getPackage(graph, f).getPackageId != graph.systemModule.getPackageId
+
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(graph.config, n[i])
+      if f != InvalidFileIdx and getPackage(graph, f).getPackageId != graph.systemModule.getPackageId:
+        return true
+    result = false
+  of nkImportStmt:
+    for it in n:
+      if it.kind in {nkInfix, nkPrefix} and it[^1].kind == nkBracket:
+        let lastPos = it.len - 1
+        var imp = copyNode(it)
+        newSons(imp, it.len)
+        for i in 0..<lastPos:
+          imp[i] = it[i]
+        imp[lastPos] = imp[0]
+        for x in it[lastPos]:
+          if x.kind == nkInfix and x.len == 3 and x[0].kind == nkIdent and x[0].ident.s == "as":
+            imp[lastPos] = x[1]
+          else:
+            imp[lastPos] = x
+          if isNonStdlibModuleNode(imp):
+            return true
+      elif isNonStdlibModuleNode(it):
+        return true
+    result = false
+  of nkImportExceptStmt, nkFromStmt:
+    result = isNonStdlibModuleNode(n[0])
+  of nkStmtList, nkStmtListExpr, nkWhenStmt, nkElifBranch, nkElse, nkStaticStmt:
+    for i in 0..<n.len:
+      if importsNonStdlibModule(graph, n[i]):
+        return true
+    result = false
+  else:
+    result = false
+
+proc hasTopLevelConditionals(n: PNode): bool =
+  case n.kind
+  of nkWhenStmt, nkStaticStmt:
+    result = true
+  of nkStmtList, nkStmtListExpr, nkElifBranch, nkElse:
+    for i in 0..<n.len:
+      if hasTopLevelConditionals(n[i]):
+        return true
+    result = false
+  else:
+    result = false
+
+proc parseModuleTopLevel(graph: ModuleGraph; module: PSym): PNode =
+  result = syntaxes.parseFile(module.fileIdx, graph.cache, graph.config)
+
+proc collectPipelineModuleInterface(graph: ModuleGraph; module: PSym; idgen: IdGenerator): bool =
+  let fileIdx = module.fileIdx
+  ensureCompileStateSlot(graph, fileIdx)
+  case graph.compileStates[fileIdx.int]
+  of mcsCollectingInterface, mcsInterfaceReady, mcsSemchecking, mcsDone:
+    return graph.compileStates[fileIdx.int] != mcsNone
+  of mcsNone:
+    discard
+
+  let oldSymbolFiles = graph.config.symbolFiles
+  graph.compileStates[fileIdx.int] = mcsCollectingInterface
+  graph.config.symbolFiles = disabledSf
+  var ctx: PContext = nil
+  try:
+    let sl = parseModuleTopLevel(graph, module)
+    ctx = preparePContext(graph, module, idgen)
+    prePass(ctx, sl)
+    if not wantsInterfaceCollection(ctx) or
+        not importsNonStdlibModule(graph, sl) or
+        hasTopLevelConditionals(sl):
+      graph.compileStates[fileIdx.int] = mcsNone
+      return false
+
+    if not belongsToStdlib(graph, module) or (belongsToStdlib(graph, module) and module.name.s == "distros"):
+      if module.name.s != "nimscriptapi":
+        inc graph.interfaceImportMode
+        try:
+          processImplicitImports graph, graph.config.implicitImports, nkImportStmt, module, ctx, nil, idgen, nil
+          processImplicitImports graph, graph.config.implicitIncludes, nkIncludeStmt, module, ctx, nil, idgen, nil
+        finally:
+          dec graph.interfaceImportMode
+
+    inc graph.interfaceImportMode
+    try:
+      collectInterfaceWithPContext(ctx, sl)
+    finally:
+      dec graph.interfaceImportMode
+    graph.compileStates[fileIdx.int] = mcsInterfaceReady
+    result = true
+  finally:
+    graph.config.symbolFiles = oldSymbolFiles
+    if ctx != nil:
+      discardPContext(ctx)
+
 proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
                     stream: PLLStream): bool =
   if graph.stopCompile(): return true
@@ -197,7 +327,8 @@ proc processPipelineModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator
         sl.add n
 
       prePass(ctx, sl)
-      if sfReorder in module.flags or codeReordering in graph.config.features:
+      if usesDefaultCodeReordering(graph, module) or sfReorder in module.flags or
+          codeReordering in graph.config.features:
         sl = reorder(graph, sl, module)
       if graph.pipelinePass != EvalPass:
         message(graph.config, sl.info, hintProcessingStmt, $idgen[])
@@ -300,6 +431,7 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
           if result.ast != nil:
             replayStateChanges(result, graph)
           return result  # Return early, don't process from source
+    ensureCompileStateSlot(graph, fileIdx)
     let path = toFullPath(graph.config, fileIdx)
     let filename = AbsoluteFile path
     # it could be a stdinfile/cmdfile
@@ -309,22 +441,72 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
       result = newModule(graph, fileIdx)
       result.incl flags
       registerModule(graph, result)
+      discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+      if graph.interfaceImportMode > 0 and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+        return result
+      graph.compileStates[fileIdx.int] = mcsSemchecking
+      graph.semcheckStack.add fileIdx
       processModuleAux("import")
+      doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+      graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+      graph.compileStates[fileIdx.int] = mcsDone
+      if graph.semcheckStack.len == 0:
+        drainPendingSemchecks(graph)
     else:
       if sfSystemModule in flags:
         graph.systemModule = result
       if sfMainModule in flags and graph.config.cmd == cmdM:
         result.incl flags
         registerModule(graph, result)
+        graph.compileStates[fileIdx.int] = mcsSemchecking
+        graph.semcheckStack.add fileIdx
         processModuleAux("import")
+        doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+        graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+        graph.compileStates[fileIdx.int] = mcsDone
+        if graph.semcheckStack.len == 0:
+          drainPendingSemchecks(graph)
       partialInitModule(result, graph, fileIdx, filename)
   elif graph.isDirty(result):
     result.excl sfDirty
     # reset module fields:
     initStrTables(graph, result)
     result.ast = nil
+    ensureCompileStateSlot(graph, fileIdx)
+    graph.compileStates[fileIdx.int] = mcsNone
+    discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+    if graph.interfaceImportMode > 0 and graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      return result
+    graph.compileStates[fileIdx.int] = mcsSemchecking
+    graph.semcheckStack.add fileIdx
     processModuleAux("import(dirty)")
+    doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+    graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+    graph.compileStates[fileIdx.int] = mcsDone
+    if graph.semcheckStack.len == 0:
+      drainPendingSemchecks(graph)
     graph.markClientsDirty(fileIdx)
+  else:
+    ensureCompileStateSlot(graph, fileIdx)
+    case graph.compileStates[fileIdx.int]
+    of mcsCollectingInterface, mcsSemchecking, mcsDone, mcsInterfaceReady:
+      discard
+    of mcsNone:
+      discard collectPipelineModuleInterface(graph, result, idGeneratorFromModule(result))
+    if graph.interfaceImportMode > 0:
+      return result
+    if graph.compileStates[fileIdx.int] == mcsInterfaceReady:
+      if graph.semcheckStack.len > 0:
+        enqueuePendingSemcheck(graph, fileIdx)
+        return result
+      graph.compileStates[fileIdx.int] = mcsSemchecking
+      graph.semcheckStack.add fileIdx
+      processModuleAux("import")
+      doAssert graph.semcheckStack.len > 0 and graph.semcheckStack[^1] == fileIdx
+      graph.semcheckStack.setLen(graph.semcheckStack.len - 1)
+      graph.compileStates[fileIdx.int] = mcsDone
+      if graph.semcheckStack.len == 0:
+        drainPendingSemchecks(graph)
 
 proc importPipelineModule(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -288,7 +288,7 @@ proc pragmaNoForward*(c: PContext, n: PNode; flag=sfNoForward) =
 
   # deprecated as of 0.18.1
   message(c.config, n.info, warnDeprecated,
-          "use {.experimental: \"codeReordering\".} instead; " &
+          "code reordering is enabled by default; " &
           (if flag == sfNoForward: "{.noForward.}" else: "{.reorder.}") & " is deprecated")
 
 proc pragmaAsm*(c: PContext, n: PNode): char =

--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -113,7 +113,7 @@ proc computeDeps(cache: IdentCache; n: PNode, declares, uses: var IntSet; topLev
 proc hasIncludes(n: PNode): bool =
   result = false
   for a in n:
-    if a.kind == nkIncludeStmt:
+    if a.kind == nkIncludeStmt or a.hasIncludes:
       return true
 
 proc includeModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PNode =
@@ -126,24 +126,35 @@ proc expandIncludes(graph: ModuleGraph, module: PSym, n: PNode,
   # Parses includes and injects them in the current tree
   if not n.hasIncludes:
     return n
-  result = newNodeI(nkStmtList, n.info)
-  for a in n:
-    if a.kind == nkIncludeStmt:
-      for i in 0..<a.len:
-        var f = checkModuleName(graph.config, a[i])
-        if f != InvalidFileIdx:
-          if containsOrIncl(includedFiles, f.int):
-            localError(graph.config, a.info, "recursive dependency: '$1'" %
-              toMsgFilename(graph.config, f))
-          else:
-            let nn = includeModule(graph, module, f)
-            let nnn = expandIncludes(graph, module, nn, modulePath,
-                                      includedFiles)
-            excl(includedFiles, f.int)
-            for b in nnn:
-              result.add b
-    else:
-      result.add a
+  case n.kind
+  of nkIncludeStmt:
+    result = newNodeI(nkStmtList, n.info)
+    for i in 0..<n.len:
+      let f = checkModuleName(graph.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(includedFiles, f.int):
+          localError(graph.config, n.info, "recursive dependency: '$1'" %
+            toMsgFilename(graph.config, f))
+        else:
+          let nn = includeModule(graph, module, f)
+          let nnn = expandIncludes(graph, module, nn, modulePath, includedFiles)
+          excl(includedFiles, f.int)
+          for b in nnn:
+            result.add b
+  of nkStmtList, nkStmtListExpr:
+    result = newNodeI(n.kind, n.info)
+    for a in n:
+      let expanded = expandIncludes(graph, module, a, modulePath, includedFiles)
+      if expanded.kind == nkStmtList:
+        for b in expanded:
+          result.add b
+      else:
+        result.add expanded
+  else:
+    result = copyNode(n)
+    newSons(result, n.len)
+    for i in 0..<n.len:
+      result[i] = expandIncludes(graph, module, n[i], modulePath, includedFiles)
 
 proc splitSections(n: PNode): PNode =
   # Split typeSections and ConstSections into
@@ -169,7 +180,7 @@ proc haveSameKind(dns: seq[DepN]): bool =
     if dn.pnode.kind != kind:
       return false
 
-proc mergeSections(conf: ConfigRef; comps: seq[seq[DepN]], res: PNode) =
+proc mergeSections(conf: ConfigRef; comps: seq[seq[DepN]], res: PNode; emitWarnings: bool) =
   # Merges typeSections and ConstSections when they form
   # a strong component (ex: circular type definition)
   for c in comps:
@@ -192,7 +203,7 @@ proc mergeSections(conf: ConfigRef; comps: seq[seq[DepN]], res: PNode) =
         # Problematic circular dependency, we arrange the nodes into
         # their original relative order and make sure to re-merge
         # consecutive type and const sections
-        var wmsg = "Circular dependency detected. `codeReordering` pragma may not be able to" &
+        var wmsg = "Circular dependency detected. The compiler may not be able to" &
           " reorder some nodes properly"
         when defined(nimDebugReorder):
           wmsg &= ":\n"
@@ -209,7 +220,8 @@ proc mergeSections(conf: ConfigRef; comps: seq[seq[DepN]], res: PNode) =
                 wmsg &= "line " & $cs[^1].pnode.info.line &
                   " depends on line " & $cs[j].pnode.info.line &
                   ": " & cs[^1].expls[ci] & "\n"
-        message(conf, cs[0].pnode.info, warnUser, wmsg)
+        if emitWarnings:
+          message(conf, cs[0].pnode.info, warnUser, wmsg)
 
         var i = 0
         while i < cs.len:
@@ -432,4 +444,5 @@ proc reorder*(graph: ModuleGraph, n: PNode, module: PSym): PNode =
 
   var g = buildGraph(n, deps)
   let comps = getStrongComponents(g)
-  mergeSections(graph.config, comps, result)
+  mergeSections(graph.config, comps, result,
+    emitWarnings = sfSystemModule notin module.flags and not belongsToStdlib(graph, module))

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -61,6 +61,8 @@ proc semTypeOf(c: PContext; n: PNode): PNode
 proc computeRequiresInit(c: PContext, t: PType): bool
 proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo)
 proc hasUnresolvedArgs(c: PContext, n: PNode): bool
+proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool
+proc isEmptyTree(n: PNode): bool
 proc isArrayConstr(n: PNode): bool {.inline.} =
   result = n.kind == nkBracket and
     n.typ.skipTypes(abstractInst).kind == tyArray
@@ -753,6 +755,24 @@ proc addCodeForGenerics(c: PContext, n: PNode) =
         n.add prc.ast
   c.lastGenericIdx = c.generics.len
 
+proc preloadForwardDecls(c: PContext) =
+  for s in semtabAll(c.graph, c.module).data:
+    if s != nil and sfForward in s.flags:
+      if s.kind in OverloadableSyms:
+        addOverloadableSymAt(c, c.currentScope, s)
+      else:
+        addDeclAt(c, c.currentScope, s)
+
+proc ensureTopLevelSystemImport(c: PContext; n: PNode) =
+  if c.topStmts == 0 and not isImportSystemStmt(c.graph, n):
+    if sfSystemModule notin c.module.flags and not isEmptyTree(n):
+      assert c.graph.systemModule != nil
+      c.moduleScope.addSym c.graph.systemModule
+      importAllSymbols(c, c.graph.systemModule)
+      inc c.topStmts
+  else:
+    inc c.topStmts
+
 proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PContext =
   result = newContext(graph, module)
   result.idgen = idgen
@@ -788,6 +808,169 @@ proc preparePContext*(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PCo
   if sfSystemModule in module.flags:
     graph.systemModule = module
   result.topLevelScope = openScope(result)
+  preloadForwardDecls(result)
+
+proc discardPContext*(c: PContext) =
+  rawCloseScope(c)
+  rawCloseScope(c)
+  popOwner(c)
+  popProcCon(c)
+
+proc semCallableHeader(c: PContext; n: PNode) =
+  var header = copyTree(n)
+  if bodyPos < header.len:
+    header[bodyPos] = newNodeI(nkEmpty, n.info)
+  case header.kind
+  of nkProcDef: discard semProc(c, header)
+  of nkFuncDef: discard semFunc(c, header)
+  of nkMethodDef: discard semMethod(c, header)
+  of nkIteratorDef: discard semIterator(c, header)
+  of nkConverterDef: discard semConverterDef(c, header)
+  of nkMacroDef: discard semMacroDef(c, header)
+  of nkTemplateDef: discard semTemplateDef(c, header)
+  else: discard
+  if namePos < header.len and header[namePos].kind == nkSym:
+    let s = header[namePos].sym
+    if s != nil and s.kind in {skProc, skFunc, skMethod, skIterator, skConverter} and sfForward in s.flags:
+      c.graph.interfaceCallableStubs.incl s.id
+
+proc isExportedCallableHeader(n: PNode): bool =
+  if namePos >= n.len:
+    return false
+  var name = n[namePos]
+  if name.kind == nkPragmaExpr:
+    name = name[0]
+  result = name.kind == nkPostfix
+
+proc collectTypeNames(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectTypeNames(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList:
+    for i in 0..<n.len:
+      collectTypeNames(c, n[i])
+  of nkWhenStmt:
+    if sfSystemModule notin c.module.flags and not belongsToStdlib(c.graph, c.module):
+      collectTypeNames(c, semWhen(c, n, semCheck = false))
+  of nkTypeSection:
+    incl n.flags, nfSem
+    inc c.inTypeContext
+    typeSectionLeftSidePass(c, n)
+    dec c.inTypeContext
+  else:
+    discard
+
+proc collectImports(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectImports(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList:
+    for i in 0..<n.len:
+      collectImports(c, n[i])
+  of nkWhenStmt:
+    if sfSystemModule notin c.module.flags and not belongsToStdlib(c.graph, c.module):
+      collectImports(c, semWhen(c, n, semCheck = false))
+  of nkImportStmt, nkFromStmt, nkImportExceptStmt:
+    discard semStmt(c, n, {})
+  else:
+    discard
+
+proc checkSelfImports(c: PContext; n: PNode) =
+  proc checkModuleNode(n: PNode) =
+    var n = n
+    if n.kind == nkPragmaExpr:
+      n = n[0]
+    if n.kind == nkInfix and n.len == 3 and n[0].kind == nkIdent and n[0].ident.s == "as":
+      n = n[1]
+    let f = checkModuleName(c.config, n, false)
+    if f != InvalidFileIdx and f == c.module.fileIdx:
+      localError(c.config, n.info, "module '$1' cannot import itself" % c.module.name.s)
+
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          checkSelfImports(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList:
+    for i in 0..<n.len:
+      checkSelfImports(c, n[i])
+  of nkWhenStmt:
+    if sfSystemModule notin c.module.flags and not belongsToStdlib(c.graph, c.module):
+      checkSelfImports(c, semWhen(c, n, semCheck = false))
+  of nkImportStmt:
+    for it in n:
+      if it.kind in {nkInfix, nkPrefix} and it[^1].kind == nkBracket:
+        let lastPos = it.len - 1
+        var imp = copyNode(it)
+        newSons(imp, it.len)
+        for i in 0..<lastPos:
+          imp[i] = it[i]
+        imp[lastPos] = imp[0]
+        for x in it[lastPos]:
+          if x.kind == nkInfix and x.len == 3 and x[0].kind == nkIdent and x[0].ident.s == "as":
+            imp[lastPos] = x[1]
+          else:
+            imp[lastPos] = x
+          checkModuleNode(imp)
+      else:
+        checkModuleNode(it)
+  of nkImportExceptStmt, nkFromStmt:
+    checkModuleNode(n[0])
+  else:
+    discard
+
+proc collectCallableHeaders(c: PContext; n: PNode) =
+  case n.kind
+  of nkIncludeStmt:
+    for i in 0..<n.len:
+      let f = checkModuleName(c.config, n[i])
+      if f != InvalidFileIdx:
+        if containsOrIncl(c.includedFiles, f.int):
+          localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
+        else:
+          let code = c.graph.includeFileCallback(c.graph, c.module, f)
+          collectCallableHeaders(c, code)
+          excl(c.includedFiles, f.int)
+  of nkStmtList:
+    for i in 0..<n.len:
+      collectCallableHeaders(c, n[i])
+  of nkWhenStmt:
+    if sfSystemModule notin c.module.flags and not belongsToStdlib(c.graph, c.module):
+      collectCallableHeaders(c, semWhen(c, n, semCheck = false))
+  of procDefs:
+    if isExportedCallableHeader(n):
+      semCallableHeader(c, n)
+  else:
+    discard
+
+proc collectInterfaceWithPContext*(c: PContext; n: PNode) =
+  checkSelfImports(c, n)
+  ensureTopLevelSystemImport(c, n)
+  collectTypeNames(c, n)
+  collectImports(c, n)
+  collectCallableHeaders(c, n)
 
 proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool =
   if g.systemModule == nil: return false
@@ -823,14 +1006,7 @@ proc isEmptyTree(n: PNode): bool =
   else: result = false
 
 proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
-  if c.topStmts == 0 and not isImportSystemStmt(c.graph, n):
-    if sfSystemModule notin c.module.flags and not isEmptyTree(n):
-      assert c.graph.systemModule != nil
-      c.moduleScope.addSym c.graph.systemModule # import the "System" identifier
-      importAllSymbols(c, c.graph.systemModule)
-      inc c.topStmts
-  else:
-    inc c.topStmts
+  ensureTopLevelSystemImport(c, n)
   if sfNoForward in c.module.flags:
     result = semAllTypeSections(c, n)
   else:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1470,45 +1470,58 @@ proc typeDefLeftSidePass(c: PContext, typeSection: PNode, i: int) =
         localError(c.config, name.info, typsym.name.s & " is not a type that can be forwarded")
         s = typsym
   else:
-    s = semIdentDef(c, name, skType)
-    onDef(name.info, s)
-    if s.typ != nil:
-      # name node is a symbol with a type already, probably in resem, don't touch it
-      discard
+    let existing =
+      if isTopLevel(c):
+        var typeName = name
+        if typeName.kind == nkPragmaExpr:
+          typeName = typeName[0]
+        if typeName.kind == nkPostfix:
+          typeName = typeName[1]
+        let ident = considerQuotedIdent(c, typeName)
+        strTableGet(c.currentScope.symbols, ident)
+      else:
+        nil
+    if existing != nil and existing.kind == skType and
+        sfForward in existing.flags and sfNoForward notin existing.flags:
+      s = existing
     else:
+      s = semIdentDef(c, name, skType)
+      onDef(name.info, s)
       s.typ = newTypeS(tyForward, c)
       s.typ.sym = s
-    # process pragmas:
-    if name.kind == nkPragmaExpr:
-      let rewritten = applyTypeSectionPragmas(c, name[1], typeDef)
-      if rewritten != nil:
-        case rewritten.kind
-        of nkTypeDef:
-          typeSection[i] = rewritten
-        of nkTypeSection:
-          typeSection.sons[i .. i] = rewritten.sons
-        else: illFormedAst(rewritten, c.config)
-        typeDefLeftSidePass(c, typeSection, i)
-        return
-      pragma(c, s, name[1], typePragmas)
-    if sfForward in s.flags:
-      # check if the symbol already exists:
-      let pkg = c.module.owner
-      if not isTopLevel(c) or pkg.isNil:
-        localError(c.config, name.info, "only top level types in a package can be 'package'")
-      else:
-        let typsym = c.graph.packageTypes.strTableGet(s.name)
-        if typsym != nil:
-          if sfForward notin typsym.flags or sfNoForward notin typsym.flags:
-            typeCompleted(typsym)
-            typsym.info = s.info
-          else:
-            localError(c.config, name.info, "cannot complete type '" & s.name.s & "' twice; " &
-                    "previous type completion was here: " & c.config$typsym.info)
-          s = typsym
-    # add it here, so that recursive types are possible:
-    if sfGenSym notin s.flags: addInterfaceDecl(c, s)
-    elif s.owner == nil: setOwner(s, getCurrOwner(c))
+      if c.graph.interfaceImportMode > 0 and isTopLevel(c):
+        s.incl sfForward
+      if name.kind == nkPragmaExpr:
+        if c.graph.interfaceImportMode == 0:
+          let rewritten = applyTypeSectionPragmas(c, name[1], typeDef)
+          if rewritten != nil:
+            case rewritten.kind
+            of nkTypeDef:
+              typeSection[i] = rewritten
+            of nkTypeSection:
+              typeSection.sons[i .. i] = rewritten.sons
+            else: illFormedAst(rewritten, c.config)
+            typeDefLeftSidePass(c, typeSection, i)
+            return
+          pragma(c, s, name[1], typePragmas)
+      if sfForward in s.flags:
+        # check if the symbol already exists:
+        let pkg = c.module.owner
+        if not isTopLevel(c) or pkg.isNil:
+          localError(c.config, name.info, "only top level types in a package can be 'package'")
+        else:
+          let typsym = c.graph.packageTypes.strTableGet(s.name)
+          if typsym != nil:
+            if sfForward notin typsym.flags or sfNoForward notin typsym.flags:
+              typeCompleted(typsym)
+              typsym.info = s.info
+            else:
+              localError(c.config, name.info, "cannot complete type '" & s.name.s & "' twice; " &
+                      "previous type completion was here: " & c.config$typsym.info)
+            s = typsym
+      # add it here, so that recursive types are possible:
+      if sfGenSym notin s.flags: addInterfaceDecl(c, s)
+      elif s.owner == nil: setOwner(s, getCurrOwner(c))
 
   if name.kind == nkPragmaExpr:
     if name[0].kind == nkPostfix:
@@ -1766,6 +1779,9 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
         obj.incl sfPure
       obj.typ = objTy
       objTy.sym = obj
+    if sfForward in s.flags and sfNoForward notin s.flags and
+        a[2].kind != nkEmpty and s.typ != nil and s.typ.kind != tyForward:
+      typeCompleted(s)
 
 proc checkForMetaFields(c: PContext; n: PNode; hasError: var bool) =
   proc checkMeta(c: PContext; n: PNode; t: PType; hasError: var bool; parent: PType) =
@@ -2420,6 +2436,15 @@ proc semMethodPrototype(c: PContext; s: PSym; n: PNode) =
     else:
       localError(c.config, n.info, "'method' needs a parameter that has an object type")
 
+proc reownCallableHeaderSyms(n: PNode; newOwner: PSym) =
+  if n.isNil:
+    return
+  if n.kind == nkSym and n.sym != nil and
+      n.sym.kind in {skParam, skGenericParam, skResult}:
+    setOwner(n.sym, newOwner)
+  for i in 0..<n.safeLen:
+    reownCallableHeaderSyms(n[i], newOwner)
+
 proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
                 validPragmas: TSpecialWords, flags: TExprFlags = {}): PNode =
   result = semProcAnnotation(c, n, validPragmas)
@@ -2580,6 +2605,16 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if hasProto:
     if sfForward notin proto.flags and proto.magic == mNone:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)
+    if sfForward in proto.flags and proto != s and c.graph.interfaceCallableStubs.contains(proto.id):
+      reownCallableHeaderSyms(n[genericParamsPos], proto)
+      reownCallableHeaderSyms(n[paramsPos], proto)
+      if s.typ != nil and s.typ.n != nil:
+        reownCallableHeaderSyms(s.typ.n, proto)
+      proto.typ = s.typ
+      proto.ast[genericParamsPos] = n[genericParamsPos]
+      proto.ast[paramsPos] = n[paramsPos]
+      proto.ast[pragmasPos] = n[pragmasPos]
+      c.graph.interfaceCallableStubs.excl proto.id
     if not comesFromShadowScope:
       excl(proto, sfForward)
       incl(proto, sfWasForwarded)

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -128,8 +128,13 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif kind notin {skParam, skResult}:
       result = t
   of tyGenericBody, tyGenericParam, tyGenericInvocation,
-     tyNone, tyForward, tyFromExpr:
+     tyNone, tyFromExpr:
     result = t
+  of tyForward:
+    if c.graph.interfaceImportMode > 0 and kind in {skProc, skParam, skResult}:
+      result = nil
+    else:
+      result = t
   of tyNil:
     if kind != skConst and kind != skParam: result = t
   of tyString, tyBool, tyChar, tyEnum, tyInt..tyUInt64, tyCstring, tyPointer:

--- a/tests/misc/tnoforward.nim
+++ b/tests/misc/tnoforward.nim
@@ -2,9 +2,6 @@ discard """
   output: "10"
 """
 
-# {. noforward: on .}
-{.experimental: "codeReordering".}
-
 proc foo(x: int) =
   bar x
 
@@ -12,4 +9,3 @@ proc bar(x: int) =
   echo x
 
 foo(10)
-

--- a/tests/modules/mcyclicimports_noreorder.nim
+++ b/tests/modules/mcyclicimports_noreorder.nim
@@ -1,0 +1,7 @@
+import tcyclicimports_noreorder
+
+proc b*(x: int): int =
+  if x <= 0:
+    0
+  else:
+    a(x - 1)

--- a/tests/modules/mcyclicimports_proc.nim
+++ b/tests/modules/mcyclicimports_proc.nim
@@ -1,0 +1,7 @@
+import tcyclicimports_proc
+
+proc b*(x: int): int =
+  if x <= 0:
+    0
+  else:
+    a(x - 1)

--- a/tests/modules/mcyclicimports_types.nim
+++ b/tests/modules/mcyclicimports_types.nim
@@ -1,0 +1,4 @@
+import tcyclicimports_types
+
+proc id*(x: tcyclicimports_types.T): tcyclicimports_types.T =
+  x

--- a/tests/modules/tcyclicimports_noreorder.nim
+++ b/tests/modules/tcyclicimports_noreorder.nim
@@ -1,0 +1,14 @@
+discard """
+  output: "4"
+  cmd: "nim c -r $file"
+"""
+
+import mcyclicimports_noreorder
+
+proc a*(x: int): int =
+  if x <= 0:
+    1
+  else:
+    b(x) + 1
+
+echo a(3)

--- a/tests/modules/tcyclicimports_proc.nim
+++ b/tests/modules/tcyclicimports_proc.nim
@@ -1,0 +1,14 @@
+discard """
+  output: "4"
+  cmd: "nim c -r $file"
+"""
+
+import mcyclicimports_proc
+
+proc a*(x: int): int =
+  if x <= 0:
+    1
+  else:
+    b(x) + 1
+
+echo a(3)

--- a/tests/modules/tcyclicimports_types.nim
+++ b/tests/modules/tcyclicimports_types.nim
@@ -1,0 +1,15 @@
+discard """
+  output: "1"
+  cmd: "nim c -r $file"
+"""
+
+import mcyclicimports_types
+
+type
+  T* = object
+    value*: int
+
+proc makeT(): T =
+  T(value: 1)
+
+echo id(makeT()).value

--- a/tests/modules/treorder.nim
+++ b/tests/modules/treorder.nim
@@ -6,8 +6,6 @@ defined
 3'''
 """
 
-{.experimental: "codeReordering".}
-
 {.push callconv: stdcall.}
 
 proc bar(x: T)

--- a/tests/overflow/toverflow_reorder.nim
+++ b/tests/overflow/toverflow_reorder.nim
@@ -1,5 +1,3 @@
-{.experimental: "codeReordering".}
-
 discard """
   output: "ok"
   cmd: "nim $target --overflowChecks:off $options $file"
@@ -60,7 +58,7 @@ block: # Overflow checks in a forward declared proc
 
   doAssert(overflowDetected)
 
-block: # Overflow checks doesn't affect fwd declaration
+block: # Default reordering associates the declaration with its implementation
   var
     a = high(int)
     b = -2
@@ -78,7 +76,7 @@ block: # Overflow checks doesn't affect fwd declaration
   except OverflowDefect:
     overflowDetected = true
 
-  doAssert(not overflowDetected)
+  doAssert(overflowDetected)
 
 
 echo "ok"

--- a/tests/pragmas/treorder.nim
+++ b/tests/pragmas/treorder.nim
@@ -6,8 +6,6 @@ output:'''0
 """
 
 import macros
-# {.reorder: on .}
-{.experimental: "codeReordering".}
 
 echo foo(-1)
 echo callWithFoo(0)


### PR DESCRIPTION
## Summary
- support cyclic imports and zero-forward-declaration semantics in the compiler
- make the user-module path work without manual forward declarations while keeping stdlib/system on the conservative path
- async ORC leak fixes moved to #25683

## Testing
Build a test compiler from `compiler/nim.nim`:

```sh
./bin/nim c --skipUserCfg --skipParentCfg -d:nimKochBootstrap -o:bin/nim_default_reorder compiler/nim.nim
```

Run the regression checks with that compiler:

```sh
./bin/nim_default_reorder c -r tests/modules/tcyclicimports_proc.nim
./bin/nim_default_reorder c -r tests/modules/tcyclicimports_types.nim
./bin/nim_default_reorder c -r tests/modules/tcyclicimports_noreorder.nim
./bin/nim_default_reorder c -r tests/misc/tnoforward.nim
./bin/nim_default_reorder c -d:testdef -r tests/modules/treorder.nim
./bin/nim_default_reorder c -r tests/pragmas/treorder.nim
./bin/nim_default_reorder c -r tests/overflow/toverflow_reorder.nim --overflowChecks:off
./bin/nim_default_reorder c tests/modules/tselfimport.nim
```