### PR TITLE
remove `GC_setStrategy`

### DIFF
--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -892,9 +892,6 @@ when not defined(useNimRtl):
             "API usage error: GC_enable called but GC is already enabled")
     dec(gch.recGcLock)
 
-  proc GC_setStrategy(strategy: GC_Strategy) =
-    discard
-
   proc GC_enableMarkAndSweep() =
     gch.cycleThreshold = InitialCycleThreshold
 

--- a/lib/system/gc_interface.nim
+++ b/lib/system/gc_interface.nim
@@ -3,14 +3,6 @@
 when not usesDestructors:
   {.pragma: nodestroy.}
 
-when hasAlloc:
-  type
-    GC_Strategy* = enum  ## The strategy the GC should use for the application.
-      gcThroughput,      ## optimize for throughput
-      gcResponsiveness,  ## optimize for responsiveness (default)
-      gcOptimizeTime,    ## optimize for speed
-      gcOptimizeSpace    ## optimize for memory footprint
-
 when hasAlloc and not defined(js) and not usesDestructors:
   proc GC_disable*() {.rtl, inl, gcsafe, raises: [].}
     ## Disables the GC. If called `n` times, `n` calls to `GC_enable`
@@ -65,9 +57,6 @@ when hasAlloc and defined(js):
 
   template GC_fullCollect* =
     {.warning: "GC_fullCollect is a no-op in JavaScript".}
-
-  template GC_setStrategy* =
-    {.warning: "GC_setStrategy is a no-op in JavaScript".}
 
   template GC_enableMarkAndSweep* =
     {.warning: "GC_enableMarkAndSweep is a no-op in JavaScript".}

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -491,8 +491,6 @@ when not defined(useNimRtl):
             "API usage error: GC_enable called but GC is already enabled")
     dec(gch.recGcLock)
 
-  proc GC_setStrategy(strategy: GC_Strategy) = discard
-
   proc GC_enableMarkAndSweep() =
     gch.cycleThreshold = InitialThreshold
 

--- a/lib/system/gc_regions.nim
+++ b/lib/system/gc_regions.nim
@@ -415,7 +415,6 @@ when hasThreadSupport:
 proc GC_disable() = discard
 proc GC_enable() = discard
 proc GC_fullCollect() = discard
-proc GC_setStrategy(strategy: GC_Strategy) = discard
 proc GC_enableMarkAndSweep() = discard
 proc GC_disableMarkAndSweep() = discard
 proc GC_getStatistics(): string = return ""

--- a/lib/system/mm/boehm.nim
+++ b/lib/system/mm/boehm.nim
@@ -76,7 +76,6 @@ when not defined(useNimRtl):
   proc GC_disable() = boehmGC_disable()
   proc GC_enable() = boehmGC_enable()
   proc GC_fullCollect() = boehmGCfullCollect()
-  proc GC_setStrategy(strategy: GC_Strategy) = discard
   proc GC_enableMarkAndSweep() = discard
   proc GC_disableMarkAndSweep() = discard
   proc GC_getStatistics(): string = return ""

--- a/lib/system/mm/go.nim
+++ b/lib/system/mm/go.nim
@@ -12,7 +12,6 @@ proc GC_disable() = discard
 proc GC_enable() = discard
 proc go_gc() {.importc: "go_gc", dynlib: goLib.}
 proc GC_fullCollect() = go_gc()
-proc GC_setStrategy(strategy: GC_Strategy) = discard
 proc GC_enableMarkAndSweep() = discard
 proc GC_disableMarkAndSweep() = discard
 

--- a/lib/system/mm/malloc.nim
+++ b/lib/system/mm/malloc.nim
@@ -55,8 +55,6 @@ when not defined(gcOrc) and not defined(gcYrc):
   proc GC_enableMarkAndSweep() = discard
   proc GC_disableMarkAndSweep() = discard
 
-proc GC_setStrategy(strategy: GC_Strategy) = discard
-
 proc getOccupiedMem(): int = discard
 proc getFreeMem(): int = discard
 proc getTotalMem(): int = discard

--- a/lib/system/mm/none.nim
+++ b/lib/system/mm/none.nim
@@ -8,7 +8,6 @@ proc initGC() = discard
 proc GC_disable() = discard
 proc GC_enable() = discard
 proc GC_fullCollect() = discard
-proc GC_setStrategy(strategy: GC_Strategy) = discard
 proc GC_enableMarkAndSweep() = discard
 proc GC_disableMarkAndSweep() = discard
 proc GC_getStatistics(): string = return ""


### PR DESCRIPTION
These functions are unused and never exposed publically - along with it, get rid of `GC_Strategy` - although it's possible someone could use this `enum` for their own code it seems unlikely.