### PR TITLE
fixes #18367 and #21222; using quote inside static block

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -308,7 +308,7 @@ proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph; idgen: IdGenerator
     callDepth: g.config.maxCallDepthVM,
     comesFromHeuristic: unknownLineInfo, callbacks: @[], callbackIndex: initTable[string, int](), errorFlag: "",
     cache: cache, config: g.config, graph: g, idgen: idgen,
-    contstantTab: initNodeTable(true))
+    contstantTab: initNodeTable(true), templInstCounter: new int)
 
 proc refresh*(c: PCtx, module: PSym; idgen: IdGenerator) =
   c.module = module

--- a/tests/vm/tquote.nim
+++ b/tests/vm/tquote.nim
@@ -1,0 +1,13 @@
+discard """
+  joinable: false
+"""
+
+import std/macros
+
+static:
+  discard quote:
+    a and b
+
+var x {.compileTime.} : NimNode = 
+  quote do:
+    echo "xxx"


### PR DESCRIPTION
fixes #18367
fixes #21222


1.  In vmdef.nim:304, newCtx now sets templInstCounter: new int when it builds TCtx.
2. vm.nim:1490 — During VM execution of templates, c.templInstCounter is passed to evalTemplate
3. evaltempl.nim:204 — instID: instID[] dereferences the ref int
4. With a nil templInstCounter, this would crash
5. The same initialization already exists on the semantic side in sem.nim:787, so this change makes the VM path consistent with the rest of the compiler.

