### PR TITLE
Fix typo in getContentType function in cgi.nim

### DIFF
--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -128,7 +128,7 @@ proc getContentLength*(): string =
 
 proc getContentType*(): string =
   ## Returns contents of the `CONTENT_TYPE` environment variable.
-  return getEnv("CONTENT_Type")
+  return getEnv("CONTENT_TYPE")
 
 proc getDocumentRoot*(): string =
   ## Returns contents of the `DOCUMENT_ROOT` environment variable.


### PR DESCRIPTION
This pull request fixes a typo in the `getContentType` function in `lib/pure/cgi.nim`, ensuring it retrieves the correct `CONTENT_TYPE` environment variable.

> Exact spelling matters: It is CONTENT_TYPE, not CONTENT_Type or Content-Type. Environment variables in CGI are case-sensitive.