### PR TITLE
fixes #25903 and #25904; add closure iterators with error handling

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -592,10 +592,7 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
           let branch = n[i]
           case branch.kind
           of nkExceptBranch:
-            if branch[0].kind == nkType:
-              branch[1] = ctx.convertExprBodyToAsgn(branch[1], tmp)
-            else:
-              branch[0] = ctx.convertExprBodyToAsgn(branch[0], tmp)
+            branch[^1] = ctx.convertExprBodyToAsgn(branch[^1], tmp)
           of nkFinally:
             discard
           else:

--- a/tests/closure/tclosure_issues.nim
+++ b/tests/closure/tclosure_issues.nim
@@ -80,3 +80,20 @@ block tissue7104:
           sp do ():
               inc i
               echo "ok ", i
+
+block: # bug #25903
+  iterator g: int {.closure.} =
+    discard try:
+        yield 0
+        0
+      except IOError, OSError:
+        0
+  let _ = g
+
+block: # bug #25904
+  iterator w: int {.closure.} =
+    discard try: 0
+      except IOError, OSError:
+        yield 0
+        0
+  let _ = w


### PR DESCRIPTION
fixes #25903
fixes #25904


`nkExceptBranch` can have variable structure depending on the exception types and it should handle the last node of the `nkExceptBranch`