### PR TITLE
fixes #22936; Generic inheritance matching gives type mismatch when object has members

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1754,6 +1754,19 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     considerPreviousT:
       if a == f or a.kind == tyGenericInst and a.skipGenericAlias[0] == f:
         bindingRet isGeneric
+      var depth = -1
+      # Generic constraints like `F: Future` reach sigmatch as a `tyGenericBody`.
+      # Accept descendants of the generic family here as well, not just direct
+      # `Future[...]` instantiations.
+      if isGenericSubtype(c, a, f, depth, f):
+        if depth > 0:
+          var askip = skippedNone
+          let aobj = a.skipToObject(askip)
+          if aobj != nil and tfFinal notin aobj.flags:
+            # Keep overload ranking consistent with other inheritance-based
+            # matches: deeper descendants are slightly worse candidates.
+            inc c.inheritancePenalty, depth + int(c.inheritancePenalty < 0)
+        bindingRet(if depth == 0: isGeneric else: isSubtype)
       let ff = last(f)
       if ff != nil:
         result = typeRel(c, ff, a, flags)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1757,10 +1757,13 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       let ff = last(f)
       if ff != nil:
         result = typeRel(c, ff, a, flags)
-      if result == isNone and a.kind == tyGenericInst:
+      if result == isNone and a.kind == tyGenericInst and trBindGenericParam in flags:
         var depth = -1
-        # Generic constraints like `F: Future` can miss in `last(f)` when the
-        # actual type inherits from a concrete generic instantiation.
+        # Generic-parameter constraints like `F: Future` can miss in `last(f)`
+        # when the actual type inherits from a concrete generic instantiation.
+        # Keep this fallback scoped to generic-parameter matching so typedesc
+        # overloads such as `type Future[T]` still prefer more specific
+        # descendants like `InternalRaisesFuture[T, E]`.
         if isGenericSubtype(c, a, f, depth, f) and depth > 0:
           var askip = skippedNone
           let aobj = a.skipToObject(askip)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1754,22 +1754,21 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     considerPreviousT:
       if a == f or a.kind == tyGenericInst and a.skipGenericAlias[0] == f:
         bindingRet isGeneric
-      var depth = -1
-      # Generic constraints like `F: Future` reach sigmatch as a `tyGenericBody`.
-      # Accept descendants of the generic family here as well, not just direct
-      # `Future[...]` instantiations.
-      if isGenericSubtype(c, a, f, depth, f):
-        if depth > 0:
+      let ff = last(f)
+      if ff != nil:
+        result = typeRel(c, ff, a, flags)
+      if result == isNone and a.kind == tyGenericInst:
+        var depth = -1
+        # Generic constraints like `F: Future` can miss in `last(f)` when the
+        # actual type inherits from a concrete generic instantiation.
+        if isGenericSubtype(c, a, f, depth, f) and depth > 0:
           var askip = skippedNone
           let aobj = a.skipToObject(askip)
           if aobj != nil and tfFinal notin aobj.flags:
             # Keep overload ranking consistent with other inheritance-based
             # matches: deeper descendants are slightly worse candidates.
             inc c.inheritancePenalty, depth + int(c.inheritancePenalty < 0)
-        bindingRet(if depth == 0: isGeneric else: isSubtype)
-      let ff = last(f)
-      if ff != nil:
-        result = typeRel(c, ff, a, flags)
+          result = isGeneric
   of tyGenericInvocation:
     var x = a.skipGenericAlias
     if x.kind == tyGenericParam and x.len > 0:

--- a/tests/typerel/t8905.nim
+++ b/tests/typerel/t8905.nim
@@ -5,3 +5,31 @@ type
 proc newFoo[T](): Foo[T] = Foo[T](newSeq[T]())
 
 var x = newFoo[Bar[int]]()
+
+# issue #22936
+
+import std/macros
+
+type
+  InternalFutureBase = object of RootObj
+
+  FutureBase = ref object of InternalFutureBase
+
+  Future[T] = ref object of FutureBase
+    internalValue: T
+
+  B[T, E] = ref object of Future[T]
+
+proc take[F: Future](fut: F) = discard
+
+proc takeMany[F: Future](futs: seq[F]) = discard
+
+macro checkFutures[F: Future](futs: seq[F]): untyped =
+  newEmptyNode()
+
+var future: B[void, void]
+var futures: seq[B[void, void]]
+
+take(future)
+takeMany(futures)
+checkFutures(futures)


### PR DESCRIPTION
fixes #22936

This pull request improves the compiler's handling of generic type constraints, specifically for subtypes of generics, and adds a test to cover this behavior. The main changes are an enhancement to the type relationship logic in the compiler and a new test case for generic subtyping with `Future`.

### Compiler improvements for generic subtyping

* Updated `typeRel` in `compiler/sigmatch.nim` to allow generic constraints (like `F: Future`) to accept not just direct instantiations but also descendants of the generic family, ensuring more flexible and correct overload resolution. Inheritance depth is now considered for overload ranking, making deeper descendants slightly less preferred, consistent with other inheritance-based matches.

### New test coverage

* Added a test in `tests/typerel/t8905.nim` to verify that generic constraints correctly accept subtypes of `Future`, including a custom `B[T, E] = ref object of Future[T]` type, and that overloads like `take`, `takeMany`, and the macro `checkFutures` work as expected with these types.