### PR TITLE
adds wasm64 (Memory64) as a first-class target

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -662,6 +662,7 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
     of "x86": result = conf.target.targetCPU == cpuI386
     of "itanium": result = conf.target.targetCPU == cpuIa64
     of "x8664": result = conf.target.targetCPU == cpuAmd64
+    of "wasm": result = conf.target.targetCPU in {cpuWasm32, cpuWasm64}
     of "posix", "unix":
       result = conf.target.targetOS in {osLinux, osMorphos, osSkyos, osIrix, osPalmos,
                             osQnx, osAtari, osAix,

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -211,7 +211,7 @@ type
     cpuPowerpc64el, cpuSparc, cpuVm, cpuHppa, cpuIa64, cpuAmd64, cpuMips,
     cpuMipsel, cpuArm, cpuArm64, cpuJS, cpuNimVM, cpuAVR, cpuMSP430,
     cpuSparc64, cpuS390x, cpuMips64, cpuMips64el, cpuRiscV32, cpuRiscV64,
-    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64
+    cpuEsp, cpuWasm32, cpuE2k, cpuLoongArch64, cpuWasm64
 
 type
   TInfoCPU* = tuple[name: string, intSize: int, endian: Endianness,
@@ -249,7 +249,8 @@ const
     (name: "esp", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "wasm32", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "e2k", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
-    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
+    (name: "loongarch64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
+    (name: "wasm64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
 
 type
   Target* = object

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -168,6 +168,19 @@ nimblepath="$home/.nimble/pkgs/"
   switch_gcc.cpp.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -D__SWITCH__ -fno-rtti -fno-exceptions -std=gnu++11"
 @end
 
+# Emscripten toolchain for WebAssembly (wasm32, or wasm64/Memory64).
+@if emscripten:
+  cc = clang
+  clang.exe = "emcc"
+  clang.linkerexe = "emcc"
+  clang.cpp.exe = "emcc"
+  clang.cpp.linkerexe = "emcc"
+  @if wasm64:
+    passC = "-sMEMORY64=1"
+    passL = "-sMEMORY64=1"
+  @end
+@end
+
 # Configuration for the Intel C/C++ compiler:
 @if windows:
   icl.options.speed = "/Ox /arch:SSE2"

--- a/lib/system/platforms.nim
+++ b/lib/system/platforms.nim
@@ -40,7 +40,8 @@ type
     wasm32,                    ## WASM, 32-bit
     e2k,                       ## MCST Elbrus 2000
     loongarch64,               ## LoongArch 64-bit processor
-    s390x                      ## IBM Z
+    s390x,                     ## IBM Z
+    wasm64                     ## WASM, 64-bit
 
   OsPlatform* {.pure.} = enum ## the OS this program will run on.
     none, dos, windows, os2, linux, morphos, skyos, solaris,
@@ -101,5 +102,6 @@ const
                elif defined(e2k): CpuPlatform.e2k
                elif defined(loongarch64): CpuPlatform.loongarch64
                elif defined(s390x): CpuPlatform.s390x
+               elif defined(wasm64): CpuPlatform.wasm64
                else: CpuPlatform.none
     ## the CPU this program will run on.

--- a/tools/nim.zsh-completion
+++ b/tools/nim.zsh-completion
@@ -78,7 +78,7 @@ _nim() {
     '--opt\:-[optimization mode]:x:(none speed size)'
     '--debugger\:native[use native debugger (gdb)]'
     '--app\:-[generate this type of app (lib=dynamic)]:x:(console gui lib staticlib)'
-    '--cpu\:-[target architecture]:x:(alpha amd64 arm arm64 avr e2k esp hppa i386 ia64 js loongarch64 m68k mips mipsel mips64 mips64el msp430 nimvm powerpc powerpc64 powerpc64el riscv32 riscv64 sparc sparc64 s390x vm wasm32)'
+    '--cpu\:-[target architecture]:x:(alpha amd64 arm arm64 avr e2k esp hppa i386 ia64 js loongarch64 m68k mips mipsel mips64 mips64el msp430 nimvm powerpc powerpc64 powerpc64el riscv32 riscv64 sparc sparc64 s390x vm wasm32 wasm64)'
     '--gc\:-[memory management algorithm to use (default\: refc)]:x:(refc arc orc markAndSweep boehm go regions none)'
     '--os\:-[operating system to compile for]:x:(AIX Amiga Android Any Atari DOS DragonFly FreeBSD FreeRTOS Genode Haiku iOS Irix JS Linux MacOS MacOSX MorphOS NetBSD Netware NimVM NintendoSwitch OS2 OpenBSD PalmOS Standalone QNX SkyOS Solaris VxWorks Windows)'
     '--panics\:-[turn panics into process termination (default\: off)]:x:(off on)'


### PR DESCRIPTION
This pull request allows setting `--cpu:wasm64`, allowing wasm64 as a first class target. This avoids having to set `-cpu:riscv64` as a workaround. Sane defaults for the emscripten toolchain are also provided.