### PR TITLE
fixes #22791; ProveField warning with nested case object

### DIFF
--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -46,7 +46,7 @@ proc isLocation(n: PNode): bool = not n.isValue
 
 proc isLet(n: PNode): bool =
   if n.kind == nkSym:
-    if n.sym.kind in {skLet, skTemp, skForVar}:
+    if n.sym.kind in {skLet, skConst, skTemp, skForVar}: # guard immutable variables
       result = true
     elif n.sym.kind == skParam and skipTypes(n.sym.typ,
                                              abstractInst).kind notin {tyVar}:

--- a/tests/objvariant/tcorrectcheckedfield.nim
+++ b/tests/objvariant/tcorrectcheckedfield.nim
@@ -20,3 +20,25 @@ block: # issue #24021
       discard
     else:
       discard foo.z
+
+
+# bug #22791
+type Foo = object
+  case a: bool
+  of false:
+    discard
+  of true:
+    case b: bool
+    of false:
+      discard
+    of true:
+      c: bool
+
+const f = Foo(a: true, b: true, c: true)
+case f.a
+of true:
+  case f.b
+  of true:
+    echo f.c
+  else: discard
+else: discard


### PR DESCRIPTION
fixes #22791

This pull request introduces a minor improvement to the handling of immutable variables in the compiler and adds a new test case for nested case objects. The most important changes are:

### Compiler improvements

* Updated the `isLet` guard in `compiler/guards.nim` to recognize `skConst` symbols as immutable variables, ensuring that constants are correctly identified alongside lets and other immutable types.

### Test coverage

* Added a new test in `tests/objvariant/tcorrectcheckedfield.nim` for bug #22791, verifying correct pattern matching and field access in nested `case` objects with constants.