### PR TITLE
fixes #25695; ORC with large object initialization and heap assignment

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1893,6 +1893,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
   var useTemp =
         isRef or
         (d.k notin {locTemp,locLocalVar,locGlobalVar,locParam,locField,locExpr}) or
+        (d.k == locExpr and d.lode.typ != nil and not sameType(d.lode.typ.skipTypes(abstractInst), t)) or
         (isPartOf(d.lode, e) != arNo)
 
   var tmp: TLoc = default(TLoc)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1892,7 +1892,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
   # check if we need to construct the object in a temporary
   var useTemp =
         isRef or
-        (d.k notin {locTemp,locLocalVar,locGlobalVar,locParam,locField}) or
+        (d.k notin {locTemp,locLocalVar,locGlobalVar,locParam,locField,locExpr}) or
         (isPartOf(d.lode, e) != arNo)
 
   var tmp: TLoc = default(TLoc)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1894,6 +1894,8 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
         isRef or
         (d.k notin {locTemp,locLocalVar,locGlobalVar,locParam,locField,locExpr}) or
         (d.k == locExpr and d.lode.typ != nil and not sameType(d.lode.typ.skipTypes(abstractInst), t)) or
+        # when d.k == locExpr and the destination type differs from the constructor type (inheritance/subtyping),
+        # a temporary is still used so that genAssignment can perform the proper type-tag and slicing checks.
         (isPartOf(d.lode, e) != arNo)
 
   var tmp: TLoc = default(TLoc)

--- a/tests/ccgbugs/tcgbug.nim
+++ b/tests/ccgbugs/tcgbug.nim
@@ -4,7 +4,7 @@ success
 M1 M2
 ok
 '''
-matrix: "--mm:refc;--mm:orc"
+matrix: "--mm:refc; --mm:orc"
 """
 
 type
@@ -179,3 +179,9 @@ proc g() =
   x.inst = QAbstractItemModel()
 
 g()
+
+block: # bug #25695
+  type A = object
+    d: array[8 * 1024 * 1024, byte]
+  let r = new A
+  r[] = A()


### PR DESCRIPTION
fixes #25695

All paths that deliver locExpr to genObjConstr produce addressable C lvalues (derefs (*p), subscripts a[i], field accesses o.f). The non-addressable locExpr values (binary ops, ternary) are only produced for simple scalar types — never for object/struct types that would trigger genObjConstr.

Moreover, genTupleConstr and genArrayConstr already construct directly into locExpr destinations without any temp or addressability check. So genObjConstr was already the conservative outlier.