### PR TITLE
fix: implicit imports drop `std/` prefix

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -930,7 +930,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       if m.len == 0:
         localError(conf, info, "Cannot resolve filename: " & arg)
       else:
-        conf.implicitImports.add m
+        conf.implicitImports.add(if arg.startsWith(stdPrefix): arg else: m)
   of "include":
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd2, passPP}:

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -13,7 +13,7 @@ import
   ast, msgs, options, idents, lookups,
   semdata, modulepaths, sigmatch, lineinfos,
   modulegraphs, wordrecg
-from std/strutils import `%`, startsWith
+from std/strutils import `%`, startsWith, replace
 from std/sequtils import addUnique
 import std/[sets, tables, intsets]
 
@@ -304,9 +304,9 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
       var prefix = ""
       if realModule.constraint != nil: prefix = realModule.constraint.strVal & "; "
       message(c.config, n.info, warnDeprecated, prefix & realModule.name.s & " is deprecated")
-    let moduleName = getModuleName(c.config, n)
-    if belongsToStdlib(c.graph, result) and not startsWith(moduleName, stdPrefix) and
-        not startsWith(moduleName, "system/") and not startsWith(moduleName, "packages/"):
+    let moduleNameNorm = getModuleName(c.config, n).replace("\\", "/")
+    if belongsToStdlib(c.graph, result) and not startsWith(moduleNameNorm, stdPrefix) and
+        not startsWith(moduleNameNorm, "system/") and not startsWith(moduleNameNorm, "packages/"):
       message(c.config, n.info, warnStdPrefix, realModule.name.s)
 
     proc suggestMod(n: PNode; s: PSym) =

--- a/tests/compiler/tcmdline_import_std_prefix.nim
+++ b/tests/compiler/tcmdline_import_std_prefix.nim
@@ -1,0 +1,10 @@
+discard """
+  matrix: "-d:nimPreviewSlimSystem --warning:StdPrefix:on --warningAsError:StdPrefix:on --import:std/objectdollar"
+  output: "(a: 23, b: 45)"
+"""
+
+type Foo = object
+  a, b: int
+
+let x = Foo(a: 23, b: 45)
+echo x


### PR DESCRIPTION
Preserves implicit imports instead of always storing the resolved absolute filename. That lets the later StdPrefix warning check see the original std/objectdollar spelling.

This is for situations where in cfg or cli warnings are enabled for the prefix. Essentially a niche combination of compiler switches don't get along e.g.

 `-d:nimPreviewSlimSystem --warning:StdPrefix:on --warningAsError:StdPrefix:on --import:std/objectdollar`

will cause:

`Error: objectdollar needs the 'std' prefix [StdPrefix]`