### PR TITLE
Fixes #25710 - nimsuggest outline misses methods

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1042,7 +1042,7 @@ proc iterateOutlineNodes(graph: ModuleGraph, n: PNode, infoPairs: SuggestFileSym
     if symData != nil and symData.sym.kind == skEnumField and symData.info.exactEquals(symData.sym.info):
        let sym = symData.sym
        graph.suggestResult(sym, sym.info, ideOutline, n.endInfo.line, n.endInfo.col)
-  elif (n.kind in {nkFuncDef, nkProcDef, nkMethodDef, nkTypeDef, nkMacroDef, nkTemplateDef, nkConverterDef, nkEnumFieldDef, nkConstDef}):
+  elif (n.kind in {nkFuncDef, nkProcDef, nkMethodDef, nkIteratorDef, nkTypeDef, nkMacroDef, nkTemplateDef, nkConverterDef, nkEnumFieldDef, nkConstDef}):
     matched = handleIdentOrSym(graph, n, n.endInfo, infoPairs)
   else:
     matched = false

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -1042,7 +1042,7 @@ proc iterateOutlineNodes(graph: ModuleGraph, n: PNode, infoPairs: SuggestFileSym
     if symData != nil and symData.sym.kind == skEnumField and symData.info.exactEquals(symData.sym.info):
        let sym = symData.sym
        graph.suggestResult(sym, sym.info, ideOutline, n.endInfo.line, n.endInfo.col)
-  elif (n.kind in {nkFuncDef, nkProcDef, nkTypeDef, nkMacroDef, nkTemplateDef, nkConverterDef, nkEnumFieldDef, nkConstDef}):
+  elif (n.kind in {nkFuncDef, nkProcDef, nkMethodDef, nkTypeDef, nkMacroDef, nkTemplateDef, nkConverterDef, nkEnumFieldDef, nkConstDef}):
     matched = handleIdentOrSym(graph, n, n.endInfo, infoPairs)
   else:
     matched = false

--- a/nimsuggest/tests/tv3_outline.nim
+++ b/nimsuggest/tests/tv3_outline.nim
@@ -37,6 +37,7 @@ outline	skMacro	tv3_outline.m	macro (arg: untyped): untyped{.noSideEffect, gcsaf
 outline	skTemplate	tv3_outline.t	template (arg: untyped): untyped	$file	11	9	""	100	11	43
 outline	skProc	tv3_outline.p	proc (){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	12	5	""	100	12	24
 outline	skConverter	tv3_outline.c	converter (s: string): int{.noSideEffect, gcsafe, raises: <inferred> [].}	$file	14	10	""	100	14	37
+outline	skMethod	tv3_outline.m	proc (f: Foo){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	15	7	""	100	15	32
 outline	skFunc	tv3_outline.f	proc (){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	16	5	""	100	16	24
 outline	skConst	tv3_outline.con	int literal(2)	$file	20	6	""	100	20	13
 outline	skProc	tv3_outline.outer	proc (){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	22	5	""	100	23	24

--- a/nimsuggest/tests/tv3_outline.nim
+++ b/nimsuggest/tests/tv3_outline.nim
@@ -36,6 +36,7 @@ outline	skType	tv3_outline.FooPrivate	FooPrivate	$file	7	2	""	100	8	22
 outline	skMacro	tv3_outline.m	macro (arg: untyped): untyped{.noSideEffect, gcsafe, raises: <inferred> [].}	$file	10	6	""	100	10	40
 outline	skTemplate	tv3_outline.t	template (arg: untyped): untyped	$file	11	9	""	100	11	43
 outline	skProc	tv3_outline.p	proc (){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	12	5	""	100	12	24
+outline	skIterator	tv3_outline.i	iterator (): int{.inline, noSideEffect, gcsafe, raises: <inferred> [].}	$file	13	9	""	100	13	27
 outline	skConverter	tv3_outline.c	converter (s: string): int{.noSideEffect, gcsafe, raises: <inferred> [].}	$file	14	10	""	100	14	37
 outline	skMethod	tv3_outline.m	proc (f: Foo){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	15	7	""	100	15	32
 outline	skFunc	tv3_outline.f	proc (){.noSideEffect, gcsafe, raises: <inferred> [].}	$file	16	5	""	100	16	24


### PR DESCRIPTION
This adds methods to the list generated by the `outline` command for  `nimsuggest --v3` and `nimsuggest --v4`.
The test file `tv3_outline.nim` was also updated to include a `skMethod` line in the expected output.
