### PR TITLE
fixes #25719; optimizes setLenSeqCall for orc

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -592,10 +592,12 @@ proc setLenStrCall(c: var TLiftCtx; x, y: PNode): PNode =
   result = genBuiltin(c, mSetLengthStr, "setLen", x) # genAddr(g, x))
   result.add lenCall
 
-proc setLenSeqCall(c: var TLiftCtx; t: PType; x, y: PNode): PNode =
+proc setLenSeqCall(c: var TLiftCtx; t: PType; x, y: PNode; noinit = false): PNode =
   let lenCall = genBuiltin(c, mLengthSeq, "len", y)
   lenCall.typ = getSysType(c.g, x.info, tyInt)
-  var op = getSysMagic(c.g, x.info, "setLen", mSetLengthSeq)
+  let name = if noinit: "setLenUninit" else: "setLen"
+  let magic = if noinit: mSetLengthSeqUninit else: mSetLengthSeq
+  var op = getSysMagic(c.g, x.info, name, magic)
   op = instantiateGeneric(c, op, t, t)
   result = newTree(nkCall, newSymNode(op, x.info), x, lenCall)
 
@@ -643,8 +645,9 @@ proc genBulkCopySeq(c: var TLiftCtx; t: PType; body, x, y: PNode) =
 proc fillSeqOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   case c.kind
   of attachedDup:
-    body.add setLenSeqCall(c, t, x, y)
-    if supportsCopyMem(t.elementType):
+    let bulkCopy = supportsCopyMem(t.elementType)
+    body.add setLenSeqCall(c, t, x, y, noinit = bulkCopy)
+    if bulkCopy:
       genBulkCopySeq(c, t, body, x, y)
     else:
       forallElements(c, t, body, x, y)
@@ -658,8 +661,9 @@ proc fillSeqOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     # This is usually more efficient than a destroy/create pair.
     # For trivially copyable types, use bulk copyMem instead of element loop.
     checkSelfAssignment(c, t, body, x, y)
-    body.add setLenSeqCall(c, t, x, y)
-    if supportsCopyMem(t.elementType):
+    let bulkCopy = supportsCopyMem(t.elementType)
+    body.add setLenSeqCall(c, t, x, y, noinit = bulkCopy)
+    if bulkCopy:
       genBulkCopySeq(c, t, body, x, y)
     else:
       forallElements(c, t, body, x, y)


### PR DESCRIPTION
fixes #25719

This pull request updates the logic for resizing sequences during certain copy operations in the `compiler/liftdestructors.nim` file. The main improvement is that the code now distinguishes between regular and uninitialized resizing based on whether the sequence's element type supports bulk memory copying, which can lead to more efficient code generation.

**Improvements to sequence resizing and copying logic:**

* Modified `setLenSeqCall` to accept a `noinit` parameter, allowing it to choose between `setLen` and `setLenUninit` operations, and to select the appropriate magic for each case.
* Updated `fillSeqOp` to determine if bulk memory copy is supported and, if so, call `setLenSeqCall` with `noinit = true` and perform a bulk copy; otherwise, it defaults to element-wise copying. This logic is now applied in both relevant locations in the function. [[1]](diffhunk://#diff-456118dde9a4e21f1b351fd72504d62fc16e9c30354dbb9a3efcb95a29067863L646-R650) [[2]](diffhunk://#diff-456118dde9a4e21f1b351fd72504d62fc16e9c30354dbb9a3efcb95a29067863L661-R666)