### PR TITLE
fixes # 25846; Uses `decltype(auto)` type when declaring temporal

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -659,9 +659,22 @@ proc getTempCpp(p: BProc, t: PType, value: Rope): TLoc =
   inc(p.labels)
   result = TLoc(snippet: "T" & rope(p.labels) & "_", k: locTemp, lode: lodeTyp t,
                 storage: OnStack, flags: {})
+  # `auto` and `decltype(auto)` works differently in C++
+  #[
+    int& foo(int& x) {
+      return x;
+    }
+
+    int main()
+    {
+        int x = 100;
+        auto y = foo(x);            // y is int
+        decltype(auto) z = foo(x);  // z is int&
+    }
+  ]#
   p.s(cpsStmts).addVar(kind = Local,
     name = result.snippet,
-    typ = "auto",
+    typ = "decltype(auto)",
     initializer = value)
 
 proc getIntTemp(p: BProc): TLoc =

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -8,11 +8,6 @@ macros api OK
 '''
 """
 
-# This is for Azure. The keyword ``alignof`` only exists in ``c++11``
-# and newer. On Azure gcc does not default to c++11 yet.
-when defined(cpp) and not defined(windows):
-  {.passC: "-std=c++11".}
-
 # Object offsets are different for inheritance objects when compiling
 # to c++.
 

--- a/tests/proc/tprocvar_var_ret.nim
+++ b/tests/proc/tprocvar_var_ret.nim
@@ -1,0 +1,55 @@
+discard """
+  targets: "c cpp"
+"""
+
+proc testVarRet(x: var int): var int = x
+
+proc testProcTypeParam(prc: proc (x: var int): var int {.nimcall.}) =
+  var x = 123
+  prc(x) = 321
+  doAssert x == 321
+  var y = 456
+  prc(x) = prc(y)
+  doAssert x == 456 and y == 456
+
+testProcTypeParam(testVarRet)
+
+var pVarRet = testVarRet
+var testVar = 1234
+pVarRet(testVar) = 5678
+doAssert testVar == 5678
+
+proc testVarRetStr(x: var string): var string = x
+
+proc testProcTypeParamStr(prc: proc (x: var string): var string {.nimcall.}) =
+  var x = "foo"
+  prc(x) = "bar"
+  doAssert x == "bar"
+  var y = "baz"
+  prc(x) = prc(y)
+  doAssert x == "baz" and y == "baz"
+
+testProcTypeParamStr(testVarRetStr)
+
+var pVarRetStr = testVarRetStr
+var testVarStr = "abc"
+pVarRetStr(testVarStr) = "def"
+doAssert testVarStr == "def"
+
+type
+  FooObj = object
+    x, y: int
+
+proc testVarRetObj(x: var FooObj): var FooObj = x
+
+proc testProcTypeParamObj(prc: proc (x: var FooObj): var FooObj {.nimcall.}) =
+  var x = FooObj(x: 111, y: 222)
+  prc(x) = FooObj(x: 333, y: 444)
+  doAssert x == FooObj(x: 333, y: 444)
+
+testProcTypeParamObj(testVarRetObj)
+
+var pVarRetObj = testVarRetObj
+var testVarObj = FooObj(x: 10, y: 20)
+pVarRetObj(testVarObj) = FooObj(x: 30, y: 40)
+doAssert testVarObj == FooObj(x: 30, y: 40)


### PR DESCRIPTION
```nim
proc testVarRet(x: var int): var int = x

proc testProcTypeParam(prc: proc (x: var int): var int {.nimcall.}) =
  var x = 123
  prc(x) = 321
  echo x

testProcTypeParam(testVarRet)
```
Nim cpp generates C++ code like following from above Nim code:

```c++
#include <iostream>

typedef int& (tyProc)(int& x_p0);

int* testVarRet(int& x) {
  return &x;
}

void testProcTypeParam(tyProc prc) {
  int x = 123;
  auto T1 = prc(x);
  T1 = 321;
  std::cout << x << std::endl;
}

int main()
{
  testProcTypeParam(testVarRet);
}
```
But the type `T1` is `int`, not `int&` so the value of local variable `x` wasn't changed.
This PR changes type of temporal variables from `auto` to `decltype(auto)` so that type of temporal variables become reference type when they are initialized with a function with reference return type.

Following C++ shows how `auto` and `decltype(auto)` in variable declarations works differently:
```c++
#include <iostream>

int& foo(int& x) {
  return x;
}

int main()
{
    int x = 100;
    auto y = foo(x);            // y is int
    decltype(auto) z = foo(x);  // z is int&
    y = 123;
    std::cout << x << ", " << y << std::endl;   // 100, 123
    z = 456;
    std::cout << x << ", " << z << std::endl;   // 456, 456

    int a = 1;
    decltype(auto) b = a;       // b is int
    decltype(auto) c = (a);     // c is int&
    b = 2;
    std::cout << a << ", " << b << std::endl;   // 1, 2
    c = 3;
    std::cout << a << ", " << c << std::endl;   // 3, 3
}
```

ref https://github.com/nim-lang/Nim/issues/25846