### PR TITLE
stdlib/os: add findExeAll iterator (fixes #20611)

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -233,6 +233,9 @@ when supportedSystem:
     ## If the system supports symlinks it also resolves them until it
     ## meets the actual file. This behavior can be disabled if desired
     ## by setting `followSymlinks = false`.
+    ##
+    ## See also:
+    ## * `findExeAll iterator`_
 
     if exe.len == 0: return
     template checkCurrentDir() =
@@ -274,6 +277,61 @@ when supportedSystem:
                 break
           return x
     result = ""
+
+  iterator findExeAll*(exe: string, followSymlinks: bool = true;
+                       extensions: openArray[string] = ExeExts): string {.
+    tags: [ReadDirEffect, ReadEnvEffect, ReadIOEffect], noNimJs.} =
+    ## Searches for `exe` in the current working directory and then
+    ## in directories listed in the ``PATH`` environment variable,
+    ## yielding every match found (like ``which -a`` on Unix).
+    ##
+    ## `exe` is added the `ExeExts`_ file extensions if it has none.
+    ##
+    ## If the system supports symlinks it also resolves them until it
+    ## meets the actual file. This behavior can be disabled if desired
+    ## by setting `followSymlinks = false`.
+    ##
+    ## See also:
+    ## * `findExe proc`_
+    if exe.len > 0:
+      template checkCurrentDir() =
+        for ext in extensions:
+          let p = addFileExt(exe, ext)
+          if fileExists(p): yield p
+      when defined(posix):
+        if '/' in exe: checkCurrentDir()
+      else:
+        checkCurrentDir()
+      let path = getEnv("PATH")
+      for candidate in split(path, PathSep):
+        if candidate.len == 0: continue
+        when defined(windows):
+          var x = (if candidate[0] == '"' and candidate[^1] == '"':
+                    substr(candidate, 1, candidate.len-2) else: candidate) /
+                  exe
+        else:
+          var x = expandTilde(candidate) / exe
+        for ext in extensions:
+          var x = addFileExt(x, ext)
+          if fileExists(x):
+            when defined(posix) and not defined(nintendoswitch):
+              while followSymlinks: # doubles as if here
+                if x.symlinkExists:
+                  var r = newString(maxSymlinkLen)
+                  var len = readlink(x.cstring, r.cstring, maxSymlinkLen)
+                  if len < 0:
+                    raiseOSError(osLastError(), exe)
+                  if len > maxSymlinkLen:
+                    r = newString(len+1)
+                    len = readlink(x.cstring, r.cstring, len)
+                  setLen(r, len)
+                  if isAbsolute(r):
+                    x = r
+                  else:
+                    x = parentDir(x) / r
+                else:
+                  break
+            yield x
 
   when weirdTarget:
     const times = "fake const"

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -298,40 +298,47 @@ when supportedSystem:
         for ext in extensions:
           let p = addFileExt(exe, ext)
           if fileExists(p): yield p
+      var searchPath = true
       when defined(posix):
-        if '/' in exe: checkCurrentDir()
+        if '/' in exe:
+          checkCurrentDir()
+          searchPath = false
       else:
         checkCurrentDir()
-      let path = getEnv("PATH")
-      for candidate in split(path, PathSep):
-        if candidate.len == 0: continue
-        when defined(windows):
-          var x = (if candidate[0] == '"' and candidate[^1] == '"':
-                    substr(candidate, 1, candidate.len-2) else: candidate) /
-                  exe
-        else:
-          var x = expandTilde(candidate) / exe
-        for ext in extensions:
-          var x = addFileExt(x, ext)
-          if fileExists(x):
-            when defined(posix) and not defined(nintendoswitch):
-              while followSymlinks: # doubles as if here
-                if x.symlinkExists:
-                  var r = newString(maxSymlinkLen)
-                  var len = readlink(x.cstring, r.cstring, maxSymlinkLen)
-                  if len < 0:
-                    raiseOSError(osLastError(), exe)
-                  if len > maxSymlinkLen:
-                    r = newString(len+1)
-                    len = readlink(x.cstring, r.cstring, len)
-                  setLen(r, len)
-                  if isAbsolute(r):
-                    x = r
+      if searchPath:
+        let path = getEnv("PATH")
+        for candidate in split(path, PathSep):
+          if candidate.len == 0: continue
+          when defined(windows):
+            var x = (if candidate.len >= 2 and candidate[0] == '"' and candidate[^1] == '"':
+                      substr(candidate, 1, candidate.len-2) else: candidate) /
+                    exe
+          else:
+            var x = expandTilde(candidate) / exe
+          for ext in extensions:
+            let xExt = addFileExt(x, ext)
+            if fileExists(xExt):
+              when defined(posix) and not defined(nintendoswitch):
+                var resolved = xExt
+                while followSymlinks: # doubles as if here
+                  if resolved.symlinkExists:
+                    var r = newString(maxSymlinkLen)
+                    var len = readlink(resolved.cstring, r.cstring, maxSymlinkLen)
+                    if len < 0:
+                      raiseOSError(osLastError(), exe)
+                    if len > maxSymlinkLen:
+                      r = newString(len+1)
+                      len = readlink(resolved.cstring, r.cstring, len)
+                    setLen(r, len)
+                    if isAbsolute(r):
+                      resolved = r
+                    else:
+                      resolved = parentDir(resolved) / r
                   else:
-                    x = parentDir(x) / r
-                else:
-                  break
-            yield x
+                    break
+                yield resolved
+              else:
+                yield xExt
 
   when weirdTarget:
     const times = "fake const"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -877,3 +877,27 @@ block: # searchExtPos
     doAssert "c:..a".searchExtPos == -1
     doAssert r"c:\..a".searchExtPos == -1
     doAssert "c:.a.b".searchExtPos == 4
+
+block: # findExeAll — fixes #20611
+  # empty exe yields nothing
+  block:
+    var count = 0
+    for x in findExeAll(""):
+      inc count
+    doAssert count == 0
+
+  # findExeAll yields files that exist
+  block:
+    for x in findExeAll("nim"):
+      doAssert fileExists(x), "findExeAll yielded non-existent path: " & x
+
+  # findExeAll includes the result of findExe (when nim is on PATH)
+  block:
+    let first = findExe("nim")
+    if first != "":
+      var found = false
+      for x in findExeAll("nim"):
+        if x == first:
+          found = true
+          break
+      doAssert found, "findExeAll did not include findExe result: " & first


### PR DESCRIPTION
## Summary

Adds `findExeAll`, an iterator that yields **all** matching executables in `PATH` — the equivalent of `which -a` on Unix systems.

```nim
import std/os

# print every `nim` executable on PATH (not just the first)
for path in findExeAll("nim"):
  echo path
```

Fixes #20611.

## Details

- Same signature as `findExe` (`exe`, `followSymlinks`, `extensions`)
- Handles symlink resolution (Posix) and Windows quoted PATH entries identically to `findExe`
- Empty `exe` argument yields nothing
- Added `See also` cross-reference in both `findExe` and `findExeAll` docs

## Test

Added a block in `tests/stdlib/tos.nim` that verifies:
1. Empty `exe` yields nothing
2. All yielded paths exist on disk (`fileExists`)
3. `findExeAll` includes the path returned by `findExe`

Tested with Nim 2.2.10 on Linux x86-64.

> Hi — I want to be upfront: I work with Claude as a co-processor. I'm 56, came to programming late, and this is genuinely how I learn and contribute. I understand what I'm submitting, but I didn't write it alone.
> If your project prefers human-only contributions, just say so — I'll close without any friction. If you're okay with this model, I'm happy to iterate on feedback.