### PR TITLE
fixes 25713; Allow addr of object variant's discriminant under uncheckedAssign

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -35,7 +35,9 @@ proc semAddr(c: PContext; n: PNode): PNode =
   let x = semExprWithType(c, n)
   if x.kind == nkSym:
     x.sym.flagsImpl.incl(sfAddrTaken)
-  if isAssignable(c, x) notin {arLValue, arLocalLValue, arAddressableConst, arLentValue}:
+  let aa = isAssignable(c, x)
+  if aa notin {arLValue, arLocalLValue, arAddressableConst, arLentValue} and
+     (aa != arDiscriminant or c.inUncheckedAssignSection <= 0):
     localError(c.config, n.info, errExprHasNoAddress)
   result.add x
   result.typ = makePtrType(c, x.typ.skipTypes({tySink}))

--- a/tests/objvariant/treassign.nim
+++ b/tests/objvariant/treassign.nim
@@ -27,9 +27,11 @@ t.curr = TokenObject(kind: Token.foo, foo: "foo")
 echo "SUCCESS"
 
 proc passToVar(x: var Token) = discard
+proc passToPtr(x: ptr Token) = discard
 
 {.cast(uncheckedAssign).}:
   passToVar(t.curr.kind)
+  passToPtr(addr t.curr.kind)
 
   t.curr = TokenObject(kind: t.curr.kind, foo: "abc")
 


### PR DESCRIPTION
#25713

```nim
type
  K = enum
    k1,k2
  Variant = object
    case kind: K
    of k1:
      discard
    of k2:
      discard

proc a(x: var K) = discard
proc b(x: ptr K) = discard

var x = Variant(kind: k1)
{.cast(uncheckedAssign).}:
  # must be within uncheckedAssign to work
  a(x.kind)
# doesn't work out of or under uncheckedAssign
b(addr x.kind)
```
