### PR TITLE
Fix generic tuple unpacking in iterators

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1101,7 +1101,7 @@ proc semForVars(c: PContext, n: PNode; flags: TExprFlags): PNode =
       iterBase.skipModifier
     else:
       skipTypes(iterBase, {tyAlias, tySink, tyOwned})
-  var iter = iterType
+  var iter = skipTypes(iterType, {tyGenericInst})
   var iterAfterVarLent = iter.skipTypes({tyGenericInst, tyAlias, tyLent, tyVar})
   # n.len == 3 means that there is one for loop variable
   # and thus no tuple unpacking:

--- a/tests/iter/t25704.nim
+++ b/tests/iter/t25704.nim
@@ -1,0 +1,13 @@
+import std/[sugar, strutils]
+
+type Res[T] = tuple[a: int, b: string]
+iterator test(): Res[string] =
+  yield (1, "")
+
+for (i, s) in test():
+  static:
+    echo typeof(i)
+    echo typeof(s)
+  let
+    a: int = i
+    b: string = s


### PR DESCRIPTION
Fixes #25704 

This makes sure that `iter` still has `tyGenericInst` skipped like before, without skipping it for `iterType` which requires it
