### PR TITLE
fixes #25942; handle tyEmpty in firstOrd/lastOrd

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -444,7 +444,7 @@ template bindConcreteTypeToUserTypeClass*(tc, concrete: PType) =
 
 proc firstOrd*(conf: ConfigRef; t: PType): Int128 =
   case t.kind
-  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError:
+  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError, tyEmpty:
     result = Zero
   of tySet, tyVar: result = firstOrd(conf, t.elementType)
   of tyArray: result = firstOrd(conf, t.indexType)
@@ -577,7 +577,7 @@ proc lastOrd*(conf: ConfigRef; t: PType): Int128 =
     result = lastOrd(conf, skipModifier(t))
   of tyUserTypeClasses:
     result = lastOrd(conf, last(t))
-  of tyError: result = Zero
+  of tyError, tyEmpty: result = Zero
   of tyOrdinal:
     if t.hasElementType: result = lastOrd(conf, skipModifier(t))
     else:

--- a/tests/types/t25942.nim
+++ b/tests/types/t25942.nim
@@ -1,0 +1,14 @@
+discard """
+  output: ""
+"""
+
+# see #25942
+proc p(h: static set[bool]) = discard len(h)
+p({})
+p({false})
+p({true, false})
+
+discard card({})
+
+proc q(h: static set[char]) = discard len(h)
+q({})


### PR DESCRIPTION
## fix

`{}` literal has element type `tyEmpty`. `len(set)` folds via `cardSet` -> `toBitSet` -> `firstOrd(elemType)`, which hit `fatal: invalid kind for firstOrd(tyEmpty)`.

Handle `tyEmpty` in `firstOrd`/`lastOrd` (return `Zero`, same as `tyError`).

```nim
proc p(h: static set[bool]) = discard len(h)
p({})  # was: fatal error: invalid kind for firstOrd(tyEmpty)
```

## test

added `tests/types/t25942.nim`