### PR TITLE
fixes #25870; var return type is always C++ reference type

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1340,12 +1340,19 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
     let resNode = prc.ast[resultPos]
     let res = resNode.sym # get result symbol
     if not isInvalidReturnType(m.config, prc.typ) and sfConstructor notin prc.flags:
+      var derefResultInReturn = false
       if sfNoInit in prc.flags: incl(res, sfNoInit)
       if sfNoInit in prc.flags and p.module.compileToCpp and (let val = easyResultAsgn(procBody); val != nil):
         var a: TLoc = initLocExprSingleUse(p, val)
         let ra = rdLoc(a)
         localVarDecl(p.s(cpsStmts), p, resNode, initializer = ra)
       else:
+        if m.config.backend == backendCpp and res.typ.kind == tyVar:
+          # When return type is `var T`, return type of generated function is `T&` and the type of result is `T*`.
+          #res.typ = newType(tyPtr, m.idgen, t.owner, res.typ[0])
+          res.typ = res.typ.exactReplica
+          res.typ.incl tfVarIsPtr
+          derefResultInReturn = true
         # declare the result symbol:
         assignLocalVar(p, resNode)
         assert(res.loc.snippet != "")
@@ -1357,7 +1364,9 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
         else:
           initLocalVar(p, res, immediateAsgn=false)
       var returnBuilder = newBuilder("\t")
-      let rres = rdLoc(res.loc)
+      var rres = rdLoc(res.loc)
+      if derefResultInReturn:
+        rres = cDeref(rres)
       returnBuilder.addReturn(rres)
       returnStmt = extract(returnBuilder)
     elif sfConstructor in prc.flags:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1858,7 +1858,6 @@ proc asgnToResultVar(c: PContext, n, le, ri: PNode) {.inline.} =
       if x.sym.kind == skResult and (x.typ.kind in {tyVar, tyLent} or classifyViewType(x.typ) != noView):
         n[0] = x # 'result[]' --> 'result'
         n[1] = takeImplicitAddr(c, ri, x.typ.kind == tyLent)
-        x.typ.incl tfVarIsPtr
         #echo x.info, " setting it for this type ", typeToString(x.typ), " ", n.info
       elif sfGlobal in x.sym.flags:
         x.typ.incl tfVarIsPtr

--- a/tests/proc/tprocvar_var_ret.nim
+++ b/tests/proc/tprocvar_var_ret.nim
@@ -1,0 +1,9 @@
+discard """
+  targets: "c cpp"
+"""
+
+proc testVarRet(x: var int): var int = x
+
+proc testProcTypeParam(prc: proc (x: var int): var int {.nimcall.}) = discard
+
+testProcTypeParam(testVarRet)


### PR DESCRIPTION
When compiling with `nim cpp`, var return type is C++ reference in default.
But `result` is assigned and `tfVarIsPtr` flag is set, var return type become a pointer.
So a var return type in procedural type in parameter type become C++ reference type but var return type in procedure definition become pointer.
So passing the procedure pointer to the procedure results in type mismatch error.

This PR always makes `var` return type to C++ reference to fix the error.
