### PR TITLE
fixes 25826; var type class parameter matches lvalues

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1907,6 +1907,11 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
             return isNone
         if doBind: put(c, f, a)
         return isGeneric
+      elif targetKind == tyVar:
+        # always matches.
+        # The argument is checked if it is lvalue or not outside of this proc.
+        if doBind: put(c, f, if aOrig.kind == tyVar: aOrig else: makeVarType(c.c, a))
+        return isGeneric
       else:
         return isNone
   of tyUserTypeClassInst, tyUserTypeClass:
@@ -2863,7 +2868,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
       else:
         noMatch()
 
-    if formal.typ.kind in {tyVar}:
+    if formal.typ.kind in {tyVar} or (formal.typ.kind == tyBuiltInTypeClass and formal.typ[0].kind == tyVar):
       let argConverter = if arg.kind == nkHiddenDeref: arg[0] else: arg
       if argConverter.kind == nkHiddenCallConv:
         if argConverter.typ.kind notin {tyVar}:

--- a/tests/typerel/tvar_type_class_param.nim
+++ b/tests/typerel/tvar_type_class_param.nim
@@ -1,0 +1,23 @@
+# issue #25826
+
+proc foo(x: var) = x = 123
+
+block:
+  var a = 0
+  foo(a)
+  doAssert a == 123
+
+proc bar(x: var int) =
+  foo(x)
+
+block:
+  var a = 0
+  bar(a)
+  doAssert a == 123
+
+proc baz(x: var int): var int = x
+
+block:
+  var a = 0
+  foo(baz(a))
+  doAssert a == 123

--- a/tests/typerel/tvar_type_class_param_fail.nim
+++ b/tests/typerel/tvar_type_class_param_fail.nim
@@ -1,0 +1,10 @@
+discard """
+  action: "reject"
+  errormsg: "type mismatch: got <int>"
+"""
+# issue #25826
+
+proc foo(x: var) = x = 123
+
+let a = 0
+foo(a)


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/25826

This PR makes var type class parameters match any lvalues.
But it makes `expr is var` is always true.
