### PR TITLE
fixes #25656; nim ic: Using a top level variable

### DIFF
--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -826,11 +826,15 @@ type
     types: Table[string, (PType, NifIndexEntry)]
     syms: Table[string, (PSym, NifIndexEntry)]
     mods: Table[FileIndex, NifModule]
+    mainModuleIdx: FileIndex
     cache: IdentCache
 
 proc createDecodeContext*(config: ConfigRef; cache: IdentCache): DecodeContext =
   ## Supposed to be a global variable
-  result = DecodeContext(infos: LineInfoWriter(config: config), cache: cache)
+  result = DecodeContext(
+    infos: LineInfoWriter(config: config),
+    mainModuleIdx: InvalidFileIdx,
+    cache: cache)
 
 proc cursorFromIndexEntry(c: var DecodeContext; module: FileIndex; entry: NifIndexEntry;
                           buf: var TokenBuf): Cursor =
@@ -881,8 +885,11 @@ proc readEmbeddedIndex(s: var Stream): Table[string, NifIndexEntry] =
   s.r.jumpTo(contentPos)  # Restore position
 
 proc moduleId(c: var DecodeContext; suffix: string; flags: set[LoadFlag] = {}): FileIndex =
-  var isKnownFile = false
-  result = c.infos.config.registerNifSuffix(suffix, isKnownFile)
+  if c.mainModuleIdx != InvalidFileIdx and suffix == moduleSuffix(c.infos.config, c.mainModuleIdx):
+    result = c.mainModuleIdx
+  else:
+    var isKnownFile = false
+    result = c.infos.config.registerNifSuffix(suffix, isKnownFile)
   # Always load the module's index if it's not already in c.mods
   # This is needed when resolving symbols from modules that were registered elsewhere
   # but haven't had their NIF index loaded yet
@@ -1176,8 +1183,7 @@ proc loadSymFromCursor(c: var DecodeContext; s: PSym; n: var Cursor; thisModule:
   if s.kindImpl == skModule:
     expect n, DotToken
     inc n
-    var isKnownFile = false
-    s.positionImpl = int c.infos.config.registerNifSuffix(thisModule, isKnownFile)
+    s.positionImpl = int moduleId(c, thisModule)
     # do to the precompiled mechanism things end up as main modules which are not!
     excl s.flagsImpl, sfMainModule
   else:
@@ -1654,6 +1660,8 @@ proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHi
 proc loadNifModule*(c: var DecodeContext; f: FileIndex; interf, interfHidden: var TStrTable;
                     flags: set[LoadFlag] = {}): PrecompiledModule =
   let suffix = ModuleSuffix(moduleSuffix(c.infos.config, f))
+  if f == c.infos.config.projectMainIdx:
+    c.mainModuleIdx = f
   result = loadNifModule(c, suffix, interf, interfHidden, flags)
 
 when isMainModule:

--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -826,14 +826,12 @@ type
     types: Table[string, (PType, NifIndexEntry)]
     syms: Table[string, (PSym, NifIndexEntry)]
     mods: Table[FileIndex, NifModule]
-    mainModuleIdx: FileIndex
     cache: IdentCache
 
 proc createDecodeContext*(config: ConfigRef; cache: IdentCache): DecodeContext =
   ## Supposed to be a global variable
   result = DecodeContext(
     infos: LineInfoWriter(config: config),
-    mainModuleIdx: InvalidFileIdx,
     cache: cache)
 
 proc cursorFromIndexEntry(c: var DecodeContext; module: FileIndex; entry: NifIndexEntry;
@@ -885,8 +883,8 @@ proc readEmbeddedIndex(s: var Stream): Table[string, NifIndexEntry] =
   s.r.jumpTo(contentPos)  # Restore position
 
 proc moduleId(c: var DecodeContext; suffix: string; flags: set[LoadFlag] = {}): FileIndex =
-  if c.mainModuleIdx != InvalidFileIdx and suffix == moduleSuffix(c.infos.config, c.mainModuleIdx):
-    result = c.mainModuleIdx
+  if suffix == moduleSuffix(c.infos.config, c.infos.config.projectMainIdx):
+    result = c.infos.config.projectMainIdx
   else:
     var isKnownFile = false
     result = c.infos.config.registerNifSuffix(suffix, isKnownFile)
@@ -1660,8 +1658,6 @@ proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHi
 proc loadNifModule*(c: var DecodeContext; f: FileIndex; interf, interfHidden: var TStrTable;
                     flags: set[LoadFlag] = {}): PrecompiledModule =
   let suffix = ModuleSuffix(moduleSuffix(c.infos.config, f))
-  if f == c.infos.config.projectMainIdx:
-    c.mainModuleIdx = f
   result = loadNifModule(c, suffix, interf, interfHidden, flags)
 
 when isMainModule:

--- a/tests/ic/tmainmodule.nim
+++ b/tests/ic/tmainmodule.nim
@@ -1,0 +1,5 @@
+var x = 1
+proc foo() =
+  x = 2
+
+foo()


### PR DESCRIPTION
fixes #25656

This pull request makes several improvements to the module identification and symbol loading logic in the Nim compiler, specifically in the `ast2nif.nim` file. The changes introduce a new helper function for determining module IDs, streamline the way module positions are set during symbol loading, and add a new test case. The main focus is on handling the main module more robustly when loading symbols.

**Module identification and symbol loading improvements:**

* Added a new `moduleId` helper function to centralize logic for determining a module's index, with special handling for the main project module.
* Updated `loadSymFromCursor` to use the new `moduleId` function, simplifying and clarifying how module positions are set for symbols of kind `skModule`.
* Refactored the initialization of `DecodeContext` for better readability.

**Testing:**

* Added a new test file `tmainmodule.nim` to cover main module handling scenarios.


> x___u1 is declared in @mtest.nim.c and foo__OOZtes1lwt2m_u2 is defined in @m@d@stes1lwt2m.nim.c.
They probably need to be generated in the same c file.

This PR maps the suffix of the main module back into the real FileIndex of the main module