### PR TITLE
closureiters: fix undeclared C identifier when using template/macro bindings in async and/or second operand

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -117,6 +117,13 @@ errors.
 
 ## Compiler changes
 
+- Fixed a bug in `lowerStmtListExprs` where variables introduced by template/macro
+  expansion in the second operand of `and`/`or` inside async procs were scoped to
+  the short-circuit `if` block, causing "undeclared identifier" C-level errors when
+  those variables were used in the enclosing `if` body. Note: as a consequence of
+  this fix, setup statements in the second operand (e.g., `let` declarations from
+  template expansion) are no longer short-circuited.
+
 - Fixed a bug where `sizeof(T)` inside a `typedesc` template called from a generic type's
   `when` clause would error with "'sizeof' requires '.importc' types to be '.completeStruct'".
   The issue was that `hasValuelessStatics` in `semtypinst.nim` didn't recognize

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -672,7 +672,15 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
         let ifBody = newNodeI(nkStmtList, cond.info)
         if cond.kind == nkStmtListExpr:
           let (st, ex) = exprToStmtList(cond)
-          ifBody.add(st)
+          # Hoist statements from the second operand to the outer scope,
+          # mirroring how the first operand is handled above (line 661).
+          # Without this, variables declared via template/macro expansion
+          # in the second operand are scoped inside the short-circuit `if`
+          # block and are inaccessible in the enclosing `if` body, causing
+          # "undeclared identifier" C-level errors in closure iterators.
+          # Note: side-effectful statements in the second operand are no
+          # longer short-circuited as a result of this change.
+          result.add(st)
           cond = ex
         ifBody.add(ctx.newTempVarAsgn(tmp, cond))
 

--- a/tests/async/tasync_and_stmtlistexpr.nim
+++ b/tests/async/tasync_and_stmtlistexpr.nim
@@ -1,0 +1,62 @@
+discard """
+  exitcode: 0
+"""
+# Regression test: variables declared via template/macro expansion in the
+# second operand of `and`/`or` inside an async proc must be accessible in
+# the enclosing `if` body. Previously `lowerStmtListExprs` in closureiters.nim
+# placed those statements in `ifBody` (nested scope) instead of the outer
+# `result`, causing "use of undeclared identifier" C errors.
+import std/asyncdispatch, std/options
+
+template bindOpt(name: untyped; expr: untyped): bool =
+  let opt = expr
+  let name {.inject.} = if opt.isSome: opt.get() else: 0
+  opt.isSome
+
+proc test() {.async.} =
+  proc getA(): Future[Option[int]] {.async.} = return some(1)
+  proc getB(): Option[int] = some(2)
+
+  if bindOpt(a, await getA()) and bindOpt(b, getB()):
+    doAssert a == 1
+    doAssert b == 2
+  else:
+    doAssert false, "bindings should have succeeded"
+
+waitFor test()
+
+proc testAndShortCircuit() {.async.} =
+  # When the second operand of `and` is a plain call (not a stmtListExpr),
+  # it must still be short-circuited when the first operand is false.
+  var called = false
+  proc sideEffect(): bool =
+    called = true
+    return true
+
+  proc getA(): Future[Option[int]] {.async.} = return none(int)
+
+  if bindOpt(a, await getA()) and sideEffect():
+    doAssert false, "first operand failed, should not enter branch"
+
+  doAssert not called, "plain non-stmtListExpr second operand must be short-circuited (and)"
+
+waitFor testAndShortCircuit()
+
+proc testOrShortCircuit() {.async.} =
+  # When the second operand of `or` is a plain call (not a stmtListExpr),
+  # it must still be short-circuited when the first operand is true.
+  var called = false
+  proc sideEffect(): bool =
+    called = true
+    return false
+
+  proc getA(): Future[Option[int]] {.async.} = return some(1)
+
+  if bindOpt(a, await getA()) or sideEffect():
+    doAssert a == 1
+  else:
+    doAssert false, "first operand succeeded, should enter branch"
+
+  doAssert not called, "plain non-stmtListExpr second operand must be short-circuited (or)"
+
+waitFor testOrShortCircuit()


### PR DESCRIPTION
## Summary

`lowerStmtListExprs` handles the second operand of `and`/`or` in closure iterators (i.e., async procs) differently from the first: when the second operand is a `nkStmtListExpr` (produced by template/macro expansion or `await`), its statements were placed in `ifBody` — the body of the short-circuit `if` block — instead of the outer `result` node.

This meant that variables declared in those statements (e.g., via an injected `let` from a template like `bindOpt`) were scoped to the short-circuit block and inaccessible in the enclosing `if` body, producing "use of undeclared identifier" errors at the C level.

The fix mirrors how the first operand is already handled (line 661): hoist the statements to `result` so they are visible in the enclosing scope. The expression part (`ex`) remains in `ifBody` and continues to be properly short-circuited. Plain (non-stmtListExpr) second operands are unaffected.

Note: as a consequence, side-effectful *statements* in the second operand (e.g., variable declarations from template expansion) are no longer short-circuited. This only affects patterns that previously failed to compile.

## Minimal reproducible example

```nim
import std/asyncdispatch, std/options

template bindOpt(name: untyped; expr: untyped): bool =
  let opt = expr
  let name {.inject.} = if opt.isSome: opt.get() else: 0
  opt.isSome

proc test() {.async.} =
  proc getA(): Future[Option[int]] {.async.} = return some(1)
  proc getB(): Option[int] = some(2)

  # Before this fix, `b` was "undeclared identifier" at C compilation:
  if bindOpt(a, await getA()) and bindOpt(b, getB()):
    doAssert a == 1
    doAssert b == 2

waitFor test()
```

## Changes

- `compiler/closureiters.nim`: change `ifBody.add(st)` to `result.add(st)` for the second operand of `and`/`or`, mirroring the existing first-operand handling
- `tests/async/tasync_and_stmtlistexpr.nim`: regression test covering the fixed bug, plus two tests confirming that plain (non-stmtListExpr) second operands remain properly short-circuited
- `changelog.md`: entry added under "Compiler changes"