### PR TITLE
Object case syntax

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2275,11 +2275,12 @@ proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   let t = skipTypes(n[2].typ,
                     abstractVarRange+{tyRef, tyPtr, tyLent, tyTypeDesc, tyOwned})
   gen(p, n[1], x)
+  let (a, tmp) = maybeMakeTemp(p, n[1], x)
   if tfFinal in t.flags:
-    r.res = "(($1) != null && $1.m_type == $2)" % [x.res, genTypeInfo(p, t)]
+    r.res = "(($1) != null && $2.m_type == $3)" % [a, tmp, genTypeInfo(p, t)]
   else:
     useMagic(p, "isObj")
-    r.res = "(($1) != null && isObj($1.m_type, $2))" % [x.res, genTypeInfo(p, t)]
+    r.res = "(($1) != null && isObj($2.m_type, $3))" % [a, tmp, genTypeInfo(p, t)]
   r.kind = resExpr
 
 proc genDefault(p: PProc, n: PNode; r: var TCompRes) =

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2276,10 +2276,10 @@ proc genOf(p: PProc, n: PNode, r: var TCompRes) =
                     abstractVarRange+{tyRef, tyPtr, tyLent, tyTypeDesc, tyOwned})
   gen(p, n[1], x)
   if tfFinal in t.flags:
-    r.res = "($1.m_type == $2)" % [x.res, genTypeInfo(p, t)]
+    r.res = "(($1) != null && $1.m_type == $2)" % [x.res, genTypeInfo(p, t)]
   else:
     useMagic(p, "isObj")
-    r.res = "isObj($1.m_type, $2)" % [x.res, genTypeInfo(p, t)]
+    r.res = "(($1) != null && isObj($1.m_type, $2))" % [x.res, genTypeInfo(p, t)]
   r.kind = resExpr
 
 proc genDefault(p: PProc, n: PNode; r: var TCompRes) =

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1498,14 +1498,13 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil
   var hasElse = false
   let caseTyp = skipTypes(n[0].typ, abstractVar-{tyTypeDesc})
   var chckCovered = caseTyp.shouldCheckCaseCovered()
-  let objectSelector = objectCaseSelectorBase(n[0].typ) != nil
   case caseTyp.kind
   of tyFloat..tyFloat128, tyString, tyCstring, tyError, shouldChckCovered, tyRange:
     discard
   else:
     popCaseContext(c)
     closeScope(c)
-    if objectSelector:
+    if objectCaseSelectorBase(n[0].typ) != nil:
       var matched = false
       let macroResult = tryHandleCaseStmtMacro(c, n, flags, matched)
       if matched:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1331,12 +1331,165 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
     result.typ = result.lastSon.typ
   closeScope(c)
 
+proc objectCaseSelectorBase(typ: PType): PType =
+  let typ = skipTypes(typ, abstractInstOwned + {tyTypeDesc, tyVar, tyLent})
+  if typ.kind notin {tyRef, tyPtr}:
+    return nil
+  result = skipTypesOrNil(typ.elementType, skipPtrs)
+  if result == nil or result.kind != tyObject or isObjLackingTypeField(result):
+    result = nil
+
+proc wrapObjectCaseBranch(c: PContext; branch, body: PNode; selectorSym: PSym): PNode =
+  if branch.len != 2 or not branch[0].isInfixAs():
+    return body
+
+  let alias = branch[0][2].sym
+  let selectorNode = newSymNode(selectorSym, branch.info)
+  let aliasInit =
+    if sameType(alias.typ, selectorSym.typ):
+      selectorNode
+    else:
+      newTreeIT(nkHiddenSubConv, branch.info, alias.typ,
+        c.graph.emptyNode, selectorNode)
+  let aliasLet = newTreeI(nkLetSection, branch.info,
+    newTreeI(nkIdentDefs, branch.info, newSymNode(alias, branch.info),
+      c.graph.emptyNode, aliasInit))
+  if isEmptyType(body.typ):
+    result = newTreeI(nkStmtList, body.info, aliasLet, body)
+  else:
+    result = newTreeIT(nkStmtListExpr, body.info, body.typ, aliasLet, body)
+
+proc semObjectCase(c: PContext; n: PNode; flags: TExprFlags;
+                   expectedType: PType = nil): PNode =
+  let selectorSym = newSym(skTemp, getIdent(c.cache, "tmpObjCase"), c.idgen,
+                           getCurrOwner(c), n[0].info)
+  selectorSym.typ = n[0].typ
+  selectorSym.flagsImpl.incl {sfGenSym, sfCursor}
+  addDecl(c, selectorSym)
+
+  let
+    boolType = getSysType(c.graph, n.info, tyBool)
+    selectorLet = newTreeI(nkLetSection, n[0].info,
+      newTreeI(nkIdentDefs, n[0].info, newSymNode(selectorSym, n[0].info),
+        c.graph.emptyNode, n[0]))
+    selectorNode = newSymNode(selectorSym, n[0].info)
+
+  var
+    ifNode = newNodeI(nkIfStmt, n.info)
+    typ = commonTypeBegin
+    expectedType = expectedType
+    hasElse = false
+
+  template invalidOrderOfBranches(branch: PNode) =
+    localError(c.config, branch.info, "invalid order of case branches")
+    break
+
+  for i in 1..<n.len:
+    let branch = n[i]
+    case branch.kind
+    of nkOfBranch:
+      if hasElse:
+        invalidOrderOfBranches(branch)
+      checkMinSonsLen(branch, 2, c.config)
+
+      openScope(c)
+      if branch[0].isInfixAs():
+        if branch.len != 2:
+          localError(c.config, branch[0].info,
+            "object case branches using 'as' must contain exactly one type")
+        let aliasType = semExprWithType(c, copyTree(branch[0][1]), {efDetermineType})
+        let alias = newSymG(skLet, branch[0][2], c)
+        alias.typ = skipTypes(aliasType.typ, {tyTypeDesc})
+        alias.flagsImpl.incl sfCursor
+        addDecl(c, alias)
+        branch[0][2] = newSymNode(alias, branch[0][2].info)
+      for j in 1..<branch.len - 1:
+        if branch[j].isInfixAs():
+          localError(c.config, branch[j].info,
+            "object case branches using 'as' must contain exactly one type")
+
+      var cond: PNode = nil
+      for j in 0..<branch.len - 1:
+        let item = if branch[j].isInfixAs(): branch[j][1] else: branch[j]
+        let ofCall = newTreeI(nkCall, item.info,
+          newSymNode(getSysMagic(c.graph, item.info, "of", mOf), item.info),
+          copyTree(selectorNode),
+          copyTree(item))
+        if cond == nil:
+          cond = ofCall
+        else:
+          cond = newTreeI(nkInfix, item.info,
+            newIdentNode(getIdent(c.cache, "or"), item.info),
+            cond, ofCall)
+
+      let elifBranch = newNodeI(nkElifBranch, branch.info, 2)
+      elifBranch[0] = forceBool(c, semExprWithType(c, cond, expectedType = boolType))
+      elifBranch[1] = semExprBranch(c, branch[^1], flags, expectedType)
+      elifBranch[1] = c.wrapObjectCaseBranch(branch, elifBranch[1], selectorSym)
+      typ = commonType(c, typ, elifBranch[1])
+      if not endsInNoReturn(elifBranch[1]):
+        expectedType = typ
+      closeScope(c)
+      ifNode.add elifBranch
+    of nkElifBranch:
+      if hasElse:
+        invalidOrderOfBranches(branch)
+      checkSonsLen(branch, 2, c.config)
+      let elifBranch = newNodeI(nkElifBranch, branch.info, 2)
+      openScope(c)
+      elifBranch[0] = forceBool(c, semExprWithType(c, branch[0], expectedType = boolType))
+      elifBranch[1] = semExprBranch(c, branch[1], flags, expectedType)
+      typ = commonType(c, typ, elifBranch[1])
+      if not endsInNoReturn(elifBranch[1]):
+        expectedType = typ
+      closeScope(c)
+      ifNode.add elifBranch
+    of nkElse:
+      checkSonsLen(branch, 1, c.config)
+      let elseBranch = newNodeI(nkElse, branch.info, 1)
+      elseBranch[0] = semExprBranchScope(c, branch[0], expectedType)
+      typ = commonType(c, typ, elseBranch[0])
+      if not endsInNoReturn(elseBranch[0]):
+        expectedType = typ
+      if hasElse:
+        message(c.config, branch.info, warnUnreachableElse)
+      hasElse = true
+      ifNode.add elseBranch
+    else:
+      illFormedAst(branch, c.config)
+
+  if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped} or
+      (not hasElse and efInTypeof notin flags):
+    for branch in ifNode:
+      discardCheck(c, branch.lastSon, flags)
+    ifNode.transitionSonsKind(nkIfStmt)
+    if typ == c.enforceVoidContext:
+      ifNode.typ = c.enforceVoidContext
+  else:
+    for branch in ifNode:
+      let body = branch.lastSon
+      if not endsInNoReturn(body):
+        branch[^1] = fitNode(c, typ, body, body.info)
+    ifNode.transitionSonsKind(nkIfExpr)
+    ifNode.typ = typ
+
+  if ifNode.typ != nil and not isEmptyType(ifNode.typ):
+    result = newTreeIT(nkStmtListExpr, n.info, ifNode.typ, selectorLet, ifNode)
+  else:
+    result = newTreeI(nkStmtList, n.info, selectorLet, ifNode)
+    if ifNode.typ == c.enforceVoidContext:
+      result.typ = c.enforceVoidContext
+
 proc semCase(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil): PNode =
   result = n
   checkMinSonsLen(n, 2, c.config)
   openScope(c)
-  pushCaseContext(c, n)
   n[0] = semExprWithType(c, n[0])
+  if objectCaseSelectorBase(n[0].typ) != nil:
+    result = semObjectCase(c, n, flags, expectedType)
+    closeScope(c)
+    return result
+  pushCaseContext(c, n)
   var covered: Int128 = toInt128(0)
   var typ = commonTypeBegin
   var expectedType = expectedType

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1254,7 +1254,8 @@ proc handleStmtMacro(c: PContext; n, selector: PNode; magicType: string;
 proc handleForLoopMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   result = handleStmtMacro(c, n, n[^2], "ForLoopStmt", flags)
 
-proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
+proc tryHandleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags;
+                            matched: var bool): PNode =
   # n[0] has been sem'checked and has a type. We use this to resolve
   # '`case`(n[0])' but then we pass 'n' to the `case` macro. This seems to
   # be the best solution.
@@ -1266,6 +1267,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   var r = resolveOverloads(c, toResolve, toResolve, {skTemplate, skMacro}, {efNoUndeclared},
                            errors, false)
   if r.state == csMatch:
+    matched = true
     var match = r.calleeSym
     markUsed(c, n[0].info, match)
     onUse(n[0].info, match)
@@ -1278,14 +1280,18 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
     of skTemplate: result = semTemplateExpr(c, toExpand, match, flags)
     else: result = errorNode(c, n[0])
   else:
-    result = errorNode(c, n[0])
-  if result.kind == nkEmpty:
-    localError(c.config, n[0].info, errSelectorMustBeOfCertainTypes)
+    result = nil
   # this would be the perfectly consistent solution with 'for loop macros',
   # but it kinda sucks for pattern matching as the matcher is not attached to
   # a type then:
   when false:
     result = handleStmtMacro(c, n, n[0], "CaseStmt")
+
+proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
+  var matched = false
+  result = tryHandleCaseStmtMacro(c, n, flags, matched)
+  if not matched or result.kind == nkEmpty:
+    localError(c.config, n[0].info, errSelectorMustBeOfCertainTypes)
 
 proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
   checkMinSonsLen(n, 3, c.config)
@@ -1484,24 +1490,29 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags; expectedType: PType = nil
   result = n
   checkMinSonsLen(n, 2, c.config)
   openScope(c)
-  n[0] = semExprWithType(c, n[0])
-  if objectCaseSelectorBase(n[0].typ) != nil:
-    result = semObjectCase(c, n, flags, expectedType)
-    closeScope(c)
-    return result
   pushCaseContext(c, n)
+  n[0] = semExprWithType(c, n[0])
   var covered: Int128 = toInt128(0)
   var typ = commonTypeBegin
   var expectedType = expectedType
   var hasElse = false
   let caseTyp = skipTypes(n[0].typ, abstractVar-{tyTypeDesc})
   var chckCovered = caseTyp.shouldCheckCaseCovered()
+  let objectSelector = objectCaseSelectorBase(n[0].typ) != nil
   case caseTyp.kind
   of tyFloat..tyFloat128, tyString, tyCstring, tyError, shouldChckCovered, tyRange:
     discard
   else:
     popCaseContext(c)
     closeScope(c)
+    if objectSelector:
+      var matched = false
+      let macroResult = tryHandleCaseStmtMacro(c, n, flags, matched)
+      if matched:
+        if macroResult.kind == nkEmpty:
+          localError(c.config, n[0].info, errSelectorMustBeOfCertainTypes)
+        return macroResult
+      return semObjectCase(c, n, flags, expectedType)
     return handleCaseStmtMacro(c, n, flags)
   template invalidOrderOfBranches(n: PNode) =
     localError(c.config, n.info, "invalid order of case branches")

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -3514,6 +3514,45 @@ expanded into a list of its elements:
     else: echo "other"
   ```
 
+When the selector has type `ref object` or `ptr object`, the `case`
+statement also supports runtime subtype selection:
+
+  ```nim
+  type
+    Base {.inheritable.} = ref object
+    Sub1 = ref object of Base
+      a: int
+    Sub2 = ref object of Base
+      b: string
+
+  proc classify(x: Base): string =
+    case x
+    of Sub1 as s1:
+      $s1.a
+    of Sub2 as s2:
+      s2.b
+    else:
+      "fallback"
+  ```
+
+In this form, each `of` branch names one or more object types and is matched
+using the same runtime subtype check as the `of` operator. `nil` does not match
+any object branch.
+
+The optional `as` form introduces a branch-local alias with the matched subtype:
+
+  ```nim
+  of Sub1 as s1:
+    echo s1.a
+  ```
+
+`as` can only be used with a single type in a branch. The alias is treated as
+the selector value converted to the branch type after the branch condition has
+already established that the conversion is valid.
+
+Object-selector case statements are not checked for exhaustiveness.
+The same selector form is also available in `case` expressions.
+
 The `case` statement doesn't produce an l-value, so the following example
 won't work:
 

--- a/tests/casestmt/tobjectcase.nim
+++ b/tests/casestmt/tobjectcase.nim
@@ -33,9 +33,14 @@ type
     b: int
 
 var onlyOne = 0
+var onlyOneOf = 0
 
 proc getObj: Base =
   inc onlyOne
+  Sub3()
+
+proc getObjForOf: Base =
+  inc onlyOneOf
   Sub3()
 
 case getObj()
@@ -47,6 +52,8 @@ of Sub3:
   discard
 
 doAssert onlyOne == 1
+doAssert getObjForOf() of Sub3
+doAssert onlyOneOf == 1
 
 proc classify(x: Base): string =
   case x

--- a/tests/casestmt/tobjectcase_inheritable.nim
+++ b/tests/casestmt/tobjectcase_inheritable.nim
@@ -1,0 +1,115 @@
+discard """
+  targets: "c cpp js"
+  output: '''
+Sub2
+Sub1
+fallback
+child
+base
+77
+again
+right
+5
+'''
+"""
+
+type
+  Base = ref object of RootObj
+  Sub1 = ref object of Base
+    a: int
+  Sub2 = ref object of Base
+    b: string
+
+  BranchBase = ref object of RootObj
+  Left = ref object of BranchBase
+  Right = ref object of BranchBase
+  LeftLeaf = ref object of Left
+  RightLeaf = ref object of Right
+
+  BaseObj {.inheritable.} = object of RootObj
+    a: int
+  SubObj = object of BaseObj
+    b: int
+
+proc classify(x: Base): string =
+  case x
+  of Sub1 as s1:
+    doAssert s1.a == 11
+    "Sub1"
+  of Sub2 as s2:
+    doAssert s2.b == "ok"
+    "Sub2"
+  else:
+    "fallback"
+
+proc family(x: Base): string =
+  case x
+  of Sub1, Sub2:
+    "child"
+  else:
+    "base"
+
+proc widen(x: Base): string =
+  case x
+  of Sub1:
+    "sub1"
+  of Base as bx:
+    doAssert bx of Base
+    "base"
+  else:
+    "fallback"
+
+proc mutate(x: Base) =
+  case x
+  of Sub1 as s1:
+    s1.a = 77
+  else:
+    discard
+
+var x: Base = Sub2(b: "ok")
+echo classify(x)
+
+x = Sub1(a: 11)
+echo classify(x)
+
+x = nil
+echo classify(x)
+
+echo family(Sub1(a: 22))
+echo widen(Base())
+
+x = Sub1(a: 1)
+mutate(x)
+echo Sub1(x).a
+
+echo(
+  case Base(Sub2(b: "again"))
+  of Sub1 as s1:
+    $s1.a
+  of Sub2 as s2:
+    s2.b
+  else:
+    "bad"
+)
+
+echo(
+  case BranchBase(RightLeaf())
+  of LeftLeaf:
+    "wrong"
+  of RightLeaf:
+    "right"
+  else:
+    "bad"
+)
+
+block:
+  var s = SubObj(a: 4, b: 5)
+  let p: ptr BaseObj = addr s
+  echo(
+    case p
+    of ptr SubObj as sp:
+      $sp.b
+    else:
+      "bad"
+  )
+  doAssert s.b == 5

--- a/tests/casestmt/tobjectcase_inheritable.nim
+++ b/tests/casestmt/tobjectcase_inheritable.nim
@@ -19,6 +19,7 @@ type
     a: int
   Sub2 = ref object of Base
     b: string
+  Sub3 = ref object of Base
 
   BranchBase = ref object of RootObj
   Left = ref object of BranchBase
@@ -30,6 +31,22 @@ type
     a: int
   SubObj = object of BaseObj
     b: int
+
+var onlyOne = 0
+
+proc getObj: Base =
+  inc onlyOne
+  Sub3()
+
+case getObj()
+of Sub1:
+  discard
+of Sub2:
+  discard
+of Sub3:
+  discard
+
+doAssert onlyOne == 1
 
 proc classify(x: Base): string =
   case x

--- a/tests/casestmt/tobjectcase_invalid_as.nim
+++ b/tests/casestmt/tobjectcase_invalid_as.nim
@@ -1,0 +1,13 @@
+discard """
+  errormsg: "object case branches using 'as' must contain exactly one type"
+"""
+
+type
+  Base = ref object of RootObj
+  Sub1 = ref object of Base
+  Sub2 = ref object of Base
+
+proc invalid(x: Base) =
+  case x
+  of Sub1 as s1, Sub2:
+    discard s1

--- a/tests/macros/tobjectcasestmtmacro.nim
+++ b/tests/macros/tobjectcasestmtmacro.nim
@@ -1,0 +1,18 @@
+discard """
+  output: "macro called"
+"""
+
+{.experimental: "caseStmtMacros".}
+
+import macros
+
+type
+  Base = ref object of RootObj
+
+macro `case`(obj: Base): untyped =
+  quote do:
+    echo "macro called"
+
+case Base()
+of 1:
+  discard


### PR DESCRIPTION
## Summary

pairs well with #25707

This PR adds object-selector case statements for inheritable ref object and ptr object types.

The main motivation is ergonomics. Nim already has the runtime subtype checks needed for this style of dispatch, and the parser already accepts the form, so this fills in the semantic support and documentation.

## What changed

case now supports object selectors such as:

```nim
type
  Base {.inheritable.} = ref object
  Sub1 = ref object of Base
    a: string
  Sub2 = ref object of Base
    b: string

case Sub4()
of Sub1 as s1:
  echo s1.a
of Sub2 as s2:
  echo s2.b
else:
  echo "fallback"
```

This uses the same runtime subtype check as the of operator.

The `as` part is optional. When present, it introduces a branch-local alias with the matched subtype.

## Design notes

The as syntax follows the existing exception handler form:

```nim
except SomeError as e:
```

so it fits an existing Nim pattern rather than introducing a new binding style.

A similar surface form is somewhat possible today with a macro that lowers to if x of T chains, but that gets clunky around overload resolution. The compiler-side change here is fairly small, so it seems reasonable to support the form directly instead of leaving it to macros.

## Scope

This PR covers:

- semantic analysis for object-selector case
- branch-local as bindings
- JS backend nil-safe of behavior needed by the lowering
- tests and manual documentation

This PR does not add exhaustiveness checking for object-selector cases.