### PR TITLE
Fix #25883 tuple sighash collision

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -211,6 +211,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]; conf: Confi
     c.hashTree(t.n, {}, conf)
   of tyTuple:
     c &= char(t.kind)
+    c &= t.len
     if t.n != nil and CoType notin flags:
       for i in 0..<t.n.len:
         assert(t.n[i].kind == nkSym)

--- a/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
+++ b/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
@@ -1,4 +1,5 @@
 discard """
+targets: "c cpp"
 output: "13"
 """
 
@@ -16,3 +17,29 @@ proc main() =
   echo c[0][2]
 
 main()
+
+block:
+  type
+    Int[V: static int] = object
+    Layout[Sh, St] = object
+      shape: Sh
+      stride: St
+  
+  func makeB(): auto =
+    Layout[((Int[2], Int[3]), Int[5], Int[7]), ((Int[1], Int[2]), Int[6], Int[30])](
+      shape: ((Int[2](), Int[3]()), Int[5](), Int[7]()),
+      stride: ((Int[1](), Int[2]()), Int[6](), Int[30]())
+    )
+  
+  func makeC(): auto =
+    Layout[((Int[2], Int[3], Int[5]), Int[7]), ((Int[1], Int[2], Int[6]), Int[30])](
+      shape: ((Int[2](), Int[3](), Int[5]()), Int[7]()),
+      stride: ((Int[1](), Int[2](), Int[6]()), Int[30]())
+    )
+  
+  
+  proc main() =
+    let b = makeB()
+    let c = makeC()
+  
+  main()

--- a/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
+++ b/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
@@ -1,5 +1,5 @@
 discard """
-output: "5"
+output: "13"
 """
 
 # bug #25883: C codegen assigns same type hash to tuples with different nesting

--- a/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
+++ b/tests/ccgbugs2/t25883_tuple_sighash_collision.nim
@@ -1,0 +1,18 @@
+discard """
+output: "5"
+"""
+
+# bug #25883: C codegen assigns same type hash to tuples with different nesting
+# but identical flattened content.
+# ((Int[1], Int[2]), Int[13], Int[14]) and ((Int[1], Int[2], Int[13]), Int[14])
+# must get distinct C type names.
+
+type
+  Int[V: static int] = object
+
+proc main() =
+  var b = ((1, 2), 13, 14)
+  var c = ((1, 2, 13), 14)
+  echo c[0][2]
+
+main()


### PR DESCRIPTION
fixes #25886
fixes #25883

See #25883 

Tuples only hash leaves so if 2 tuples have the same flattened representation they collide in the C codegen.

Fix by hashing the length as well to disambiguate nesting levels.