### PR TITLE
optimizes `setLen` for orc; disabling overflow checks

### DIFF
--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -262,8 +262,11 @@ proc setLen[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
         if xu.p == nil or (xu.p.cap and not strlitFlag) < newlen:
           xu.p = cast[typeof(xu.p)](prepareSeqAddUninit(oldLen, xu.p, newlen - oldLen, sizeof(T), alignof(T)))
         xu.len = newlen
+
+        {.push overflowChecks: off.}
         for i in oldLen..<newlen:
           xu.p.data[i] = default(T)
+        {.pop.}
 
 proc newSeq[T](s: var seq[T], len: Natural) =
   shrink(s, 0)


### PR DESCRIPTION


This pull request introduces a minor but important change to the `setLen` procedure in `lib/system/seqs_v2.nim`. The main update is the temporary disabling of overflow checks during the initialization loop when extending the sequence length, which can improve performance and avoid unnecessary checks during this operation.

Memory and performance improvement:

* Disabled overflow checks for the loop that initializes new elements to their default value when increasing the length of a sequence in `setLen`, by wrapping the loop with `{.push overflowChecks: off.}` and `{.pop.}`.