### PR TITLE
fixes #25724; Invalid C code generation with iterator/nimvm

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -336,7 +336,7 @@ proc introduceNewLocalVars(c: PTransf, n: PNode): PNode =
     if a.kind == nkSym:
       n[1] = transformSymAux(c, a)
     return n
-  of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef: # todo optimize nosideeffects?
+  of nkLambdaKinds, nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef: # todo optimize nosideeffects?
     result = newTransNode(n)
     let x = newSymNode(copySym(n[namePos].sym, c.idgen))
     c.transCon.mapping[n[namePos].sym.itemId] = x

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -457,3 +457,12 @@ let runes1 = buggyVersion("en")  # <-- CRASHES HERE
 
 doAssert runes1.len == runes2.len
 # echo "Got ", runes1.len, " runes"
+
+
+block: # bug #25724
+  iterator c(): int =
+    when nimvm: yield 0
+    else: yield 1
+  for w in c():
+    let n = w
+    (proc() = discard n)()


### PR DESCRIPTION
fixes #25724

This pull request introduces a small but important fix in the compiler and adds a new test case related to iterators. The main change in the compiler ensures that lambda-like constructs are handled consistently with other procedure definitions, while the new test in the suite covers a previously untested scenario.

**Compiler improvements:**
* Updated `introduceNewLocalVars` in `compiler/transf.nim` to handle all `nkLambdaKinds` in addition to `nkProcDef`, `nkFuncDef`, `nkMethodDef`, and `nkConverterDef`, ensuring consistent transformation of all lambda-like constructs.

**Testing:**
* Added a block to `tests/iter/titer_issues.nim` to test iterator behavior in both compile-time and run-time contexts, addressing bug #25724.