### PR TITLE
fix #25870 #25846: var return type signature mismatch in C++ backend

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -746,9 +746,11 @@ proc getTempCpp(p: BProc, t: PType, value: Rope): TLoc =
   inc(p.labels)
   result = TLoc(snippet: "T" & rope(p.labels) & "_", k: locTemp, lode: lodeTyp t,
                 storage: OnStack, flags: {})
+  # decltype(auto) preserves references (e.g. int& from a var return proc)
+  # while auto would strip them, causing wrong codegen. See #25846.
   p.s(cpsStmts).addVar(kind = Local,
     name = result.snippet,
-    typ = "auto",
+    typ = "decltype(auto)",
     initializer = value)
 
 proc getIntTemp(p: BProc): TLoc =
@@ -1503,6 +1505,15 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
     let resNode = prc.ast[resultPos]
     let res = resNode.sym # get result symbol
     if not isInvalidReturnType(m.config, prc.typ) and sfConstructor notin prc.flags:
+      # For C++ backend with var/lent return: the proc signature uses T& (reference)
+      # but the result local var needs T* (pointer) so we can take its address.
+      # We set tfVarIsPtr on a COPY of the type so it doesn't leak into the proc
+      # type's return type (which would cause signature mismatch). See #25870.
+      var derefResultInReturn = false
+      if p.module.compileToCpp and res.typ.kind == tyVar:
+        res.typ = res.typ.exactReplica(m.idgen)
+        res.typ.incl tfVarIsPtr
+        derefResultInReturn = true
       if sfNoInit in prc.flags: incl(res, sfNoInit)
       if sfNoInit in prc.flags and p.module.compileToCpp and (let val = easyResultAsgn(procBody); val != nil):
         var a: TLoc = initLocExprSingleUse(p, val)
@@ -1520,7 +1531,9 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
         else:
           initLocalVar(p, res, immediateAsgn=false)
       var returnBuilder = newBuilder("\t")
-      let rres = rdLoc(res.loc)
+      var rres = rdLoc(res.loc)
+      if derefResultInReturn:
+        rres = cDeref(rres)
       returnBuilder.addReturn(rres)
       returnStmt = extract(returnBuilder)
     elif sfConstructor in prc.flags:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1930,7 +1930,10 @@ proc asgnToResultVar(c: PContext, n, le, ri: PNode) {.inline.} =
       if x.sym.kind == skResult and (x.typ.kind in {tyVar, tyLent} or classifyViewType(x.typ) != noView):
         n[0] = x # 'result[]' --> 'result'
         n[1] = takeImplicitAddr(c, ri, x.typ.kind == tyLent)
-        markResultVarIsPtr(c, x)
+        # Don't set tfVarIsPtr here — it leaks into the proc type's return type
+        # (they share the same PType object in non-IC mode), causing a mismatch
+        # between the proc definition signature and proc type parameters in C++.
+        # The flag is now applied in cgen.nim on a copy. See #25870, #25846.
         #echo x.info, " setting it for this type ", typeToString(x.typ), " ", n.info
       elif sfGlobal in x.sym.flags:
         markResultVarIsPtr(c, x)

--- a/tests/proc/tprocvar_var_ret.nim
+++ b/tests/proc/tprocvar_var_ret.nim
@@ -1,0 +1,61 @@
+discard """
+  targets: "c cpp"
+"""
+
+# Test 1: basic var return type passed as proc parameter
+# See #25870, #25846
+proc testVarRet(x: var int): var int = x
+
+proc testProcTypeParam(prc: proc (x: var int): var int {.nimcall.}) =
+  var x = 123
+  prc(x) = 321
+  doAssert x == 321
+
+testProcTypeParam(testVarRet)
+
+# Test 2: direct call
+var v = 42
+doAssert testVarRet(v) == 42
+testVarRet(v) = 99
+doAssert v == 99
+
+# Test 3: assign proc to var
+var pVarRet = testVarRet
+var testVar = 1234
+pVarRet(testVar) = 5678
+doAssert testVar == 5678
+
+# Test 4: var return with string
+proc testVarRetStr(x: var string): var string = x
+
+proc testProcTypeParamStr(prc: proc (x: var string): var string {.nimcall.}) =
+  var x = "foo"
+  prc(x) = "bar"
+  doAssert x == "bar"
+
+testProcTypeParamStr(testVarRetStr)
+
+# Test 5: var return with object
+type
+  FooObj = object
+    x, y: int
+
+proc testVarRetObj(x: var FooObj): var FooObj = x
+
+proc testProcTypeParamObj(prc: proc (x: var FooObj): var FooObj {.nimcall.}) =
+  var x = FooObj(x: 111, y: 222)
+  prc(x) = FooObj(x: 333, y: 444)
+  doAssert x == FooObj(x: 333, y: 444)
+
+testProcTypeParamObj(testVarRetObj)
+
+# Test 6: chained var return through proc type param
+proc testProcTypeParamChain(prc: proc (x: var int): var int {.nimcall.}) =
+  var x = 100
+  var y = 200
+  prc(x) = prc(y)
+  doAssert x == 200
+
+testProcTypeParamChain(testVarRet)
+
+echo "ok"


### PR DESCRIPTION
## Problem

When compiling with `nim cpp`, a proc with `var T` return type has a signature mismatch between its definition and its use as a proc type parameter. This causes either a Clang compile error (#25870) or wrong runtime behavior (#25846).

## Root Cause

`asgnToResultVar` in `semexprs.nim` set `tfVarIsPtr` directly on the result sym's type. In non-IC mode this type object is shared with the proc type's return type, so the flag leaked into the proc signature — making the definition use `T*` (pointer) while proc type parameters still used `T&` (reference).

Additionally, `getTempCpp` used `auto` which strips references in C++, so `auto T1 = prc(x)` copied instead of borrowing.

## Fix

1. **semexprs.nim**: Stop setting `tfVarIsPtr` on the result sym in `asgnToResultVar`. The flag was leaking into the shared proc type.

2. **cgen.nim**: In `genProcLvl3`, when compiling to C++ with a `var` return type, copy the type via `exactReplica` and set `tfVarIsPtr` on the copy only — keeping the proc signature's return type clean (`T&`). The return statement dereferences the result pointer (`*result`).

3. **cgen.nim**: `getTempCpp` now uses `decltype(auto)` instead of `auto` to preserve references.

## Test

`tests/proc/tprocvar_var_ret.nim` covers:
- var int / var string / var object return types
- proc type parameters with var return
- direct calls and indirect calls through proc variables
- chained var return through proc type params

Fixes #25870, fixes #25846.

Supersedes #25874 (conflicting, author stepped aside) and #25862 (partial fix only).
