### PR TITLE
Fixe quit(errormsg: string, ...) comment in system.nim

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2604,7 +2604,7 @@ else:
       rawQuit(errorcode.cint)
 
 proc quit*(errormsg: string, errorcode = QuitFailure) {.noreturn.} =
-  ## A shorthand for `echo(errormsg); quit(errorcode)`.
+  ## A shorthand for `writeLine(stderr, errormsg); quit(errorcode)`.
   when defined(nimscript) or defined(js) or (hostOS == "standalone"):
     echo errormsg
   else:


### PR DESCRIPTION
The shorthand mentioning `echo` is not really accurate. `echo` writes to stdout while `quit` writes to stderr.