### PR TITLE
std: Move some terminal-related wrappers to `winlean`

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -103,7 +103,6 @@ when defined(windows):
   import std/os
 
   const
-    DUPLICATE_SAME_ACCESS = 2
     FOREGROUND_BLUE = 1
     FOREGROUND_GREEN = 2
     FOREGROUND_RED = 4
@@ -115,14 +114,7 @@ when defined(windows):
     FOREGROUND_RGB = FOREGROUND_RED or FOREGROUND_GREEN or FOREGROUND_BLUE
     BACKGROUND_RGB = BACKGROUND_RED or BACKGROUND_GREEN or BACKGROUND_BLUE
 
-    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
-
   type
-    SHORT = int16
-    COORD = object
-      x: SHORT
-      y: SHORT
-
     SMALL_RECT = object
       left: SHORT
       top: SHORT
@@ -140,13 +132,6 @@ when defined(windows):
       dwSize: DWORD
       bVisible: WINBOOL
 
-  proc duplicateHandle(hSourceProcessHandle: Handle, hSourceHandle: Handle,
-                       hTargetProcessHandle: Handle, lpTargetHandle: ptr Handle,
-                       dwDesiredAccess: DWORD, bInheritHandle: WINBOOL,
-                       dwOptions: DWORD): WINBOOL{.stdcall, dynlib: "kernel32",
-      importc: "DuplicateHandle".}
-  proc getCurrentProcess(): Handle{.stdcall, dynlib: "kernel32",
-                                     importc: "GetCurrentProcess".}
   proc getConsoleScreenBufferInfo(hConsoleOutput: Handle,
     lpConsoleScreenBufferInfo: ptr CONSOLE_SCREEN_BUFFER_INFO): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "GetConsoleScreenBufferInfo".}
@@ -190,30 +175,6 @@ when defined(windows):
                               getStdHandle(STD_ERROR_HANDLE)])
     if h > 0: return h
     return 0
-
-  proc setConsoleCursorPosition(hConsoleOutput: Handle,
-                                dwCursorPosition: COORD): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "SetConsoleCursorPosition".}
-
-  proc fillConsoleOutputCharacter(hConsoleOutput: Handle, cCharacter: char,
-                                  nLength: DWORD, dwWriteCoord: COORD,
-                                  lpNumberOfCharsWritten: ptr DWORD): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "FillConsoleOutputCharacterA".}
-
-  proc fillConsoleOutputAttribute(hConsoleOutput: Handle, wAttribute: int16,
-                                  nLength: DWORD, dwWriteCoord: COORD,
-                                  lpNumberOfAttrsWritten: ptr DWORD): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "FillConsoleOutputAttribute".}
-
-  proc setConsoleTextAttribute(hConsoleOutput: Handle,
-                               wAttributes: int16): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "SetConsoleTextAttribute".}
-
-  proc getConsoleMode(hConsoleHandle: Handle, dwMode: ptr DWORD): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "GetConsoleMode".}
-
-  proc setConsoleMode(hConsoleHandle: Handle, dwMode: DWORD): WINBOOL{.
-      stdcall, dynlib: "kernel32", importc: "SetConsoleMode".}
 
   proc getCursorPos(h: Handle): tuple [x, y: int] =
     var c: CONSOLE_SCREEN_BUFFER_INFO
@@ -915,9 +876,6 @@ when defined(windows):
     var mode = DWORD 0
     discard getConsoleMode(hi, addr mode)
     let origMode = mode
-    const
-      ENABLE_PROCESSED_INPUT = 1
-      ENABLE_ECHO_INPUT = 4
     mode = (mode or ENABLE_PROCESSED_INPUT) and not ENABLE_ECHO_INPUT
 
     discard setConsoleMode(hi, mode)

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -26,6 +26,7 @@ type WinChar* = Utf16Char
 # See https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
 type
   Handle* = int
+  SHORT* = int16
   LONG* = int32
   ULONG* = int32
   PULONG* = ptr int
@@ -998,9 +999,56 @@ type
     uChar*: int16
     dwControlKeyState*: DWORD
 
+  # https://learn.microsoft.com/en-us/windows/console/coord-str
+  COORD* = object
+    x*: SHORT
+    y*: SHORT
+
+const
+  # used by std/terminal
+  # https://learn.microsoft.com/en-us/windows/console/setconsolemode
+  ENABLE_ECHO_INPUT* = 0x0004
+  ENABLE_INSERT_MODE* = 0x0020
+  ENABLE_LINE_INPUT* = 0x0002
+  ENABLE_MOUSE_INPUT* = 0x0010
+  ENABLE_PROCESSED_INPUT* = 0x0001
+  ENABLE_QUICK_EDIT_MODE* = 0x0040
+  ENABLE_WINDOW_INPUT* = 0x0008
+  ENABLE_VIRTUAL_TERMINAL_INPUT* = 0x0200
+
+  ENABLE_PROCESSED_OUTPUT* = 0x0001
+  ENABLE_WRAP_AT_EOL_OUTPUT* = 0x0002
+  ENABLE_VIRTUAL_TERMINAL_PROCESSING* = 0x0004
+  DISABLE_NEWLINE_AUTO_RETURN* = 0x0008
+  ENABLE_LVB_GRID_WORLDWIDE* = 0x0010
+
 proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                       lpNumberOfEventsRead: ptr cint): cint
      {.stdcall, dynlib: "kernel32", importc: "ReadConsoleInputW".}
+
+proc getConsoleMode*(hConsoleHandle: Handle, dwMode: ptr DWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "GetConsoleMode".}
+
+proc setConsoleMode*(hConsoleHandle: Handle, dwMode: DWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "SetConsoleMode".}
+
+proc setConsoleCursorPosition*(hConsoleOutput: Handle,
+                              dwCursorPosition: COORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "SetConsoleCursorPosition".}
+
+proc fillConsoleOutputCharacter*(hConsoleOutput: Handle, cCharacter: char,
+                                nLength: DWORD, dwWriteCoord: COORD,
+                                lpNumberOfCharsWritten: ptr DWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "FillConsoleOutputCharacterA".}
+
+proc fillConsoleOutputAttribute*(hConsoleOutput: Handle, wAttribute: int16,
+                                nLength: DWORD, dwWriteCoord: COORD,
+                                lpNumberOfAttrsWritten: ptr DWORD): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "FillConsoleOutputAttribute".}
+
+proc setConsoleTextAttribute*(hConsoleOutput: Handle,
+                              wAttributes: int16): WINBOOL{.
+    stdcall, dynlib: "kernel32", importc: "SetConsoleTextAttribute".}
 
 type
   LPFIBER_START_ROUTINE* = proc (param: pointer) {.stdcall.}


### PR DESCRIPTION
`duplicateHandle` and `DUPLICATE_SAME_ACCESS` were already in winlean, other stuff moved. 

Since std already uses them in `terminal` privately, makes sense to move them and export.

Almost every library/app concerned with terminal handling rewraps these:

- [illwill](https://github.com/johnnovak/illwill)
- [nim-noise](https://github.com/jangko/nim-noise)
- [cliprompts](https://github.com/indiscipline/cliprompts)
- [termui](https://github.com/jjv360/nim-termui)
- [Nev](https://github.com/Nimaoth/Nev) 
- [nim-chronicles](https://github.com/status-im/nim-chronicles)
- [termtools](https://github.com/iffy/termtools) 

