### PR TITLE
Haiku: linking libbsd for kqueue is moved at the module level

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -134,11 +134,11 @@ nimblepath="$home/.nimble/pkgs/"
     # BSD got posix_spawn only recently, so we deactivate it for osproc:
     define:useFork
   @elif haiku:
-    gcc.options.linker = "-Wl,--as-needed -lnetwork -lbsd"
-    gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork -lbsd"
-    clang.options.linker = "-Wl,--as-needed -lnetwork -lbsd"
-    clang.cpp.options.linker = "-Wl,--as-needed -lnetwork -lbsd"
-    tcc.options.linker = "-Wl,--as-needed -lnetwork -lbsd"
+    gcc.options.linker = "-Wl,--as-needed -lnetwork"
+    gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    tcc.options.linker = "-Wl,--as-needed -lnetwork"
   @elif not genode:
     # -fopenmp
     gcc.options.linker = "-ldl"


### PR DESCRIPTION
As noted in https://github.com/nim-lang/Nim/pull/25953#discussion_r3522906057 the linking can be done at the module level, this is thus a partial revert of fa4f9c9759fbb9c82021745425c76bc886d8c805