### PR TITLE
fix #24521: propagate checkDir in static walkDir

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -148,9 +148,9 @@ proc getCurrentExceptionWrapper(a: VmArgs) {.nimcall.} =
 proc raiseDefectWrapper(a: VmArgs) {.nimcall.} =
   discard
 
-proc staticWalkDirImpl(path: string, relative: bool): PNode =
+proc staticWalkDirImpl(path: string, relative, checkDir: bool): PNode =
   result = newNode(nkBracket)
-  for k, f in walkDir(path, relative):
+  for k, f in walkDir(path, relative, checkDir):
     result.add toLit((k, f))
 
 from std / compilesettings import SingleValueSetting, MultipleValueSetting
@@ -270,7 +270,7 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop getCurrentException
     systemop raiseDefect
     registerCallback c, "stdlib.staticos.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
-      setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
+      setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1), getBool(a, 2)))
     registerCallback c, "stdlib.staticos.staticDirExists", proc (a: VmArgs) {.nimcall.} =
       setResult(a, dirExists(getString(a, 0)))
     registerCallback c, "stdlib.staticos.staticFileExists", proc (a: VmArgs) {.nimcall.} =

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -190,11 +190,11 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
   ## * `walkDirRec iterator`_
 
   when nimvm:
-    for k, v in items(staticWalkDir(dir, relative)):
+    for k, v in items(staticWalkDir(dir, relative, checkDir)):
       yield (k, v)
   else:
     when weirdTarget:
-      for k, v in items(staticWalkDir(dir, relative)):
+      for k, v in items(staticWalkDir(dir, relative, checkDir)):
         yield (k, v)
     elif defined(windows):
       var f: WIN32_FIND_DATA

--- a/lib/std/staticos.nim
+++ b/lib/std/staticos.nim
@@ -26,7 +26,7 @@ type
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
-proc staticWalkDir*(dir: string; relative = false): seq[
+proc staticWalkDir*(dir: string; relative = false, checkDir = false): seq[
                   tuple[kind: PathComponent, path: string]] {.compileTime.} =
   ## Walks over the directory `dir` and returns a seq with each directory or
   ## file in `dir`. The component type and full path for each item are returned.
@@ -35,4 +35,6 @@ proc staticWalkDir*(dir: string; relative = false): seq[
   ## * If `relative` is true (default: false)
   ##   the resulting path is shortened to be relative to ``dir``,
   ##   otherwise the full path is returned.
+  ## * If `checkDir` is true, `OSError` is raised when `dir`
+  ##   doesn't exist.
   raiseAssert "implemented in the vmops"

--- a/tests/stdlib/tstaticos.nim
+++ b/tests/stdlib/tstaticos.nim
@@ -6,3 +6,8 @@ block:
     doAssert staticFileExists("MISSINGDIR") == false
     doAssert staticDirExists(currentSourcePath().parentDir)
     doAssert staticFileExists(currentSourcePath())
+
+    # bug #24521: checkDir=false (default) must not raise on a missing dir
+    var count = 0
+    for k, p in walkDir("MISSINGDIR"): count.inc
+    doAssert count == 0

--- a/tests/stdlib/twalkdir_checkdir_static.nim
+++ b/tests/stdlib/twalkdir_checkdir_static.nim
@@ -1,0 +1,14 @@
+discard """
+  errormsg: "unhandled exception"
+  file: ""
+  matrix: "--mm:orc"
+"""
+
+# bug #24521: static walkDir(checkDir=true) should raise OSError when the
+# directory doesn't exist. Previously the checkDir flag was dropped by the
+# nimvm/weirdTarget branch which forwards to the staticWalkDir vmop.
+import std/os
+
+static:
+  for k, p in walkDir("nonexistentdirectory", checkDir = true):
+    discard


### PR DESCRIPTION
## Summary
- Propagate `checkDir` parameter in `staticWalkDir` so that the static (VM) implementation matches the runtime `walkDir` behavior.
- `staticWalkDir` now accepts an optional `checkDir = false` argument, forwarded to the native `walkDir`.
- Adds regression tests for backward compatibility and the static block error path.

Fixes #24521
