### PR TITLE
jsfetch accept full HttpMethods

### DIFF
--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -2,47 +2,51 @@
 when not defined(js):
   {.fatal: "Module jsfetch is designed to be used with the JavaScript backend.".}
 
-import std/[asyncjs, jsheaders, jsformdata]
+import std/[asyncjs, jsformdata, jsheaders]
+export jsformdata, jsheaders
 from std/httpcore import HttpMethod
 from std/jsffi import JsObject
 
 type
-  FetchOptions* = ref object of JsRoot  ## Options for Fetch API.
+  FetchOptions* = ref object of JsRoot ## Options for Fetch API.
     keepalive*: bool
     metod* {.importjs: "method".}: cstring
-    body*, integrity*, referrer*, mode*, credentials*, cache*, redirect*, referrerPolicy*: cstring
+    body*, integrity*, referrer*, mode*, credentials*, cache*, redirect*,
+      referrerPolicy*: cstring
     headers*: Headers
 
-  FetchModes* = enum  ## Mode options.
+  FetchModes* = enum ## Mode options.
     fmCors = "cors"
     fmNoCors = "no-cors"
     fmSameOrigin = "same-origin"
 
-  FetchCredentials* = enum  ## Credential options. See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+  FetchCredentials* = enum
+    ## Credential options. See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
     fcInclude = "include"
     fcSameOrigin = "same-origin"
     fcOmit = "omit"
 
-  FetchCaches* = enum  ## https://developer.mozilla.org/docs/Web/API/Request/cache
+  FetchCaches* = enum ## https://developer.mozilla.org/docs/Web/API/Request/cache
     fchDefault = "default"
     fchNoStore = "no-store"
     fchReload = "reload"
     fchNoCache = "no-cache"
     fchForceCache = "force-cache"
 
-  FetchRedirects* = enum  ## Redirects options.
+  FetchRedirects* = enum ## Redirects options.
     frFollow = "follow"
     frError = "error"
     frManual = "manual"
 
-  FetchReferrerPolicies* = enum  ## Referrer Policy options.
+  FetchReferrerPolicies* = enum ## Referrer Policy options.
     frpNoReferrer = "no-referrer"
     frpNoReferrerWhenDowngrade = "no-referrer-when-downgrade"
     frpOrigin = "origin"
     frpOriginWhenCrossOrigin = "origin-when-cross-origin"
     frpUnsafeUrl = "unsafe-url"
 
-  Response* = ref object of JsRoot  ## https://developer.mozilla.org/en-US/docs/Web/API/Response
+  Response* = ref object of JsRoot
+    ## https://developer.mozilla.org/en-US/docs/Web/API/Response
     bodyUsed*, ok*, redirected*: bool
     typ* {.importjs: "type".}: cstring
     url*, statusText*: cstring
@@ -50,7 +54,8 @@ type
     headers*: Headers
     body*: cstring
 
-  Request* = ref object of JsRoot  ## https://developer.mozilla.org/en-US/docs/Web/API/Request
+  Request* = ref object of JsRoot
+    ## https://developer.mozilla.org/en-US/docs/Web/API/Request
     bodyUsed*, ok*, redirected*: bool
     typ* {.importjs: "type".}: cstring
     url*, statusText*: cstring
@@ -64,7 +69,9 @@ func newResponse*(body: cstring | FormData): Response {.importjs: "(new Response
 func newRequest*(url: cstring): Request {.importjs: "(new Request(#))".}
   ## Constructor for `Request`. This does *not* call `fetch()`. Same as `new Request()`.
 
-func newRequest*(url: cstring; fetchOptions: FetchOptions): Request {.importjs: "(new Request(#, #))".}
+func newRequest*(
+  url: cstring, fetchOptions: FetchOptions
+): Request {.importjs: "(new Request(#, #))".}
   ## Constructor for `Request` with `fetchOptions`. Same as `fetch(url, fetchOptions)`.
 
 func clone*(self: Response | Request): Response {.importjs: "#.$1()".}
@@ -79,43 +86,72 @@ proc json*(self: Response): Future[JsObject] {.importjs: "#.$1()".}
 proc formData*(self: Response): Future[FormData] {.importjs: "#.$1()".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Response/formData
 
-proc unsafeNewFetchOptions*(metod, body, mode, credentials, cache, referrerPolicy: cstring;
-    keepalive: bool; redirect = "follow".cstring; referrer = "client".cstring; integrity = "".cstring; headers: Headers = newHeaders()): FetchOptions {.importjs:
-    "{method: #, body: #, mode: #, credentials: #, cache: #, referrerPolicy: #, keepalive: #, redirect: #, referrer: #, integrity: #, headers: #}".}
-  ## .. warning:: Unsafe `newfetchOptions`.
+proc unsafeNewFetchOptions*(
+  metod, body, mode, credentials, cache, referrerPolicy: cstring,
+  keepalive: bool,
+  redirect = "follow".cstring,
+  referrer = "client".cstring,
+  integrity = "".cstring,
+  headers: Headers = newHeaders(),
+): FetchOptions {.
+  importjs:
+    "{method: #, body: #, mode: #, credentials: #, cache: #, referrerPolicy: #, keepalive: #, redirect: #, referrer: #, integrity: #, headers: #}"
+.} ## .. warning:: Unsafe `newfetchOptions`.
 
-func newfetchOptions*(metod: HttpMethod; body: cstring;
-    mode: FetchModes; credentials: FetchCredentials; cache: FetchCaches; referrerPolicy: FetchReferrerPolicies;
-    keepalive: bool; redirect = frFollow; referrer = "client".cstring; integrity = "".cstring,
-    headers: Headers = newHeaders()): FetchOptions =
+func newfetchOptions*(
+    metod = HttpGet,
+    body: cstring = nil,
+    mode = fmCors,
+    credentials = fcSameOrigin,
+    cache = fchDefault,
+    referrerPolicy = frpNoReferrerWhenDowngrade,
+    keepalive = false,
+    redirect = frFollow,
+    referrer = "client".cstring,
+    integrity = "".cstring,
+    headers: Headers = newHeaders(),
+): FetchOptions =
   ## Constructor for `FetchOptions`.
   result = FetchOptions(
-    body: body, mode: cstring($mode), credentials: cstring($credentials), cache: cstring($cache), referrerPolicy: cstring($referrerPolicy),
-    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity,
-    metod: (case metod
-      of HttpHead:   "HEAD".cstring
-      of HttpGet:    "GET".cstring
-      of HttpPost:   "POST".cstring
-      of HttpPut:    "PUT".cstring
-      of HttpDelete: "DELETE".cstring
-      of HttpPatch:  "PATCH".cstring
-      else:          "GET".cstring
-    )
+    body: if metod notin {HttpHead, HttpGet}: body else: nil,
+    mode: cstring($mode),
+    credentials: cstring($credentials),
+    cache: cstring($cache),
+    referrerPolicy: cstring($referrerPolicy),
+    keepalive: keepalive,
+    redirect: cstring($redirect),
+    referrer: referrer,
+    integrity: integrity,
+    headers: headers,
+    # metod: (case metod
+    #   of HttpHead:   "HEAD".cstring
+    #   of HttpGet:    "GET".cstring
+    #   of HttpPost:   "POST".cstring
+    #   of HttpPut:    "PUT".cstring
+    #   of HttpDelete: "DELETE".cstring
+    #   of HttpPatch:  "PATCH".cstring
+    #   else:          "GET".cstring
+    # )
+    metod: $metod
   )
 
 proc fetch*(url: cstring | Request): Future[Response] {.importjs: "$1(#)".}
   ## `fetch()` API, simple `GET` only, returns a `Future[Response]`.
 
-proc fetch*(url: cstring | Request; options: FetchOptions): Future[Response] {.importjs: "$1(#, #)".}
+proc fetch*(
+  url: cstring | Request, options: FetchOptions
+): Future[Response] {.importjs: "$1(#, #)".}
   ## `fetch()` API that takes a `FetchOptions`, returns a `Future[Response]`.
 
-func toCstring*(self: Request | Response | FetchOptions): cstring {.importjs: "JSON.stringify(#)".}
+func toCstring*(
+  self: Request | Response | FetchOptions
+): cstring {.importjs: "JSON.stringify(#)".}
 
-func `$`*(self: Request | Response | FetchOptions): string = $toCstring(self)
-
+func `$`*(self: Request | Response | FetchOptions): string =
+  $toCstring(self)
 
 runnableExamples("-r:off"):
-  import std/[asyncjs, jsconsole, jsheaders, jsformdata]
+  import std/[asyncjs, jsconsole, jsformdata, jsheaders]
   from std/httpcore import HttpMethod
   from std/jsffi import JsObject
   from std/sugar import `=>`
@@ -132,7 +168,7 @@ runnableExamples("-r:off"):
       redirect = "follow".cstring,
       referrer = "client".cstring,
       integrity = "".cstring,
-      headers = newHeaders()
+      headers = newHeaders(),
     )
     assert options0.keepalive == false
     assert options0.metod == "POST".cstring
@@ -148,7 +184,7 @@ runnableExamples("-r:off"):
 
   block:
     let options1: FetchOptions = newFetchOptions(
-      metod =  HttpPost,
+      metod = HttpPost,
       body = """{"key": "value"}""".cstring,
       mode = fmNoCors,
       credentials = fcOmit,
@@ -158,7 +194,7 @@ runnableExamples("-r:off"):
       redirect = frFollow,
       referrer = "client".cstring,
       integrity = "".cstring,
-      headers = newHeaders()
+      headers = newHeaders(),
     )
     assert options1.keepalive == false
     assert options1.metod == $HttpPost
@@ -191,7 +227,7 @@ runnableExamples("-r:off"):
       discard example()
 
     block:
-      proc example2 {.async.} =
+      proc example2() {.async.} =
         await fetch("https://api.github.com/users/torvalds".cstring)
           .then((response: Response) => response.json())
           .then((json: JsObject) => console.log(json))

--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -8,42 +8,45 @@ from std/httpcore import HttpMethod
 from std/jsffi import JsObject
 
 type
-  FetchOptions* = ref object of JsRoot  ## Options for Fetch API.
+  FetchOptions* = ref object of JsRoot ## Options for Fetch API.
     keepalive*: bool
     metod* {.importjs: "method".}: cstring
-    body*, integrity*, referrer*, mode*, credentials*, cache*, redirect*, referrerPolicy*: cstring
+    body*, integrity*, referrer*, mode*, credentials*, cache*, redirect*,
+      referrerPolicy*: cstring
     headers*: Headers
 
-  FetchModes* = enum  ## Mode options.
+  FetchModes* = enum ## Mode options.
     fmCors = "cors"
     fmNoCors = "no-cors"
     fmSameOrigin = "same-origin"
 
-  FetchCredentials* = enum  ## Credential options. See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+  FetchCredentials* = enum
+    ## Credential options. See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
     fcInclude = "include"
     fcSameOrigin = "same-origin"
     fcOmit = "omit"
 
-  FetchCaches* = enum  ## https://developer.mozilla.org/docs/Web/API/Request/cache
+  FetchCaches* = enum ## https://developer.mozilla.org/docs/Web/API/Request/cache
     fchDefault = "default"
     fchNoStore = "no-store"
     fchReload = "reload"
     fchNoCache = "no-cache"
     fchForceCache = "force-cache"
 
-  FetchRedirects* = enum  ## Redirects options.
+  FetchRedirects* = enum ## Redirects options.
     frFollow = "follow"
     frError = "error"
     frManual = "manual"
 
-  FetchReferrerPolicies* = enum  ## Referrer Policy options.
+  FetchReferrerPolicies* = enum ## Referrer Policy options.
     frpNoReferrer = "no-referrer"
     frpNoReferrerWhenDowngrade = "no-referrer-when-downgrade"
     frpOrigin = "origin"
     frpOriginWhenCrossOrigin = "origin-when-cross-origin"
     frpUnsafeUrl = "unsafe-url"
 
-  Response* = ref object of JsRoot  ## https://developer.mozilla.org/en-US/docs/Web/API/Response
+  Response* = ref object of JsRoot
+    ## https://developer.mozilla.org/en-US/docs/Web/API/Response
     bodyUsed*, ok*, redirected*: bool
     typ* {.importjs: "type".}: cstring
     url*, statusText*: cstring
@@ -51,7 +54,8 @@ type
     headers*: Headers
     body*: cstring
 
-  Request* = ref object of JsRoot  ## https://developer.mozilla.org/en-US/docs/Web/API/Request
+  Request* = ref object of JsRoot
+    ## https://developer.mozilla.org/en-US/docs/Web/API/Request
     bodyUsed*, ok*, redirected*: bool
     typ* {.importjs: "type".}: cstring
     url*, statusText*: cstring
@@ -65,7 +69,9 @@ func newResponse*(body: cstring | FormData): Response {.importjs: "(new Response
 func newRequest*(url: cstring): Request {.importjs: "(new Request(#))".}
   ## Constructor for `Request`. This does *not* call `fetch()`. Same as `new Request()`.
 
-func newRequest*(url: cstring; fetchOptions: FetchOptions): Request {.importjs: "(new Request(#, #))".}
+func newRequest*(
+  url: cstring, fetchOptions: FetchOptions
+): Request {.importjs: "(new Request(#, #))".}
   ## Constructor for `Request` with `fetchOptions`. Same as `fetch(url, fetchOptions)`.
 
 func clone*(self: Response | Request): Response {.importjs: "#.$1()".}
@@ -80,41 +86,69 @@ proc json*(self: Response): Future[JsObject] {.importjs: "#.$1()".}
 proc formData*(self: Response): Future[FormData] {.importjs: "#.$1()".}
   ## https://developer.mozilla.org/en-US/docs/Web/API/Response/formData
 
-proc unsafeNewFetchOptions*(metod, body, mode, credentials, cache, referrerPolicy: cstring;
-    keepalive: bool; redirect = "follow".cstring; referrer = "client".cstring; integrity = "".cstring; headers: Headers = newHeaders()): FetchOptions {.importjs:
-    "{method: #, body: #, mode: #, credentials: #, cache: #, referrerPolicy: #, keepalive: #, redirect: #, referrer: #, integrity: #, headers: #}".}
-  ## .. warning:: Unsafe `newfetchOptions`.
+proc unsafeNewFetchOptions*(
+  metod, body, mode, credentials, cache, referrerPolicy: cstring,
+  keepalive: bool,
+  redirect = "follow".cstring,
+  referrer = "client".cstring,
+  integrity = "".cstring,
+  headers: Headers = newHeaders(),
+): FetchOptions {.
+  importjs:
+    "{method: #, body: #, mode: #, credentials: #, cache: #, referrerPolicy: #, keepalive: #, redirect: #, referrer: #, integrity: #, headers: #}"
+.} ## .. warning:: Unsafe `newfetchOptions`.
 
-func newfetchOptions*(metod = HttpGet; body: cstring = nil;
-    mode = fmCors; credentials = fcSameOrigin; cache = fchDefault; referrerPolicy = frpNoReferrerWhenDowngrade;
-    keepalive = false; redirect = frFollow; referrer = "client".cstring; integrity = "".cstring,
-    headers: Headers = newHeaders()): FetchOptions =
+func newfetchOptions*(
+    metod = HttpGet,
+    body: cstring = nil,
+    mode = fmCors,
+    credentials = fcSameOrigin,
+    cache = fchDefault,
+    referrerPolicy = frpNoReferrerWhenDowngrade,
+    keepalive = false,
+    redirect = frFollow,
+    referrer = "client".cstring,
+    integrity = "".cstring,
+    headers: Headers = newHeaders(),
+): FetchOptions =
   ## Constructor for `FetchOptions`.
   result = FetchOptions(
-    body: if metod notin {HttpHead, HttpGet}: body else: nil, 
-    mode: cstring($mode), credentials: cstring($credentials), cache: cstring($cache), referrerPolicy: cstring($referrerPolicy),
-    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity, headers: headers,
-    metod: (case metod
-      of HttpHead:   "HEAD".cstring
-      of HttpGet:    "GET".cstring
-      of HttpPost:   "POST".cstring
-      of HttpPut:    "PUT".cstring
-      of HttpDelete: "DELETE".cstring
-      of HttpPatch:  "PATCH".cstring
-      else:          "GET".cstring
-    )
+    body: if metod notin {HttpHead, HttpGet}: body else: nil,
+    mode: cstring($mode),
+    credentials: cstring($credentials),
+    cache: cstring($cache),
+    referrerPolicy: cstring($referrerPolicy),
+    keepalive: keepalive,
+    redirect: cstring($redirect),
+    referrer: referrer,
+    integrity: integrity,
+    headers: headers,
+    # metod: (case metod
+    #   of HttpHead:   "HEAD".cstring
+    #   of HttpGet:    "GET".cstring
+    #   of HttpPost:   "POST".cstring
+    #   of HttpPut:    "PUT".cstring
+    #   of HttpDelete: "DELETE".cstring
+    #   of HttpPatch:  "PATCH".cstring
+    #   else:          "GET".cstring
+    # )
+    metod: $metod
   )
 
 proc fetch*(url: cstring | Request): Future[Response] {.importjs: "$1(#)".}
   ## `fetch()` API, simple `GET` only, returns a `Future[Response]`.
 
-proc fetch*(url: cstring | Request; options: FetchOptions): Future[Response] {.importjs: "$1(#, #)".}
+proc fetch*(
+  url: cstring | Request, options: FetchOptions
+): Future[Response] {.importjs: "$1(#, #)".}
   ## `fetch()` API that takes a `FetchOptions`, returns a `Future[Response]`.
 
-func toCstring*(self: Request | Response | FetchOptions): cstring {.importjs: "JSON.stringify(#)".}
+func toCstring*(
+  self: Request | Response | FetchOptions
+): cstring {.importjs: "JSON.stringify(#)".}
 
-func `$`*(self: Request | Response | FetchOptions): string = $toCstring(self)
-
+func `$`*(self: Request | Response | FetchOptions): string =
+  $toCstring(self)
 
 runnableExamples("-r:off"):
   import std/[asyncjs, jsconsole, jsformdata, jsheaders]
@@ -134,7 +168,7 @@ runnableExamples("-r:off"):
       redirect = "follow".cstring,
       referrer = "client".cstring,
       integrity = "".cstring,
-      headers = newHeaders()
+      headers = newHeaders(),
     )
     assert options0.keepalive == false
     assert options0.metod == "POST".cstring
@@ -150,7 +184,7 @@ runnableExamples("-r:off"):
 
   block:
     let options1: FetchOptions = newFetchOptions(
-      metod =  HttpPost,
+      metod = HttpPost,
       body = """{"key": "value"}""".cstring,
       mode = fmNoCors,
       credentials = fcOmit,
@@ -160,7 +194,7 @@ runnableExamples("-r:off"):
       redirect = frFollow,
       referrer = "client".cstring,
       integrity = "".cstring,
-      headers = newHeaders()
+      headers = newHeaders(),
     )
     assert options1.keepalive == false
     assert options1.metod == $HttpPost
@@ -193,7 +227,7 @@ runnableExamples("-r:off"):
       discard example()
 
     block:
-      proc example2 {.async.} =
+      proc example2() {.async.} =
         await fetch("https://api.github.com/users/torvalds".cstring)
           .then((response: Response) => response.json())
           .then((json: JsObject) => console.log(json))


### PR DESCRIPTION
All HttpMethods in fetch

Note: I added a single line of code and commented out (removed) one code block, but GitHub is showing a lot of changes. Maybe the merge created a diff against an older version, or maybe something caused the code to get reformatted. I tried to fix it, but I haven't been able to.