### PR TITLE
fixes #25868; access static and template tuple parameters by field name

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -24,6 +24,20 @@ const
   errFieldInitTwice = "field initialized twice: '$1'"
   errUndeclaredFieldX = "undeclared field: '$1'"
 
+proc namedTupleLike(c: PContext; named, anon: PType; info: TLineInfo): PType =
+  ## A fresh tuple with `named`'s field names but `anon`'s concrete field types, so a
+  ## positional (anonymous) tuple literal passed to a named-tuple parameter is reachable by
+  ## field name. Returns `anon` unchanged if `named` is malformed. #25868
+  result = newType(tyTuple, c.idgen, getCurrOwner(c))
+  result.n = newNodeI(nkRecList, info)
+  for i in 0 ..< anon.len:
+    if named.n[i].kind != nkSym: return anon                    # malformed type; do not relabel
+    let field = newSym(skField, named.n[i].sym.name, c.idgen, result.owner, info)
+    field.typ = anon[i]
+    field.position = i
+    result.n.add newSymNode(field)
+    rawAddSon(result, anon[i])
+
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}; expectedType: PType = nil): PNode =
   rememberExpansion(c, n.info, s)
@@ -33,6 +47,18 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
   # Note: This is n.info on purpose. It prevents template from creating an info
   # context when called from an another template
   pushInfoContext(c.config, n.info, s.detailedInfo)
+  # #25868: relabel a positional tuple-literal arg to the formal's named tuple so a template
+  # tuple param is reachable by field name; nfSem keeps it through substitution.
+  if n.kind in nkCallKinds and s.typ != nil and s.typ.n != nil:
+    for i in 1 ..< n.len:
+      if i < s.typ.n.len and s.typ.n[i].kind == nkSym and s.typ.n[i].sym.typ != nil and
+          n[i].kind in {nkPar, nkTupleConstr} and n[i].typ != nil:
+        let formal = s.typ.n[i].sym.typ.skipTypes({tyStatic, tyGenericInst, tyAlias, tySink})
+        let actual = n[i].typ.skipTypes({tyGenericInst, tyAlias, tySink})
+        if formal.kind == tyTuple and actual.kind == tyTuple and actual.n == nil and
+            formal.n != nil and formal.n.len == actual.len:
+          n[i].typ = namedTupleLike(c, formal, actual, n[i].info)
+          n[i].flags.incl nfSem
   result = evalTemplate(n, s, getCurrOwner(c), c.config, c.cache,
                         c.templInstCounter, c.idgen, efFromHlo in flags)
   if efNoSemCheck notin flags:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2063,7 +2063,18 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
               result = typeRel(c, f.base, a, flags)
         else:
           result = isGeneric
-        if result != isNone: put(c, f, aOrig)
+        if result != isNone:
+          # #25868: a static tuple param is its value node; copy it (aOrig is reused across
+          # overload candidates) and relabel to the formal's named tuple.
+          if f.base.kind == tyTuple and aOrig.base != nil and aOrig.base.kind == tyTuple and
+              aOrig.n != nil and sameType(aOrig.base, f.base, {IgnoreTupleFields}):
+            let value = copyTree(aOrig.n)
+            value.typ = f.base
+            var nt = newTypeS(tyStatic, c.c, f.base)
+            nt.n = value
+            put(c, f, nt)
+          else:
+            put(c, f, aOrig)
       elif aOrig.n != nil and aOrig.n.typ != nil:
         result = if f.base.kind != tyNone:
                    typeRel(c, f.last, aOrig.n.typ, flags)

--- a/tests/template/t25868.nim
+++ b/tests/template/t25868.nim
@@ -1,0 +1,37 @@
+discard """
+  matrix: "--mm:orc; --mm:arc; --mm:refc"
+"""
+
+# bug #25868: a named tuple passed through a `static` or `template` parameter could only be
+# accessed positionally (layout[0]), not by field name (layout.shape), because an anonymous
+# tuple literal kept its nameless type instead of the formal's named type.
+
+block template_and_static:
+  template t(layout: tuple[shape, strides: int]): (int, int) = (layout.shape, layout.strides)
+  doAssert t((2, 4)) == (2, 4)
+  proc p(layout: static[tuple[shape, strides: int]]): (int, int) = (layout.shape, layout.strides)
+  doAssert p((2, 4)) == (2, 4)
+
+block concept_field:  # the original report: template + static + nested + a concept field type
+  type
+    IntTuple = concept x
+      x is tuple
+      for field in fields(x):
+        field is IntOrIntTuple
+    IntOrIntTuple = int or IntTuple
+  template coalesce(layout: static[tuple[shape, strides: IntOrIntTuple]]): untyped =
+    (layout.shape, layout.strides)
+  let r = coalesce(((2, 4, 6, 8), (1, 2, 8, 48)))
+  doAssert r[0] == (2, 4, 6, 8)
+  doAssert r[1] == (1, 2, 8, 48)
+
+block named_literal_unaffected:  # a literal that already carries names must stay working
+  template t(layout: tuple[shape, strides: int]): int = layout.shape
+  doAssert t((shape: 2, strides: 4)) == 2
+  proc p(layout: static[tuple[shape, strides: int]]): int = layout.shape
+  doAssert p((shape: 2, strides: 4)) == 2
+
+block incompatible_rejected:  # the relabel must not accept structurally-wrong tuples
+  proc p(layout: static[tuple[shape, strides: int]]): int = layout.shape
+  doAssert not compiles(p((1, 2, 3)))   # wrong arity
+  doAssert not compiles(p((1, "x")))    # wrong field type


### PR DESCRIPTION
fixes #25868

## Bug

A named tuple passed to a `static` or `template` parameter could only be accessed positionally, not by field name:

```nim
template f(layout: tuple[shape, strides: int]): int = layout.shape
echo f((2, 4))   # Error: undeclared field: 'shape'   (workaround: layout[0])
```

The same failed for `proc f(layout: static[tuple[shape, strides: int]])`. An ordinary (non-static) proc parameter works. Present since at least 2.0.0, on every backend.

## Root cause

A named-tuple formal coerces an anonymous tuple argument `(2, 4)` to its named type so the field names apply, but only for ordinary proc parameters (sigmatch's `fitNode`). Two binding paths skip that step, leaving the argument with its nameless `(int, int)` type:

- **static**: in `sigmatch`'s `tyStatic` binding, the static parameter is bound to the argument's value node, whose type is the anonymous `(int, int)`. A static parameter *is* its value node, so field access resolves against the nameless type.
- **template**: a template substitutes the raw argument node; `fitNode`/`changeType` is never run for template arguments (only `semFinishOperands`, the proc path, does it).

## Fix

Apply the formal's named tuple type to the argument in both paths, mirroring the proc path:

- `sigmatch.nim`: when a static parameter's anonymous-tuple base structurally matches the formal's named tuple, relabel the value node to the formal type before binding.
- `semexprs.nim` (`semTemplateExpr`): before expansion, for a typed tuple parameter given a positional tuple literal, relabel the argument to `namedTupleLike(formal, actual)` — a tuple carrying the formal's field *names* with the argument's concrete field *types*, so field access resolves while each value keeps its concrete type (this also handles the `concept`-field case in the report, which a plain `changeType` cannot).

Both are gated on arity and a structural match. The static path uses `sameType(..., {IgnoreTupleFields})` for that match: the flag is documented "backends only", but here it is used purely for structural comparison (field types, names aside) and we then supply the names from the formal, so it is sound in the front-end. An incompatible or non-tuple argument is left untouched.

## Tests

`tests/template/t25868.nim`: template and static field access, the original concept-field case, a named literal (the already-working path), and an incompatible argument that must still be rejected. Runs under `--mm:orc; --mm:arc; --mm:refc`.
