### PR TITLE
fixes #21350; don't require default(T) for seq element types that don't have one

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -928,7 +928,10 @@ proc default*[T](_: typedesc[T]): T {.magic: "Default", noSideEffect.} =
 proc reset*[T](obj: var T) {.noSideEffect.} =
   ## Resets an object `obj` to its default value.
   when nimvm:
-    obj = default(typeof(obj))
+    when compiles(default(typeof(obj))):
+      obj = default(typeof(obj))
+    else:
+      `=wasMoved`(obj)
   else:
     when defined(gcDestructors):
       {.cast(noSideEffect), cast(raises: []), cast(tags: []).}:

--- a/lib/system/seqs_v2.nim
+++ b/lib/system/seqs_v2.nim
@@ -265,7 +265,12 @@ proc setLen[T](s: var seq[T], newlen: Natural) {.nodestroy.} =
 
         {.push overflowChecks: off.}
         for i in oldLen..<newlen:
-          xu.p.data[i] = default(T)
+          when compiles(default(T)):
+            xu.p.data[i] = default(T)
+          else:
+            # T has no valid default (e.g. a {.requiresInit.} variant); the
+            # UnsafeSetLen warning already covers this. Zero-fill the new slots.
+            `=wasMoved`(xu.p.data[i])
         {.pop.}
 
 proc newSeq[T](s: var seq[T], len: Natural) =

--- a/tests/collections/t21350.nim
+++ b/tests/collections/t21350.nim
@@ -1,0 +1,38 @@
+discard """
+  matrix: "--mm:orc; --mm:arc; --mm:refc"
+"""
+
+# bug #21350: a seq of a {.requiresInit.} object variant must be usable.
+# Two shapes, because they hit different paths:
+#   * int-only variant (supportsCopyMem) -> only setLen-grow's default(T)
+#   * variant with a string (not copyMem) -> also shrink's reset
+# setLen-grow on a no-default element is covered by the UnsafeSetLen warning.
+{.push warning[UnsafeSetLen]: off, warning[UnsafeDefault]: off.}
+
+block: # int-only variant (the original #21350 shape); declaration alone used to fail
+  type RI {.requiresInit.} = object
+    case o: bool
+    of true: discard
+    else: foo: int
+  var s: seq[RI]
+  s.add RI(o: false, foo: 1)
+  s.add RI(o: true)
+  doAssert s.len == 2
+  doAssert (not s[0].o) and s[0].foo == 1
+  doAssert s[1].o
+
+block: # non-copyMem element (string) also exercises shrink/reset
+  type R {.requiresInit.} = object
+    case o: bool
+    of true:  v: int
+    of false: e: string
+  var s = newSeqOfCap[R](4)
+  s.add R(o: true, v: 1)
+  s.add R(o: false, e: "x")
+  doAssert s.len == 2
+  doAssert (not s[1].o) and s[1].e == "x"
+  s.setLen(1)            # shrink: reset on the removed element
+  doAssert s.len == 1
+  doAssert s[0].o and s[0].v == 1
+
+{.pop.}


### PR DESCRIPTION
fixes #21350

## Bug

A `seq` of a `{.requiresInit.}` object variant can't be used at all, not even
declared (this is #21350's repro):

```nim
type Object {.requiresInit.} = object
  case kind: bool
  of true: discard
  else: foo: int

var s: seq[Object]   # Error: The Object type requires the following fields to be initialized: foo
```

It doesn't need a non-trivial field, even this all-int variant fails. Works under
`--mm:refc` (old seq impl) and on Nim 1.6, so it came in with `seqs_v2`. `add`,
`shrink`, and indexing don't need a default for the element, but the code that does
(`setLen`-grow, and `reset` for non-`copyMem` elements) gets instantiated anyway
and fails to compile.

## Root cause

Two spots hard-require `default(T)` for the element even when it isn't reached:

- `reset` (`system.nim`): the `when nimvm` branch did `obj = default(typeof(obj))`.
  The runtime ARC/ORC path already uses `=destroy` + `=wasMoved`, no default.
- `setLen`-grow (`seqs_v2.nim`): fills new slots with `default(T)`.

## Fix

Guard both with `when compiles(default(T))`, falling back to `=wasMoved` when `T`
has no valid default. Declaring, `add`, `shrink`, and indexing all work. The only
case that needs a default is `setLen`-grow (filling new slots). For a no-default
element it zero-fills, which is what the existing `UnsafeSetLen` warning already
implies. Normal seqs are unchanged: `when compiles` takes the `default(T)` branch,
so the new branch is dead code for any type with a default.

## Question for maintainers

`setLen`-grow on a no-default element now zero-fills, matching the existing
`UnsafeSetLen` warning (a warning, not an error today). Since `requiresInit` is
meant to forbid silent zero values, you may prefer this to be an error. Enforcing
that reliably would be compiler-side, since `setLen` is a magic and an stdlib raise
isn't reliable. There's also a real choice in how. A runtime check could still
allow `shrink`, or `setLen` on such a seq could be rejected outright at compile
time. I didn't want to assume the policy or the mechanism. If you'd like it
hardened, say which way and I'll do a focused follow-up. This PR keeps the current
warning-not-error behavior.

The `Option[T]` sibling (`none(R)` needs `default(R)` via `options.nim`) is a
separate site and not touched here.

## Test

`tests/collections/t21350.nim`, run under `--mm:orc`, `--mm:arc`, `--mm:refc`:
declare a `seq[R]`, `add` both variant branches, shrink, and index.

## Checks

- Compiler bootstraps (`koch boot`) with the patched stdlib.
- `testament cat` green on collections, destructor, arc, init, types (0 failures).
  The new test passes on orc, arc, and refc.
- `--mm:refc` still works (it always did).
