### PR TITLE
fix sortVTableDispatchers KeyError on re-entrant method registration via when isMainModule

### DIFF
--- a/compiler/vtables.nim
+++ b/compiler/vtables.nim
@@ -152,6 +152,8 @@ proc sortVTableDispatchers*(g: ModuleGraph) =
         rootItemIdCount.inc(baseType.itemId)
       for idx in 0..<g.methods[bucket].methods.len:
         let obj = g.methods[bucket].methods[idx].typ.firstParamType.skipTypes(skipPtrs)
+        if obj.itemId notin itemTable:
+          itemTable[obj.itemId] = newSeq[PSym](methodIndexLen)
         itemTable[obj.itemId][mIndex] = g.methods[bucket].methods[idx]
 
   for baseType in rootTypeSeq:

--- a/tests/method/mvtables_reentry_a.nim
+++ b/tests/method/mvtables_reentry_a.nim
@@ -1,0 +1,5 @@
+type
+  VtableBaseA* = ref object of RootObj
+
+method say*(a: VtableBaseA): string {.base.} =
+  "base"

--- a/tests/method/mvtables_reentry_b.nim
+++ b/tests/method/mvtables_reentry_b.nim
@@ -1,0 +1,7 @@
+import mvtables_reentry_a
+
+type
+  VtableDerivedB* = ref object of VtableBaseA
+
+method say*(d: VtableDerivedB): string =
+  "derived"

--- a/tests/method/tvtable_reentry.nim
+++ b/tests/method/tvtable_reentry.nim
@@ -1,0 +1,19 @@
+discard """
+  targets: "c cpp"
+"""
+
+import mvtables_reentry_a
+
+type
+  MainType = ref object of VtableBaseA
+
+method say*(m: MainType): string =
+  "main"
+
+when isMainModule:
+  import mvtables_reentry_b
+
+  let a: VtableBaseA = VtableDerivedB()
+  doAssert a.say() == "derived"
+  let m: VtableBaseA = MainType()
+  doAssert m.say() == "main"


### PR DESCRIPTION
Encountered in realistic scenario. Didn't really look at this one. AI one shot it lol

When a module defines method-bearing types and a when isMainModule
block imports additional modules that also define methods on the same
type hierarchy, sortVTableDispatchers crashes with:

  Error: unhandled exception: key not found: (module: N, item: M) [KeyError]

Root cause: the itemTable built during vtable sorting is populated
from g.objectTree[baseType], which only contains types from the
current compilation pass. When when isMainModule triggers re-import
of method-bearing modules, the method bucket contains types from both
passes. Types from the first pass have ItemIds not present in the
second pass's object tree, so itemTable[obj.itemId] raises KeyError
at line 155.

Fix: if obj.itemId is missing from itemTable, create an empty slot
array of the correct length. The entry is a local temporary — the
second loop in sortVTableDispatchers only calls setMethodsPerType
for types in the current object tree, so types from the prior pass
retain their already-established dispatch. The entry exists solely to
prevent the KeyError during the assignment loop.

The methodIndexLen used for the new entry is the bucket's slot count,
which is correct for any type in the hierarchy.

Added test tests/method/tvtable_reentry.nim that defines methods
across three types in two compilation passes and verifies dispatch
correctness for all three.