### PR TITLE
resem type section macros if output is not type section ast

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -559,7 +559,8 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   #if c.evalContext == nil:
   #  c.evalContext = c.createEvalContext(emStatic)
   result = evalMacroCall(c.module, c.idgen, c.graph, c.templInstCounter, n, nOrig, sym)
-  if efNoSemCheck notin flags:
+  if efNoSemCheck notin flags and not (efTypeSectionMacro in flags and
+      result.kind in {nkTypeDef, nkTypeSection}):
     result = semAfterMacroCall(c, n, result, sym, flags, expectedType)
   if c.config.macrosToExpand.hasKey(sym.name.s):
     message(c.config, nOrig.info, hintExpandMacro, renderTree(result, {

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -87,6 +87,7 @@ type
     efWantNoDefaults
     efIgnoreDefaults # var statements without initialization
     efAllowSymChoice # symchoice node should not be resolved
+    efTypeSectionMacro # allow `nkTypeDef` and selectively resem for type section macros
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -35,7 +35,8 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
   pushInfoContext(c.config, n.info, s.detailedInfo)
   result = evalTemplate(n, s, getCurrOwner(c), c.config, c.cache,
                         c.templInstCounter, c.idgen, efFromHlo in flags)
-  if efNoSemCheck notin flags:
+  if efNoSemCheck notin flags and not (efTypeSectionMacro in flags and
+      result.kind in {nkTypeDef, nkTypeSection}):
     result = semAfterMacroCall(c, n, result, s, flags, expectedType)
   popInfoContext(c.config)
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1972,8 +1972,8 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
             doAssert r[0].kind == nkSym
             let m = r[0].sym
             case m.kind
-            of skMacro: return semMacroExpr(c, r, r, m, {efNoSemCheck})
-            of skTemplate: return semTemplateExpr(c, r, m, {efNoSemCheck})
+            of skMacro: return semMacroExpr(c, r, r, m, {efTypeSectionMacro})
+            of skTemplate: return semTemplateExpr(c, r, m, {efTypeSectionMacro})
             else: doAssert(false, "cannot happen")
 
 proc semProcTypeWithScope(c: PContext, n: PNode,

--- a/tests/pragmas/ttypedef_macro_resem.nim
+++ b/tests/pragmas/ttypedef_macro_resem.nim
@@ -1,0 +1,30 @@
+discard """
+  nimout: '''
+got: default
+got: abc
+'''
+"""
+
+import std/macros
+
+macro fooReorder(body: untyped, a: static string = "default"): untyped =
+  echo "got: ", a
+  result = body
+
+macro foo(args: varargs[untyped]): untyped =
+  var reordered = newNimNode(nnkCall, args)
+  reordered.add bindSym"fooReorder"
+  let last = args.len - 1
+  reordered.add args[last]
+  for i in 0 ..< last:
+    reordered.add args[i]
+  result = reordered
+
+type
+  Obj1 {.foo.} = object
+    x: int
+  Obj2 {.foo: "abc".} = object
+    y: int
+
+let x = Obj1(x: 123)
+let y = Obj2(y: 456)


### PR DESCRIPTION
Type pragma macros are evaluated with `efNoSemCheck` which means the result node of the macro is left untyped and fed back to the type section statement to be semchecked later. This is important for mutually recursive type AST to work properly.

However only 1 layer of macro execution is a big limitation and makes some things impossible like optional typed args in the macro call or feeding to a typed macro as in #13830, #15334, #18864 and related issues. This is unless we wrap in `nkStmtListType` assigned to `_` but this loses mutual recursion functionality.

Since any output that is not `nkTypeDef` or `nkTypeSection` is going to be rejected by the type section processor anyway, we allow these to be resemmed in case they are nodes calling into another macro that will produce a type section node. In the case that it does, the expression flag propagates and prevents semchecking for these nodes as well, allowing the type section to handle them properly. The nodes that get resemmed could be restricted to just the nodes that can produce type section AST like calls, but it is probably better to not be restrictive and makes sense just to mirror the "whitelisted" nodes in the type section processor.

Since any case affected by this was directly disallowed before, this is fully backwards compatible, and enables a substantial amount of uses for type pragma macros. So maybe this could be treated as a bugfix rather than a new feature and backported. Although other issues might come up with this that would also need backporting more fixes later, but it is not likely to require a revert or break code.

I can also add this to the manual but it would require an explanation of type section semchecking mechanics which is not already there.