### PR TITLE
fixes #25671; commands: fix --maxLoopIterationsVM positive check

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -951,7 +951,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectArg(conf, switch, arg, pass, info)
     var value: int = 10_000_000
     discard parseSaturatedNatural(arg, value)
-    if not value > 0: localError(conf, info, "maxLoopIterationsVM must be a positive integer greater than zero")
+    if value <= 0: localError(conf, info, "maxLoopIterationsVM must be a positive integer greater than zero")
     conf.maxLoopIterationsVM = value
   of "maxcalldepthvm":
     expectArg(conf, switch, arg, pass, info)


### PR DESCRIPTION
Fixes bug #25671.

The previous condition `not value > 0` was parsed as `(not value) > 0`, not `not (value > 0)`, so the check did not reliably enforce a positive `--maxLoopIterationsvm` limit. Align with `--maxcalldepthvm` by using `value <= 0`.