### PR TITLE
fixes #25735; sso C++: nimToCStringConv

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -370,7 +370,7 @@ proc expressionsNeedsTmp(p: BProc, a: TLoc): TLoc =
 proc genArgStringToCString(p: BProc, n: PNode; result: var Builder; needsTmp: bool) {.inline.} =
   var a = initLocExpr(p, n[0])
   let tmp = withTmpIfNeeded(p, a, needsTmp)
-  let ra = if p.config.isDefined("nimsso"): addrLoc(p.config, tmp) else: tmp.rdLoc
+  let ra = if p.config.isDefined("nimsso"): byRefLoc(p, tmp) else: tmp.rdLoc
   result.addCall(cgsymValue(p.module, "nimToCStringConv"), ra)
 
 proc genArg(p: BProc, n: PNode, param: PSym; call: PNode; result: var Builder; needsTmp = false) =

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2736,7 +2736,7 @@ proc genConv(p: BProc, e: PNode, d: var TLoc) =
 
 proc convStrToCStr(p: BProc, n: PNode, d: var TLoc) =
   var a: TLoc = initLocExpr(p, n[0])
-  let arg = if p.config.isDefined("nimsso"): addrLoc(p.config, a) else: rdLoc(a)
+  let arg = if p.config.isDefined("nimsso"): byRefLoc(p, a) else: rdLoc(a)
   putIntoDest(p, d, n,
     cgCall(p, "nimToCStringConv", arg),
     a.storage)

--- a/tests/system/tnimsso.nim
+++ b/tests/system/tnimsso.nim
@@ -1,0 +1,7 @@
+discard """
+  matrix: "-d:nimsso"
+  targets: "c cpp"
+"""
+
+var s = "abc"
+discard s.cstring


### PR DESCRIPTION
fixes #25735

This pull request updates how string-to-C-string conversions are handled when the `nimsso` configuration flag is enabled, and adds a new system test to validate the behavior. The main changes focus on switching from using `addrLoc` to `byRefLoc` for argument preparation, which likely improves correctness or compatibility with the `nimsso` mode.

**Code generation improvements for `nimsso` mode:**

* In both `compiler/ccgcalls.nim` (`genArgStringToCString`) and `compiler/ccgexprs.nim` (`convStrToCStr`), replaced the use of `addrLoc` with `byRefLoc` when preparing arguments for string-to-C-string conversions under the `nimsso` configuration flag. This change ensures that references are handled appropriately according to the requirements of `nimsso`. [[1]](diffhunk://#diff-42181cc6f4202af843e7835ea514df2efe85e4faae3bc797a39a0c422547b558L373-R373) [[2]](diffhunk://#diff-4509107d295d7d32b1887c8993cd0f56113ae60f36113e7d8778646dabd92ebcL2739-R2739)

**Testing:**

* Added a new system test `tests/system/tnimsso.nim` that runs with the `-d:nimsso` flag on both C and C++ targets, checking that string-to-C-string conversion works as expected in `nimsso` mode.