### PR TITLE
fixes #25651

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -151,7 +151,7 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
       # may introduce new symbols with caveats described in recalc branch
       matches(c, n, orig, z)
 
-      if z.state == csGotTyForward:
+      if z.state == csGotTyForward and efDetermineType in flags:
         best.state = csGotTyForward
         best.call = z.call
         break

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -151,6 +151,11 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
       # may introduce new symbols with caveats described in recalc branch
       matches(c, n, orig, z)
 
+      if z.state == csGotTyForward:
+        best.state = csGotTyForward
+        best.call = z.call
+        break
+
       if allowTypeBoundOps:
         # this match may have given some arguments new types,
         # in which case add their type bound ops as well
@@ -176,6 +181,8 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
           var cmp = cmpCandidates(best, z)
           if cmp < 0: best = z   # x is better than the best so far
           elif cmp == 0: alt = z # x is as good as the best so far
+        of csGotTyForward:
+          assert false
       elif errorsEnabled or z.diagnosticsEnabled:
         errors.add(CandidateError(
           sym: sym,
@@ -588,7 +595,9 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
 
   let overloadsState = result.state
   if overloadsState != csMatch:
-    if nfDotField in n.flags:
+    if overloadsState == csGotTyForward:
+      return
+    elif nfDotField in n.flags:
       internalAssert c.config, f.kind in nkIdentKinds and n.len >= 2
 
       # leave the op head symbol empty,
@@ -933,6 +942,8 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
               "Non-matching candidates for " & renderTree(n) & "\n" &
               candidates)
     result = semResolvedCall(c, r, n, flags, expectedType)
+  elif r.state == csGotTyForward:
+    return r.call
   else:
     if c.inGenericContext > 0 and c.matchedConcept == nil:
       result = semGenericStmt(c, n)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -943,6 +943,8 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
               candidates)
     result = semResolvedCall(c, r, n, flags, expectedType)
   elif r.state == csGotTyForward:
+    # `r.call.typ.kind == tyForward` so that caller can see this call contains a tyForward type argument
+    # see `matchesAux` proc in sigmatch.nim
     return r.call
   else:
     if c.inGenericContext > 0 and c.matchedConcept == nil:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1000,7 +1000,7 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
     result = semOverloadedCall(c, n, nOrig,
       {skProc, skFunc, skMethod, skConverter, skMacro, skTemplate}, flags, expectedType)
 
-  if result != nil:
+  if result != nil and not (result.typ != nil and result.typ.kind == tyForward):
     if result[0].kind != nkSym:
       if not (c.inGenericContext > 0): # see generic context check in semOverloadedCall
         internalError(c.config, "semOverloadedCallAnalyseEffects")
@@ -1058,7 +1058,7 @@ proc semFinishOperands(c: PContext; n: PNode; isBracketExpr = false) =
 proc afterCallActions(c: PContext; n, orig: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   if efNoSemCheck notin flags and n.typ != nil and n.typ.kind == tyError:
     return errorNode(c, n)
-  if n.typ != nil and n.typ.kind == tyFromExpr and c.inGenericContext > 0:
+  if n.typ != nil and ((n.typ.kind == tyFromExpr and c.inGenericContext > 0) or n.typ.kind == tyForward):
     return n
 
   result = n

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -462,9 +462,6 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
 
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   var t = semTypeNode(c, n[0], nil)
-  if t != nil and t.kind == tyForward:
-    n.typ = t   # assign `tyForward` type so that caller can easily see it contains `tyForward` type
-    return n
   result = newNodeIT(nkObjConstr, n.info, t)
   for i in 0..<n.len:
     result.add n[i]

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -462,6 +462,9 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
 
 proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags; expectedType: PType = nil): PNode =
   var t = semTypeNode(c, n[0], nil)
+  if t != nil and t.kind == tyForward:
+    n.typ = t   # assign `tyForward` type so that caller can easily see it contains `tyForward` type
+    return n
   result = newNodeIT(nkObjConstr, n.info, t)
   for i in 0..<n.len:
     result.add n[i]

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1915,7 +1915,7 @@ proc semTypeExpr(c: PContext, n: PNode; prev: PType): PType =
         # unnecessary new type creation
         let alias = maybeAliasType(c, result, prev)
         if alias != nil: result = alias
-  elif n.typ.kind == tyFromExpr and c.inGenericContext > 0:
+  elif n.typ.kind == tyFromExpr and c.inGenericContext > 0 or n.typ.kind == tyForward:
     # sometimes not possible to distinguish type from value in generic body,
     # for example `T.Foo`, so both are handled under `tyFromExpr`
     result = n.typ
@@ -2308,7 +2308,10 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       elif op.s == "owned" and optOwnedRefs notin c.config.globalOptions and n.len == 2:
         result = semTypeExpr(c, n[1], prev)
       else:
+        let prevN = copyTree(n)
         result = semTypeExpr(c, n, prev)
+        if result.kind == tyForward:
+          c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN)
   of nkWhenStmt:
     var whenResult = semWhen(c, n, false)
     if whenResult.kind == nkStmtList: whenResult.transitionSonsKind(nkStmtListType)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1773,7 +1773,21 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   else:
     var m = newCandidate(c, t)
     m.isNoCall = true
-    matches(c, n, copyTree(n), m)
+    # `matches` proc can modify `n`.
+    # if there is a `tyForward` type in `n`, `matches` cannot work and modify `n` correctly.
+    # that case, add `prevN` to `c.forwardTypeUpdates` so that the type is resemed with original `n`.
+    let prevN = copyTree(n)
+    matches(c, n, prevN, m)
+
+    if m.state == csGotTyForward:
+      if prev == nil:
+        result = newTypeS(tyForward, c)
+        result.sym = s
+      else:
+        assignType(result, newTypeS(tyForward, c))
+        result.sym = s
+      c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN) #fixes 1500
+      return
 
     if m.state != csMatch:
       var err = "cannot instantiate "
@@ -1839,7 +1853,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
         else:
           assignType(result, newTypeS(tyForward, c))
           result.sym = s
-        c.forwardTypeUpdates.add (getCurrOwner(c), result, n) #fixes 1500
+        c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN) #fixes 1500
         return
       else:
         result = instGenericContainer(c, n.info, result,

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1775,21 +1775,11 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     m.isNoCall = true
     # `matches` proc can modify `n`.
     # if there is a `tyForward` type in `n`, `matches` cannot work and modify `n` correctly.
-    # that case, add `prevN` to `c.forwardTypeUpdates` so that the type is resemed with original `n`.
-    let prevN = copyTree(n)
-    matches(c, n, prevN, m)
+    # that case, add `nOrig` to `c.forwardTypeUpdates` so that the type is resemed with original `n`.
+    let nOrig = copyTree(n)
+    matches(c, n, nOrig, m)
 
-    if m.state == csGotTyForward:
-      if prev == nil:
-        result = newTypeS(tyForward, c)
-        result.sym = s
-      else:
-        assignType(result, newTypeS(tyForward, c))
-        result.sym = s
-      c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN) #fixes 1500
-      return
-
-    if m.state != csMatch:
+    if m.state notin {csMatch, csGotTyForward}:
       var err = "cannot instantiate "
       err.addTypeHeader(c.config, t)
       err.add "\ngot: <$1>\nbut expected: <$2>" % [describeArgs(c, n), describeArgs(c, t.n, 0)]
@@ -1804,7 +1794,6 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     var isConcrete = true
     let rType = m.call[0].typ
     let mIndex = if rType != nil: rType.len - 1 else: -1
-    var hasForwardTypeParam = false
     for i in 1..<m.call.len:
       var typ = m.call[i].typ
       # is this a 'typedesc' *parameter*? If so, use the typedesc type,
@@ -1821,15 +1810,12 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
           skip = false
         addToResult(typ, skip)
 
-      if typ.kind == tyForward:
-        hasForwardTypeParam = true
-
     if isConcrete:
       if s.ast == nil and s.typ.kind != tyCompositeTypeClass:
         # XXX: What kind of error is this? is it still relevant?
         localError(c.config, n.info, errCannotInstantiateX % s.name.s)
         result = newOrPrevType(tyError, prev, c)
-      elif containsGenericInvocationWithForward(n[0]) or hasForwardTypeParam:
+      elif containsGenericInvocationWithForward(n[0]) or m.state == csGotTyForward:
         # isConcrete == false means this generic type is not instanciated here because
         # it invoked with generic parameters.
         # Even if isConcrete == true, don't instanciate it now if there are
@@ -1853,7 +1839,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
         else:
           assignType(result, newTypeS(tyForward, c))
           result.sym = s
-        c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN) #fixes 1500
+        c.forwardTypeUpdates.add (getCurrOwner(c), result, nOrig) #fixes 1500
         return
       else:
         result = instGenericContainer(c, n.info, result,
@@ -2308,10 +2294,10 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       elif op.s == "owned" and optOwnedRefs notin c.config.globalOptions and n.len == 2:
         result = semTypeExpr(c, n[1], prev)
       else:
-        let prevN = copyTree(n)
+        let nOrig = copyTree(n)
         result = semTypeExpr(c, n, prev)
         if result.kind == tyForward:
-          c.forwardTypeUpdates.add (getCurrOwner(c), result, prevN)
+          c.forwardTypeUpdates.add (getCurrOwner(c), result, nOrig)
   of nkWhenStmt:
     var whenResult = semWhen(c, n, false)
     if whenResult.kind == nkStmtList: whenResult.transitionSonsKind(nkStmtListType)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -3016,8 +3016,12 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
           m.typedescMatched = false
           var newlyTyped = false
           n[a] = prepareOperand(c, formal.typ, n[a], newlyTyped)
-          if (n[a].typ != nil and n[a].typ.kind == tyForward) or
-             (n[a].kind == nkSym and n[a].sym.typ != nil and n[a].sym.typ.kind == tyForward):
+          if ((n[a].typ != nil and n[a].typ.kind == tyForward) or
+              (n[a].kind == nkSym and n[a].sym.typ != nil and n[a].sym.typ.kind == tyForward)) and
+              not (m.calleeSym != nil and sfCustomPragma in m.calleeSym.flags):
+            # exclude custom pragma template (used as a pragma in a type section) to avoid generating compile errors from existing code
+            # maybe it should not be excluded if `formal.typ` is not generic.
+
             # set tyForward type to `m.call.typ` so that caller can easily see this call contains a tyForward type param.
             m.call.typ = if n[a].typ != nil and n[a].typ.kind == tyForward: n[a].typ else: n[a].sym.typ
             noMatch(true)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -3016,7 +3016,8 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
           m.typedescMatched = false
           var newlyTyped = false
           n[a] = prepareOperand(c, formal.typ, n[a], newlyTyped)
-          if n[a].typ != nil and n[a].typ.kind == tyForward or n[a].kind == nkSym and n[a].sym.typ.kind == tyForward:
+          if (n[a].typ != nil and n[a].typ.kind == tyForward) or
+             (n[a].kind == nkSym and n[a].sym.typ != nil and n[a].sym.typ.kind == tyForward):
             # set tyForward type to `m.call.typ` so that caller can easily see this call contains a tyForward type param.
             m.call.typ = if n[a].typ != nil and n[a].typ.kind == tyForward: n[a].typ else: n[a].sym.typ
             noMatch(true)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -34,7 +34,11 @@ type
                         # its position can differ from `arg` because of varargs
 
   TCandidateState* = enum
-    csEmpty, csMatch, csNoMatch
+    csEmpty, csMatch, csNoMatch,
+    csGotTyForward      # got a type contains `tyForward` kind
+                        # (possible in a type section, see `semTypeSection` proc)
+                        # cannot match correctly because the actual type is unknown
+                        # should match again when the type got semchecked
 
   CandidateError* = object
     sym*: PSym
@@ -2730,6 +2734,8 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
                 x = z
               elif cmp == 0:
                 y = z           # z is as good as x
+            of csGotTyForward:
+              assert false
 
       if x.state == csEmpty:
         result = nil
@@ -2845,12 +2851,12 @@ proc findFirstArgBlock(m: var TCandidate, n: PNode): int =
     else: break
 
 proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var IntSet) =
-  template noMatch() =
+  template noMatch(isTyForward = false) =
     if m.calleeSym != nil and m.calleeSym.kind notin {skTemplate, skMacro}:
       c.mergeShadowScope
     else:
       c.closeShadowScope
-    m.state = csNoMatch
+    m.state = if isTyForward: csGotTyForward else: csNoMatch
     m.firstMismatch.arg = a
     m.firstMismatch.formal = formal
     return
@@ -3010,9 +3016,14 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
           m.typedescMatched = false
           var newlyTyped = false
           n[a] = prepareOperand(c, formal.typ, n[a], newlyTyped)
-          if newlyTyped: m.newlyTypedOperands.add(a)
-          arg = paramTypesMatch(m, formal.typ, n[a].typ,
-                                    n[a], nOrig[a])
+          if n[a].typ != nil and n[a].typ.kind == tyForward or n[a].kind == nkSym and n[a].sym.typ.kind == tyForward:
+            # set tyForward type to `m.call.typ` so that caller can easily see this call contains a tyForward type param.
+            m.call.typ = if n[a].typ != nil and n[a].typ.kind == tyForward: n[a].typ else: n[a].sym.typ
+            noMatch(true)
+          else:
+            if newlyTyped: m.newlyTypedOperands.add(a)
+            arg = paramTypesMatch(m, formal.typ, n[a].typ,
+                                      n[a], nOrig[a])
           if arg == nil:
             noMatch()
           if formal.typ.isVarargsTyped and m.calleeSym.kind in {skTemplate, skMacro}:
@@ -3082,7 +3093,7 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
   if m.state == csNoMatch: return
   var marker = initIntSet()
   matchesAux(c, n, nOrig, m, marker)
-  if m.state == csNoMatch: return
+  if m.state in {csNoMatch, csGotTyForward}: return
   # check that every formal parameter got a value:
   for f in 1..<m.callee.n.len:
     let formal = m.callee.n[f].sym

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -3022,7 +3022,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
             # exclude custom pragma template (used as a pragma in a type section) to avoid generating compile errors from existing code
             # maybe it should not be excluded if `formal.typ` is not generic.
 
-            # set tyForward type to `m.call.typ` so that caller can easily see this call contains a tyForward type param.
+            # set tyForward type to `m.call.typ` so that caller can easily see this call contains a tyForward type argument.
             m.call.typ = if n[a].typ != nil and n[a].typ.kind == tyForward: n[a].typ else: n[a].sym.typ
             noMatch(true)
           else:

--- a/tests/types/tgeneric_inst_with_tyforward_expression.nim
+++ b/tests/types/tgeneric_inst_with_tyforward_expression.nim
@@ -1,0 +1,24 @@
+# issue #25651
+type
+  GeneStatic[DefaultVal: static[auto]] = object
+    x: typeof(DefaultVal)
+
+type
+  ObjA = GeneStatic[TyForward()]
+  ObjA2 = GeneStatic[TyForward(tyFx: 123, tyFy: "XYZ")]
+  ObjB = GeneStatic[default(TyForward)]
+  ObjC = object
+    x: GeneStatic[TyForward()]
+    y: GeneStatic[TyForward(tyFx: 456, tyFy: "ABC")]
+    z: GeneStatic[default(TyForward)]
+
+  TyForward = object
+    tyFx: int
+    tyFy = "test val"
+
+doAssert ObjA().DefaultVal == TyForward()
+doAssert ObjA2().DefaultVal == TyForward(tyFx: 123, tyFy: "XYZ")
+doAssert ObjB().DefaultVal == TyForward()
+doAssert ObjC().x.DefaultVal == TyForward()
+doAssert ObjC().y.DefaultVal == TyForward(tyFx: 456, tyFy: "ABC")
+doAssert ObjC().z.DefaultVal == TyForward()


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/issues/25651

This PR makes `semGeneric` proc can detect that generic types are instantiated with expressions contains types declared later in the type section.
`matchesAux` checks `tyForward` type in arguments so that generic type instantiation and calls can detect `tyForward` types.