### PR TITLE
fixes #25968; ignores "-Wpsabi"

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -65,6 +65,7 @@ __EMSCRIPTEN__
 #  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
 #  pragma GCC diagnostic ignored "-Wpointer-bool-conversion"
 #  pragma GCC diagnostic ignored "-Wconstant-conversion"
+#  pragma GCC diagnostic ignored "-Wpsabi"
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
fixes #25968

 https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
> -Wpsabi (C, Objective-C, C++ and Objective-C++ only)
>
> -Wpsabi enables warnings about processor-specific ABI changes, such as changes in alignment requirements or how function arguments are passed. On several targets, including AArch64, ARM, x86, MIPS, RS6000/PowerPC, and S/390, these details have changed between different versions of GCC and/or different versions of the C or C++ language standards in ways that affect binary compatibility of compiled code. With -Wpsabi, GCC can detect potentially incompatible usages and warn you about them.

Hide this spurious diagnostic message by ignoring `-Wpsabi`