### PR TITLE
Explicitly convert cstring to string

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -207,10 +207,10 @@ when defined(nativeStacktrace) and nativeStackTraceSupported:
       if enabled:
         if dlresult != 0:
           var oldLen = s.len
-          add(s, tempDlInfo.dli_fname)
+          add(s, cstrToStrBuiltin(tempDlInfo.dli_fname))
           if tempDlInfo.dli_sname != nil:
             for k in 1..max(1, 25-(s.len-oldLen)): add(s, ' ')
-            add(s, tempDlInfo.dli_sname)
+            add(s, cstrToStrBuiltin(tempDlInfo.dli_sname))
         else:
           add(s, '?')
         add(s, "\n")


### PR DESCRIPTION
I was updating nim to 2.2.10 in nixpkgs 

https://github.com/NixOS/nixpkgs/pull/538469

and without this change the build failed, because add(string, cstring) is not defined. I think it's caused by a change of position of the includes in system, but with this it works fine.