### PR TITLE
fixes #25942 #25938; type inference for static container type

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2087,7 +2087,18 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
               result = typeRel(c, f.base, a, flags)
         else:
           result = isGeneric
-        if result != isNone: put(c, f, aOrig)
+        if result != isNone:
+          if f.base.kind notin {tyNone, tyGenericParam} and
+              aOrig.kind == tyStatic and aOrig.n != nil and aOrig.n.typ != nil and
+              aOrig.n.typ.isEmptyContainer:
+            # we need to infer the inner type for empty containers
+            let literal = aOrig.n.copyTree
+            literal.typ = f.base
+            let staticArg = newTypeS(tyStatic, c.c, f.base)
+            staticArg.n = literal
+            put(c, f, staticArg)
+          else:
+            put(c, f, aOrig)
       elif aOrig.n != nil and aOrig.n.typ != nil:
         result = if f.base.kind != tyNone:
                    typeRel(c, f.last, aOrig.n.typ, flags)

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -457,3 +457,20 @@ block: # bug #22600
 
   var x: c[2]
   x.init()
+
+block:
+  # bug #25938
+
+  proc p(h: static set[bool] = {}) =
+    discard false in h
+
+  p()
+  p({})
+
+block:
+  # bug #25942
+
+  proc p(h: static set[bool]) = discard len(h)
+  p({})
+
+


### PR DESCRIPTION
fixes #25942 
fixes #25938

After a successful match to a concrete static T, normalizes an empty static container literal to the formal payload type before binding it. This prevents `static[set[empty]]({})` from leaking into the instantiated proc body.