### PR TITLE
fixes  #25591; error with capture in closure iterator

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -771,6 +771,8 @@ proc liftCapturedVars(n: PNode; owner: PSym; d: var DetectionPass;
         let oldInContainer = c.inContainer
         c.inContainer = 0
         var body = transformBody(d.graph, d.idgen, s, {})
+        if not d.processed.containsOrIncl(s.id):
+          detectCapturedVars(body, s, d)
         body = liftCapturedVars(body, s, d, c)
         if c.envVars.getOrDefault(s.id).isNil:
           s.transformedBody = body

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -520,6 +520,8 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
   of nkLambdaKinds, nkIteratorDef:
     if n.typ != nil:
       detectCapturedVars(n[namePos], owner, c)
+  of nkClosure:
+    detectCapturedVars(n[1], owner, c)
   of nkReturnStmt:
     detectCapturedVars(n[0], owner, c)
   of nkIdentDefs:

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -239,6 +239,17 @@ block t2023_objiter:
   var o = init()
   echo(o.iter())
 
+  block: # bug #25591
+    iterator h(): int =
+      let n = 0
+      (proc() = discard n)()
+      yield 0
+
+    proc a() =
+      iterator m(): int {.closure.} = (for _ in h(): discard)
+      let _ = m
+
+    a()
 
 block:
   # bug #13739


### PR DESCRIPTION
fixes  #25591

This pull request makes targeted improvements to the compiler's lambda lifting logic and adds a new test case to cover a previously reported bug involving object iterators and closures. The most significant changes are an enhancement to how closure nodes are handled during captured variable detection and the addition of a regression test for bug #25591.

Compiler improvements:

* Updated the `detectCapturedVars` procedure in `compiler/lambdalifting.nim` to ensure that closure nodes (`nkClosure`) are properly traversed for captured variable detection, which helps with correct lambda lifting and closure analysis.

Testing and bug coverage:

* Added a new block in `tests/iter/titer_issues.nim` to reproduce and verify the fix for bug #25591, involving iterators that capture variables via closures. This ensures that the compiler correctly handles this edge case in user code.