### PR TITLE
fix: duplicated "to" in alloc.nim comments

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -691,7 +691,7 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
     removeChunkFromMatrix2(a, result, fl, sl)
     if result.size >= size + PageSize:
       splitChunk(a, result, size)
-  # set 'used' to to true:
+  # set 'used' to true:
   result.prevSize = 1
   track("setUsedToFalse", addr result.size, sizeof(int))
   sysAssert result.owner == addr a, "getBigChunk: No owner set!"
@@ -708,7 +708,7 @@ proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
   result.next = nil
   result.prev = nil
   result.size = size
-  # set 'used' to to true:
+  # set 'used' to true:
   result.prevSize = 1
   result.owner = addr a
   incl(a, a.chunkStarts, pageIndex(result))


### PR DESCRIPTION
Two one-line typo fixes for duplicated "to" in `lib/system/alloc.nim`:
- "# set 'used' to to true:" → "# set 'used' to true:" (occurs twice, lines ~694 and ~711)

No code/behavior change.