### PR TITLE
[backport] fixes #4086, #9355 for v2.2.x (#25799)

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -853,6 +853,16 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
     if a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       hasUserSpecifiedType = true
+      # Issue #4086: `var f: Foo` for `type Foo[T = int]` auto-expands to
+      # `Foo[int]` when every generic param has a default. Restricted to
+      # var/let/const declarations so it does not affect type-level
+      # computations like `arity(SomeGeneric)` in template/typetraits
+      # contexts where bare generic-body references are intentional.
+      if typ != nil and typ.kind == tyGenericBody and typ.sym != nil:
+        let auto = tryGenericBodyDefaultInvocation(c,
+            newSymNode(typ.sym, a[^2].info), typ.sym, nil)
+        if auto != nil:
+          typ = auto
 
     var typFlags: TTypeAllowedFlags = {}
 
@@ -1009,6 +1019,16 @@ proc semConst(c: PContext, n: PNode): PNode =
     if a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       hasUserSpecifiedType = true
+      # Issue #4086: `var f: Foo` for `type Foo[T = int]` auto-expands to
+      # `Foo[int]` when every generic param has a default. Restricted to
+      # var/let/const declarations so it does not affect type-level
+      # computations like `arity(SomeGeneric)` in template/typetraits
+      # contexts where bare generic-body references are intentional.
+      if typ != nil and typ.kind == tyGenericBody and typ.sym != nil:
+        let auto = tryGenericBodyDefaultInvocation(c,
+            newSymNode(typ.sym, a[^2].info), typ.sym, nil)
+        if auto != nil:
+          typ = auto
 
     var typFlags: TTypeAllowedFlags = {}
 

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -62,14 +62,34 @@ proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext): PType =
 
 proc newConstraint(c: PContext, k: TTypeKind): PType =
   result = newTypeS(tyBuiltInTypeClass, c)
-  result.flags.incl tfCheckedForDestructor
+  result.incl tfCheckedForDestructor
   result.addSonSkipIntLit(newTypeS(k, c), c.idgen)
+
+proc skipGenericPrev(prev: PType): PType =
+  result = prev
+  if prev.kind == tyGenericBody and prev.last.kind != tyNone:
+    result = prev.last
+
+proc prevIsKind(prev: PType, kind: TTypeKind): bool {.inline.} =
+  result = prev != nil and skipGenericPrev(prev).kind == kind
 
 proc semEnum(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 0: return newConstraint(c, tyEnum)
   elif n.len == 1:
     # don't create an empty tyEnum; fixes #3052
     return errorType(c)
+  if prevIsKind(prev, tyEnum):
+    # the symbol already has an enum type (likely resem), don't define a new enum
+    # but add the enum fields to scope from the original type
+    let isPure = sfPure in prev.sym.flags
+    for enumField in prev.n:
+      assert enumField.kind == nkSym
+      let e = enumField.sym
+      if not isPure:
+        addInterfaceOverloadableSymAt(c, c.currentScope, e)
+      else:
+        declarePureEnumField(c, e)
+    return prev
   var
     counter, x: BiggestInt = 0
     e: PSym = nil
@@ -131,7 +151,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       if i != 1:
         if x != counter:
           needsReorder = true
-          incl(result.flags, tfEnumHasHoles)
+          incl(result, tfEnumHasHoles)
       e.ast = strVal # might be nil
       counter = x
     of nkSym:
@@ -164,7 +184,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       identToReplace[] = symNode
     if e.position == 0: hasNull = true
     if result.sym != nil and sfExported in result.sym.flags:
-      e.flags.incl {sfUsed, sfExported}
+      e.incl {sfUsed, sfExported}
 
     result.n.add symNode
     styleCheckDef(c, e)
@@ -190,9 +210,9 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     )
 
   if isPure and sfExported in result.sym.flags:
-    addPureEnum(c, LazySym(sym: result.sym))
+    addPureEnum(c, result.sym)
   if tfNotNil in e.typ.flags and not hasNull:
-    result.flags.incl tfRequiresInit
+    result.incl tfRequiresInit
   setToStringProc(c.graph, result, genEnumToStrProc(result, n.info, c.graph, c.idgen))
 
 proc semSet(c: PContext, n: PNode, prev: PType): PType =
@@ -203,7 +223,7 @@ proc semSet(c: PContext, n: PNode, prev: PType): PType =
     if base.kind in {tyGenericInst, tyAlias, tySink}: base = skipModifier(base)
     if base.kind notin {tyGenericParam, tyGenericInvocation}:
       if base.kind == tyForward:
-        c.skipTypes.add n
+        c.forwardTypeUpdates.add (getCurrOwner(c), result, n)
       elif not isOrdinalType(base, allowEnumWithHoles = true):
         localError(c.config, n.info, errOrdinalTypeExpected % typeToString(base, preferDesc))
       elif lengthOrd(c.config, base) > MaxSetElements:
@@ -298,6 +318,62 @@ proc fitDefaultNode(c: PContext, n: var PNode, expectedType: PType) =
     typeAllowedCheck(c, n.info, n.typ, skConst, {taProcContextIsNotMacro, taIsDefaultField})
   dec c.inStaticContext
 
+proc containsForwardTypeAux(t: PType; seen: var IntSet): bool
+
+proc containsForwardTypeAux(n: PNode; seen: var IntSet): bool =
+  result = false
+  if n.isNil or n.kind in nkLiterals + {nkNilLit, nkEmpty, nkType}:
+    return
+  if containsForwardTypeAux(n.typ, seen) or
+     (n.kind == nkSym and n.sym.typ != n.typ and containsForwardTypeAux(n.sym.typ, seen)):
+    return true
+
+  for i in 0 ..< n.safeLen:
+    if containsForwardTypeAux(n[i], seen):
+      return true
+
+proc containsForwardTypeAux(t: PType; seen: var IntSet): bool =
+  result = false
+  if t.isNil:
+    return
+  if t.kind == tyForward:
+    return true
+
+  if not containsOrIncl(seen, t.id):
+    if containsForwardTypeAux(t.n, seen):
+      return true
+
+    for i in 0 ..< t.len:
+      if containsForwardTypeAux(t[i], seen):
+        return true
+
+proc containsForwardType(arg: PNode): bool =
+  var seen = initIntSet()
+  containsForwardTypeAux(arg, seen)
+
+proc containsForwardType(t: PType): bool =
+  var seen = initIntSet()
+  containsForwardTypeAux(t, seen)
+
+proc semFieldDefault(c: PContext; owner, expectedType: PType; field: PNode): PType =
+  result = expectedType
+  field[^1] = semExprWithType(c, field[^1], {efDetermineType, efAllowSymChoice}, result)
+  if result == nil:
+    result = field[^1].typ
+
+  if c.inGenericContext == 0:
+    if containsForwardType(field[^1]):
+      c.forwardFieldUpdates.add (owner, field, result)
+    else:
+      fitDefaultNode(c, field[^1], result)
+      result = field[^1].typ.skipIntLit(c.idgen)
+      propagateToOwner(owner, result)
+
+proc semDelayedFieldDefault(c: PContext; owner, expectedType: PType; field: PNode) =
+  resetSemFlag(field[^1])
+  fitDefaultNode(c, field[^1], expectedType)
+  propagateToOwner(owner, field[^1].typ.skipIntLit(c.idgen))
+
 proc isRecursiveType*(t: PType): bool =
   # handle simple recusive types before typeFinalPass
   var cycleDetector = initIntSet()
@@ -313,6 +389,9 @@ proc addSonSkipIntLitChecked(c: PContext; father, son: PType; it: PNode, id: IdG
 
 proc semDistinct(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 0: return newConstraint(c, tyDistinct)
+  if prevIsKind(prev, tyDistinct):
+    # the symbol already has a distinct type (likely resem), don't create a new type
+    return skipGenericPrev(prev)
   result = newOrPrevType(tyDistinct, prev, c)
   addSonSkipIntLitChecked(c, result, semTypeNode(c, n[0], nil), n[0], c.idgen)
   if n.len > 1: result.n = n[1]
@@ -355,7 +434,7 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
   for i in 0..1:
     if hasUnresolvedArgs(c, range[i]):
       result.n.add makeStaticExpr(c, range[i])
-      result.flags.incl tfUnresolved
+      result.incl tfUnresolved
     else:
       result.n.add semConstExpr(c, range[i])
 
@@ -375,15 +454,15 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
       if not isDefined(c.config, "nimPreviewRangeDefault"):
         let n = result.n
         if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
-          incl(result.flags, tfRequiresInit)
+          incl(result, tfRequiresInit)
         elif n[1].kind in {nkCharLit..nkUInt64Lit} and n[1].intVal < 0:
-          incl(result.flags, tfRequiresInit)
+          incl(result, tfRequiresInit)
         elif n[0].kind in {nkFloatLit..nkFloat64Lit} and
             n[0].floatVal > 0.0:
-          incl(result.flags, tfRequiresInit)
+          incl(result, tfRequiresInit)
         elif n[1].kind in {nkFloatLit..nkFloat64Lit} and
             n[1].floatVal < 0.0:
-          incl(result.flags, tfRequiresInit)
+          incl(result, tfRequiresInit)
     else:
       if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
         localError(c.config, n[0].info, "range types need to be constructed with '..', '..<' is not supported")
@@ -430,10 +509,10 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
           let info = if n.safeLen > 1: n[1].info else: n.info
           localError(c.config, info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
         result = makeRangeWithStaticExpr(c, e)
-        if c.inGenericContext > 0: result.flags.incl tfUnresolved
+        if c.inGenericContext > 0: result.incl tfUnresolved
       else:
         result = e.typ.skipTypes({tyTypeDesc})
-        result.flags.incl tfImplicitStatic
+        result.incl tfImplicitStatic
     elif e.kind in (nkCallKinds + {nkBracketExpr}) and hasUnresolvedArgs(c, e):
       if not isOrdinalType(e.typ.skipTypes({tyStatic, tyAlias, tyGenericInst, tySink})):
         localError(c.config, n[1].info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
@@ -512,7 +591,7 @@ proc firstRange(config: ConfigRef, t: PType): PNode =
     result = newFloatNode(nkFloatLit, firstFloat(t))
   else:
     result = newIntNode(nkIntLit, firstOrd(config, t))
-  result.typ() = t
+  result.typ = t
 
 proc semTuple(c: PContext, n: PNode, prev: PType): PType =
   var typ: PType
@@ -527,13 +606,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
     var hasDefaultField = a[^1].kind != nkEmpty
     if hasDefaultField:
       typ = if a[^2].kind != nkEmpty: semTypeNode(c, a[^2], nil) else: nil
-      if c.inGenericContext > 0:
-        a[^1] = semExprWithType(c, a[^1], {efDetermineType, efAllowSymChoice}, typ)
-        if typ == nil:
-          typ = a[^1].typ
-      else:
-        fitDefaultNode(c, a[^1], typ)
-        typ = a[^1].typ.skipIntLit(c.idgen)
+      typ = semFieldDefault(c, result, typ, a)
     elif a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       if c.graph.config.isDefined("nimPreviewRangeDefault") and typ.skipTypes(abstractInst).kind == tyRange:
@@ -572,7 +645,7 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
       result = newSymG(kind, n[1], c)
       var v = considerQuotedIdent(c, n[0])
       if sfExported in allowed and v.id == ord(wStar):
-        incl(result.flags, sfExported)
+        incl(result, sfExported)
       else:
         if not (sfExported in allowed):
           localError(c.config, n[0].info, errXOnlyAtModuleScope % "export")
@@ -782,7 +855,7 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   if a[0].kind != nkSym:
     internalError(c.config, "semRecordCase: discriminant is no symbol")
     return
-  incl(a[0].sym.flags, sfDiscriminant)
+  incl(a[0].sym, sfDiscriminant)
   var covered = toInt128(0)
   var chckCovered = false
   var typ = skipTypes(a[0].typ, abstractVar-{tyTypeDesc})
@@ -899,14 +972,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
     var hasDefaultField = n[^1].kind != nkEmpty
     if hasDefaultField:
       typ = if n[^2].kind != nkEmpty: semTypeNode(c, n[^2], nil) else: nil
-      if c.inGenericContext > 0:
-        n[^1] = semExprWithType(c, n[^1], {efDetermineType, efAllowSymChoice}, typ)
-        if typ == nil:
-          typ = n[^1].typ
-      else:
-        fitDefaultNode(c, n[^1], typ)
-        typ = n[^1].typ.skipIntLit(c.idgen)
-        propagateToOwner(rectype, typ)
+      typ = semFieldDefault(c, rectype, typ, n)
     elif n[^2].kind == nkEmpty:
       localError(c.config, n.info, errTypeExpected)
       typ = errorType(c)
@@ -925,14 +991,19 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
                  else:
                    n[i].info
       suggestSym(c.graph, info, f, c.graph.usageSym)
+      # this must only be enabled for cmd == cmdNif as its a minor breaking
+      # change otherwise :-(
+      if c.config.cmd == cmdCompileToNif:
+        n[i] = newSymNode(f)
       f.typ = typ
       f.position = pos
       f.options = c.config.options
       if fieldOwner != nil and
          {sfImportc, sfExportc} * fieldOwner.flags != {} and
          not hasCaseFields and f.loc.snippet == "":
-        f.loc.snippet = rope(f.name.s)
-        f.flags.incl {sfImportc, sfExportc} * fieldOwner.flags
+        ensureMutable f
+        f.locImpl.snippet = rope(f.name.s)
+        f.incl {sfImportc, sfExportc} * fieldOwner.flags
       inc(pos)
       if containsOrIncl(check, f.name.id):
         localError(c.config, info, "attempt to redefine: '" & f.name.s & "'")
@@ -1001,11 +1072,15 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
   result = nil
   if n.len == 0:
     return newConstraint(c, tyObject)
+  if prevIsKind(prev, tyObject) and sfForward notin prev.sym.flags:
+    # the symbol already has an object type (likely resem), don't create a new type
+    return skipGenericPrev(prev)
   var check = initIntSet()
   var pos = 0
   var base, realBase: PType = nil
   # n[0] contains the pragmas (if any). We process these later...
   checkSonsLen(n, 3, c.config)
+  var needsForwardUpdate = false
   if n[1].kind != nkEmpty:
     realBase = semTypeNode(c, n[1][0], nil)
     base = skipTypesOrNil(realBase, skipPtrs)
@@ -1027,7 +1102,7 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
             return newType(tyError, c.idgen, result.owner)
 
       elif concreteBase.kind == tyForward:
-        c.skipTypes.add n #we retry in the final pass
+        needsForwardUpdate = true
       else:
         if concreteBase.kind != tyError:
           localError(c.config, n[1].info, "inheritance only works with non-final objects; " &
@@ -1037,10 +1112,14 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
         realBase = nil
   if n.kind != nkObjectTy: internalError(c.config, n.info, "semObjectNode")
   result = newOrPrevType(tyObject, prev, c)
+  if needsForwardUpdate:
+    # if the inherited object is a forward type,
+    # the entire object needs to be checked again
+    c.forwardTypeUpdates.add (getCurrOwner(c), result, n) # we retry in the final pass
   rawAddSon(result, realBase)
   if realBase == nil and tfInheritable in flags:
-    result.flags.incl tfInheritable
-  if tfAcyclic in flags: result.flags.incl tfAcyclic
+    result.incl tfInheritable
+  if tfAcyclic in flags: result.incl tfAcyclic
   if result.n.isNil:
     result.n = newNodeI(nkRecList, n.info)
   else:
@@ -1055,14 +1134,17 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
     s.typ = result
     pragma(c, s, n[0], typePragmas)
   if base == nil and tfInheritable notin result.flags:
-    incl(result.flags, tfFinal)
+    incl(result, tfFinal)
   if c.inGenericContext == 0 and computeRequiresInit(c, result):
-    result.flags.incl tfRequiresInit
+    result.incl tfRequiresInit
 
 proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
   if n.len < 1:
     result = newConstraint(c, kind)
   else:
+    if prevIsKind(prev, kind) and tfRefsAnonObj in prev.skipTypes({tyGenericBody}).flags:
+      # the symbol already has an object type (likely resem), don't create a new type
+      return skipGenericPrev(prev)
     let isCall = int ord(n.kind in nkCallKinds+{nkBracketExpr})
     let n = if n[0].kind == nkBracket: n[0] else: n
     checkMinSonsLen(n, 1, c.config)
@@ -1097,22 +1179,22 @@ proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
           addSonSkipIntLit(result, region, c.idgen)
     addSonSkipIntLit(result, t, c.idgen)
     if tfPartial in result.flags:
-      if result.elementType.kind == tyObject: incl(result.elementType.flags, tfPartial)
+      if result.elementType.kind == tyObject: incl(result.elementType, tfPartial)
     # if not isNilable: result.flags.incl tfNotNil
     case wrapperKind
     of tyOwned:
       if optOwnedRefs in c.config.globalOptions:
         let t = newTypeS(tyOwned, c, result)
-        t.flags.incl tfHasOwned
+        t.incl tfHasOwned
         result = t
     of tySink:
       let t = newTypeS(tySink, c, result)
       result = t
     else: discard
     if result.kind == tyRef and
-        c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
+        c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc, gcYrc} and
         tfTriggersCompileTime notin result.flags:
-      result.flags.incl tfHasAsgn
+      result.incl tfHasAsgn
 
 proc findEnforcedStaticType(t: PType): PType =
   # This handles types such as `static[T] and Foo`,
@@ -1169,7 +1251,7 @@ proc addImplicitGeneric(c: PContext; typeClass: PType, typId: PIdent;
         # but `static[auto]` requires upgrading it to a `tyStatic` wrapper so
         # it is instantiated as a compile-time value (`skConst`).
         genericParams[i].sym.linkTo(typeClass)
-        typeClass.flags.incl tfImplicitTypeParam
+        typeClass.incl tfImplicitTypeParam
         return typeClass
       else:
         return genericParams[i].typ
@@ -1177,10 +1259,10 @@ proc addImplicitGeneric(c: PContext; typeClass: PType, typId: PIdent;
   let owner = if typeClass.sym != nil: typeClass.sym
               else: getCurrOwner(c)
   var s = newSym(skType, finalTypId, c.idgen, owner, info)
-  if sfExplain in owner.flags: s.flags.incl sfExplain
-  if typId == nil: s.flags.incl(sfAnon)
+  if sfExplain in owner.flags: s.incl sfExplain
+  if typId == nil: s.incl(sfAnon)
   s.linkTo(typeClass)
-  typeClass.flags.incl tfImplicitTypeParam
+  typeClass.incl tfImplicitTypeParam
   s.position = genericParams.len
   genericParams.add newSymNode(s)
   result = typeClass
@@ -1213,7 +1295,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       localError(c.config, info, errMacroBodyDependsOnGenericTypes % paramName)
     result = addImplicitGeneric(c, newTypeS(tyStatic, c, base),
         paramTypId, info, genericParams, paramName)
-    if result != nil: result.flags.incl({tfHasStatic, tfUnresolved})
+    if result != nil: result.incl({tfHasStatic, tfUnresolved})
 
   of tyTypeDesc:
     if tfUnresolved notin paramType.flags:
@@ -1224,7 +1306,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
         # XXX Why doesn't this check for tyTypeDesc instead?
         paramTypId = nil
       let t = newTypeS(tyTypeDesc, c, paramType.base)
-      incl t.flags, tfCheckedForDestructor
+      incl t, tfCheckedForDestructor
       result = addImplicitGeneric(c, t, paramTypId, info, genericParams, paramName)
     else:
       result = nil
@@ -1274,7 +1356,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     for i in 0..<paramType.len - 1:
       if paramType[i].kind == tyStatic:
         var staticCopy = paramType[i].exactReplica
-        staticCopy.flags.incl tfInferrableStatic
+        staticCopy.incl tfInferrableStatic
         result.rawAddSon staticCopy
       else:
         result.rawAddSon newTypeS(tyAnything, c)
@@ -1312,7 +1394,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       let liftBody = recurse(paramType.skipModifier, true)
       if liftBody != nil:
         result = liftBody
-        result.flags.incl tfHasMeta
+        result.incl tfHasMeta
         #result.shouldHaveMeta
 
   of tyGenericInvocation:
@@ -1343,7 +1425,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     markUsed(c, paramType.sym.info, paramType.sym)
     onUse(paramType.sym.info, paramType.sym)
     if tfWildcard in paramType.flags:
-      paramType.flags.excl tfWildcard
+      paramType.excl tfWildcard
       paramType.sym.transitionGenericParamToType()
 
   else: result = nil
@@ -1439,7 +1521,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           elif hasUnresolvedArgs(c, def):
             # template default value depends on other parameter
             # don't do any typechecking
-            def.typ() = makeTypeFromExpr(c, def.copyTree)
+            def.typ = makeTypeFromExpr(c, def.copyTree)
             break determineType
           elif typ != nil and typ.kind == tyTyped:
             canBeVoid = true
@@ -1458,15 +1540,20 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
         if isEmptyContainer(typ):
           localError(c.config, a.info, "cannot infer the type of parameter '" & $a[0] & "'")
 
-        if typ.kind == tyTypeDesc:
+        if typ.kind == tyTypeDesc or typ.kind == tyGenericParam:
           # consider a proc such as:
           # proc takesType(T = int)
           # a naive analysis may conclude that the proc type is type[int]
           # which will prevent other types from matching - clearly a very
           # surprising behavior. We must instead fix the expected type of
-          # the proc to be the unbound typedesc type:
+          # the proc to be the unbound typedesc type.
+          # Issue #9355: also handles `proc foo[T](U = T)` where the default
+          # references another generic param. The default is a generic-param
+          # symbol whose typ is tyGenericParam (not tyTypeDesc); we treat
+          # such a parameter as an unbound typedesc param so it behaves like
+          # the explicit `proc foo[T](U: type = T)` form.
           typ = newTypeS(tyTypeDesc, c, newTypeS(tyNone, c))
-          typ.flags.incl tfCheckedForDestructor
+          typ.incl tfCheckedForDestructor
 
       elif def.typ != nil and def.typ.kind != tyFromExpr: # def.typ can be void
         # if def.typ != nil and def.typ.kind != tyNone:
@@ -1491,7 +1578,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
     for j in 0..<a.len-2:
       var arg = newSymG(skParam, if a[j].kind == nkPragmaExpr: a[j][0] else: a[j], c)
       if arg.name.id == ord(wUnderscore):
-        arg.flags.incl(sfGenSym)
+        arg.incl(sfGenSym)
       elif containsOrIncl(check, arg.name.id):
         localError(c.config, a[j].info, "attempt to redefine: '" & arg.name.s & "'")
       if a[j].kind == nkPragmaExpr:
@@ -1557,7 +1644,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       # 'auto' as a return type does not imply a generic:
       elif r.kind == tyAnything:
         r = copyType(r, c.idgen, r.owner)
-        r.flags.incl tfRetType
+        r.incl tfRetType
       elif r.kind == tyStatic:
         # type allowed should forbid this type
         discard
@@ -1569,13 +1656,13 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
             r = lifted
             #if r.kind != tyGenericParam:
             #echo "came here for ", typeToString(r)
-            r.flags.incl tfRetType
+            r.incl tfRetType
         r = skipIntLit(r, c.idgen)
         if kind == skIterator:
           # see tchainediterators
           # in cases like iterator foo(it: iterator): typeof(it)
           # we don't need to change the return type to iter[T]
-          result.flags.incl tfIterator
+          result.incl tfIterator
           # XXX Would be nice if we could get rid of this
       result[0] = r
       let oldFlags = result.flags
@@ -1583,17 +1670,17 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       if oldFlags != result.flags:
         # XXX This rather hacky way keeps 'tflatmap' compiling:
         if tfHasMeta notin oldFlags:
-          result.flags.excl tfHasMeta
-      result.n.typ() = r
+          result.excl tfHasMeta
+      result.n.typ = r
 
   if isCurrentlyGeneric():
     for n in genericParams:
       if {sfUsed, sfAnon} * n.sym.flags == {}:
-        result.flags.incl tfUnresolved
+        result.incl tfUnresolved
 
       if tfWildcard in n.sym.typ.flags:
         n.sym.transitionGenericParamToType()
-        n.sym.typ.flags.excl tfWildcard
+        n.sym.typ.excl tfWildcard
 
 proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
   checkMinSonsLen(n, 1, c.config)
@@ -1601,8 +1688,8 @@ proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
     n[i] = semStmt(c, n[i], {})
   if n.len > 0:
     result = semTypeNode(c, n[^1], prev)
-    n.typ() = result
-    n[^1].typ() = result
+    n.typ = result
+    n[^1].typ = result
   else:
     result = nil
 
@@ -1615,15 +1702,15 @@ proc semBlockType(c: PContext, n: PNode, prev: PType): PType =
   if n[0].kind notin {nkEmpty, nkSym}:
     addDecl(c, newSymS(skLabel, n[0], c))
   result = semStmtListType(c, n[1], prev)
-  n[1].typ() = result
-  n.typ() = result
+  n[1].typ = result
+  n.typ = result
   closeScope(c)
   c.p.breakInLoop = oldBreakInLoop
   dec(c.p.nestedBlockCounter)
 
 proc semGenericParamInInvocation(c: PContext, n: PNode): PType =
   result = semTypeNode(c, n, nil)
-  n.typ() = makeTypeDesc(c, result)
+  n.typ = makeTypeDesc(c, result)
 
 proc trySemObjectTypeForInheritedGenericInst(c: PContext, n: PNode, t: PType): bool =
   var
@@ -1654,6 +1741,33 @@ proc containsGenericInvocationWithForward(n: PNode): bool =
           return true
   return false
 
+proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType
+
+proc tryGenericBodyDefaultInvocation*(c: PContext, n: PNode, s: PSym,
+                                      prev: PType): PType =
+  ## Issue #4086 sub-case: `type Foo[T = int]; var f: Foo` is sugar for
+  ## `var f: Foo[int]` when every generic param has a default. Synthesize
+  ## a `Foo[default1, default2, ...]` bracket node and dispatch to the
+  ## existing `semGeneric` so the default-substitution machinery (added
+  ## for issues #4086 / #9355) handles cascading and parameter-referencing
+  ## defaults uniformly.
+  result = nil
+  if s.typ == nil: return
+  let body = s.typ.skipTypes({tyAlias})
+  if body.kind != tyGenericBody or body.len < 2: return
+  for i in 0..<body.len-1:
+    let p = body[i]
+    if p.kind != tyGenericParam or p.sym == nil or p.sym.ast == nil:
+      return
+  var bracket = newNodeI(nkBracketExpr, n.info)
+  if n.kind == nkSym:
+    bracket.add n
+  else:
+    bracket.add newSymNode(s, n.info)
+  for i in 0..<body.len-1:
+    bracket.add copyTree(body[i].sym.ast)
+  result = semGeneric(c, bracket, s, prev)
+
 proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   if s.typ == nil:
     localError(c.config, n.info, "cannot instantiate the '$1' $2" %
@@ -1681,6 +1795,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     for i in 1..<n.len:
       var elem = semGenericParamInInvocation(c, n[i])
       addToResult(elem, true)
+    c.forwardTypeUpdates.add (getCurrOwner(c), result, n)
     return
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
@@ -1707,8 +1822,36 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     var isConcrete = true
     let rType = m.call[0].typ
     let mIndex = if rType != nil: rType.len - 1 else: -1
+    var hasForwardTypeParam = false
+
+    # Issues #4086, #9355: when a generic param's default value references
+    # earlier type params (e.g. `type Foo[T; U = seq[T]]` or `func foo[T](U = T)`)
+    # substitute those references with already-resolved bindings before
+    # adding to the invocation. Bindings are accumulated as the loop walks
+    # left-to-right, so cascade defaults like `[T; U = seq[T]; V = seq[U]]`
+    # work too (each iteration resolves against the previous ones).
+    # Skip the bookkeeping entirely when no param has a default — this
+    # generic body cannot need substitution and the work would just be
+    # pure overhead (matters for large generic graphs / forward cycles).
+    var hasAnyDefault = false
+    for i in 0..<t.len-1:
+      let p = t[i]
+      if p.kind == tyGenericParam and p.sym != nil and p.sym.ast != nil:
+        hasAnyDefault = true
+        break
+    var defaultBindings = initLayeredTypeMap()
+    var hasDefaultBinding = false
+
     for i in 1..<m.call.len:
       var typ = m.call[i].typ
+
+      if hasDefaultBinding and nfDefaultParam in m.call[i].flags and
+         containsGenericType(typ):
+        var cl = initTypeVars(c, defaultBindings, n.info, getCurrOwner(c))
+        let substituted = replaceTypeVarsT(cl, typ)
+        if substituted != nil:
+          typ = substituted
+
       # is this a 'typedesc' *parameter*? If so, use the typedesc type,
       # unstripped.
       if m.call[i].kind == nkSym and m.call[i].sym.kind == skParam and
@@ -1723,13 +1866,44 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
           skip = false
         addToResult(typ, skip)
 
+      if hasAnyDefault and i - 1 < t.kidsLen and t[i - 1].kind == tyGenericParam:
+        defaultBindings.put(t[i - 1], typ.skipTypes({tyTypeDesc}))
+        hasDefaultBinding = true
+
+      if typ.kind == tyForward:
+        hasForwardTypeParam = true
+
     if isConcrete:
       if s.ast == nil and s.typ.kind != tyCompositeTypeClass:
         # XXX: What kind of error is this? is it still relevant?
         localError(c.config, n.info, errCannotInstantiateX % s.name.s)
         result = newOrPrevType(tyError, prev, c)
-      elif containsGenericInvocationWithForward(n[0]):
-        c.skipTypes.add n #fixes 1500
+      elif containsGenericInvocationWithForward(n[0]) or hasForwardTypeParam:
+        # isConcrete == false means this generic type is not instanciated here because
+        # it invoked with generic parameters.
+        # Even if isConcrete == true, don't instanciate it now if there are
+        # unresolved `tyForward` type params.
+        # Such `tyForward` type params will be semchecked later and we can
+        # instanciate this next time.
+        # Some generic types like std/options.Option[T] need the kind of the
+        # given type argument before their fields can be resolved.
+
+        # return `tyForward` instead of `tyGenericInvocation` because:
+        # ```nim
+        #   type Foo = object
+        #     x: Option[Foo]
+        # ```
+        # returning `tyGenericInvocation` makes `Option[Foo]` to `tyGenericInvocation` and
+        # next time `semGeneric` is called with `Option[Foo]`, containsGenericType(typeof(`Foo`)) == true
+        # and `isConcrete == false`.
+        if prev == nil:
+          result = newTypeS(tyForward, c)
+          result.sym = s
+        else:
+          assignType(result, newTypeS(tyForward, c))
+          result.sym = s
+        c.forwardTypeUpdates.add (getCurrOwner(c), result, n) #fixes 1500
+        return
       else:
         result = instGenericContainer(c, n.info, result,
                                       allowMetaTypes = false)
@@ -1745,7 +1919,10 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       if not trySemObjectTypeForInheritedGenericInst(c, n, tx):
         return newOrPrevType(tyError, prev, c)
     var position = 0
-    recomputeFieldPositions(tx, tx.n, position)
+    # it can be that we cached this generic instance. In this case, we don't have to
+    # recompute the field positions:
+    if tx.state != Sealed:
+      recomputeFieldPositions(tx, tx.n, position)
 
 proc maybeAliasType(c: PContext; typeExpr, prev: PType): PType =
   if prev != nil and (prev.kind == tyGenericBody or
@@ -1815,7 +1992,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   # if n.len == 0: return newConstraint(c, tyTypeClass)
   if isNewStyleConcept(n):
     result = newOrPrevType(tyConcept, prev, c)
-    result.flags.incl tfCheckedForDestructor
+    result.incl tfCheckedForDestructor
     result.n = semConceptDeclaration(c, n)
     return result
 
@@ -1826,7 +2003,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   var owner = getCurrOwner(c)
   var candidateTypeSlot = newTypeS(tyAlias, c, c.errorType)
   result = newOrPrevType(tyUserTypeClass, prev, c, son = candidateTypeSlot)
-  result.flags.incl tfCheckedForDestructor
+  result.incl tfCheckedForDestructor
   result.n = n
 
   if inherited.kind != nkEmpty:
@@ -1848,8 +2025,8 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
       # if modifier == tyRef:
         # dummyType.flags.incl tfNotNil
       if modifier == tyTypeDesc:
-        dummyType.flags.incl tfConceptMatchedTypeSym
-        dummyType.flags.incl tfCheckedForDestructor
+        dummyType.incl tfConceptMatchedTypeSym
+        dummyType.incl tfCheckedForDestructor
     else:
       dummyName = param
       dummyType = candidateTypeSlot
@@ -1862,7 +2039,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
     var dummyParam = newSym(if modifier == tyTypeDesc: skType else: skVar,
                             dummyName.ident, c.idgen, owner, param.info)
     dummyParam.typ = dummyType
-    incl dummyParam.flags, sfUsed
+    incl dummyParam.flagsImpl, sfUsed
     addDecl(c, dummyParam)
 
   result.n[3] = semConceptBody(c, n[3])
@@ -1947,7 +2124,7 @@ proc semStaticType(c: PContext, childNode: PNode, prev: PType): PType =
   result = newOrPrevType(tyStatic, prev, c)
   var base = semTypeNode(c, childNode, nil).skipTypes({tyTypeDesc, tyAlias})
   result.rawAddSon(base)
-  result.flags.incl tfHasStatic
+  result.incl tfHasStatic
 
 proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
@@ -1957,12 +2134,12 @@ proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   closeScope(c)
   result = ex.typ
   if result.kind == tyFromExpr:
-    result.flags.incl tfNonConstExpr
+    result.incl tfNonConstExpr
   elif result.kind == tyStatic:
     let base = result.skipTypes({tyStatic})
     if c.inGenericContext > 0 and base.containsGenericType:
       result = makeTypeFromExpr(c, copyTree(ex))
-      result.flags.incl tfNonConstExpr
+      result.incl tfNonConstExpr
     else:
       result = base
   fixupTypeOf(c, prev, result)
@@ -1982,12 +2159,12 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
   closeScope(c)
   result = ex.typ
   if result.kind == tyFromExpr:
-    result.flags.incl tfNonConstExpr
+    result.incl tfNonConstExpr
   elif result.kind == tyStatic:
     let base = result.skipTypes({tyStatic})
     if c.inGenericContext > 0 and base.containsGenericType:
       result = makeTypeFromExpr(c, copyTree(ex))
-      result.flags.incl tfNonConstExpr
+      result.incl tfNonConstExpr
     else:
       result = base
   fixupTypeOf(c, prev, result)
@@ -2014,7 +2191,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         # proc signature for example
         if c.inGenericInst > 0:
           let bound = result.typ.elementType.sym
-          # the symbol may still point to the uninstantiated generic body type
+          # the symbol may still point to the uninstantiated generic body type 
           if bound != nil and bound.typ == result.typ.elementType:
             return bound
           return result
@@ -2023,14 +2200,14 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
           return errorSym(c, n)
         result = result.typ.sym.copySym(c.idgen)
         result.typ = exactReplica(result.typ)
-        result.typ.flags.incl tfUnresolved
+        result.typ.incl tfUnresolved
 
       if result.kind == skGenericParam:
         if result.typ.kind == tyGenericParam and result.typ.len == 0 and
            tfWildcard in result.typ.flags:
           # collapse the wild-card param to a type
           result.transitionGenericParamToType()
-          result.typ.flags.excl tfWildcard
+          result.typ.excl tfWildcard
           return
         else:
           localError(c.config, n.info, errTypeExpected)
@@ -2056,7 +2233,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         n.transitionNoneToSym()
         n.sym = result
         n.info = oldInfo
-        n.typ() = result.typ
+        n.typ = result.typ
     else:
       localError(c.config, n.info, "identifier expected")
       result = errorSym(c, n)
@@ -2072,7 +2249,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     # for ``typeof(countup(1,3))``, see ``tests/ttoseq``.
     checkSonsLen(n, 1, c.config)
     result = semTypeOf(c, n[0], prev)
-    if result.kind == tyTypeDesc: result.flags.incl tfExplicit
+    if result.kind == tyTypeDesc: result.incl tfExplicit
   of nkPar:
     if n.len == 1: result = semTypeNode(c, n[0], prev)
     else:
@@ -2092,7 +2269,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       if result.skipTypes({tyGenericInst, tyAlias, tySink, tyOwned}).kind in NilableTypes+GenericTypes:
         if tfNotNil in result.flags:
           result = freshType(c, result, prev)
-          result.flags.excl(tfNotNil)
+          result.excl(tfNotNil)
       else:
         localError(c.config, n.info, errGenerated, "invalid type")
     elif n[0].kind notin nkIdentKinds:
@@ -2155,7 +2332,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
             result = makeTypeFromExpr(c, newTree(nkStmtListType, n.copyTree))
           of NilableTypes + {tyGenericInvocation, tyForward}:
             result = freshType(c, result, prev)
-            result.flags.incl(tfNotNil)
+            result.incl(tfNotNil)
           else:
             localError(c.config, n.info, errGenerated, "invalid type")
         of 2:
@@ -2205,7 +2382,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     of mSeq:
       result = semContainer(c, n, tySequence, "seq", prev)
       if optSeqDestructors in c.config.globalOptions:
-        incl result.flags, tfHasAsgn
+        incl result, tfHasAsgn
     of mVarargs: result = semVarargs(c, n, prev)
     of mTypeDesc, mType, mTypeOf:
       if n.len != 2:
@@ -2217,7 +2394,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         localError(c.config, n.info, errXExpectsOneTypeParam % name)
       else:
         result = makeTypeDesc(c, semTypeNode(c, n[1], nil))
-        result.flags.incl tfExplicit
+        result.incl tfExplicit
     of mStatic:
       if n.len != 2:
         localError(c.config, n.info, errXExpectsOneTypeParam % "static")
@@ -2341,7 +2518,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = newTypeS(tyBuiltInTypeClass, c)
       let child = newTypeS(tyProc, c)
       if n.kind == nkIteratorTy:
-        child.flags.incl tfIterator
+        child.incl tfIterator
       if n.len > 0 and n[1].kind != nkEmpty and n[1].len > 0:
         # typeclass with pragma
         let symKind = if n.kind == nkIteratorTy: skIterator else: skProc
@@ -2359,9 +2536,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         result = newOrPrevType(tyError, prev, c)
 
       if n.kind == nkIteratorTy and result.kind == tyProc:
-        result.flags.incl(tfIterator)
-      if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
-        result.flags.incl tfHasAsgn
+        result.incl(tfIterator)
+      if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc, gcYrc}:
+        result.incl tfHasAsgn
   of nkEnumTy: result = semEnum(c, n, prev)
   of nkType: result = n.typ
   of nkStmtListType: result = semStmtListType(c, n, prev)
@@ -2372,7 +2549,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     when false:
       localError(c.config, n.info, "type expected, but got: " & renderTree(n))
       result = newOrPrevType(tyError, prev, c)
-  n.typ() = result
+  n.typ = result
   dec c.inTypeContext
 
 proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
@@ -2391,7 +2568,7 @@ proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
 
 proc setMagicIntegral(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
   setMagicType(conf, m, kind, size)
-  incl m.typ.flags, tfCheckedForDestructor
+  incl m.typ, tfCheckedForDestructor
 
 proc processMagicType(c: PContext, m: PSym) =
   case m.magic
@@ -2415,7 +2592,7 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicType(c.config, m, tyString, szUncomputedSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
     if optSeqDestructors in c.config.globalOptions:
-      incl m.typ.flags, tfHasAsgn
+      incl m.typ, tfHasAsgn
   of mCstring:
     setMagicIntegral(c.config, m, tyCstring, c.config.target.ptrSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
@@ -2452,7 +2629,7 @@ proc processMagicType(c: PContext, m: PSym) =
   of mSeq:
     setMagicType(c.config, m, tySequence, szUncomputedSize)
     if optSeqDestructors in c.config.globalOptions:
-      incl m.typ.flags, tfHasAsgn
+      incl m.typ, tfHasAsgn
     if defined(nimsuggest) or c.config.cmd == cmdCheck: # bug #18985
       discard
     else:
@@ -2465,8 +2642,8 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicIntegral(c.config, m, tyIterable, 0)
     rawAddSon(m.typ, newTypeS(tyNone, c))
   of mPNimrodNode:
-    incl m.typ.flags, tfTriggersCompileTime
-    incl m.typ.flags, tfCheckedForDestructor
+    incl m.typ, tfTriggersCompileTime
+    incl m.typ, tfCheckedForDestructor
   of mException: discard
   of mBuiltinType:
     case m.name.s
@@ -2474,7 +2651,7 @@ proc processMagicType(c: PContext, m: PSym) =
     of "sink": setMagicType(c.config, m, tySink, szUncomputedSize)
     of "owned":
       setMagicType(c.config, m, tyOwned, c.config.target.ptrSize)
-      incl m.typ.flags, tfHasOwned
+      incl m.typ, tfHasOwned
     else: localError(c.config, m.info, errTypeExpected)
   else: localError(c.config, m.info, errTypeExpected)
 
@@ -2507,7 +2684,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
           if typ.kind == tyTypeDesc:
             if typ.elementType.kind == tyNone:
               typ = newTypeS(tyTypeDesc, c, newTypeS(tyNone, c))
-              incl typ.flags, tfCheckedForDestructor
+              incl typ, tfCheckedForDestructor
           else:
             typ = semGenericConstraints(c, typ)
 
@@ -2519,15 +2696,15 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
         else:
           # the following line fixes ``TV2*[T:SomeNumber=TR] = array[0..1, T]``
           # from manyloc/named_argument_bug/triengine:
-          def.typ() = def.typ.skipTypes({tyTypeDesc})
+          def.typ = def.typ.skipTypes({tyTypeDesc})
           if not containsGenericType(def.typ):
             def = fitNode(c, typ, def, def.info)
 
       if typ == nil:
         typ = newTypeS(tyGenericParam, c)
-        if father == nil: typ.flags.incl tfWildcard
+        if father == nil: typ.incl tfWildcard
 
-      typ.flags.incl tfGenericTypeParam
+      typ.incl tfGenericTypeParam
 
       for j in 0..<a.len-2:
         var finalType: PType
@@ -2549,7 +2726,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
               localError(c.config, paramName.info, errInOutFlagNotExtern % $paramName[0])
           covarianceFlag = if paramName[0].ident.s == "in": tfContravariant
                           else: tfCovariant
-          if father != nil: father.flags.incl tfCovariant
+          if father != nil: father.incl tfCovariant
           paramName = paramName[1]
 
         var s = if finalType.kind == tyStatic or tfWildcard in typ.flags:
@@ -2557,7 +2734,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
           else:
             newSymG(skType, paramName, c).linkTo(finalType)
 
-        if covarianceFlag != tfUnresolved: s.typ.flags.incl(covarianceFlag)
+        if covarianceFlag != tfUnresolved: s.typ.incl(covarianceFlag)
         if def.kind != nkEmpty: s.ast = def
         s.position = result.len
         result.addSym(s)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -62,34 +62,14 @@ proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext): PType =
 
 proc newConstraint(c: PContext, k: TTypeKind): PType =
   result = newTypeS(tyBuiltInTypeClass, c)
-  result.incl tfCheckedForDestructor
+  result.flags.incl tfCheckedForDestructor
   result.addSonSkipIntLit(newTypeS(k, c), c.idgen)
-
-proc skipGenericPrev(prev: PType): PType =
-  result = prev
-  if prev.kind == tyGenericBody and prev.last.kind != tyNone:
-    result = prev.last
-
-proc prevIsKind(prev: PType, kind: TTypeKind): bool {.inline.} =
-  result = prev != nil and skipGenericPrev(prev).kind == kind
 
 proc semEnum(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 0: return newConstraint(c, tyEnum)
   elif n.len == 1:
     # don't create an empty tyEnum; fixes #3052
     return errorType(c)
-  if prevIsKind(prev, tyEnum):
-    # the symbol already has an enum type (likely resem), don't define a new enum
-    # but add the enum fields to scope from the original type
-    let isPure = sfPure in prev.sym.flags
-    for enumField in prev.n:
-      assert enumField.kind == nkSym
-      let e = enumField.sym
-      if not isPure:
-        addInterfaceOverloadableSymAt(c, c.currentScope, e)
-      else:
-        declarePureEnumField(c, e)
-    return prev
   var
     counter, x: BiggestInt = 0
     e: PSym = nil
@@ -151,7 +131,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       if i != 1:
         if x != counter:
           needsReorder = true
-          incl(result, tfEnumHasHoles)
+          incl(result.flags, tfEnumHasHoles)
       e.ast = strVal # might be nil
       counter = x
     of nkSym:
@@ -184,7 +164,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       identToReplace[] = symNode
     if e.position == 0: hasNull = true
     if result.sym != nil and sfExported in result.sym.flags:
-      e.incl {sfUsed, sfExported}
+      e.flags.incl {sfUsed, sfExported}
 
     result.n.add symNode
     styleCheckDef(c, e)
@@ -210,9 +190,9 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     )
 
   if isPure and sfExported in result.sym.flags:
-    addPureEnum(c, result.sym)
+    addPureEnum(c, LazySym(sym: result.sym))
   if tfNotNil in e.typ.flags and not hasNull:
-    result.incl tfRequiresInit
+    result.flags.incl tfRequiresInit
   setToStringProc(c.graph, result, genEnumToStrProc(result, n.info, c.graph, c.idgen))
 
 proc semSet(c: PContext, n: PNode, prev: PType): PType =
@@ -223,7 +203,7 @@ proc semSet(c: PContext, n: PNode, prev: PType): PType =
     if base.kind in {tyGenericInst, tyAlias, tySink}: base = skipModifier(base)
     if base.kind notin {tyGenericParam, tyGenericInvocation}:
       if base.kind == tyForward:
-        c.forwardTypeUpdates.add (getCurrOwner(c), result, n)
+        c.skipTypes.add n
       elif not isOrdinalType(base, allowEnumWithHoles = true):
         localError(c.config, n.info, errOrdinalTypeExpected % typeToString(base, preferDesc))
       elif lengthOrd(c.config, base) > MaxSetElements:
@@ -318,62 +298,6 @@ proc fitDefaultNode(c: PContext, n: var PNode, expectedType: PType) =
     typeAllowedCheck(c, n.info, n.typ, skConst, {taProcContextIsNotMacro, taIsDefaultField})
   dec c.inStaticContext
 
-proc containsForwardTypeAux(t: PType; seen: var IntSet): bool
-
-proc containsForwardTypeAux(n: PNode; seen: var IntSet): bool =
-  result = false
-  if n.isNil or n.kind in nkLiterals + {nkNilLit, nkEmpty, nkType}:
-    return
-  if containsForwardTypeAux(n.typ, seen) or
-     (n.kind == nkSym and n.sym.typ != n.typ and containsForwardTypeAux(n.sym.typ, seen)):
-    return true
-
-  for i in 0 ..< n.safeLen:
-    if containsForwardTypeAux(n[i], seen):
-      return true
-
-proc containsForwardTypeAux(t: PType; seen: var IntSet): bool =
-  result = false
-  if t.isNil:
-    return
-  if t.kind == tyForward:
-    return true
-
-  if not containsOrIncl(seen, t.id):
-    if containsForwardTypeAux(t.n, seen):
-      return true
-
-    for i in 0 ..< t.len:
-      if containsForwardTypeAux(t[i], seen):
-        return true
-
-proc containsForwardType(arg: PNode): bool =
-  var seen = initIntSet()
-  containsForwardTypeAux(arg, seen)
-
-proc containsForwardType(t: PType): bool =
-  var seen = initIntSet()
-  containsForwardTypeAux(t, seen)
-
-proc semFieldDefault(c: PContext; owner, expectedType: PType; field: PNode): PType =
-  result = expectedType
-  field[^1] = semExprWithType(c, field[^1], {efDetermineType, efAllowSymChoice}, result)
-  if result == nil:
-    result = field[^1].typ
-
-  if c.inGenericContext == 0:
-    if containsForwardType(field[^1]):
-      c.forwardFieldUpdates.add (owner, field, result)
-    else:
-      fitDefaultNode(c, field[^1], result)
-      result = field[^1].typ.skipIntLit(c.idgen)
-      propagateToOwner(owner, result)
-
-proc semDelayedFieldDefault(c: PContext; owner, expectedType: PType; field: PNode) =
-  resetSemFlag(field[^1])
-  fitDefaultNode(c, field[^1], expectedType)
-  propagateToOwner(owner, field[^1].typ.skipIntLit(c.idgen))
-
 proc isRecursiveType*(t: PType): bool =
   # handle simple recusive types before typeFinalPass
   var cycleDetector = initIntSet()
@@ -389,9 +313,6 @@ proc addSonSkipIntLitChecked(c: PContext; father, son: PType; it: PNode, id: IdG
 
 proc semDistinct(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 0: return newConstraint(c, tyDistinct)
-  if prevIsKind(prev, tyDistinct):
-    # the symbol already has a distinct type (likely resem), don't create a new type
-    return skipGenericPrev(prev)
   result = newOrPrevType(tyDistinct, prev, c)
   addSonSkipIntLitChecked(c, result, semTypeNode(c, n[0], nil), n[0], c.idgen)
   if n.len > 1: result.n = n[1]
@@ -434,7 +355,7 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
   for i in 0..1:
     if hasUnresolvedArgs(c, range[i]):
       result.n.add makeStaticExpr(c, range[i])
-      result.incl tfUnresolved
+      result.flags.incl tfUnresolved
     else:
       result.n.add semConstExpr(c, range[i])
 
@@ -454,15 +375,15 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
       if not isDefined(c.config, "nimPreviewRangeDefault"):
         let n = result.n
         if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
-          incl(result, tfRequiresInit)
+          incl(result.flags, tfRequiresInit)
         elif n[1].kind in {nkCharLit..nkUInt64Lit} and n[1].intVal < 0:
-          incl(result, tfRequiresInit)
+          incl(result.flags, tfRequiresInit)
         elif n[0].kind in {nkFloatLit..nkFloat64Lit} and
             n[0].floatVal > 0.0:
-          incl(result, tfRequiresInit)
+          incl(result.flags, tfRequiresInit)
         elif n[1].kind in {nkFloatLit..nkFloat64Lit} and
             n[1].floatVal < 0.0:
-          incl(result, tfRequiresInit)
+          incl(result.flags, tfRequiresInit)
     else:
       if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
         localError(c.config, n[0].info, "range types need to be constructed with '..', '..<' is not supported")
@@ -509,10 +430,10 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
           let info = if n.safeLen > 1: n[1].info else: n.info
           localError(c.config, info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
         result = makeRangeWithStaticExpr(c, e)
-        if c.inGenericContext > 0: result.incl tfUnresolved
+        if c.inGenericContext > 0: result.flags.incl tfUnresolved
       else:
         result = e.typ.skipTypes({tyTypeDesc})
-        result.incl tfImplicitStatic
+        result.flags.incl tfImplicitStatic
     elif e.kind in (nkCallKinds + {nkBracketExpr}) and hasUnresolvedArgs(c, e):
       if not isOrdinalType(e.typ.skipTypes({tyStatic, tyAlias, tyGenericInst, tySink})):
         localError(c.config, n[1].info, errOrdinalTypeExpected % typeToString(e.typ, preferDesc))
@@ -591,7 +512,7 @@ proc firstRange(config: ConfigRef, t: PType): PNode =
     result = newFloatNode(nkFloatLit, firstFloat(t))
   else:
     result = newIntNode(nkIntLit, firstOrd(config, t))
-  result.typ = t
+  result.typ() = t
 
 proc semTuple(c: PContext, n: PNode, prev: PType): PType =
   var typ: PType
@@ -606,7 +527,13 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
     var hasDefaultField = a[^1].kind != nkEmpty
     if hasDefaultField:
       typ = if a[^2].kind != nkEmpty: semTypeNode(c, a[^2], nil) else: nil
-      typ = semFieldDefault(c, result, typ, a)
+      if c.inGenericContext > 0:
+        a[^1] = semExprWithType(c, a[^1], {efDetermineType, efAllowSymChoice}, typ)
+        if typ == nil:
+          typ = a[^1].typ
+      else:
+        fitDefaultNode(c, a[^1], typ)
+        typ = a[^1].typ.skipIntLit(c.idgen)
     elif a[^2].kind != nkEmpty:
       typ = semTypeNode(c, a[^2], nil)
       if c.graph.config.isDefined("nimPreviewRangeDefault") and typ.skipTypes(abstractInst).kind == tyRange:
@@ -645,7 +572,7 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
       result = newSymG(kind, n[1], c)
       var v = considerQuotedIdent(c, n[0])
       if sfExported in allowed and v.id == ord(wStar):
-        incl(result, sfExported)
+        incl(result.flags, sfExported)
       else:
         if not (sfExported in allowed):
           localError(c.config, n[0].info, errXOnlyAtModuleScope % "export")
@@ -855,7 +782,7 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   if a[0].kind != nkSym:
     internalError(c.config, "semRecordCase: discriminant is no symbol")
     return
-  incl(a[0].sym, sfDiscriminant)
+  incl(a[0].sym.flags, sfDiscriminant)
   var covered = toInt128(0)
   var chckCovered = false
   var typ = skipTypes(a[0].typ, abstractVar-{tyTypeDesc})
@@ -972,7 +899,14 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
     var hasDefaultField = n[^1].kind != nkEmpty
     if hasDefaultField:
       typ = if n[^2].kind != nkEmpty: semTypeNode(c, n[^2], nil) else: nil
-      typ = semFieldDefault(c, rectype, typ, n)
+      if c.inGenericContext > 0:
+        n[^1] = semExprWithType(c, n[^1], {efDetermineType, efAllowSymChoice}, typ)
+        if typ == nil:
+          typ = n[^1].typ
+      else:
+        fitDefaultNode(c, n[^1], typ)
+        typ = n[^1].typ.skipIntLit(c.idgen)
+        propagateToOwner(rectype, typ)
     elif n[^2].kind == nkEmpty:
       localError(c.config, n.info, errTypeExpected)
       typ = errorType(c)
@@ -991,19 +925,14 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
                  else:
                    n[i].info
       suggestSym(c.graph, info, f, c.graph.usageSym)
-      # this must only be enabled for cmd == cmdNif as its a minor breaking
-      # change otherwise :-(
-      if c.config.cmd == cmdCompileToNif:
-        n[i] = newSymNode(f)
       f.typ = typ
       f.position = pos
       f.options = c.config.options
       if fieldOwner != nil and
          {sfImportc, sfExportc} * fieldOwner.flags != {} and
          not hasCaseFields and f.loc.snippet == "":
-        ensureMutable f
-        f.locImpl.snippet = rope(f.name.s)
-        f.incl {sfImportc, sfExportc} * fieldOwner.flags
+        f.loc.snippet = rope(f.name.s)
+        f.flags.incl {sfImportc, sfExportc} * fieldOwner.flags
       inc(pos)
       if containsOrIncl(check, f.name.id):
         localError(c.config, info, "attempt to redefine: '" & f.name.s & "'")
@@ -1072,15 +1001,11 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
   result = nil
   if n.len == 0:
     return newConstraint(c, tyObject)
-  if prevIsKind(prev, tyObject) and sfForward notin prev.sym.flags:
-    # the symbol already has an object type (likely resem), don't create a new type
-    return skipGenericPrev(prev)
   var check = initIntSet()
   var pos = 0
   var base, realBase: PType = nil
   # n[0] contains the pragmas (if any). We process these later...
   checkSonsLen(n, 3, c.config)
-  var needsForwardUpdate = false
   if n[1].kind != nkEmpty:
     realBase = semTypeNode(c, n[1][0], nil)
     base = skipTypesOrNil(realBase, skipPtrs)
@@ -1102,7 +1027,7 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
             return newType(tyError, c.idgen, result.owner)
 
       elif concreteBase.kind == tyForward:
-        needsForwardUpdate = true
+        c.skipTypes.add n #we retry in the final pass
       else:
         if concreteBase.kind != tyError:
           localError(c.config, n[1].info, "inheritance only works with non-final objects; " &
@@ -1112,14 +1037,10 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
         realBase = nil
   if n.kind != nkObjectTy: internalError(c.config, n.info, "semObjectNode")
   result = newOrPrevType(tyObject, prev, c)
-  if needsForwardUpdate:
-    # if the inherited object is a forward type,
-    # the entire object needs to be checked again
-    c.forwardTypeUpdates.add (getCurrOwner(c), result, n) # we retry in the final pass
   rawAddSon(result, realBase)
   if realBase == nil and tfInheritable in flags:
-    result.incl tfInheritable
-  if tfAcyclic in flags: result.incl tfAcyclic
+    result.flags.incl tfInheritable
+  if tfAcyclic in flags: result.flags.incl tfAcyclic
   if result.n.isNil:
     result.n = newNodeI(nkRecList, n.info)
   else:
@@ -1134,17 +1055,14 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
     s.typ = result
     pragma(c, s, n[0], typePragmas)
   if base == nil and tfInheritable notin result.flags:
-    incl(result, tfFinal)
+    incl(result.flags, tfFinal)
   if c.inGenericContext == 0 and computeRequiresInit(c, result):
-    result.incl tfRequiresInit
+    result.flags.incl tfRequiresInit
 
 proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
   if n.len < 1:
     result = newConstraint(c, kind)
   else:
-    if prevIsKind(prev, kind) and tfRefsAnonObj in prev.skipTypes({tyGenericBody}).flags:
-      # the symbol already has an object type (likely resem), don't create a new type
-      return skipGenericPrev(prev)
     let isCall = int ord(n.kind in nkCallKinds+{nkBracketExpr})
     let n = if n[0].kind == nkBracket: n[0] else: n
     checkMinSonsLen(n, 1, c.config)
@@ -1179,22 +1097,22 @@ proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
           addSonSkipIntLit(result, region, c.idgen)
     addSonSkipIntLit(result, t, c.idgen)
     if tfPartial in result.flags:
-      if result.elementType.kind == tyObject: incl(result.elementType, tfPartial)
+      if result.elementType.kind == tyObject: incl(result.elementType.flags, tfPartial)
     # if not isNilable: result.flags.incl tfNotNil
     case wrapperKind
     of tyOwned:
       if optOwnedRefs in c.config.globalOptions:
         let t = newTypeS(tyOwned, c, result)
-        t.incl tfHasOwned
+        t.flags.incl tfHasOwned
         result = t
     of tySink:
       let t = newTypeS(tySink, c, result)
       result = t
     else: discard
     if result.kind == tyRef and
-        c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc, gcYrc} and
+        c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc} and
         tfTriggersCompileTime notin result.flags:
-      result.incl tfHasAsgn
+      result.flags.incl tfHasAsgn
 
 proc findEnforcedStaticType(t: PType): PType =
   # This handles types such as `static[T] and Foo`,
@@ -1251,7 +1169,7 @@ proc addImplicitGeneric(c: PContext; typeClass: PType, typId: PIdent;
         # but `static[auto]` requires upgrading it to a `tyStatic` wrapper so
         # it is instantiated as a compile-time value (`skConst`).
         genericParams[i].sym.linkTo(typeClass)
-        typeClass.incl tfImplicitTypeParam
+        typeClass.flags.incl tfImplicitTypeParam
         return typeClass
       else:
         return genericParams[i].typ
@@ -1259,10 +1177,10 @@ proc addImplicitGeneric(c: PContext; typeClass: PType, typId: PIdent;
   let owner = if typeClass.sym != nil: typeClass.sym
               else: getCurrOwner(c)
   var s = newSym(skType, finalTypId, c.idgen, owner, info)
-  if sfExplain in owner.flags: s.incl sfExplain
-  if typId == nil: s.incl(sfAnon)
+  if sfExplain in owner.flags: s.flags.incl sfExplain
+  if typId == nil: s.flags.incl(sfAnon)
   s.linkTo(typeClass)
-  typeClass.incl tfImplicitTypeParam
+  typeClass.flags.incl tfImplicitTypeParam
   s.position = genericParams.len
   genericParams.add newSymNode(s)
   result = typeClass
@@ -1295,7 +1213,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       localError(c.config, info, errMacroBodyDependsOnGenericTypes % paramName)
     result = addImplicitGeneric(c, newTypeS(tyStatic, c, base),
         paramTypId, info, genericParams, paramName)
-    if result != nil: result.incl({tfHasStatic, tfUnresolved})
+    if result != nil: result.flags.incl({tfHasStatic, tfUnresolved})
 
   of tyTypeDesc:
     if tfUnresolved notin paramType.flags:
@@ -1306,7 +1224,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
         # XXX Why doesn't this check for tyTypeDesc instead?
         paramTypId = nil
       let t = newTypeS(tyTypeDesc, c, paramType.base)
-      incl t, tfCheckedForDestructor
+      incl t.flags, tfCheckedForDestructor
       result = addImplicitGeneric(c, t, paramTypId, info, genericParams, paramName)
     else:
       result = nil
@@ -1356,7 +1274,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     for i in 0..<paramType.len - 1:
       if paramType[i].kind == tyStatic:
         var staticCopy = paramType[i].exactReplica
-        staticCopy.incl tfInferrableStatic
+        staticCopy.flags.incl tfInferrableStatic
         result.rawAddSon staticCopy
       else:
         result.rawAddSon newTypeS(tyAnything, c)
@@ -1394,7 +1312,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       let liftBody = recurse(paramType.skipModifier, true)
       if liftBody != nil:
         result = liftBody
-        result.incl tfHasMeta
+        result.flags.incl tfHasMeta
         #result.shouldHaveMeta
 
   of tyGenericInvocation:
@@ -1425,7 +1343,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     markUsed(c, paramType.sym.info, paramType.sym)
     onUse(paramType.sym.info, paramType.sym)
     if tfWildcard in paramType.flags:
-      paramType.excl tfWildcard
+      paramType.flags.excl tfWildcard
       paramType.sym.transitionGenericParamToType()
 
   else: result = nil
@@ -1521,7 +1439,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           elif hasUnresolvedArgs(c, def):
             # template default value depends on other parameter
             # don't do any typechecking
-            def.typ = makeTypeFromExpr(c, def.copyTree)
+            def.typ() = makeTypeFromExpr(c, def.copyTree)
             break determineType
           elif typ != nil and typ.kind == tyTyped:
             canBeVoid = true
@@ -1553,7 +1471,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           # such a parameter as an unbound typedesc param so it behaves like
           # the explicit `proc foo[T](U: type = T)` form.
           typ = newTypeS(tyTypeDesc, c, newTypeS(tyNone, c))
-          typ.incl tfCheckedForDestructor
+          typ.flags.incl tfCheckedForDestructor
 
       elif def.typ != nil and def.typ.kind != tyFromExpr: # def.typ can be void
         # if def.typ != nil and def.typ.kind != tyNone:
@@ -1578,7 +1496,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
     for j in 0..<a.len-2:
       var arg = newSymG(skParam, if a[j].kind == nkPragmaExpr: a[j][0] else: a[j], c)
       if arg.name.id == ord(wUnderscore):
-        arg.incl(sfGenSym)
+        arg.flags.incl(sfGenSym)
       elif containsOrIncl(check, arg.name.id):
         localError(c.config, a[j].info, "attempt to redefine: '" & arg.name.s & "'")
       if a[j].kind == nkPragmaExpr:
@@ -1644,7 +1562,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       # 'auto' as a return type does not imply a generic:
       elif r.kind == tyAnything:
         r = copyType(r, c.idgen, r.owner)
-        r.incl tfRetType
+        r.flags.incl tfRetType
       elif r.kind == tyStatic:
         # type allowed should forbid this type
         discard
@@ -1656,13 +1574,13 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
             r = lifted
             #if r.kind != tyGenericParam:
             #echo "came here for ", typeToString(r)
-            r.incl tfRetType
+            r.flags.incl tfRetType
         r = skipIntLit(r, c.idgen)
         if kind == skIterator:
           # see tchainediterators
           # in cases like iterator foo(it: iterator): typeof(it)
           # we don't need to change the return type to iter[T]
-          result.incl tfIterator
+          result.flags.incl tfIterator
           # XXX Would be nice if we could get rid of this
       result[0] = r
       let oldFlags = result.flags
@@ -1670,17 +1588,17 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       if oldFlags != result.flags:
         # XXX This rather hacky way keeps 'tflatmap' compiling:
         if tfHasMeta notin oldFlags:
-          result.excl tfHasMeta
-      result.n.typ = r
+          result.flags.excl tfHasMeta
+      result.n.typ() = r
 
   if isCurrentlyGeneric():
     for n in genericParams:
       if {sfUsed, sfAnon} * n.sym.flags == {}:
-        result.incl tfUnresolved
+        result.flags.incl tfUnresolved
 
       if tfWildcard in n.sym.typ.flags:
         n.sym.transitionGenericParamToType()
-        n.sym.typ.excl tfWildcard
+        n.sym.typ.flags.excl tfWildcard
 
 proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
   checkMinSonsLen(n, 1, c.config)
@@ -1688,8 +1606,8 @@ proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
     n[i] = semStmt(c, n[i], {})
   if n.len > 0:
     result = semTypeNode(c, n[^1], prev)
-    n.typ = result
-    n[^1].typ = result
+    n.typ() = result
+    n[^1].typ() = result
   else:
     result = nil
 
@@ -1702,15 +1620,15 @@ proc semBlockType(c: PContext, n: PNode, prev: PType): PType =
   if n[0].kind notin {nkEmpty, nkSym}:
     addDecl(c, newSymS(skLabel, n[0], c))
   result = semStmtListType(c, n[1], prev)
-  n[1].typ = result
-  n.typ = result
+  n[1].typ() = result
+  n.typ() = result
   closeScope(c)
   c.p.breakInLoop = oldBreakInLoop
   dec(c.p.nestedBlockCounter)
 
 proc semGenericParamInInvocation(c: PContext, n: PNode): PType =
   result = semTypeNode(c, n, nil)
-  n.typ = makeTypeDesc(c, result)
+  n.typ() = makeTypeDesc(c, result)
 
 proc trySemObjectTypeForInheritedGenericInst(c: PContext, n: PNode, t: PType): bool =
   var
@@ -1795,7 +1713,6 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     for i in 1..<n.len:
       var elem = semGenericParamInInvocation(c, n[i])
       addToResult(elem, true)
-    c.forwardTypeUpdates.add (getCurrOwner(c), result, n)
     return
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
@@ -1822,7 +1739,6 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     var isConcrete = true
     let rType = m.call[0].typ
     let mIndex = if rType != nil: rType.len - 1 else: -1
-    var hasForwardTypeParam = false
 
     # Issues #4086, #9355: when a generic param's default value references
     # earlier type params (e.g. `type Foo[T; U = seq[T]]` or `func foo[T](U = T)`)
@@ -1870,40 +1786,13 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
         defaultBindings.put(t[i - 1], typ.skipTypes({tyTypeDesc}))
         hasDefaultBinding = true
 
-      if typ.kind == tyForward:
-        hasForwardTypeParam = true
-
     if isConcrete:
       if s.ast == nil and s.typ.kind != tyCompositeTypeClass:
         # XXX: What kind of error is this? is it still relevant?
         localError(c.config, n.info, errCannotInstantiateX % s.name.s)
         result = newOrPrevType(tyError, prev, c)
-      elif containsGenericInvocationWithForward(n[0]) or hasForwardTypeParam:
-        # isConcrete == false means this generic type is not instanciated here because
-        # it invoked with generic parameters.
-        # Even if isConcrete == true, don't instanciate it now if there are
-        # unresolved `tyForward` type params.
-        # Such `tyForward` type params will be semchecked later and we can
-        # instanciate this next time.
-        # Some generic types like std/options.Option[T] need the kind of the
-        # given type argument before their fields can be resolved.
-
-        # return `tyForward` instead of `tyGenericInvocation` because:
-        # ```nim
-        #   type Foo = object
-        #     x: Option[Foo]
-        # ```
-        # returning `tyGenericInvocation` makes `Option[Foo]` to `tyGenericInvocation` and
-        # next time `semGeneric` is called with `Option[Foo]`, containsGenericType(typeof(`Foo`)) == true
-        # and `isConcrete == false`.
-        if prev == nil:
-          result = newTypeS(tyForward, c)
-          result.sym = s
-        else:
-          assignType(result, newTypeS(tyForward, c))
-          result.sym = s
-        c.forwardTypeUpdates.add (getCurrOwner(c), result, n) #fixes 1500
-        return
+      elif containsGenericInvocationWithForward(n[0]):
+        c.skipTypes.add n #fixes 1500
       else:
         result = instGenericContainer(c, n.info, result,
                                       allowMetaTypes = false)
@@ -1919,10 +1808,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
       if not trySemObjectTypeForInheritedGenericInst(c, n, tx):
         return newOrPrevType(tyError, prev, c)
     var position = 0
-    # it can be that we cached this generic instance. In this case, we don't have to
-    # recompute the field positions:
-    if tx.state != Sealed:
-      recomputeFieldPositions(tx, tx.n, position)
+    recomputeFieldPositions(tx, tx.n, position)
 
 proc maybeAliasType(c: PContext; typeExpr, prev: PType): PType =
   if prev != nil and (prev.kind == tyGenericBody or
@@ -1992,7 +1878,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   # if n.len == 0: return newConstraint(c, tyTypeClass)
   if isNewStyleConcept(n):
     result = newOrPrevType(tyConcept, prev, c)
-    result.incl tfCheckedForDestructor
+    result.flags.incl tfCheckedForDestructor
     result.n = semConceptDeclaration(c, n)
     return result
 
@@ -2003,7 +1889,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   var owner = getCurrOwner(c)
   var candidateTypeSlot = newTypeS(tyAlias, c, c.errorType)
   result = newOrPrevType(tyUserTypeClass, prev, c, son = candidateTypeSlot)
-  result.incl tfCheckedForDestructor
+  result.flags.incl tfCheckedForDestructor
   result.n = n
 
   if inherited.kind != nkEmpty:
@@ -2025,8 +1911,8 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
       # if modifier == tyRef:
         # dummyType.flags.incl tfNotNil
       if modifier == tyTypeDesc:
-        dummyType.incl tfConceptMatchedTypeSym
-        dummyType.incl tfCheckedForDestructor
+        dummyType.flags.incl tfConceptMatchedTypeSym
+        dummyType.flags.incl tfCheckedForDestructor
     else:
       dummyName = param
       dummyType = candidateTypeSlot
@@ -2039,7 +1925,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
     var dummyParam = newSym(if modifier == tyTypeDesc: skType else: skVar,
                             dummyName.ident, c.idgen, owner, param.info)
     dummyParam.typ = dummyType
-    incl dummyParam.flagsImpl, sfUsed
+    incl dummyParam.flags, sfUsed
     addDecl(c, dummyParam)
 
   result.n[3] = semConceptBody(c, n[3])
@@ -2124,7 +2010,7 @@ proc semStaticType(c: PContext, childNode: PNode, prev: PType): PType =
   result = newOrPrevType(tyStatic, prev, c)
   var base = semTypeNode(c, childNode, nil).skipTypes({tyTypeDesc, tyAlias})
   result.rawAddSon(base)
-  result.incl tfHasStatic
+  result.flags.incl tfHasStatic
 
 proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
@@ -2134,12 +2020,12 @@ proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   closeScope(c)
   result = ex.typ
   if result.kind == tyFromExpr:
-    result.incl tfNonConstExpr
+    result.flags.incl tfNonConstExpr
   elif result.kind == tyStatic:
     let base = result.skipTypes({tyStatic})
     if c.inGenericContext > 0 and base.containsGenericType:
       result = makeTypeFromExpr(c, copyTree(ex))
-      result.incl tfNonConstExpr
+      result.flags.incl tfNonConstExpr
     else:
       result = base
   fixupTypeOf(c, prev, result)
@@ -2159,12 +2045,12 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
   closeScope(c)
   result = ex.typ
   if result.kind == tyFromExpr:
-    result.incl tfNonConstExpr
+    result.flags.incl tfNonConstExpr
   elif result.kind == tyStatic:
     let base = result.skipTypes({tyStatic})
     if c.inGenericContext > 0 and base.containsGenericType:
       result = makeTypeFromExpr(c, copyTree(ex))
-      result.incl tfNonConstExpr
+      result.flags.incl tfNonConstExpr
     else:
       result = base
   fixupTypeOf(c, prev, result)
@@ -2191,7 +2077,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         # proc signature for example
         if c.inGenericInst > 0:
           let bound = result.typ.elementType.sym
-          # the symbol may still point to the uninstantiated generic body type 
+          # the symbol may still point to the uninstantiated generic body type
           if bound != nil and bound.typ == result.typ.elementType:
             return bound
           return result
@@ -2200,14 +2086,14 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
           return errorSym(c, n)
         result = result.typ.sym.copySym(c.idgen)
         result.typ = exactReplica(result.typ)
-        result.typ.incl tfUnresolved
+        result.typ.flags.incl tfUnresolved
 
       if result.kind == skGenericParam:
         if result.typ.kind == tyGenericParam and result.typ.len == 0 and
            tfWildcard in result.typ.flags:
           # collapse the wild-card param to a type
           result.transitionGenericParamToType()
-          result.typ.excl tfWildcard
+          result.typ.flags.excl tfWildcard
           return
         else:
           localError(c.config, n.info, errTypeExpected)
@@ -2233,7 +2119,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         n.transitionNoneToSym()
         n.sym = result
         n.info = oldInfo
-        n.typ = result.typ
+        n.typ() = result.typ
     else:
       localError(c.config, n.info, "identifier expected")
       result = errorSym(c, n)
@@ -2249,7 +2135,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     # for ``typeof(countup(1,3))``, see ``tests/ttoseq``.
     checkSonsLen(n, 1, c.config)
     result = semTypeOf(c, n[0], prev)
-    if result.kind == tyTypeDesc: result.incl tfExplicit
+    if result.kind == tyTypeDesc: result.flags.incl tfExplicit
   of nkPar:
     if n.len == 1: result = semTypeNode(c, n[0], prev)
     else:
@@ -2269,7 +2155,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       if result.skipTypes({tyGenericInst, tyAlias, tySink, tyOwned}).kind in NilableTypes+GenericTypes:
         if tfNotNil in result.flags:
           result = freshType(c, result, prev)
-          result.excl(tfNotNil)
+          result.flags.excl(tfNotNil)
       else:
         localError(c.config, n.info, errGenerated, "invalid type")
     elif n[0].kind notin nkIdentKinds:
@@ -2332,7 +2218,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
             result = makeTypeFromExpr(c, newTree(nkStmtListType, n.copyTree))
           of NilableTypes + {tyGenericInvocation, tyForward}:
             result = freshType(c, result, prev)
-            result.incl(tfNotNil)
+            result.flags.incl(tfNotNil)
           else:
             localError(c.config, n.info, errGenerated, "invalid type")
         of 2:
@@ -2382,7 +2268,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     of mSeq:
       result = semContainer(c, n, tySequence, "seq", prev)
       if optSeqDestructors in c.config.globalOptions:
-        incl result, tfHasAsgn
+        incl result.flags, tfHasAsgn
     of mVarargs: result = semVarargs(c, n, prev)
     of mTypeDesc, mType, mTypeOf:
       if n.len != 2:
@@ -2394,7 +2280,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         localError(c.config, n.info, errXExpectsOneTypeParam % name)
       else:
         result = makeTypeDesc(c, semTypeNode(c, n[1], nil))
-        result.incl tfExplicit
+        result.flags.incl tfExplicit
     of mStatic:
       if n.len != 2:
         localError(c.config, n.info, errXExpectsOneTypeParam % "static")
@@ -2518,7 +2404,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = newTypeS(tyBuiltInTypeClass, c)
       let child = newTypeS(tyProc, c)
       if n.kind == nkIteratorTy:
-        child.incl tfIterator
+        child.flags.incl tfIterator
       if n.len > 0 and n[1].kind != nkEmpty and n[1].len > 0:
         # typeclass with pragma
         let symKind = if n.kind == nkIteratorTy: skIterator else: skProc
@@ -2536,9 +2422,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         result = newOrPrevType(tyError, prev, c)
 
       if n.kind == nkIteratorTy and result.kind == tyProc:
-        result.incl(tfIterator)
-      if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc, gcYrc}:
-        result.incl tfHasAsgn
+        result.flags.incl(tfIterator)
+      if result.callConv == ccClosure and c.config.selectedGC in {gcArc, gcOrc, gcAtomicArc}:
+        result.flags.incl tfHasAsgn
   of nkEnumTy: result = semEnum(c, n, prev)
   of nkType: result = n.typ
   of nkStmtListType: result = semStmtListType(c, n, prev)
@@ -2549,7 +2435,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     when false:
       localError(c.config, n.info, "type expected, but got: " & renderTree(n))
       result = newOrPrevType(tyError, prev, c)
-  n.typ = result
+  n.typ() = result
   dec c.inTypeContext
 
 proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
@@ -2568,7 +2454,7 @@ proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
 
 proc setMagicIntegral(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
   setMagicType(conf, m, kind, size)
-  incl m.typ, tfCheckedForDestructor
+  incl m.typ.flags, tfCheckedForDestructor
 
 proc processMagicType(c: PContext, m: PSym) =
   case m.magic
@@ -2592,7 +2478,7 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicType(c.config, m, tyString, szUncomputedSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
     if optSeqDestructors in c.config.globalOptions:
-      incl m.typ, tfHasAsgn
+      incl m.typ.flags, tfHasAsgn
   of mCstring:
     setMagicIntegral(c.config, m, tyCstring, c.config.target.ptrSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
@@ -2629,7 +2515,7 @@ proc processMagicType(c: PContext, m: PSym) =
   of mSeq:
     setMagicType(c.config, m, tySequence, szUncomputedSize)
     if optSeqDestructors in c.config.globalOptions:
-      incl m.typ, tfHasAsgn
+      incl m.typ.flags, tfHasAsgn
     if defined(nimsuggest) or c.config.cmd == cmdCheck: # bug #18985
       discard
     else:
@@ -2642,8 +2528,8 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicIntegral(c.config, m, tyIterable, 0)
     rawAddSon(m.typ, newTypeS(tyNone, c))
   of mPNimrodNode:
-    incl m.typ, tfTriggersCompileTime
-    incl m.typ, tfCheckedForDestructor
+    incl m.typ.flags, tfTriggersCompileTime
+    incl m.typ.flags, tfCheckedForDestructor
   of mException: discard
   of mBuiltinType:
     case m.name.s
@@ -2651,7 +2537,7 @@ proc processMagicType(c: PContext, m: PSym) =
     of "sink": setMagicType(c.config, m, tySink, szUncomputedSize)
     of "owned":
       setMagicType(c.config, m, tyOwned, c.config.target.ptrSize)
-      incl m.typ, tfHasOwned
+      incl m.typ.flags, tfHasOwned
     else: localError(c.config, m.info, errTypeExpected)
   else: localError(c.config, m.info, errTypeExpected)
 
@@ -2684,7 +2570,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
           if typ.kind == tyTypeDesc:
             if typ.elementType.kind == tyNone:
               typ = newTypeS(tyTypeDesc, c, newTypeS(tyNone, c))
-              incl typ, tfCheckedForDestructor
+              incl typ.flags, tfCheckedForDestructor
           else:
             typ = semGenericConstraints(c, typ)
 
@@ -2696,15 +2582,15 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
         else:
           # the following line fixes ``TV2*[T:SomeNumber=TR] = array[0..1, T]``
           # from manyloc/named_argument_bug/triengine:
-          def.typ = def.typ.skipTypes({tyTypeDesc})
+          def.typ() = def.typ.skipTypes({tyTypeDesc})
           if not containsGenericType(def.typ):
             def = fitNode(c, typ, def, def.info)
 
       if typ == nil:
         typ = newTypeS(tyGenericParam, c)
-        if father == nil: typ.incl tfWildcard
+        if father == nil: typ.flags.incl tfWildcard
 
-      typ.incl tfGenericTypeParam
+      typ.flags.incl tfGenericTypeParam
 
       for j in 0..<a.len-2:
         var finalType: PType
@@ -2726,7 +2612,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
               localError(c.config, paramName.info, errInOutFlagNotExtern % $paramName[0])
           covarianceFlag = if paramName[0].ident.s == "in": tfContravariant
                           else: tfCovariant
-          if father != nil: father.incl tfCovariant
+          if father != nil: father.flags.incl tfCovariant
           paramName = paramName[1]
 
         var s = if finalType.kind == tyStatic or tfWildcard in typ.flags:
@@ -2734,7 +2620,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
           else:
             newSymG(skType, paramName, c).linkTo(finalType)
 
-        if covarianceFlag != tfUnresolved: s.typ.incl(covarianceFlag)
+        if covarianceFlag != tfUnresolved: s.typ.flags.incl(covarianceFlag)
         if def.kind != nkEmpty: s.ast = def
         s.position = result.len
         result.addSym(s)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -3126,7 +3126,7 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
           if formal.typ.kind == tyTypeDesc and defaultValue.typ != nil and
              defaultValue.typ.kind != tyTypeDesc:
             let typedescTyp = newTypeS(tyTypeDesc, c, defaultValue.typ)
-            typedescTyp.incl tfCheckedForDestructor
+            typedescTyp.flags.incl tfCheckedForDestructor
             defaultValue.typ = typedescTyp
         if defaultValue.kind == nkNilLit:
           defaultValue = implicitConv(nkHiddenStdConv, formal.typ, defaultValue, m, c)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -3105,6 +3105,29 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
         if nfDefaultRefsParam in formal.ast.flags:
           m.call.flags.incl nfDefaultRefsParam
         var defaultValue = copyTree(formal.ast)
+        # Issues #4086, #9355: when the default value is a bare reference
+        # to an earlier generic type param (e.g. `func foo[T](U: type = T)`
+        # or its untyped form `func foo[T](U = T)`) — recognised by the
+        # default's static type being `tyGenericParam` — substitute T
+        # against the explicit-instantiation bindings via
+        # `prepareTypesInBody` (which updates both the AST sym and its
+        # typ) and wrap the result as `tyTypeDesc` so the
+        # `tfImplicitTypeParam` binding path below treats it like a
+        # literal type default (`U: type = int`).
+        # Other defaults (value expressions like `arr.high`, proc-call
+        # expressions like `newTensor[T](0)` whose result type is a
+        # `tyGenericInvocation`/`tyGenericInst`, etc.) have a non-
+        # `tyGenericParam` type and are left untouched, so the existing
+        # default-handling machinery takes care of them.
+        if defaultValue.typ != nil and
+           defaultValue.typ.kind == tyGenericParam and
+           m.calleeSym != nil:
+          defaultValue = prepareTypesInBody(c, m.bindings, defaultValue, m.calleeSym)
+          if formal.typ.kind == tyTypeDesc and defaultValue.typ != nil and
+             defaultValue.typ.kind != tyTypeDesc:
+            let typedescTyp = newTypeS(tyTypeDesc, c, defaultValue.typ)
+            typedescTyp.incl tfCheckedForDestructor
+            defaultValue.typ = typedescTyp
         if defaultValue.kind == nkNilLit:
           defaultValue = implicitConv(nkHiddenStdConv, formal.typ, defaultValue, m, c)
         # proc foo(x: T = 0.0)

--- a/tests/generics/tgeneric_param_default_deps.nim
+++ b/tests/generics/tgeneric_param_default_deps.nim
@@ -2,6 +2,8 @@ discard """
   matrix: "; --mm:refc"
 """
 
+import std/deques
+
 # Generic type parameter defaults that reference other type parameters
 # (issues #4086, #9355).
 #
@@ -89,3 +91,33 @@ block: # distinct of a defaulted instantiation
   var f: DistFoo
   Foo[int](f).data.add 7
   doAssert Foo[int](f).data == @[7]
+
+block: # union constraint + default referencing T (review request)
+  type Foo[T; U: seq[T]|Deque[T] = seq[T]] = object
+    data: U
+  var f: Foo[int]
+  f.data.add 42
+  doAssert f.data is seq[int]
+  doAssert f.data == @[42]
+
+block: # typeclass constraint + concrete-type default (review request)
+  type Foo[T: SomeInteger = int] = object
+    x: T
+  var f: Foo
+  f.x = 7
+  doAssert f.x is int
+  var g: Foo[int64]
+  g.x = 9'i64
+  doAssert g.x is int64
+
+block: # concept constraint + default (review request)
+  type HasLen = concept x
+    x.len is int
+  type Foo[T: HasLen = string] = object
+    val: T
+  var f: Foo
+  f.val = "hi"
+  doAssert f.val.len == 2
+  var g: Foo[seq[int]]
+  g.val = @[1, 2, 3]
+  doAssert g.val.len == 3

--- a/tests/generics/tgeneric_param_default_deps.nim
+++ b/tests/generics/tgeneric_param_default_deps.nim
@@ -1,0 +1,91 @@
+discard """
+  matrix: "; --mm:refc"
+"""
+
+# Generic type parameter defaults that reference other type parameters
+# (issues #4086, #9355).
+#
+# Currently fails on Nim 2.3.1 devel:
+#   #9355 sample 1: `Error: type expected`
+#   #9355 sample 2: `Error: cannot instantiate: 'U:type'`
+#   type-side    : `Error: invalid type: 'Foo[system.int, seq[T]]' for var`
+#
+# Other languages (C++, TypeScript, Rust, Scala) all support this pattern.
+# Nim already supports T-independent defaults like `[T; U = int]`; this
+# extends support to defaults that reference earlier type parameters.
+
+block: # #9355 sample 1: proc default referencing T (untyped form)
+  func foo[T](U = T): U = discard
+  # `U` defaults to whatever T resolves to.
+  doAssert foo[int]() is int
+  doAssert foo[string]() is string
+
+block: # #9355 sample 2: proc default with `type =` referencing T
+  func foo[T](U: type = T): U = discard
+  doAssert foo[int]() is int
+  doAssert foo[float]() is float
+
+block: # #4086 type-side: object generic param default `seq[T]`
+  type Foo[T; U = seq[T]] = object
+    data: U
+  var f: Foo[int]
+  f.data.add 42
+  doAssert f.data == @[42]
+
+block: # nested reference: U default uses T, V default uses U
+  type Foo[T; U = seq[T]; V = seq[U]] = object
+    data: V
+  var f: Foo[int]
+  f.data.add @[1, 2]
+  doAssert f.data == @[@[1, 2]]
+
+block: # type-side direct: U = T
+  type Foo[T; U = T] = object
+    a: T
+    b: U
+  var f: Foo[int]
+  f.a = 1
+  f.b = 2
+  doAssert f.b is int
+
+block: # type-side compound: U = ref T
+  type Foo[T; U = ref T] = object
+    p: U
+  var f: Foo[int]
+  f.p = new(int)
+  f.p[] = 9
+  doAssert f.p[] == 9
+
+block: # type-side compound: U = array[3, T]
+  type Foo[T; U = array[3, T]] = object
+    arr: U
+  var f: Foo[int]
+  f.arr[0] = 10
+  f.arr[2] = 30
+  doAssert f.arr[0] == 10
+  doAssert f.arr[2] == 30
+
+block: # #4086 original: all params defaulted, invocation with no args
+  type Foo[T = int] = object
+    x: T
+  var f: Foo
+  f.x = 42
+  doAssert f.x == 42
+
+block: # alias of a defaulted instantiation
+  type Foo[T; U = T] = object
+    a: T
+    b: U
+  type IntFoo = Foo[int]
+  var f: IntFoo
+  f.a = 1
+  f.b = 2
+  doAssert f.b is int
+
+block: # distinct of a defaulted instantiation
+  type Foo[T; U = seq[T]] = object
+    data: U
+  type DistFoo = distinct Foo[int]
+  var f: DistFoo
+  Foo[int](f).data.add 7
+  doAssert Foo[int](f).data == @[7]


### PR DESCRIPTION
## Backport of #25799 to v2.2.x

Backport of #25799 ("fixes #4086, #9355; allow generic param defaults to reference other type params") to the v2.2.x maintenance branch.

Prerequisite: #25799 should be merged to devel first.

### How this differs from a plain cherry-pick

Direct cherry-pick of #25799 onto version-2-2 doesn't work as-is because:
- `containsForwardType*` helpers (= the `hasForwardTypeParam` machinery from #25519) don't exist in v2.2.x — inlined locally
- Several compiler-internal API differences (e.g. `result.flags.incl X` vs devel's `result.incl X`, absence of `LazySym` wrapper for `addPureEnum`, `c.skipTypes.add n` vs `c.forwardTypeUpdates.add (...)`)

The patch adapts to v2.2.x by inlining the missing helpers and matching the older API. Touched file set is the same as #25799:

- compiler/semtypes.nim
- compiler/semstmts.nim
- compiler/sigmatch.nim
- tests/generics/tgeneric_param_default_deps.nim

### Verification

Local on Linux x86_64, Nim 2.2.11 (bin/nim built fresh from this branch via csources_v3 + koch boot):

- `nim check compiler/nim.nim` — [SuccessX]
- target test `tests/generics/tgeneric_param_default_deps.nim` — PASS
- testament regression on the same 19 cats as #25799 (`generic generics objects typerel types metatype statictypes concepts proc overload template macros tuples collections distinct varstmt let varres assign init`) — no FAILURE summary in any cat. (One valgrind-tagged test in `objects` aborted locally because valgrind is not installed; CI should cover that path.)

ref: #25799 (devel)
Related issues: #4086, #9355