### PR TITLE
fixes #25803: add genCppConstructorExpr for full type-prefixed expression

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -696,6 +696,24 @@ proc genCppInitializer(m: BModule, prc: BProc; typ: PType; didGenTemp: var bool)
       if prc == nil:
         assert p.blocks.len == 0, "BProc belongs to a struct doesnt have blocks"
 
+# Unlike genCppInitializer which returns just the braced value list (e.g. "{a, b}"),
+# genCppConstructorExpr returns a full type-prefixed expression (e.g. "Foo(a, b)").
+# This is used when a standalone construction expression is needed — e.g. on the
+# right-hand side of an assignment — whereas genCppInitializer is used in variable
+# declarations where the type is already written separately before the initializer.
+proc genCppConstructorExpr(m: BModule, prc: BProc; typ: PType; didGenTemp: var bool): Snippet =
+  var params = ""
+  if typ.itemId in m.g.graph.initializersPerType:
+    let call = m.g.graph.initializersPerType[typ.itemId]
+    if call != nil:
+      var p = prc
+      if p == nil:
+        p = BProc(module: m)
+      params = genCppParamsForCtor(p, call, didGenTemp)
+      if prc == nil:
+        assert p.blocks.len == 0, "BProc belongs to a struct doesnt have blocks"
+  result = getTypeDesc(m, typ, dkVar) & "(" & params & ")"
+
 proc genRecordFieldsAux(m: BModule; n: PNode,
                         rectype: PType,
                         check: var IntSet; result: var Builder; unionPrefix = "") =

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -696,24 +696,6 @@ proc genCppInitializer(m: BModule, prc: BProc; typ: PType; didGenTemp: var bool)
       if prc == nil:
         assert p.blocks.len == 0, "BProc belongs to a struct doesnt have blocks"
 
-# Unlike genCppInitializer which returns just the braced value list (e.g. "{a, b}"),
-# genCppConstructorExpr returns a full type-prefixed expression (e.g. "Foo(a, b)").
-# This is used when a standalone construction expression is needed — e.g. on the
-# right-hand side of an assignment — whereas genCppInitializer is used in variable
-# declarations where the type is already written separately before the initializer.
-proc genCppConstructorExpr(m: BModule, prc: BProc; typ: PType; didGenTemp: var bool): Snippet =
-  var params = ""
-  if typ.itemId in m.g.graph.initializersPerType:
-    let call = m.g.graph.initializersPerType[typ.itemId]
-    if call != nil:
-      var p = prc
-      if p == nil:
-        p = BProc(module: m)
-      params = genCppParamsForCtor(p, call, didGenTemp)
-      if prc == nil:
-        assert p.blocks.len == 0, "BProc belongs to a struct doesnt have blocks"
-  result = getTypeDesc(m, typ, dkVar) & "(" & params & ")"
-
 proc genRecordFieldsAux(m: BModule; n: PNode,
                         rectype: PType,
                         check: var IntSet; result: var Builder; unionPrefix = "") =
@@ -2130,3 +2112,21 @@ proc genTypeSection(m: BModule, n: PNode) =
       discard getTypeDescAux(m, s.typ, intSet, descKindFromSymKind(s.kind))
       if m.g.generatedHeader != nil:
         discard getTypeDescAux(m.g.generatedHeader, s.typ, intSet, descKindFromSymKind(s.kind))
+
+# Unlike genCppInitializer which returns just the braced value list (e.g. "{a, b}"),
+# genCppConstructorExpr returns a full type-prefixed expression (e.g. "Foo(a, b)").
+# This is used when a standalone construction expression is needed — e.g. on the
+# right-hand side of an assignment — whereas genCppInitializer is used in variable
+# declarations where the type is already written separately before the initializer.
+proc genCppConstructorExpr(m: BModule, prc: BProc; typ: PType; didGenTemp: var bool): Snippet =
+  var params = ""
+  if typ.itemId in m.g.graph.initializersPerType:
+    let call = m.g.graph.initializersPerType[typ.itemId]
+    if call != nil:
+      var p = prc
+      if p == nil:
+        p = BProc(module: m)
+      params = genCppParamsForCtor(p, call, didGenTemp)
+      if prc == nil:
+        assert p.blocks.len == 0, "BProc belongs to a struct doesnt have blocks"
+  result = getTypeDesc(m, typ, dkVar) & "(" & params & ")"

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -526,7 +526,7 @@ proc resetLoc(p: BProc, loc: var TLoc) =
   if isImportedCppType(typ):
     var didGenTemp = false
     let rl = rdLoc(loc)
-    let init = genCppInitializer(p.module, p, typ, didGenTemp)
+    let init = genCppConstructorExpr(p.module, p, typ, didGenTemp)
     p.s(cpsStmts).addAssignment(rl, init)
     return
   if optSeqDestructors in p.config.globalOptions and typ.kind in {tyString, tySequence}:

--- a/tests/cpp/tcpp_default_ctor_assignment.h
+++ b/tests/cpp/tcpp_default_ctor_assignment.h
@@ -1,0 +1,30 @@
+#ifndef TCPP_DEFAULT_CTOR_ASSIGNMENT_H
+#define TCPP_DEFAULT_CTOR_ASSIGNMENT_H
+
+struct AmbiguousAssign {
+  int x;
+  const char* y;
+
+  AmbiguousAssign(): x(0), y(nullptr) {}
+  AmbiguousAssign(int x, const char* y): x(x), y(y) {}
+
+  AmbiguousAssign& operator=(int v) {
+    x = v;
+    y = nullptr;
+    return *this;
+  }
+
+  AmbiguousAssign& operator=(const char* s) {
+    x = 0;
+    y = s;
+    return *this;
+  }
+
+  AmbiguousAssign& operator=(const AmbiguousAssign& other) {
+    x = other.x;
+    y = other.y;
+    return *this;
+  }
+};
+
+#endif

--- a/tests/cpp/tcpp_default_ctor_assignment.nim
+++ b/tests/cpp/tcpp_default_ctor_assignment.nim
@@ -1,0 +1,14 @@
+discard """
+  cmd: "nim cpp $file"
+"""
+
+type
+  AmbiguousAssign {.importcpp, header: "tcpp_default_ctor_assignment.h".} = object
+    x: cint
+    y: cstring
+
+proc main =
+  var xs = newSeq[AmbiguousAssign](3)
+  doAssert xs.len == 3
+
+main()


### PR DESCRIPTION
fixes #25803

This pull request introduces a new approach for generating C++ constructor expressions in the Nim compiler's C++ backend, ensuring that type-prefixed construction is used when needed (such as in assignments), rather than just braced initializer lists. It also adds a new test case (with corresponding C++ header) to verify correct behavior when assigning to types with overloaded assignment operators and constructors.

**C++ code generation improvements:**

* Added `genCppConstructorExpr` in `ccgtypes.nim`, which generates a full type-prefixed constructor expression (e.g., `Foo(a, b)`) for C++ code generation, as opposed to just a braced initializer list. This is important for contexts like assignments where the type must be explicit.
* Updated `resetLoc` in `cgen.nim` to use `genCppConstructorExpr` instead of `genCppInitializer` when initializing imported C++ types, ensuring correct code generation for assignments.

**Testing:**

* Added a new C++ header file, `tcpp_default_ctor_assignment.h`, defining a struct `AmbiguousAssign` with overloaded assignment operators and constructors to test ambiguous assignment scenarios.
* Added a corresponding Nim test, `tcpp_default_ctor_assignment.nim`, which exercises construction and assignment for the imported C++ type, ensuring the new code generation logic works as intended.