### PR TITLE
fix: duplicated words in manual.md and gc_common.nim comment

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8874,7 +8874,7 @@ Byref pragma
 The `byref` pragma can be applied to an object or tuple type or a proc param.
 When applied to a type it instructs the compiler to pass the type by reference
 (hidden pointer) to procs. When applied to a param it will take precedence, even
-if the the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
+if the type was marked as `bycopy`. When an `importc` type has a `byref` pragma or
 parameters are marked as `byref` in an `importc` proc, these params translate to pointers.
 When an `importcpp` type has a `byref` pragma, these params translate to
 C++ references `&`.

--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -143,7 +143,7 @@ when nimCoroutines:
 
   proc find(first: var GcStack, bottom: pointer): ptr GcStack =
     ## Find stack struct based on bottom pointer. If `bottom` is nil then main
-    ## thread stack is is returned.
+    ## thread stack is returned.
     if bottom == nil:
       return addr(gch.stack)
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated words:
- `doc/manual.md` — "if the the type was marked as `bycopy`" → "if the type was marked as `bycopy`"
- `lib/system/gc_common.nim` — "## thread stack is is returned." → "## thread stack is returned."

No code/behavior change.