### PR TITLE
ccgstmts: fix 'occured' -> 'occurred' typo in emitted C++ exception comment

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1165,7 +1165,7 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
         throw;
       }
     } catch(...) {
-      // C++ exception occured, not under Nim's control.
+      // C++ exception occurred, not under Nim's control.
     }
     {
       /* finally: */


### PR DESCRIPTION
Inline C++ comment emitted by `compiler/ccgstmts.nim:1168` into generated code read `C++ exception occured, not under Nim's control`. Doc-only change in the emitted source.