### PR TITLE
fixes wasMoved for C++

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2815,6 +2815,19 @@ proc genWasMoved(p: BProc; n: PNode) =
     #linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
     #  [addrLoc(p.config, a), getTypeDesc(p.module, a.t)])
 
+proc genWasMovedCall(p: BProc; op: PSym; arg: PNode) =
+  # generate a call to the `wasMoved` hook for C++
+  var call = newNodeIT(nkCall, arg.info, op.typ.returnType)
+  call.add newSymNode(op)
+  if op.typ != nil and op.typ.signatureLen > 1 and op.typ.firstParamType.kind == tyVar:
+    var addrArg = newNodeIT(nkHiddenAddr, arg.info, op.typ.firstParamType)
+    addrArg.add arg
+    call.add addrArg
+  else:
+    call.add arg
+  var noDest = default(TLoc)
+  genCall(p, call, noDest)
+
 proc genMove(p: BProc; n: PNode; d: var TLoc) =
   var a: TLoc = initLocExpr(p, n[1].skipAddr, {lfEnforceDeref, lfPrepareForMutation})
   if n.len == 4:
@@ -2843,23 +2856,26 @@ proc genMove(p: BProc; n: PNode; d: var TLoc) =
       if op == nil:
         resetLoc(p, a)
       else:
-        var b = initLocExpr(p, newSymNode(op))
-        case skipTypes(a.t, abstractVar+{tyStatic}).kind
-        of tyOpenArray, tyVarargs: # todo fixme generated `wasMoved` hooks for
-                                   # openarrays, but it probably shouldn't?
-          let ra = rdLoc(a)
-          var s: string
-          if reifiedOpenArray(a.lode):
-            if a.t.kind in {tyVar, tyLent}:
-              s = derefField(ra, "Field0") & cArgumentSeparator & derefField(ra, "Field1")
-            else:
-              s = dotField(ra, "Field0") & cArgumentSeparator & dotField(ra, "Field1")
-          else:
-            s = ra & cArgumentSeparator & ra & "Len_0"
-          p.s(cpsStmts).addCallStmt(rdLoc(b), s)
+        if {sfInfixCall, sfNamedParamCall} * op.flags != {}:
+          genWasMovedCall(p, op, n[1].skipAddr)
         else:
-          let val = if p.module.compileToCpp: rdLoc(a) else: byRefLoc(p, a)
-          p.s(cpsStmts).addCallStmt(rdLoc(b), val)
+          var b = initLocExpr(p, newSymNode(op))
+          case skipTypes(a.t, abstractVar+{tyStatic}).kind
+          of tyOpenArray, tyVarargs: # todo fixme generated `wasMoved` hooks for
+                                     # openarrays, but it probably shouldn't?
+            let ra = rdLoc(a)
+            var s: string
+            if reifiedOpenArray(a.lode):
+              if a.t.kind in {tyVar, tyLent}:
+                s = derefField(ra, "Field0") & cArgumentSeparator & derefField(ra, "Field1")
+              else:
+                s = dotField(ra, "Field0") & cArgumentSeparator & dotField(ra, "Field1")
+            else:
+              s = ra & cArgumentSeparator & ra & "Len_0"
+            p.s(cpsStmts).addCallStmt(rdLoc(b), s)
+          else:
+            let val = if p.module.compileToCpp: rdLoc(a) else: byRefLoc(p, a)
+            p.s(cpsStmts).addCallStmt(rdLoc(b), val)
     else:
       genAssignment(p, d, a, {})
       resetLoc(p, a)

--- a/tests/ccgbugs2/t25800.nim
+++ b/tests/ccgbugs2/t25800.nim
@@ -1,0 +1,30 @@
+discard """
+  cmd: "nim cpp $file"
+  action: "compile"
+"""
+
+# Bug Report 1: {.importcpp.} on =wasMoved generates invalid preprocessor directive #.
+{.emit: """/*TYPESECTION*/
+struct CppRef {
+  int* data;
+  CppRef() : data(new int(42)) {}
+  ~CppRef() { delete data; data = nullptr; }
+  void reset() { delete data; data = nullptr; }
+};
+""".}
+
+type CppRef* {.importcpp, bycopy, noInit.} = object
+
+proc `=destroy`(x: var CppRef) {.importcpp: "#.~CppRef()".}
+proc `=wasMoved`(x: var CppRef) {.importcpp: "#.reset()".}
+proc `=copy`(dest: var CppRef; src: CppRef) {.importcpp: "dest = src".}
+proc `=sink`(dest: var CppRef; src: CppRef) {.importcpp: "dest = std::move(src)".}
+
+# This triggers =wasMoved when passing to sink parameter
+proc consume(x: sink CppRef) = discard
+
+proc test() =
+  var x: CppRef
+  consume(move(x))  # =wasMoved MUST be called here after the move
+
+test()


### PR DESCRIPTION
ref #25800

This pull request introduces a fix to the Nim compiler's C++ code generation for user-defined move semantics, specifically ensuring that the `=wasMoved` hook is correctly invoked for types with custom move logic. It also adds a regression test to verify the fix for C++ interop. The main changes are as follows:

### Compiler code generation improvements

* Added a new helper procedure, `genWasMovedCall`, in `ccgexprs.nim` to generate calls to the user-defined `=wasMoved` hook for C++ types, handling both value and address parameter conventions.
* Updated the `genMove` procedure to use `genWasMovedCall` when the attached `=wasMoved` operator has specific flags (`sfInfixCall`, `sfNamedParamCall`), ensuring the correct invocation of the hook during move operations.

### Testing

* Added a new test file, `tests/ccgbugs2/t25800.nim`, to verify that the `=wasMoved` hook is correctly called for C++ types with custom move logic, preventing invalid code generation and ensuring proper resource management.