### PR TITLE
fixes #25821; unary minus off by one mistake [backport]

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -1349,7 +1349,7 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
           lexMessage(L, errGenerated, "invalid token: no whitespace between number and identifier")
     of '-':
       if L.buf[L.bufpos+1] in {'0'..'9'} and
-          (L.bufpos-1 == 0 or L.buf[L.bufpos-1] in UnaryMinusWhitelist):
+          (L.bufpos == 0 or L.buf[L.bufpos-1] in UnaryMinusWhitelist):
         # x)-23 # binary minus
         # ,-23  # unary minus
         # \n-78 # unary minus? Yes.

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -544,6 +544,12 @@ proc main() =
     var x = 5
     doAssert fmt"{(x=7;123.456)=:13e}" == "(x=7;123.456)= 1.234560e+02"
     doAssert x==7
+
+  block: # binary operators in interpolated expressions
+    let n = 1
+    doAssert &"{n-1}" == "0"
+    doAssert fmt"{n-1}" == "0"
+
   block: #curly bracket expressions and tuples
     proc formatValue(result: var string; value:Table|bool|JsonNode; specifier:string) = result.add $value
 


### PR DESCRIPTION
fixes #25821

This pull request includes a minor bug fix in the lexer and adds new test cases for string formatting with binary operators in interpolated expressions.

Lexer bug fix:

* Fixed an off-by-one error in the unary minus detection logic in the `rawGetTok` procedure in `lexer.nim`, ensuring that the start-of-buffer condition is correctly checked.

Testing improvements:

* Added tests to `tstrformat.nim` to verify that binary operators (such as subtraction) work correctly inside interpolated string expressions using both `&` and `fmt`.