### PR TITLE
fixes #22475; improve undeclared identifier errors with import chain

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -611,6 +611,13 @@ proc errorUndeclaredIdentifier*(c: PContext; info: TLineInfo; name: string, extr
       err.add "; if declared in a template, this identifier may be inconsistently marked inject or gensym"
     if extra.len != 0:
       err.add extra
+    # Show import chain for better error messages
+    if c.graph.importStack.len > 1:
+      err.add "\nimported from "
+      for i in 0..<c.graph.importStack.len-1:
+        if i > 0: err.add "\n  which imports "
+        err.add toFilename(c.config, c.graph.importStack[i])
+      err.add "\n  at " & toFilename(c.config, info) & "(" & $info.line & ", " & $info.col & ")"
     if c.recursiveDep.len > 0:
       err.add "\nThis might be caused by a recursive module dependency:\n"
       err.add c.recursiveDep

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -464,6 +464,12 @@ proc throws(tracked, n, orig: PNode) =
     if orig != nil:
       let x = copyTree(orig)
       x.typ = n.typ
+      # Store the effect source location as a child node for call chain tracking
+      if n.info != orig.info:
+        let src = newNode(nkType)
+        src.info = n.info
+        src.typ = n.typ
+        x.add src
       tracked.add x
     else:
       tracked.add n
@@ -1736,8 +1742,14 @@ proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg:
       while rr.kind in {nkStmtList, nkStmtListExpr} and rr.len > 0: rr = rr.lastSon
       for (s, info) in unknownRaises.items:
         message(g.config, info, hintUnknownRaises, s.name.s)
-      message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated,
-              renderTree(rr) & " " & msg & typeToString(r.typ))
+      var effectMsg = renderTree(rr) & " " & msg & typeToString(r.typ)
+      # Show call chain if available (from throws proc)
+      if r.len > 0 and isForbids:
+        effectMsg.add "\ncall chain:"
+        for i in 0..<r.len:
+          effectMsg.add "\n  from " & toFilename(g.config, r[i].info) &
+                        "(" & $r[i].info.line & ", " & $r[i].info.col & ")"
+      message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated, effectMsg)
       popInfoContext(g.config)
   # hint about unnecessarily listed exception types:
   if hints:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -464,12 +464,6 @@ proc throws(tracked, n, orig: PNode) =
     if orig != nil:
       let x = copyTree(orig)
       x.typ = n.typ
-      # Store the effect source location as a child node for call chain tracking
-      if n.info != orig.info:
-        let src = newNode(nkType)
-        src.info = n.info
-        src.typ = n.typ
-        x.add src
       tracked.add x
     else:
       tracked.add n
@@ -1743,12 +1737,10 @@ proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg:
       for (s, info) in unknownRaises.items:
         message(g.config, info, hintUnknownRaises, s.name.s)
       var effectMsg = renderTree(rr) & " " & msg & typeToString(r.typ)
-      # Show call chain if available (from throws proc)
-      if r.len > 0 and isForbids:
-        effectMsg.add "\ncall chain:"
-        for i in 0..<r.len:
-          effectMsg.add "\n  from " & toFilename(g.config, r[i].info) &
-                        "(" & $r[i].info.line & ", " & $r[i].info.col & ")"
+      # Show effect origin location for forbids violations
+      if isForbids and r.info != spec.info:
+        effectMsg.add "\n  effect origin: " & toFilename(g.config, r.info) &
+                      "(" & $r.info.line & ", " & $r.info.col & ")"
       message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated, effectMsg)
       popInfoContext(g.config)
   # hint about unnecessarily listed exception types:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -444,7 +444,7 @@ template bindConcreteTypeToUserTypeClass*(tc, concrete: PType) =
 
 proc firstOrd*(conf: ConfigRef; t: PType): Int128 =
   case t.kind
-  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError:
+  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError, tyEmpty:
     result = Zero
   of tySet, tyVar: result = firstOrd(conf, t.elementType)
   of tyArray: result = firstOrd(conf, t.indexType)
@@ -577,7 +577,7 @@ proc lastOrd*(conf: ConfigRef; t: PType): Int128 =
     result = lastOrd(conf, skipModifier(t))
   of tyUserTypeClasses:
     result = lastOrd(conf, last(t))
-  of tyError: result = Zero
+  of tyError, tyEmpty: result = Zero
   of tyOrdinal:
     if t.hasElementType: result = lastOrd(conf, skipModifier(t))
     else:

--- a/tests/types/t25942.nim
+++ b/tests/types/t25942.nim
@@ -1,0 +1,14 @@
+discard """
+  output: ""
+"""
+
+# see #25942
+proc p(h: static set[bool]) = discard len(h)
+p({})
+p({false})
+p({true, false})
+
+discard card({})
+
+proc q(h: static set[char]) = discard len(h)
+q({})


### PR DESCRIPTION
Fixes #22475

When an undeclared identifier error occurs in an imported module, the error message now shows the import chain to help users understand where the error originated.

**Before:**
\\\
lib/pure/endians.nim(131, 57) Error: undeclared identifier: 'copyMem'
\\\

**After:**
\\\
lib/pure/endians.nim(131, 57) Error: undeclared identifier: 'copyMem'
imported from test.nim
  which imports oids.nim
  at endians.nim(131, 56)
\\\

This helps users identify that the error comes from \std/oids\ -> \endians.nim\ chain when using JS backend.