### PR TITLE
Add Nix certificate path to ssl_certs.nim

### DIFF
--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -36,6 +36,8 @@ elif defined(linux):
     # Android
     "/data/data/com.termux/files/usr/etc/tls/cert.pem",
     "/system/etc/security/cacerts",
+    # Nix
+    "/etc/ssl/certs/ca-bundle.crt"
   ]
 elif defined(bsd):
   const certificatePaths = [


### PR DESCRIPTION
This makes it easier to run Nix built containers for Nim programs since by default Nim doesn't search environment variables for SSL certs so its a little annoying having to move around files 

- https://github.com/NixOS/nixpkgs/blob/10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac/pkgs/by-name/ca/cacert/package.nix#L85