### PR TITLE
stop a temp register from being freed if addressed for `lent`

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1842,6 +1842,8 @@ proc genArrAccessOpcode(c: PCtx; n: PNode; dest: var TDest; opc: TOpcode;
   if dest < 0: dest = c.getTemp(n.typ)
   if opc in {opcLdArrAddr, opcLdStrIdxAddr} and gfNodeAddr in flags:
     c.gABC(n, opc, dest, a, b)
+    if c.prc.regInfo[a].kind >= slotTempUnknown:
+      c.prc.regInfo[a].kind = slotTempPerm
   elif needsRegLoad():
     var cc = c.getTemp(n.typ)
     c.gABC(n, opc, cc, a, b)
@@ -1858,6 +1860,8 @@ proc genObjAccessAux(c: PCtx; n: PNode; a, b: int, dest: var TDest; flags: TGenF
   if dest < 0: dest = c.getTemp(n.typ)
   if {gfNodeAddr} * flags != {}:
     c.gABC(n, opcLdObjAddr, dest, a, b)
+    if a < c.prc.regInfo.len and c.prc.regInfo[a].kind >= slotTempUnknown:
+      c.prc.regInfo[a].kind = slotTempPerm
   elif needsRegLoad():
     var cc = c.getTemp(n.typ)
     c.gABC(n, opcLdObj, cc, a, b)

--- a/tests/vm/t25849.nim
+++ b/tests/vm/t25849.nim
@@ -1,0 +1,16 @@
+discard """
+  targets: "c cpp js"
+"""
+
+import std/os
+from std/sequtils import toSeq
+
+iterator items(a: array[3, string]): lent string {.inline.} =
+  for i in 0..2:
+    yield a[i]
+
+static:
+  const key = "NIM_TESTS_TOSENV_KEY"
+  for val in items(["a", "b", "c"]):
+    putEnv(key, val)
+    doAssert (key, val) in toSeq(envPairs())


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/issues/25849

The important part is in compiler/vmgen.nim:1838: when the VM lowers a[i] or a.b as an address-producing operation, it emits opcLdArrAddr / opcLdObjAddr. That returns an alias into the storage owned by the source register. Before the patch, that source register could still betreated as a normal temporary and later reclaimed or reused by the allocator. Once that happened, the address result was still live, but the backing temp was no longer guaranteed to exist, which is what led to the nil/illegal-storage crash.

The fix is to pin that source temp by changing its slot kind to slotTempPerm right after emitting the address load. You can see the same lifetime rule already existed for the generic addr(...) path around compiler/vmgen.nim:1551: if the source is a temporary and we take its address, the compiler marks it permanent so freeTemp won’t recycle it. The patch extends that exact rule to array and object address loads:

- compiler/vmgen.nim:1843
- compiler/vmgen.nim:1861

slotTempPerm is outside the normal freeTemp range in compiler/vmgen.nim:248, so once a temp is upgraded to permanent, the VM allocator stops treating it as reusable. That is the actual root-cause fix: it preserves the backing storage for the address result until the surrounding evaluation is done.

The regression test in tests/vm/t25849.nim:8 forces exactly that path with a local lent iterator over an array and a static VM evaluation.