### PR TITLE
fix #18556: avoid crash on nested void proc result assignment

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2115,7 +2115,12 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     let rhs = semExprWithType(c, n[1], {efTypeAllowed}, le)
     if lhs.kind == nkSym and lhs.sym.kind == skResult:
       n.typ = c.enforceVoidContext
-      if c.p.owner.kind != skMacro and resultTypeIsInferrable(lhs.sym.typ):
+      # Only infer the return type for the current proc's own 'result' sym.
+      # When 'result' refers to an outer proc's result (captured via closure
+      # from within a nested void proc), the inner proc has no resultSym and
+      # the inference below would crash on the internalAssert. Issue #18556.
+      if lhs.sym.owner == c.p.owner and
+         c.p.owner.kind != skMacro and resultTypeIsInferrable(lhs.sym.typ):
         var rhsTyp = rhs.typ
         if rhsTyp.kind in tyUserTypeClasses and rhsTyp.isResolvedUserTypeClass:
           rhsTyp = rhsTyp.last


### PR DESCRIPTION
## Summary
- Type-incorrect nested proc with \esult = expr\ caused compiler internal error crash instead of a friendly type error.
- Root cause: when \esult\ inside a nested void proc was captured via closure and referred to the outer proc's \esultSym\, \semAsgn\ assumed it belonged to the current proc and hit \internalAssert(c.p.resultSym != nil)\ on the void proc which has no \esultSym\.

## Fix
Only run the return-type inference path when the result sym actually belongs to the current proc owner:

\\\
im
if lhs.sym.owner == c.p.owner and
   c.p.owner.kind != skMacro and resultTypeIsInferrable(lhs.sym.typ):
\\\

## Repro
\\\
im
proc p(): auto =
  result = proc(): auto =
    result = 42  # type error: should be friendly, not crash
\\\

Before: \internalError\ crash at \compiler/semexprs.nim:2125\.
After: \	ype mismatch: p(): void\ friendly error.

## Testing
- Original issue repro now emits friendly type error instead of crash
- koch boot rebuild succeeds

Fixes #18556.