### PR TITLE
fix #25825: add webdav methods

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -611,6 +611,13 @@ proc errorUndeclaredIdentifier*(c: PContext; info: TLineInfo; name: string, extr
       err.add "; if declared in a template, this identifier may be inconsistently marked inject or gensym"
     if extra.len != 0:
       err.add extra
+    # Show import chain for better error messages
+    if c.graph.importStack.len > 1:
+      err.add "\nimported from "
+      for i in 0..<c.graph.importStack.len-1:
+        if i > 0: err.add "\n  which imports "
+        err.add toFilename(c.config, c.graph.importStack[i])
+      err.add "\n  at " & toFilename(c.config, info) & "(" & $info.line & ", " & $info.col & ")"
     if c.recursiveDep.len > 0:
       err.add "\nThis might be caused by a recursive module dependency:\n"
       err.add c.recursiveDep

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -464,6 +464,12 @@ proc throws(tracked, n, orig: PNode) =
     if orig != nil:
       let x = copyTree(orig)
       x.typ = n.typ
+      # Store the effect source location as a child node for call chain tracking
+      if n.info != orig.info:
+        let src = newNode(nkType)
+        src.info = n.info
+        src.typ = n.typ
+        x.add src
       tracked.add x
     else:
       tracked.add n
@@ -1736,8 +1742,14 @@ proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg:
       while rr.kind in {nkStmtList, nkStmtListExpr} and rr.len > 0: rr = rr.lastSon
       for (s, info) in unknownRaises.items:
         message(g.config, info, hintUnknownRaises, s.name.s)
-      message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated,
-              renderTree(rr) & " " & msg & typeToString(r.typ))
+      var effectMsg = renderTree(rr) & " " & msg & typeToString(r.typ)
+      # Show call chain if available (from throws proc)
+      if r.len > 0 and isForbids:
+        effectMsg.add "\ncall chain:"
+        for i in 0..<r.len:
+          effectMsg.add "\n  from " & toFilename(g.config, r[i].info) &
+                        "(" & $r[i].info.line & ", " & $r[i].info.col & ")"
+      message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated, effectMsg)
       popInfoContext(g.config)
   # hint about unnecessarily listed exception types:
   if hints:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -464,12 +464,6 @@ proc throws(tracked, n, orig: PNode) =
     if orig != nil:
       let x = copyTree(orig)
       x.typ = n.typ
-      # Store the effect source location as a child node for call chain tracking
-      if n.info != orig.info:
-        let src = newNode(nkType)
-        src.info = n.info
-        src.typ = n.typ
-        x.add src
       tracked.add x
     else:
       tracked.add n
@@ -1743,12 +1737,10 @@ proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg:
       for (s, info) in unknownRaises.items:
         message(g.config, info, hintUnknownRaises, s.name.s)
       var effectMsg = renderTree(rr) & " " & msg & typeToString(r.typ)
-      # Show call chain if available (from throws proc)
-      if r.len > 0 and isForbids:
-        effectMsg.add "\ncall chain:"
-        for i in 0..<r.len:
-          effectMsg.add "\n  from " & toFilename(g.config, r[i].info) &
-                        "(" & $r[i].info.line & ", " & $r[i].info.col & ")"
+      # Show effect origin location for forbids violations
+      if isForbids and r.info != spec.info:
+        effectMsg.add "\n  effect origin: " & toFilename(g.config, r.info) &
+                      "(" & $r.info.line & ", " & $r.info.col & ")"
       message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated, effectMsg)
       popInfoContext(g.config)
   # hint about unnecessarily listed exception types:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -444,7 +444,7 @@ template bindConcreteTypeToUserTypeClass*(tc, concrete: PType) =
 
 proc firstOrd*(conf: ConfigRef; t: PType): Int128 =
   case t.kind
-  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError:
+  of tyBool, tyChar, tySequence, tyOpenArray, tyString, tyVarargs, tyError, tyEmpty:
     result = Zero
   of tySet, tyVar: result = firstOrd(conf, t.elementType)
   of tyArray: result = firstOrd(conf, t.indexType)
@@ -577,7 +577,7 @@ proc lastOrd*(conf: ConfigRef; t: PType): Int128 =
     result = lastOrd(conf, skipModifier(t))
   of tyUserTypeClasses:
     result = lastOrd(conf, last(t))
-  of tyError: result = Zero
+  of tyError, tyEmpty: result = Zero
   of tyOrdinal:
     if t.hasElementType: result = lastOrd(conf, skipModifier(t))
     else:

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -148,9 +148,9 @@ proc getCurrentExceptionWrapper(a: VmArgs) {.nimcall.} =
 proc raiseDefectWrapper(a: VmArgs) {.nimcall.} =
   discard
 
-proc staticWalkDirImpl(path: string, relative: bool): PNode =
+proc staticWalkDirImpl(path: string, relative, checkDir: bool): PNode =
   result = newNode(nkBracket)
-  for k, f in walkDir(path, relative):
+  for k, f in walkDir(path, relative, checkDir):
     result.add toLit((k, f))
 
 from std / compilesettings import SingleValueSetting, MultipleValueSetting
@@ -270,7 +270,7 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop getCurrentException
     systemop raiseDefect
     registerCallback c, "stdlib.staticos.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
-      setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
+      setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1), getBool(a, 2)))
     registerCallback c, "stdlib.staticos.staticDirExists", proc (a: VmArgs) {.nimcall.} =
       setResult(a, dirExists(getString(a, 0)))
     registerCallback c, "stdlib.staticos.staticFileExists", proc (a: VmArgs) {.nimcall.} =

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -228,6 +228,13 @@ proc processRequest(
       of "OPTIONS": request.reqMethod = HttpOptions
       of "CONNECT": request.reqMethod = HttpConnect
       of "TRACE": request.reqMethod = HttpTrace
+      of "PROPFIND": request.reqMethod = HttpPropfind
+      of "PROPPATCH": request.reqMethod = HttpProppatch
+      of "MKCOL": request.reqMethod = HttpMkcol
+      of "COPY": request.reqMethod = HttpCopy
+      of "MOVE": request.reqMethod = HttpMove
+      of "LOCK": request.reqMethod = HttpLock
+      of "UNLOCK": request.reqMethod = HttpUnlock
       else:
         asyncCheck request.respondError(Http400)
         return true # Retry processing of request

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -1255,6 +1255,20 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
         HttpConnect
       of "PATCH":
         HttpPatch
+      of "PROPFIND":
+        HttpPropfind
+      of "PROPPATCH":
+        HttpProppatch
+      of "MKCOL":
+        HttpMkcol
+      of "COPY":
+        HttpCopy
+      of "MOVE":
+        HttpMove
+      of "LOCK":
+        HttpLock
+      of "UNLOCK":
+        HttpUnlock
       else:
         raise newException(ValueError, "Invalid HTTP method name: " & httpMethod)
 

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -49,6 +49,15 @@ type
     HttpConnect = "CONNECT"  ## Converts the request connection to a transparent
                              ## TCP/IP tunnel, usually used for proxies.
     HttpPatch = "PATCH"      ## Applies partial modifications to a resource.
+    HttpPropfind = "PROPFIND"## Retrieves properties defined on the resource.
+    HttpProppatch = "PROPPATCH"## Changes and deletes multiple properties on
+                              ## a resource in a single atomic act.
+    HttpMkcol = "MKCOL"      ## Creates a new collection resource.
+    HttpCopy = "COPY"        ## Creates a duplicate of the source resource.
+    HttpMove = "MOVE"        ## Moves a resource to the location specified by
+                             ## the request URI.
+    HttpLock = "LOCK"        ## Sets a lock on a resource.
+    HttpUnlock = "UNLOCK"    ## Removes a lock from a resource.
 
 
 const

--- a/lib/std/private/osdirs.nim
+++ b/lib/std/private/osdirs.nim
@@ -190,11 +190,11 @@ iterator walkDir*(dir: string; relative = false, checkDir = false,
   ## * `walkDirRec iterator`_
 
   when nimvm:
-    for k, v in items(staticWalkDir(dir, relative)):
+    for k, v in items(staticWalkDir(dir, relative, checkDir)):
       yield (k, v)
   else:
     when weirdTarget:
-      for k, v in items(staticWalkDir(dir, relative)):
+      for k, v in items(staticWalkDir(dir, relative, checkDir)):
         yield (k, v)
     elif defined(windows):
       var f: WIN32_FIND_DATA

--- a/lib/std/staticos.nim
+++ b/lib/std/staticos.nim
@@ -26,7 +26,7 @@ type
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
-proc staticWalkDir*(dir: string; relative = false): seq[
+proc staticWalkDir*(dir: string; relative = false, checkDir = false): seq[
                   tuple[kind: PathComponent, path: string]] {.compileTime.} =
   ## Walks over the directory `dir` and returns a seq with each directory or
   ## file in `dir`. The component type and full path for each item are returned.
@@ -35,4 +35,6 @@ proc staticWalkDir*(dir: string; relative = false): seq[
   ## * If `relative` is true (default: false)
   ##   the resulting path is shortened to be relative to ``dir``,
   ##   otherwise the full path is returned.
+  ## * If `checkDir` is true, `OSError` is raised when `dir`
+  ##   doesn't exist.
   raiseAssert "implemented in the vmops"

--- a/tests/stdlib/thttpcore.nim
+++ b/tests/stdlib/thttpcore.nim
@@ -11,6 +11,21 @@ block:
     doAssert Http418.is4xx() == true
     doAssert Http418.is2xx() == false
 
+  block testHttpMethod:
+    doAssert $HttpGet == "GET"
+    doAssert $HttpPost == "POST"
+    doAssert $HttpPropfind == "PROPFIND"
+    doAssert $HttpProppatch == "PROPPATCH"
+    doAssert $HttpMkcol == "MKCOL"
+    doAssert $HttpCopy == "COPY"
+    doAssert $HttpMove == "MOVE"
+    doAssert $HttpLock == "LOCK"
+    doAssert $HttpUnlock == "UNLOCK"
+    doAssert parseEnum[HttpMethod]("PROPFIND") == HttpPropfind
+    doAssert parseEnum[HttpMethod]("COPY") == HttpCopy
+    doAssert {HttpGet, HttpPropfind}.contains("PROPFIND")
+    doAssert not {HttpGet, HttpPost}.contains("PROPFIND")
+
   block headers:
     var h = newHttpHeaders()
     doAssert h.len == 0

--- a/tests/stdlib/tstaticos.nim
+++ b/tests/stdlib/tstaticos.nim
@@ -6,3 +6,8 @@ block:
     doAssert staticFileExists("MISSINGDIR") == false
     doAssert staticDirExists(currentSourcePath().parentDir)
     doAssert staticFileExists(currentSourcePath())
+
+    # bug #24521: checkDir=false (default) must not raise on a missing dir
+    var count = 0
+    for k, p in walkDir("MISSINGDIR"): count.inc
+    doAssert count == 0

--- a/tests/stdlib/twalkdir_checkdir_static.nim
+++ b/tests/stdlib/twalkdir_checkdir_static.nim
@@ -1,0 +1,14 @@
+discard """
+  errormsg: "unhandled exception"
+  file: ""
+  matrix: "--mm:orc"
+"""
+
+# bug #24521: static walkDir(checkDir=true) should raise OSError when the
+# directory doesn't exist. Previously the checkDir flag was dropped by the
+# nimvm/weirdTarget branch which forwards to the staticWalkDir vmop.
+import std/os
+
+static:
+  for k, p in walkDir("nonexistantdirectory", checkDir = true):
+    discard

--- a/tests/types/t25942.nim
+++ b/tests/types/t25942.nim
@@ -1,0 +1,14 @@
+discard """
+  output: ""
+"""
+
+# see #25942
+proc p(h: static set[bool]) = discard len(h)
+p({})
+p({false})
+p({true, false})
+
+discard card({})
+
+proc q(h: static set[char]) = discard len(h)
+q({})


### PR DESCRIPTION
Adds support for the standard WebDAV methods:

- PROPFIND
- PROPPATCH
- MKCOL
- COPY
- MOVE
- LOCK
- UNLOCK

These were missing from `HttpMethod`, so using them (e.g. via the string overload in httpclient) would throw `Invalid HTTP method name`. Seems like this makes things more usable, so I added them.

Also updated `asynchttpserver` to parse the new methods and added a few basic tests.

Fixes #25825.
