### PR TITLE
Update the parser to better handle *: for command syntax.

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -594,6 +594,20 @@ proc starWasExportMarker*(em: var Emitter) =
     em.tokens.add("*")
     em.kinds.add ltExportMarker
     dec em.col, 2
+  elif em.endsWith(" ", "*", " ", ":", " ") or
+      em.endsWith(" ", "*", " ", "=", " "):
+    let delimiter = em.tokens[^2]
+    setLen(em.tokens, em.tokens.len-5)
+    setLen(em.kinds, em.kinds.len-5)
+    em.tokens.add("*")
+    em.kinds.add ltExportMarker
+    em.tokens.add(" ")
+    em.kinds.add ltSpaces
+    em.tokens.add(delimiter)
+    em.kinds.add ltOther
+    em.tokens.add(" ")
+    em.kinds.add ltSpaces
+    dec em.col, 1
 
 proc commaWasSemicolon*(em: var Emitter) =
   if em.semicolons == detectSemicolonKind:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -326,7 +326,7 @@ proc isUnary(tok: Token): bool =
   tok.spacing == {tsLeading}
 
 proc checkBinary(p: Parser, tok: Token) {.inline.} =
-  ## Check if the given token is a binary operator.
+  ## Check and warn if the operator spacing is inconsistent.
   # we don't check '..' here as that's too annoying
   if tok.tokType == tkOpr:
     if tok.spacing == {tsTrailing}:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -507,12 +507,12 @@ proc exprColonEqExpr(p: var Parser): PNode =
   else:
     result = colonOrEquals(p, a)
 
-proc commandParamExpr(p: var Parser): PNode
+proc commandParam(p: var Parser): PNode
 
 proc exprEqExpr(p: var Parser): PNode =
   #| exprEqExpr = commandParam ('=' expr
   #|                           / doBlock extraPostExprBlock*)?
-  var a = commandParamExpr(p)
+  var a = commandParam(p)
   if p.tok.tokType == tkDo:
     result = postExprBlocks(p, a)
   else:
@@ -917,14 +917,13 @@ proc namedParams(p: var Parser, callee: PNode,
   # progress guaranteed
   exprColonEqExprListAux(p, endTok, result)
 
-proc commandParam(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNode =
-  #| commandParam = (symbol '*' &(':' | '=')) / expr
+proc commandParamAux(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNode =
   if mode == pmTypeDesc:
     result = simpleExpr(p, mode)
   elif not isFirstParam:
     result = exprEqExpr(p)
   else:
-    result = commandParamExpr(p)
+    result = commandParam(p)
     if p.tok.tokType == tkDo:
       result = postExprBlocks(p, result)
   isFirstParam = false
@@ -938,7 +937,8 @@ proc isCommandExportStart(p: Parser, a: PNode): bool {.inline.} =
   result = a.kind in {nkIdent, nkAccQuoted} and
     p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0
 
-proc commandParamExpr(p: var Parser): PNode =
+proc commandParam(p: var Parser): PNode =
+  #| commandParam = (symbol '*' &(':' | '=')) / expr
   if isCommandParamSymbol(p.tok):
     result = primary(p, pmNormal)
     if isCommandExportStart(p, result):
@@ -965,7 +965,7 @@ proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
     var isFirstParam = true
     # progress NOT guaranteed
     p.hasProgress = false
-    result.add commandParam(p, isFirstParam, mode)
+    result.add commandParamAux(p, isFirstParam, mode)
 
 proc isDotLike(tok: Token): bool =
   result = tok.tokType == tkOpr and tok.ident.s.len > 1 and
@@ -1553,7 +1553,7 @@ proc parseTypeDefValue(p: var Parser): PNode =
         while p.tok.tokType == tkComma:
           getTok(p)
           optInd(p, result)
-          result.add(commandParam(p, isFirstParam, pmTypeDef))
+          result.add(commandParamAux(p, isFirstParam, pmTypeDef))
       result = postExprBlocks(p, result)
   result = binaryNot(p, result)
   setEndInfo()
@@ -1669,7 +1669,7 @@ proc parseExprStmt(p: var Parser): PNode =
       result = newTree(nkCommand, a.info, a)
       let baseIndent = p.currInd
       while true:
-        result.add(commandParam(p, isFirstParam, pmNormal))
+        result.add(commandParamAux(p, isFirstParam, pmNormal))
         if p.tok.tokType != tkComma or
           (p.tok.indent >= 0 and p.tok.indent < baseIndent):
           break

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -287,13 +287,24 @@ proc newStrNodeP(kind: TNodeKind, strVal: sink string, p: Parser): PNode =
 proc newIdentNodeP(ident: PIdent, p: Parser): PNode =
   result = newAtom(ident, parLineInfo(p))
 
+proc newPostfixNode(opNode, a: PNode): PNode =
+  result = newNode(nkPostfix, opNode.info)
+  result.add(opNode)
+  result.add(a)
+
 proc parsePostfix(p: var Parser, a: PNode): PNode =
   when defined(nimpretty):
     starWasExportMarker(p.em)
-  result = newNodeP(nkPostfix, p)
-  result.add(newIdentNodeP(p.tok.ident, p))
-  result.add(a)
+  result = newPostfixNode(newIdentNodeP(p.tok.ident, p), a)
   getTok(p)
+
+proc parseCommandExportPostfix(p: var Parser, opNode: PNode,
+                               a: var PNode): bool =
+  if p.tok.tokType in {tkColon, tkEquals} and p.tok.indent < 0:
+    when defined(nimpretty):
+      starWasExportMarker(p.em)
+    a = newPostfixNode(opNode, a)
+    result = true
 
 proc parseExpr(p: var Parser, mode = pmNormal): PNode
 proc parseStmt(p: var Parser): PNode
@@ -314,12 +325,12 @@ proc isUnary(tok: Token): bool =
   tok.tokType in {tkOpr, tkDotDot} and
   tok.spacing == {tsLeading}
 
-proc checkBinary(p: Parser) {.inline.} =
-  ## Check if the current parser token is a binary operator.
+proc checkBinary(p: Parser, tok: Token) {.inline.} =
+  ## Check if the given token is a binary operator.
   # we don't check '..' here as that's too annoying
-  if p.tok.tokType == tkOpr:
-    if p.tok.spacing == {tsTrailing}:
-      parMessage(p, warnInconsistentSpacing, prettyTok(p.tok))
+  if tok.tokType == tkOpr:
+    if tok.spacing == {tsTrailing}:
+      lexMessageTok(p.lex, warnInconsistentSpacing, tok, prettyTok(tok))
 
 #| module = complexOrSimpleStmt ^* (';' / IND{=})
 #|
@@ -873,13 +884,10 @@ proc commandParam(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNo
       result = postExprBlocks(p, result)
   isFirstParam = false
 
-proc isCommandParamExportMarker(p: Parser): bool {.inline.} =
-  result = false
-  if p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0 and
-      tsLeading notin p.tok.spacing:
-    var pos = p.lex.bufpos
-    while p.lex.buf[pos] == ' ': inc pos
-    result = p.lex.buf[pos] in {':', '='} and p.lex.buf[pos+1] notin OpChars
+proc isCommandExportMarkerStart(p: Parser, mode: PrimaryMode, a: PNode): bool {.inline.} =
+  result = mode == pmCommandParam and a.kind in {nkIdent, nkAccQuoted} and
+    p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0 and
+    tsLeading notin p.tok.spacing
 
 proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
   if mode == pmTrySimple:
@@ -970,15 +978,15 @@ proc parseOperators(p: var Parser, headNode: PNode,
   # the operator itself must not start on a new line:
   # progress guaranteed
   while opPrec >= limit and p.tok.indent < 0 and not isUnary(p.tok):
-    if mode == pmCommandParam and result.kind in {nkIdent, nkAccQuoted} and
-        isCommandParamExportMarker(p):
-      result = parsePostfix(p, result)
-      break
-    checkBinary(p)
+    let opTok = p.tok
+    let commandExportMarkerStart = isCommandExportMarkerStart(p, mode, result)
     let leftAssoc = ord(not isRightAssociative(p.tok))
-    var a = newNodeP(nkInfix, p)
-    var opNode = newIdentNodeP(p.tok.ident, p) # skip operator:
+    let opNode = newIdentNodeP(p.tok.ident, p) # skip operator:
     getTok(p)
+    if commandExportMarkerStart and parseCommandExportPostfix(p, opNode, result):
+      break
+    checkBinary(p, opTok)
+    var a = newNode(nkInfix, opNode.info)
     flexComment(p, a)
     optPar(p)
     # read sub-expression with higher priority:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -87,7 +87,7 @@ type
     smNormal, smAllowNil, smAfterDot
 
   PrimaryMode = enum
-    pmNormal, pmTypeDesc, pmTypeDef, pmTrySimple
+    pmNormal, pmTypeDesc, pmTypeDef, pmTrySimple, pmCommandParam
 
 when defined(nimCustomAst):
   # For the `customast` version we cannot share nodes, not even empty nodes:
@@ -287,7 +287,15 @@ proc newStrNodeP(kind: TNodeKind, strVal: sink string, p: Parser): PNode =
 proc newIdentNodeP(ident: PIdent, p: Parser): PNode =
   result = newAtom(ident, parLineInfo(p))
 
-proc parseExpr(p: var Parser): PNode
+proc parsePostfix(p: var Parser, a: PNode): PNode =
+  when defined(nimpretty):
+    starWasExportMarker(p.em)
+  result = newNodeP(nkPostfix, p)
+  result.add(newIdentNodeP(p.tok.ident, p))
+  result.add(a)
+  getTok(p)
+
+proc parseExpr(p: var Parser, mode = pmNormal): PNode
 proc parseStmt(p: var Parser): PNode
 proc parseTypeDesc(p: var Parser, fullExpr = false): PNode
 proc parseTypeDefValue(p: var Parser): PNode
@@ -446,10 +454,10 @@ proc exprColonEqExpr(p: var Parser): PNode =
   else:
     result = colonOrEquals(p, a)
 
-proc exprEqExpr(p: var Parser): PNode =
+proc exprEqExpr(p: var Parser, mode = pmNormal): PNode =
   #| exprEqExpr = expr ('=' expr
   #|                   / doBlock extraPostExprBlock*)?
-  var a = parseExpr(p)
+  var a = parseExpr(p, mode)
   if p.tok.tokType == tkDo:
     result = postExprBlocks(p, a)
   else:
@@ -858,12 +866,19 @@ proc commandParam(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNo
   if mode == pmTypeDesc:
     result = simpleExpr(p, mode)
   elif not isFirstParam:
-    result = exprEqExpr(p)
+    result = exprEqExpr(p, pmCommandParam)
   else:
-    result = parseExpr(p)
+    result = parseExpr(p, pmCommandParam)
     if p.tok.tokType == tkDo:
       result = postExprBlocks(p, result)
   isFirstParam = false
+
+proc isExportMarkerBeforeColon(p: Parser): bool {.inline.} =
+  result = false
+  if p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0:
+    var pos = p.lex.bufpos
+    while p.lex.buf[pos] == ' ': inc pos
+    result = p.lex.buf[pos] == ':' and p.lex.buf[pos+1] notin OpChars
 
 proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
   if mode == pmTrySimple:
@@ -947,10 +962,17 @@ proc parseOperators(p: var Parser, headNode: PNode,
   result = headNode
   # expand while operators have priorities higher than 'limit'
   var opPrec = getPrecedence(p.tok)
-  let modeB = if mode == pmTypeDef: pmTypeDesc else: mode
+  let modeB =
+    if mode == pmTypeDef: pmTypeDesc
+    elif mode == pmCommandParam: pmNormal
+    else: mode
   # the operator itself must not start on a new line:
   # progress guaranteed
   while opPrec >= limit and p.tok.indent < 0 and not isUnary(p.tok):
+    if mode == pmCommandParam and result.kind in {nkIdent, nkAccQuoted} and
+        isExportMarkerBeforeColon(p):
+      result = parsePostfix(p, result)
+      break
     checkBinary(p)
     let leftAssoc = ord(not isRightAssociative(p.tok))
     var a = newNodeP(nkInfix, p)
@@ -968,17 +990,20 @@ proc parseOperators(p: var Parser, headNode: PNode,
   setEndInfo()
 
 proc simpleExprAux(p: var Parser, limit: int, mode: PrimaryMode): PNode =
-  var mode = mode
-  result = primary(p, mode)
-  if mode == pmTrySimple:
-    mode = pmNormal
+  var operatorMode = mode
+  let primaryMode =
+    if mode == pmCommandParam: pmNormal
+    else: mode
+  result = primary(p, primaryMode)
+  if operatorMode == pmTrySimple:
+    operatorMode = pmNormal
   if p.tok.tokType == tkCurlyDotLe and (p.tok.indent < 0 or realInd(p)) and
-     mode == pmNormal:
+     operatorMode in {pmNormal, pmCommandParam}:
     var pragmaExp = newNodeP(nkPragmaExpr, p)
     pragmaExp.add result
     pragmaExp.add p.parsePragma
     result = pragmaExp
-  result = parseOperators(p, result, limit, mode)
+  result = parseOperators(p, result, limit, operatorMode)
 
 proc simpleExpr(p: var Parser, mode = pmNormal): PNode =
   when defined(nimpretty):
@@ -1022,12 +1047,7 @@ proc identVis(p: var Parser; allowDot=false): PNode =
   #| identVisDot = symbol '.' optInd symbolOrKeyword OPR?
   var a = parseSymbol(p)
   if p.tok.tokType == tkOpr:
-    when defined(nimpretty):
-      starWasExportMarker(p.em)
-    result = newNodeP(nkPostfix, p)
-    result.add(newIdentNodeP(p.tok.ident, p))
-    result.add(a)
-    getTok(p)
+    result = parsePostfix(p, a)
   elif p.tok.tokType == tkDot and allowDot:
     result = dotExpr(p, a)
   else:
@@ -1314,7 +1334,7 @@ template nimprettyDontTouch(body) =
   when defined(nimpretty):
     dec p.em.keepIndents
 
-proc parseExpr(p: var Parser): PNode =
+proc parseExpr(p: var Parser, mode = pmNormal): PNode =
   #| expr = (blockExpr
   #|       | ifExpr
   #|       | whenExpr
@@ -1343,7 +1363,7 @@ proc parseExpr(p: var Parser): PNode =
   of tkTry:
     nimprettyDontTouch:
       result = parseTry(p, isExpr=true)
-  else: result = simpleExpr(p)
+  else: result = simpleExpr(p, mode)
   setEndInfo()
 
 proc parseEnum(p: var Parser): PNode
@@ -1354,7 +1374,8 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
   #| simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
   #| commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
   #|                  'static'|'enum'|'tuple'|'object'|'proc')
-  #| primary = simplePrimary (commandStart expr (doBlock extraPostExprBlock*)?)?
+  #| commandParam = symbol '*' &':' / expr
+  #| primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
   #|         / operatorB primary
   #|         / routineExpr
   #|         / rawTypeDesc

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -87,7 +87,7 @@ type
     smNormal, smAllowNil, smAfterDot
 
   PrimaryMode = enum
-    pmNormal, pmTypeDesc, pmTypeDef, pmTrySimple, pmCommandParam
+    pmNormal, pmTypeDesc, pmTypeDef, pmTrySimple
 
 when defined(nimCustomAst):
   # For the `customast` version we cannot share nodes, not even empty nodes:
@@ -121,6 +121,8 @@ proc postExprBlocks(p: var Parser, x: PNode): PNode
 proc parseExprStmt(p: var Parser): PNode
 proc parseBlock(p: var Parser): PNode
 proc primary(p: var Parser, mode: PrimaryMode): PNode
+proc parseOperators(p: var Parser, headNode: PNode,
+                    limit: int, mode: PrimaryMode): PNode
 proc simpleExprAux(p: var Parser, limit: int, mode: PrimaryMode): PNode
 
 # implementation
@@ -298,16 +300,15 @@ proc parsePostfix(p: var Parser, a: PNode): PNode =
   result = newPostfixNode(newIdentNodeP(p.tok.ident, p), a)
   getTok(p)
 
-proc parseCommandExportPostfix(p: var Parser, opNode: PNode,
-                               a: var PNode): bool =
-  result = false
+proc commandExportPostfix(p: var Parser, opNode, a: PNode): PNode =
+  ## Builds postfix export before same-line ':' or '='.
+  result = nil
   if p.tok.tokType in {tkColon, tkEquals} and p.tok.indent < 0:
     when defined(nimpretty):
       starWasExportMarker(p.em)
-    a = newPostfixNode(opNode, a)
-    result = true
+    result = newPostfixNode(opNode, a)
 
-proc parseExpr(p: var Parser, mode = pmNormal): PNode
+proc parseExpr(p: var Parser): PNode
 proc parseStmt(p: var Parser): PNode
 proc parseTypeDesc(p: var Parser, fullExpr = false): PNode
 proc parseTypeDefValue(p: var Parser): PNode
@@ -332,6 +333,46 @@ proc checkBinary(p: Parser, tok: Token) {.inline.} =
   if tok.tokType == tkOpr:
     if tok.spacing == {tsTrailing}:
       lexMessageTok(p.lex, warnInconsistentSpacing, tok, prettyTok(tok))
+
+proc infixOperandMode(mode: PrimaryMode): PrimaryMode {.inline.} =
+  if mode == pmTypeDef: pmTypeDesc
+  else: mode
+
+proc parseInfix(p: var Parser, a, opNode: PNode,
+                opPrec, leftAssoc: int, mode: PrimaryMode): PNode {.inline.} =
+  ## Parses an infix expression with a known operator.
+  result = newNode(nkInfix, opNode.info)
+  flexComment(p, result)
+  optPar(p)
+  # read sub-expression with higher priority:
+  var b = simpleExprAux(p, opPrec + leftAssoc, mode)
+  result.add(opNode)
+  result.add(a)
+  result.add(b)
+
+proc parseInfixAfterOp(p: var Parser, a: PNode,
+                       opTok: Token, opNode: PNode): PNode =
+  ## Continues infix parsing after consuming the operator.
+  let opPrec = getPrecedence(opTok)
+  let leftAssoc = ord(not isRightAssociative(opTok))
+  checkBinary(p, opTok)
+  result = parseInfix(p, a, opNode, opPrec, leftAssoc, pmNormal)
+  result = parseOperators(p, result, -1, pmNormal)
+
+proc simpleExprTail(p: var Parser, headNode: PNode,
+                    limit: int, mode: PrimaryMode): PNode {.inline.} =
+  ## Parses pragmas and operators after a primary.
+  var operatorMode = mode
+  result = headNode
+  if operatorMode == pmTrySimple:
+    operatorMode = pmNormal
+  if p.tok.tokType == tkCurlyDotLe and (p.tok.indent < 0 or realInd(p)) and
+     operatorMode == pmNormal:
+    var pragmaExp = newNodeP(nkPragmaExpr, p)
+    pragmaExp.add result
+    pragmaExp.add p.parsePragma
+    result = pragmaExp
+  result = parseOperators(p, result, limit, operatorMode)
 
 #| module = complexOrSimpleStmt ^* (';' / IND{=})
 #|
@@ -466,10 +507,12 @@ proc exprColonEqExpr(p: var Parser): PNode =
   else:
     result = colonOrEquals(p, a)
 
-proc exprEqExpr(p: var Parser, mode = pmNormal): PNode =
-  #| exprEqExpr = expr ('=' expr
-  #|                   / doBlock extraPostExprBlock*)?
-  var a = parseExpr(p, mode)
+proc commandParamExpr(p: var Parser): PNode
+
+proc exprEqExpr(p: var Parser): PNode =
+  #| exprEqExpr = commandParam ('=' expr
+  #|                           / doBlock extraPostExprBlock*)?
+  var a = commandParamExpr(p)
   if p.tok.tokType == tkDo:
     result = postExprBlocks(p, a)
   else:
@@ -875,20 +918,43 @@ proc namedParams(p: var Parser, callee: PNode,
   exprColonEqExprListAux(p, endTok, result)
 
 proc commandParam(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNode =
+  #| commandParam = (symbol '*' &(':' | '=')) / expr
   if mode == pmTypeDesc:
     result = simpleExpr(p, mode)
   elif not isFirstParam:
-    result = exprEqExpr(p, pmCommandParam)
+    result = exprEqExpr(p)
   else:
-    result = parseExpr(p, pmCommandParam)
+    result = commandParamExpr(p)
     if p.tok.tokType == tkDo:
       result = postExprBlocks(p, result)
   isFirstParam = false
 
-proc isCommandExportMarkerStart(p: Parser, mode: PrimaryMode, a: PNode): bool {.inline.} =
-  result = mode == pmCommandParam and a.kind in {nkIdent, nkAccQuoted} and
-    p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0 and
-    tsLeading notin p.tok.spacing
+proc isCommandParamSymbol(tok: Token): bool {.inline.} =
+  ## Checks for a symbol-led command parameter.
+  result = tok.tokType in tkBuiltInMagics + {tkSymbol, tkAccent, tkOut}
+
+proc isCommandExportStart(p: Parser, a: PNode): bool {.inline.} =
+  ## Checks for '*' on the same line after a symbol.
+  result = a.kind in {nkIdent, nkAccQuoted} and
+    p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0
+
+proc commandParamExpr(p: var Parser): PNode =
+  if isCommandParamSymbol(p.tok):
+    result = primary(p, pmNormal)
+    if isCommandExportStart(p, result):
+      let opTok = p.tok
+      let opNode = newIdentNodeP(p.tok.ident, p)
+      getTok(p)
+      let postfix = commandExportPostfix(p, opNode, result)
+      if postfix != nil:
+        result = postfix
+        setEndInfo()
+        return
+      result = parseInfixAfterOp(p, result, opTok, opNode)
+    else:
+      result = simpleExprTail(p, result, -1, pmNormal)
+  else:
+    result = parseExpr(p)
 
 proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
   if mode == pmTrySimple:
@@ -972,48 +1038,22 @@ proc parseOperators(p: var Parser, headNode: PNode,
   result = headNode
   # expand while operators have priorities higher than 'limit'
   var opPrec = getPrecedence(p.tok)
-  let modeB =
-    if mode == pmTypeDef: pmTypeDesc
-    elif mode == pmCommandParam: pmNormal
-    else: mode
+  let modeB = infixOperandMode(mode)
   # the operator itself must not start on a new line:
   # progress guaranteed
   while opPrec >= limit and p.tok.indent < 0 and not isUnary(p.tok):
     let opTok = p.tok
-    let commandExportMarkerStart = isCommandExportMarkerStart(p, mode, result)
+    checkBinary(p, opTok)
     let leftAssoc = ord(not isRightAssociative(p.tok))
     let opNode = newIdentNodeP(p.tok.ident, p) # skip operator:
     getTok(p)
-    if commandExportMarkerStart and parseCommandExportPostfix(p, opNode, result):
-      break
-    checkBinary(p, opTok)
-    var a = newNode(nkInfix, opNode.info)
-    flexComment(p, a)
-    optPar(p)
-    # read sub-expression with higher priority:
-    var b = simpleExprAux(p, opPrec + leftAssoc, modeB)
-    a.add(opNode)
-    a.add(result)
-    a.add(b)
-    result = a
+    result = parseInfix(p, result, opNode, opPrec, leftAssoc, modeB)
     opPrec = getPrecedence(p.tok)
   setEndInfo()
 
 proc simpleExprAux(p: var Parser, limit: int, mode: PrimaryMode): PNode =
-  var operatorMode = mode
-  let primaryMode =
-    if mode == pmCommandParam: pmNormal
-    else: mode
-  result = primary(p, primaryMode)
-  if operatorMode == pmTrySimple:
-    operatorMode = pmNormal
-  if p.tok.tokType == tkCurlyDotLe and (p.tok.indent < 0 or realInd(p)) and
-     operatorMode in {pmNormal, pmCommandParam}:
-    var pragmaExp = newNodeP(nkPragmaExpr, p)
-    pragmaExp.add result
-    pragmaExp.add p.parsePragma
-    result = pragmaExp
-  result = parseOperators(p, result, limit, operatorMode)
+  result = primary(p, mode)
+  result = simpleExprTail(p, result, limit, mode)
 
 proc simpleExpr(p: var Parser, mode = pmNormal): PNode =
   when defined(nimpretty):
@@ -1344,7 +1384,7 @@ template nimprettyDontTouch(body) =
   when defined(nimpretty):
     dec p.em.keepIndents
 
-proc parseExpr(p: var Parser, mode = pmNormal): PNode =
+proc parseExpr(p: var Parser): PNode =
   #| expr = (blockExpr
   #|       | ifExpr
   #|       | whenExpr
@@ -1373,7 +1413,7 @@ proc parseExpr(p: var Parser, mode = pmNormal): PNode =
   of tkTry:
     nimprettyDontTouch:
       result = parseTry(p, isExpr=true)
-  else: result = simpleExpr(p, mode)
+  else: result = simpleExpr(p)
   setEndInfo()
 
 proc parseEnum(p: var Parser): PNode
@@ -1384,7 +1424,6 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
   #| simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
   #| commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
   #|                  'static'|'enum'|'tuple'|'object'|'proc')
-  #| commandParam = (symbol '*' &(':' | '=')) / expr
   #| primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
   #|         / operatorB primary
   #|         / routineExpr

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -300,6 +300,7 @@ proc parsePostfix(p: var Parser, a: PNode): PNode =
 
 proc parseCommandExportPostfix(p: var Parser, opNode: PNode,
                                a: var PNode): bool =
+  result = false
   if p.tok.tokType in {tkColon, tkEquals} and p.tok.indent < 0:
     when defined(nimpretty):
       starWasExportMarker(p.em)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -873,12 +873,13 @@ proc commandParam(p: var Parser, isFirstParam: var bool; mode: PrimaryMode): PNo
       result = postExprBlocks(p, result)
   isFirstParam = false
 
-proc isExportMarkerBeforeColon(p: Parser): bool {.inline.} =
+proc isCommandParamExportMarker(p: Parser): bool {.inline.} =
   result = false
-  if p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0:
+  if p.tok.tokType == tkOpr and p.tok.ident.s == "*" and p.tok.indent < 0 and
+      tsLeading notin p.tok.spacing:
     var pos = p.lex.bufpos
     while p.lex.buf[pos] == ' ': inc pos
-    result = p.lex.buf[pos] == ':' and p.lex.buf[pos+1] notin OpChars
+    result = p.lex.buf[pos] in {':', '='} and p.lex.buf[pos+1] notin OpChars
 
 proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
   if mode == pmTrySimple:
@@ -970,7 +971,7 @@ proc parseOperators(p: var Parser, headNode: PNode,
   # progress guaranteed
   while opPrec >= limit and p.tok.indent < 0 and not isUnary(p.tok):
     if mode == pmCommandParam and result.kind in {nkIdent, nkAccQuoted} and
-        isExportMarkerBeforeColon(p):
+        isCommandParamExportMarker(p):
       result = parsePostfix(p, result)
       break
     checkBinary(p)
@@ -1374,7 +1375,7 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
   #| simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
   #| commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
   #|                  'static'|'enum'|'tuple'|'object'|'proc')
-  #| commandParam = (symbol '*' &':') / expr
+  #| commandParam = (symbol '*' &(':' | '=')) / expr
   #| primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
   #|         / operatorB primary
   #|         / routineExpr

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1374,7 +1374,7 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
   #| simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
   #| commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
   #|                  'static'|'enum'|'tuple'|'object'|'proc')
-  #| commandParam = symbol '*' &':' / expr
+  #| commandParam = (symbol '*' &':') / expr
   #| primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
   #|         / operatorB primary
   #|         / routineExpr

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -97,7 +97,8 @@ expr = (blockExpr
 simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
 commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
                  'static'|'enum'|'tuple'|'object'|'proc')
-primary = simplePrimary (commandStart expr (doBlock extraPostExprBlock*)?)?
+commandParam = symbol '*' &':' / expr
+primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
         / operatorB primary
         / routineExpr
         / rawTypeDesc

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -97,7 +97,7 @@ expr = (blockExpr
 simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
 commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
                  'static'|'enum'|'tuple'|'object'|'proc')
-commandParam = (symbol '*' &':') / expr
+commandParam = (symbol '*' &(':' | '=')) / expr
 primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
         / operatorB primary
         / routineExpr

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -97,7 +97,7 @@ expr = (blockExpr
 simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
 commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
                  'static'|'enum'|'tuple'|'object'|'proc')
-commandParam = symbol '*' &':' / expr
+commandParam = (symbol '*' &':') / expr
 primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
         / operatorB primary
         / routineExpr

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -30,8 +30,8 @@ symbol = '`' (KEYW|IDENT|literal|(operator|'('|')'|'['|']'|'{'|'}'|'=')+)+ '`'
 symbolOrKeyword = symbol | KEYW
 exprColonEqExpr = expr ((':'|'=') expr
                        / doBlock extraPostExprBlock*)?
-exprEqExpr = expr ('=' expr
-                  / doBlock extraPostExprBlock*)?
+exprEqExpr = commandParam ('=' expr
+                          / doBlock extraPostExprBlock*)?
 exprList = expr ^+ comma
 optionalExprList = expr ^* comma
 exprColonEqExprList = exprColonEqExpr (comma exprColonEqExpr)* (comma)?
@@ -61,6 +61,7 @@ identOrLiteral = generalizedLit | symbol | literal
                | castExpr
 tupleConstr = '(' optInd (exprColonEqExpr comma?)* optPar ')'
 arrayConstr = '[' optInd (exprColonEqExpr comma?)* optPar ']'
+commandParam = (symbol '*' &(':' | '=')) / expr
 primarySuffix = '(' (exprColonEqExpr comma?)* ')'
       | '.' optInd symbolOrKeyword ('[:' exprList ']' ( '(' exprColonEqExpr ')' )?)? generalizedLit?
       | DOTLIKEOP optInd symbolOrKeyword generalizedLit?
@@ -97,7 +98,6 @@ expr = (blockExpr
 simplePrimary = SIGILLIKEOP? identOrLiteral primarySuffix*
 commandStart = &('`'|IDENT|literal|'cast'|'addr'|'type'|'var'|'out'|
                  'static'|'enum'|'tuple'|'object'|'proc')
-commandParam = (symbol '*' &(':' | '=')) / expr
 primary = simplePrimary (commandStart commandParam (doBlock extraPostExprBlock*)?)?
         / operatorB primary
         / routineExpr

--- a/tests/macros/mcommandpostfixexport.nim
+++ b/tests/macros/mcommandpostfixexport.nim
@@ -1,0 +1,37 @@
+import macros
+
+macro signature*(name, body: untyped): untyped =
+  doAssert name.kind == nnkPostfix
+  result = quote do:
+    type `name` = object
+      value*: int
+
+signature Thing*:
+  discard
+
+signature Spaced* :
+  discard
+
+macro signatureWithFlag*(flag, name, body: untyped): untyped =
+  doAssert flag.eqIdent("public")
+  doAssert name.kind == nnkPostfix
+  result = quote do:
+    type `name` = object
+      value*: int
+
+signatureWithFlag public, Other*:
+  discard
+
+macro takesInfix*(arg, body: untyped): untyped =
+  doAssert arg.kind == nnkInfix
+  doAssert arg[0].eqIdent("*")
+  result = newStmtList()
+
+takesInfix 2 * 3:
+  discard
+
+macro takesPragma*(arg: untyped): untyped =
+  doAssert arg.kind == nnkPragmaExpr
+  result = newStmtList()
+
+takesPragma value {.commandParamPragma.}

--- a/tests/macros/mcommandpostfixexport.nim
+++ b/tests/macros/mcommandpostfixexport.nim
@@ -30,8 +30,30 @@ macro takesInfix*(arg, body: untyped): untyped =
 takesInfix 2 * 3:
   discard
 
+macro takesMulAssign*(arg: untyped): untyped =
+  doAssert arg.kind == nnkInfix
+  doAssert arg[0].eqIdent("*=")
+  result = newStmtList()
+
+takesMulAssign value *= 2
+
 macro takesPragma*(arg: untyped): untyped =
   doAssert arg.kind == nnkPragmaExpr
   result = newStmtList()
 
 takesPragma value {.commandParamPragma.}
+
+macro module*(args: varargs[untyped]): untyped =
+  doAssert args.len == 1
+  let alias = args[0]
+  doAssert alias.kind == nnkExprEqExpr
+  doAssert alias[0].kind == nnkPostfix
+  doAssert alias[0][0].eqIdent("*")
+  doAssert alias[0][1].eqIdent("UserIdSet")
+  doAssert alias[1].kind == nnkCurlyExpr
+  let name = alias[0]
+  result = quote do:
+    type `name` = object
+      value*: int
+
+module UserIdSet* = SortedSet{UserById}

--- a/tests/macros/mcommandpostfixexport.nim
+++ b/tests/macros/mcommandpostfixexport.nim
@@ -30,6 +30,15 @@ macro takesInfix*(arg, body: untyped): untyped =
 takesInfix 2 * 3:
   discard
 
+macro takesIdentInfix*(arg: untyped): untyped =
+  doAssert arg.kind == nnkInfix
+  doAssert arg[0].eqIdent("*")
+  doAssert arg[1].eqIdent("left")
+  doAssert arg[2].eqIdent("right")
+  result = newStmtList()
+
+takesIdentInfix left*right
+
 macro takesMulAssign*(arg: untyped): untyped =
   doAssert arg.kind == nnkInfix
   doAssert arg[0].eqIdent("*=")

--- a/tests/macros/mcommandpostfixexport.nim
+++ b/tests/macros/mcommandpostfixexport.nim
@@ -12,6 +12,9 @@ signature Thing*:
 signature Spaced* :
   discard
 
+signature SpacedBeforeStar * :
+  discard
+
 macro signatureWithFlag*(flag, name, body: untyped): untyped =
   doAssert flag.eqIdent("public")
   doAssert name.kind == nnkPostfix
@@ -38,6 +41,14 @@ macro takesIdentInfix*(arg: untyped): untyped =
   result = newStmtList()
 
 takesIdentInfix left*right
+takesIdentInfix left * right
+
+macro takesGStrLit*(arg: untyped): untyped =
+  doAssert arg.kind == nnkCallStrLit
+  doAssert arg[0].eqIdent("tag")
+  result = newStmtList()
+
+takesGStrLit tag"1"
 
 macro takesMulAssign*(arg: untyped): untyped =
   doAssert arg.kind == nnkInfix
@@ -58,7 +69,8 @@ macro module*(args: varargs[untyped]): untyped =
   doAssert alias.kind == nnkExprEqExpr
   doAssert alias[0].kind == nnkPostfix
   doAssert alias[0][0].eqIdent("*")
-  doAssert alias[0][1].eqIdent("UserIdSet")
+  doAssert alias[0][1].eqIdent("UserIdSet") or
+    alias[0][1].eqIdent("SpacedAlias")
   doAssert alias[1].kind == nnkCurlyExpr
   let name = alias[0]
   result = quote do:
@@ -66,3 +78,4 @@ macro module*(args: varargs[untyped]): untyped =
       value*: int
 
 module UserIdSet* = SortedSet{UserById}
+module SpacedAlias * = SortedSet{UserById}

--- a/tests/macros/tcommandpostfixexport.nim
+++ b/tests/macros/tcommandpostfixexport.nim
@@ -1,0 +1,14 @@
+discard """
+  output: ""
+"""
+
+import mcommandpostfixexport
+
+let x = Thing(value: 3)
+doAssert x.value == 3
+
+let y = Other(value: 4)
+doAssert y.value == 4
+
+let z = Spaced(value: 5)
+doAssert z.value == 5

--- a/tests/macros/tcommandpostfixexport.nim
+++ b/tests/macros/tcommandpostfixexport.nim
@@ -12,3 +12,6 @@ doAssert y.value == 4
 
 let z = Spaced(value: 5)
 doAssert z.value == 5
+
+let userIdSet = UserIdSet(value: 6)
+doAssert userIdSet.value == 6


### PR DESCRIPTION
This is something that I've run into a few times over the years and it's always bothered me. I've wanted the ability to support the below syntax for generating public symbols with my macros:

```
mymacro Thing*:
   ...
```

This currently is parsed as an incomplete infix * expression and fails with:
```
Error: expression expected, but found ':'
```

This PR adds a new primary mode called `pmCommandParam` for command style call parameters.  In that mode only, an identifier or quoted identifier followed by *: is parsed as  `nnkPostfix(ident"*", ident"Thing")`

`isExportMarkerBeforeColon.` nirrors the lexer’s existing *: split rule by requiring the colon not to be followed by another operator character, and it does not allow for newlines.

The change is purposely limited to command macro/block syntax. Normal infix command arguments such as
  `m 2 * 3:` continue to parse as nnkInfix.

I could not find any open issues or forum posts related to this issue so I'm not sure if this has been discussed before. 

Let me know if you want some more tests or negative tests for this. I left this kind of light since I wasn't sure what you would want or if this syntax was purposelessly not allowed. 