### PR TITLE
Fix invalid Mac OS X minimum version in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ architecture combinations:
 |--------------------------------|----------------------------------------|
 | Windows (Windows XP or greater) | x86 and x86_64                             |
 | Linux (most distributions)     | x86, x86_64, ppc64, and armv6l             |
-| Mac OS X (10.04 or greater)    | x86, x86_64, ppc64, and Apple Silicon (ARM64) |
+| Mac OS X (10.4 or greater)     | x86, x86_64, ppc64, and Apple Silicon (ARM64) |
 
 More platforms are supported, however, they are not tested regularly and they
 may not be as stable as the above-listed platforms.


### PR DESCRIPTION

**Repo:** nim-lang/Nim (⭐ 16000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Correct the supported platform table in the top-level README by changing the Mac OS X minimum version from `10.04` to `10.4`.

## Why
`10.04` is not a valid Mac OS X release number, so the existing text is misleading for anyone reading the build and platform support guidance. Fixing it keeps the README accurate without changing project behavior or widening scope.

## Testing
Verified the README diff locally and confirmed the corrected `Mac OS X (10.4 or greater)` entry appears in `readme.md`. No code or test suite changes were needed for this docs-only patch.

## Risk
Low / documentation-only change with no runtime impact.
