### PR TITLE
fix #25978: show call chain for forbids violations

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -1715,6 +1715,27 @@ proc subtypeRelation(g: ModuleGraph; spec, real: PNode): bool =
   else:
     return safeInheritanceDiff(g.excType(real), spec.typ) <= 0
 
+proc traceForbidsOrigin(g: ModuleGraph; r: PNode; conf: ConfigRef) =
+  var current = r
+  var visited = initIntSet()
+  while current.kind in nkCallKinds and current[0].kind == nkSym:
+    let s = current[0].sym
+    if s.id in visited: break
+    visited.incl(s.id)
+    if s.typ == nil or s.typ.n == nil or s.typ.n[0].kind != nkEffectList: break
+    let effectList = s.typ.n[0]
+    if effectList.len == 0: break
+    let tags = effectList[tagEffects]
+    if tags == nil: break
+    var next: PNode = nil
+    for tag in items(tags):
+      if tag.typ != nil and sameType(tag.typ.skipTypes(skipPtrs), r.typ.skipTypes(skipPtrs)):
+        next = tag
+        break
+    if next == nil or next.info == current.info: break
+    message(conf, next.info, hintUser, "effect propagated from here")
+    current = next
+
 proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg: string, hints: bool;
                      effectPredicate: proc (g: ModuleGraph; a, b: PNode): bool {.nimcall.};
                      hintsArg: PNode = nil; isForbids: bool = false; unknownRaises: seq[(PSym, TLineInfo)] = @[]) =
@@ -1731,14 +1752,20 @@ proc checkRaisesSpec(g: ModuleGraph; emitWarnings: bool; spec, real: PNode, msg:
         if isForbids:
           break search
       # XXX call graph analysis would be nice here!
-      pushInfoContext(g.config, spec.info)
       var rr = if r.kind == nkRaiseStmt: r[0] else: r
       while rr.kind in {nkStmtList, nkStmtListExpr} and rr.len > 0: rr = rr.lastSon
       for (s, info) in unknownRaises.items:
         message(g.config, info, hintUnknownRaises, s.name.s)
-      message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated,
-              renderTree(rr) & " " & msg & typeToString(r.typ))
-      popInfoContext(g.config)
+      if isForbids:
+        message(g.config, spec.info, hintUser, ".forbids spec declared here")
+        traceForbidsOrigin(g, r, g.config)
+        message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated,
+                renderTree(rr) & " " & msg & typeToString(r.typ))
+      else:
+        pushInfoContext(g.config, spec.info)
+        message(g.config, r.info, if emitWarnings: warnEffect else: errGenerated,
+                renderTree(rr) & " " & msg & typeToString(r.typ))
+        popInfoContext(g.config)
   # hint about unnecessarily listed exception types:
   if hints:
     for s in 0..<spec.len:

--- a/tests/effects/tforbids_trace.nim
+++ b/tests/effects/tforbids_trace.nim
@@ -1,0 +1,18 @@
+discard """
+  action: compile
+  errormsg: "c() has an illegal effect: NestedPoll"
+  line: 18
+"""
+
+type
+  NestedPoll* = object of RootEffect
+
+proc poll*() {.tags: [NestedPoll].} =
+  discard
+
+proc a*() = poll()
+proc b*() = a()
+proc c*() = b()
+
+proc test*() {.forbids: [NestedPoll].} =
+  c()


### PR DESCRIPTION
`.forbids` violations previously reported only the immediate call site with a misleading "template/generic instantiation from here" message, giving no indication of where the forbidden effect actually originates.

This PR:
- Replaces `pushInfoContext` (which produced the misleading template/generic message) with a direct ".forbids spec declared here" hint
- Adds `traceForbidsOrigin` which walks the callee's effect list to trace the effect back through the call graph, emitting a hint at each hop

Before:
```
test.nim(11, 25) template/generic instantiation from here
test.nim(12, 4) Error: c() has an illegal effect: NestedPoll
```

After:
```
test.nim(11, 25) Hint: .forbids spec declared here
test.nim(9, 14)  Hint: effect propagated from here
test.nim(8, 14)  Hint: effect propagated from here
test.nim(7, 17)  Hint: effect propagated from here
test.nim(4, 23)  Hint: effect propagated from here
test.nim(12, 4)  Error: c() has an illegal effect: NestedPoll
```

The `raises` path is unchanged — only `isForbids` takes the new code path.
