### PR TITLE
logging: fix LevelNames[0] for lvlAll (was DEBUG)

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -191,7 +191,7 @@ type
 
 const
   LevelNames*: array[Level, string] = [
-    "DEBUG", "DEBUG", "INFO", "NOTICE", "WARN", "ERROR", "FATAL", "NONE"
+    "ALL", "DEBUG", "INFO", "NOTICE", "WARN", "ERROR", "FATAL", "NONE"
   ] ## Array of strings representing each logging level.
 
   defaultFmtStr* = "$levelname "                         ## The default format string.


### PR DESCRIPTION
The `LevelNames` table duplicated `"DEBUG"` for the first two slots; index `0` corresponds to `lvlAll`, so the label should be `"ALL"`.