### PR TITLE
fixes #25674; parsecfg: bound-check CR/LF pair in replace()

### DIFF
--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -556,7 +556,7 @@ proc replace(s: string): string =
   while i < s.len():
     if s[i] == '\\':
       d.add(r"\\")
-    elif s[i] == '\c' and s[i+1] == '\l':
+    elif s[i] == '\c' and i+1 < s.len() and s[i+1] == '\l':
       d.add(r"\c\l")
       inc(i)
     elif s[i] == '\c':

--- a/tests/stdlib/tparsecfg.nim
+++ b/tests/stdlib/tparsecfg.nim
@@ -130,3 +130,9 @@ block:
   doAssert dict.getSectionValue(section4, "can_values_be_as_well") == "True"
   doAssert dict.getSectionValue(section4, "does_that_mean_anything_special") == "False"
   doAssert dict.getSectionValue(section4, "purpose") == "formatting for readability"
+
+block: # bug #25674
+  var dict = newConfig()
+  dict.setSectionKey("", "key", "value\c")
+  var s = newStringStream()
+  dict.writeConfig(s)


### PR DESCRIPTION
Fixes bug #25674.

`replace` read `s[i+1]` for a CRLF pair without ensuring `i+1 < s.len()`, so a value ending in a lone `\\c` (quoted in `writeConfig`) raised `IndexDefect`.

- Fix: only treat `\\c\\l` when the following character exists.
- Test: `tests/stdlib/tparsecfg.nim` block bug #25674 — fails before fix, passes after.