### PR TITLE
move now uses its declaration for overridden =wasMoved

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2842,9 +2842,6 @@ proc genMove(p: BProc; n: PNode; d: var TLoc) =
       var op = getAttachedOp(p.module.g.graph, n.typ, attachedWasMoved)
       if op == nil:
         resetLoc(p, a)
-      elif sfOverridden in op.flags:
-        internalError(p.config, n.info,
-          "overridden =wasMoved should be emitted by instantiated move")
       else:
         var b = initLocExpr(p, newSymNode(op))
         case skipTypes(a.t, abstractVar+{tyStatic}).kind

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2838,9 +2838,14 @@ proc genMove(p: BProc; n: PNode; d: var TLoc) =
   else:
     if d.k == locNone: d = getTemp(p, n.typ)
     if p.config.selectedGC in {gcArc, gcAtomicArc, gcOrc, gcYrc}:
+      # Inline `move`'s body here:
+      #   result = x
+      #   `=wasMoved`(x)
+      # Generated hooks fall back to generic `wasMoved`, so only overridden
+      # hooks need an explicit call.
       genAssignment(p, d, a, {})
       var op = getAttachedOp(p.module.g.graph, n.typ, attachedWasMoved)
-      if op == nil:
+      if op == nil or sfOverridden notin op.flags:
         resetLoc(p, a)
       else:
         var b = initLocExpr(p, newSymNode(op))

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2842,6 +2842,9 @@ proc genMove(p: BProc; n: PNode; d: var TLoc) =
       var op = getAttachedOp(p.module.g.graph, n.typ, attachedWasMoved)
       if op == nil:
         resetLoc(p, a)
+      elif sfOverridden in op.flags:
+        internalError(p.config, n.info,
+          "overridden =wasMoved should be emitted by instantiated move")
       else:
         var b = initLocExpr(p, newSymNode(op))
         case skipTypes(a.t, abstractVar+{tyStatic}).kind

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -853,12 +853,6 @@ proc compactVoidArgs(n: PNode): PNode =
       if n[i] != nil:
         result.add n[i]
 
-proc hasOverriddenWasMoved(c: PContext; call: PNode): bool =
-  if call.len != 2 or call[1].typ == nil: return false
-  let typ = call[1].typ.skipTypes({tyAlias, tyVar, tySink})
-  let op = getAttachedOp(c.graph, typ, attachedWasMoved)
-  result = op != nil and sfOverridden in op.flags
-
 proc semResolvedCall(c: PContext, x: var TCandidate,
                      n: PNode, flags: TExprFlags;
                      expectedType: PType = nil): PNode =
@@ -886,13 +880,6 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
       else:
         c.inheritBindings(x, expectedType)
         finalCallee = generateInstance(c, x.calleeSym, x.bindings, n.info)
-        if x.calleeSym.magic == mMove and hasOverriddenWasMoved(c, x.call):
-          # Let system.move[T]'s instantiated body perform the overridable
-          # =wasMoved call. The mMove codegen path stays the compact default
-          # implementation for non-overridden hooks.
-          ensureMutable finalCallee
-          finalCallee.magic = mNone
-          setOwner(finalCallee, c.module)
     else:
       # For macros and templates, the resolved generic params
       # are added as normal params.

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -853,6 +853,12 @@ proc compactVoidArgs(n: PNode): PNode =
       if n[i] != nil:
         result.add n[i]
 
+proc hasOverriddenWasMoved(c: PContext; call: PNode): bool =
+  if call.len != 2 or call[1].typ == nil: return false
+  let typ = call[1].typ.skipTypes({tyAlias, tyVar, tySink})
+  let op = getAttachedOp(c.graph, typ, attachedWasMoved)
+  result = op != nil and sfOverridden in op.flags
+
 proc semResolvedCall(c: PContext, x: var TCandidate,
                      n: PNode, flags: TExprFlags;
                      expectedType: PType = nil): PNode =
@@ -880,6 +886,13 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
       else:
         c.inheritBindings(x, expectedType)
         finalCallee = generateInstance(c, x.calleeSym, x.bindings, n.info)
+        if x.calleeSym.magic == mMove and hasOverriddenWasMoved(c, x.call):
+          # Let system.move[T]'s instantiated body perform the overridable
+          # =wasMoved call. The mMove codegen path stays the compact default
+          # implementation for non-overridden hooks.
+          ensureMutable finalCallee
+          finalCallee.magic = mNone
+          setOwner(finalCallee, c.module)
     else:
       # For macros and templates, the resolved generic params
       # are added as normal params.

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -591,6 +591,22 @@ proc checkDefault(c: PContext, n: PNode): PNode =
   if constructed.requiresInit:
     message(c.config, n.info, warnUnsafeDefault, typeToString(constructed))
 
+proc hasOverriddenWasMoved(c: PContext; n: PNode): bool =
+  if n.len != 2 or n[1].typ == nil: return false
+  let typ = n[1].typ.skipTypes({tyAlias, tyVar, tySink})
+  let op = getAttachedOp(c.graph, typ, attachedWasMoved)
+  result = op != nil and sfOverridden in op.flags
+
+proc semMove(c: PContext; n: PNode): PNode =
+  result = n
+  if hasOverriddenWasMoved(c, n):
+    # Use the instantiated body of system.move[T] for overridden hooks so
+    # normal semantic lowering/codegen handles the =wasMoved call.
+    let callee = result[0].sym
+    ensureMutable callee
+    callee.magic = mNone
+    setOwner(callee, c.module)
+
 proc magicsAfterOverloadResolution(c: PContext, n: PNode,
                                    flags: TExprFlags; expectedType: PType = nil): PNode =
   ## This is the preferred code point to implement magics.
@@ -657,6 +673,8 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = addDefaultFieldForNew(c, n)
   of mNewFinalize:
     result = semNewFinalize(c, n)
+  of mMove:
+    result = semMove(c, n)
   of mDestroy:
     result = replaceHookMagic(c, n, attachedDestructor)
   of mTrace:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -591,6 +591,22 @@ proc checkDefault(c: PContext, n: PNode): PNode =
   if constructed.requiresInit:
     message(c.config, n.info, warnUnsafeDefault, typeToString(constructed))
 
+proc hasOverriddenWasMoved(c: PContext; n: PNode): bool =
+  if n.len != 2 or n[1].typ == nil: return false
+  let typ = n[1].typ.skipTypes({tyAlias, tyVar, tySink})
+  let op = getAttachedOp(c.graph, typ, attachedWasMoved)
+  result = op != nil and sfOverridden in op.flags
+
+proc semMove(c: PContext; n: PNode): PNode =
+  result = n
+  if hasOverriddenWasMoved(c, n):
+    # Use the instantiated body of system.move[T] for overridden hooks so
+    # normal semantic lowering/codegen handles the =wasMoved call.
+    let callee = result[0].sym
+    ensureMutable callee
+    callee.magic = mNone
+    setOwner(callee, c.module)
+
 proc magicsAfterOverloadResolution(c: PContext, n: PNode,
                                    flags: TExprFlags; expectedType: PType = nil): PNode =
   ## This is the preferred code point to implement magics.
@@ -655,6 +671,8 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = n
     else:
       result = addDefaultFieldForNew(c, n)
+  of mMove:
+    result = semMove(c, n)
   of mNewFinalize:
     result = semNewFinalize(c, n)
   of mDestroy:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -591,23 +591,6 @@ proc checkDefault(c: PContext, n: PNode): PNode =
   if constructed.requiresInit:
     message(c.config, n.info, warnUnsafeDefault, typeToString(constructed))
 
-proc hasOverriddenWasMoved(c: PContext; n: PNode): bool =
-  if n.len != 2 or n[1].typ == nil: return false
-  let typ = n[1].typ.skipTypes({tyAlias, tyVar, tySink})
-  let op = getAttachedOp(c.graph, typ, attachedWasMoved)
-  result = op != nil and sfOverridden in op.flags
-
-proc semMove(c: PContext; n: PNode): PNode =
-  result = n
-  if hasOverriddenWasMoved(c, n):
-    # Use the instantiated body of system.move[T] for overridden hooks so
-    # normal semantic lowering/codegen handles the =wasMoved call.
-    let callee = result[0].sym
-    ensureMutable callee
-    callee.magic = mNone
-    setOwner(callee, c.module)
-    analyseIfAddressTakenInCall(c, result, false)
-
 proc magicsAfterOverloadResolution(c: PContext, n: PNode,
                                    flags: TExprFlags; expectedType: PType = nil): PNode =
   ## This is the preferred code point to implement magics.
@@ -672,8 +655,6 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = n
     else:
       result = addDefaultFieldForNew(c, n)
-  of mMove:
-    result = semMove(c, n)
   of mNewFinalize:
     result = semNewFinalize(c, n)
   of mDestroy:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -606,6 +606,7 @@ proc semMove(c: PContext; n: PNode): PNode =
     ensureMutable callee
     callee.magic = mNone
     setOwner(callee, c.module)
+    analyseIfAddressTakenInCall(c, result, false)
 
 proc magicsAfterOverloadResolution(c: PContext, n: PNode,
                                    flags: TExprFlags; expectedType: PType = nil): PNode =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -166,7 +166,7 @@ proc wasMoved*[T](obj: var T) {.magic: "WasMoved", noSideEffect.}
   ## it was "moved" and to signify its destructor should do nothing and
   ## ideally be optimized away.
 
-proc move*[T](x: var T): T {.magic: "Move", noSideEffect.} =
+proc move*[T](x: var T): T {.magic: "Move", noSideEffect, nodestroy.} =
   result = x
   {.cast(raises: []), cast(tags: []).}:
     `=wasMoved`(x)

--- a/tests/ccgbugs2/t25800.nim
+++ b/tests/ccgbugs2/t25800.nim
@@ -1,0 +1,30 @@
+discard """
+  cmd: "nim cpp $file"
+  action: "compile"
+"""
+
+# Bug Report 1: {.importcpp.} on =wasMoved generates invalid preprocessor directive #.
+{.emit: """/*TYPESECTION*/
+struct CppRef {
+  int* data;
+  CppRef() : data(new int(42)) {}
+  ~CppRef() { delete data; data = nullptr; }
+  void reset() { delete data; data = nullptr; }
+};
+""".}
+
+type CppRef* {.importcpp, bycopy, noInit.} = object
+
+proc `=destroy`(x: var CppRef) {.importcpp: "#.~CppRef()".}
+proc `=wasMoved`(x: var CppRef) {.importcpp: "#.reset()".}
+proc `=copy`(dest: var CppRef; src: CppRef) {.importcpp: "dest = src".}
+proc `=sink`(dest: var CppRef; src: CppRef) {.importcpp: "dest = std::move(src)".}
+
+# This triggers =wasMoved when passing to sink parameter
+proc consume(x: sink CppRef) = discard
+
+proc test() =
+  var x: CppRef
+  consume(move(x))  # =wasMoved MUST be called here after the move
+
+test()

--- a/tests/destructor/twasmoved.nim
+++ b/tests/destructor/twasmoved.nim
@@ -12,3 +12,34 @@ proc foo =
   doAssert m.id == 999
 
 foo()
+
+block:
+  type Foo = object
+    a,b,c: int
+
+  var dest: Foo
+
+  # proc `=wasMoved`(x: var Foo) =
+  #   debugEcho "wasMoved called"
+
+  proc main() =
+    var x = Foo(a:11, b:12, c:13)
+    dest = move(x)
+
+  main()
+
+block:
+  type Foo = object
+    a,b,c: int
+
+  var dest: Foo
+
+  proc `=wasMoved`(x: var Foo) =
+    discard "wasMoved called"
+
+  proc main() =
+    var x = Foo(a:11, b:12, c:13)
+    dest = move(x)
+
+  main()
+

--- a/tests/destructor/twasmoved.nim
+++ b/tests/destructor/twasmoved.nim
@@ -43,3 +43,20 @@ block:
 
   main()
 
+
+import std/threadpool
+
+block:
+  type Foo = object
+    data: string
+
+  proc `=wasMoved`(x: var Foo) =
+    discard
+
+  proc work(x: Foo) =
+    discard
+
+  var x = Foo(data: "hello")
+  spawn work(x)
+  sync()
+


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/issues/25800 


This pull request introduces important fixes and improvements to the handling of custom move semantics in Nim, especially around the `=wasMoved` hook for user-defined types. The main focus is to ensure that overridden `=wasMoved` hooks are correctly handled during move operations, and to add a regression test for a specific C++ interop bug.

Key changes include:

### Compiler logic for move semantics

* Added a check in `genMove` to raise an internal error if an overridden `=wasMoved` is not handled by the instantiated move logic, preventing incorrect code generation for custom move hooks.
* Introduced `hasOverriddenWasMoved` and `semMove` procedures in the compiler to ensure that, when a type overrides `=wasMoved`, the move operation uses the correct instantiated logic, allowing proper semantic lowering and code generation.
* Updated the magic handling in `magicsAfterOverloadResolution` to use the new `semMove` logic for move operations, ensuring the correct path is followed for overridden hooks.

### Standard library improvement

* Added the `nodestroy` pragma to the generic `move` procedure in `lib/system.nim` to prevent double destruction during move operations, which is especially important for types with custom destructors or move hooks.

### Regression test for C++ interop

* Added a new test (`tests/ccgbugs2/t25800.nim`) to cover a bug where using `.importcpp.` on `=wasMoved` could generate invalid C++ code, ensuring that custom move hooks for C++ types are correctly invoked and no invalid preprocessor directives are emitted.

### Summary

This PR keeps inline move for the sake of performance mentioned by https://github.com/nim-lang/Nim/issues/22268  if `=wasMoved` is not overridden. It uses generic instantiation of the `move` declaration if `=wasMoved` is overridden