### PR TITLE
fixes genMagicExpr: handle mAsgn for Isolated[T] with primitive types in tuple assignment

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2940,6 +2940,13 @@ proc genEnumToStr(p: BProc, e: PNode, d: var TLoc) =
 
 proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   case op
+  of mAsgn:
+    let kind = if e[0].sym.name.s == "=sink": nkSinkAsgn else: nkAsgn
+    let lhs = e[1].skipHiddenAddr
+    let n = newTreeI(kind, e.info, lhs, e[2])
+    n.typ = e.typ
+    cow(p, e[2])
+    genAsgn(p, n, fastAsgn = kind != nkAsgn)
   of mOr, mAnd: genAndOr(p, e, d, op)
   of mNot..mUnaryMinusF64: unaryArith(p, e, d, op)
   of mUnaryMinusI..mAbsI: unaryArithOverflow(p, e, d, op)

--- a/tests/arc/tisolated_primitive.nim
+++ b/tests/arc/tisolated_primitive.nim
@@ -1,0 +1,12 @@
+# Issue: genMagicExpr: mAsgn internal error when using Isolated[T] with primitive types
+# in tuple assignment to pointer dereference
+
+import std/isolation
+
+proc main() =
+  var x: ptr Isolated[float]
+  x = cast[ptr Isolated[float]](alloc0(sizeof(Isolated[float])))
+  x[] = isolate(42.0)
+  dealloc(x)
+
+main()


### PR DESCRIPTION
  Explicit `=sink` calls such as `Isolated[T].=sink` can delegate to a field type like `float`, which has no attached sink op. In that case `replaceHookMagic` leaves the builtin `mAsgn` call in place. `genMagicExpr` did not lower that shape, which caused the regression. Mapping `=sink` to `nkSinkAsgn` and other builtin assignment hooks to `nkAsgn`.