### PR TITLE
make explicit copy and hook calls keep their symbol

### DIFF
--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -775,9 +775,17 @@ proc replaceHookMagic*(c: PContext, n: PNode, kind: TTypeAttachedOp): PNode =
       result[0] = newSymNode(op)
       analyseIfAddressTakenInCall(c, result, false)
   of attachedSink:
-    result = c.semAsgnOpr(c, n, nkSinkAsgn)
+    result = n
+    let t = n[1].typ.skipTypes({tyAlias, tyVar, tySink})
+    let op = getAttachedOp(c.graph, t, kind)
+    if op != nil:
+      result[0] = newSymNode(op)
   of attachedAsgn:
-    result = c.semAsgnOpr(c, n, nkAsgn)
+    result = n
+    let t = n[1].typ.skipTypes({tyAlias, tyVar, tySink})
+    let op = getAttachedOp(c.graph, t, kind)
+    if op != nil:
+      result[0] = newSymNode(op)
   of attachedDeepCopy:
     result = n
     let t = n[1].typ.skipTypes({tyAlias, tyVar, tySink})

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -615,9 +615,9 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mAsgn:
     case n[0].sym.name.s
     of "=", "=copy":
-      result = semAsgnOpr(c, n, nkAsgn)
+      result = replaceHookMagic(c, n, attachedAsgn)
     of "=sink":
-      result = semAsgnOpr(c, n, nkSinkAsgn)
+      result = replaceHookMagic(c, n, attachedSink)
     else:
       result = semShallowCopy(c, n, flags)
   of mIsPartOf: result = semIsPartOf(c, n, flags)

--- a/tests/arc/tnodestroyexplicithook2.nim
+++ b/tests/arc/tnodestroyexplicithook2.nim
@@ -1,0 +1,45 @@
+discard """
+  output: '''
+246
+246
+'''
+"""
+
+# issue #25730
+
+type
+  Inner[T] = object
+    x: T
+  Foo[T] = object
+    inner: Inner[T]
+  Bar[T] = object
+    foo: Foo[T]
+
+proc `=sink`[T](a: var Inner[T], b: Inner[T]) {.nodestroy.} =
+  a.x = b.x * 2
+
+proc `=copy`[T](a: var Inner[T], b: Inner[T]) {.nodestroy.} =
+  a.x = b.x * 2
+
+when true:
+  proc `=sink`[T](a: var Bar[T], b: Bar[T]) {.nodestroy.} =
+    `=sink`(a.foo, b.foo)
+
+  proc `=copy`[T](a: var Bar[T], b: Bar[T]) {.nodestroy.} =
+    `=copy`(a.foo, b.foo)
+
+proc useSink() =
+  let a = Bar[int](foo: Foo[int](inner: Inner[int](x: 123)))
+  var b: Bar[int]
+  `=sink`(b, a)
+  echo b.foo.inner.x
+
+useSink()
+
+proc useCopy() =
+  let a = Bar[int](foo: Foo[int](inner: Inner[int](x: 123)))
+  var b: Bar[int]
+  `=copy`(b, a)
+  echo b.foo.inner.x
+
+useCopy()


### PR DESCRIPTION
fixes #25730

As mentioned in the issue this results in less optimized output, it always generates the explicitly called hook as a proc rather than an inline assignment. But maybe this is a reasonable trade since it only happens on explicit `=sink`/`=copy` calls.

Any way to optimize it requires detecting either the type or the found hook as a trivial assignment. I am not sure how to do these, the hook isn't like destructors that propagate empty statements in `liftdestructors` (which is what `isTrivial` checks for), it needs to propagate simple assignments instead. And there is no logic for the type, `tfHasAsgn` is misleading since it only checks if the destructor is trivial, because there is no check for a trivial assignment.

Did not mark as backported but the only issue I can think of is the performance issue above, otherwise it would be more correct if anything.