### PR TITLE
fixes #25999 - nim track fails for generic procs

### DIFF
--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -1694,7 +1694,9 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
   # skipped. Layout: (offer <genericSym> <instSym> <genericParamsCount> <type>...).
   for off in genericOffers:
     w.deps.addParLe offerTag, NoLineInfo
-    w.deps.addSymUse pool.syms.getOrIncl(w.toNifSymName(off.generic)), NoLineInfo
+    # Put the source generic before its generated instance for position lookup.
+    w.deps.addSymUse pool.syms.getOrIncl(w.toNifSymName(off.generic)),
+      trLineInfo(w, off.generic.infoImpl)
     w.deps.addSymUse pool.syms.getOrIncl(w.toNifSymName(off.inst)), NoLineInfo
     w.deps.addIntLit off.genericParamsCount
     for ct in off.concreteTypes:
@@ -1709,13 +1711,14 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
   w.deps.addStrLit toFullPath(config, FileIndex(thisModule))
   w.deps.addParRi
 
-  # Template/macro expansions leave no trace in the sem'checked AST, so record
-  # each as `(expansion <symUse @call-site>)`: a `Symbol` use of the expanded
-  # routine carrying the ORIGINAL call-site line info. The loader skips the tag
-  # (processTopLevel), but `idetools` scans every `Symbol` token in the buffer,
-  # so this restores "find usages / goto-def" for templates and macros.
+  # Record source-level routine occurrences replaced by template/macro expansion
+  # or generic instantiation as `(expansion <symUse @call-site>)`. The loader
+  # skips the tag, but `idetools` scans its `Symbol` token for IDE queries.
+  var emittedExpansions = initHashSet[(ItemId, int32, uint16, int16)]()
   for (sym, info) in expansions:
     if sym == nil: continue
+    let key = (sym.itemId, info.fileIndex.int32, info.line, info.col)
+    if emittedExpansions.containsOrIncl(key): continue
     w.deps.addParLe expansionTag, NoLineInfo
     w.deps.addSymUse pool.syms.getOrIncl(w.toNifSymName(sym)), trLineInfo(w, info)
     w.deps.addParRi
@@ -3346,8 +3349,9 @@ proc processTopLevel(c: var DecodeContext; cur: var Cursor; flags: set[LoadFlag]
         # not needed by the loader, just skip past it.
         skip cur
       elif tagIs(cur, "expansion"):
-        # template/macro expansion usage record for tooling (`idetools` scans it
-        # as a `Symbol` use); the loader itself needs nothing from it.
+        # template/macro/generic proc expansion usage record for tooling
+        # (`idetools` scans it as a `Symbol` use); the loader itself needs
+        # nothing from it.
         skip cur
       elif tagIs(cur, "sig"):
         # signature-symbol occurrence record for tooling (`idetools` scans it as a

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -178,9 +178,10 @@ type
     procGlobals*: seq[PNode]
     nifReplayActions*: Table[int32, seq[PNode]]  # module position -> replay actions for NIF
     nifExpansions*: Table[int32, seq[(PSym, TLineInfo)]]
-      # module position -> (template/macro sym, call-site info) for every expansion
-      # in that module. Templates/macros leave no trace in the sem'checked AST, so
-      # this side-channel (written into the `.bif`, see ast2nif) is what lets
+      # module position -> (template/macro/generic proc sym, call-site info) for every
+      # expansion in that module. Templates/macros leave no trace in the sem'checked AST
+      # (generic proc instantiations don't point to the original generic definition),
+      # so this side-channel (written into the `.bif`, see ast2nif) is what lets
       # `nim track --usages`/`--def` find them. Populated by `rememberExpansion`.
     cachedMods: IntSet
     hookClosure: IntSet # modules whose serialized hooks were already registered

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -727,11 +727,17 @@ proc markConvertersUsed*(c: PContext, n: PNode) =
     if a.kind == nkHiddenCallConv and a[0].kind == nkSym:
       markUsed(c, a.info, a[0].sym)
 
+proc commitGenericExpansions(c: PContext, m: TCandidate) =
+  for expansion in m.pendingGenericExpansions:
+    rememberExpansion(c, expansion.info, expansion.sym)
+
 proc indexTypesMatch(c: PContext, f, a: PType, arg: PNode): PNode =
   var m = newCandidate(c, f)
   result = paramTypesMatch(m, f, a, arg, nil)
   if m.genericConverter and result != nil:
     instGenericConvertersArg(c, result, m)
+  if result != nil:
+    commitGenericExpansions(c, m)
   when defined(icDbg):
     if result == nil and f != nil and a != nil and f.kind == tyEnum:
       echo "INDEXMISMATCH f=", typeToString(f), " itemId=", f.itemId,
@@ -750,6 +756,7 @@ proc inferWithMetatype(c: PContext, formal: PType,
   if m.genericConverter and result != nil:
     instGenericConvertersArg(c, result, m)
   if result != nil:
+    commitGenericExpansions(c, m)
     # This almost exactly replicates the steps taken by the compiler during
     # param matching. It performs an embarrassing amount of back-and-forth
     # type jugling, but it's the price to pay for consistency and correctness
@@ -915,6 +922,8 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
           x.call.add tn
         else:
           internalAssert c.config, false
+  if finalCallee.instantiatedFrom != nil:
+    rememberExpansion(c, info, finalCallee.instantiatedFrom)
   markUsed(c, info, finalCallee, isGenericInstance = true)
   onUse(info, finalCallee, isGenericInstance = true)
 
@@ -925,6 +934,7 @@ proc semResolvedCall(c: PContext, x: var TCandidate,
   if finalCallee.magic notin {mArrGet, mArrPut}:
     result.typ = finalCallee.typ.returnType
   updateDefaultParams(c, result)
+  commitGenericExpansions(c, x)
 
 proc canDeref(n: PNode): bool {.inline.} =
   result = n.len >= 2 and (let t = n[1].typ;
@@ -1029,6 +1039,8 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym, doError: bool)
         result.typ = makeTypeFromExpr(c, result.copyTree)
       elif doError:
         notFoundError(c, n, errors)
+    else:
+      rememberExpansion(c, getCallLineInfo(n), s)
   elif a.kind in {nkClosedSymChoice, nkOpenSymChoice}:
     # choose the generic proc with the proper number of type parameters.
     result = newNodeI(a.kind, getCallLineInfo(n))

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -667,7 +667,7 @@ proc rememberExpansion*(c: PContext; info: TLineInfo; expandedSym: PSym) =
   ## referencing the generic definition for tools to use for definitions
   ## and usages, since they are instantiated by the compiler.
   ## This is pecial logic that helps remember macro/template/generic proc
-  ## expansions, saving the data for thethe "NIF" file mechanism to handle.
+  ## expansions, saving the data for the "NIF" file mechanism to handle.
   ##
   ## We only bother when a NIF file is actually going to be written (IC / `nim m`,
   ## `--compress`, or a running suggestion engine); a plain `nim c` throws the

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -662,12 +662,12 @@ proc sealRodFile*(c: PContext) =
     c.idgen.sealed = true # no further additions are allowed
 
 proc rememberExpansion*(c: PContext; info: TLineInfo; expandedSym: PSym) =
-  ## Templates and macros are very special in Nim; these have
-  ## inlining semantics so after semantic checking they leave no trace
-  ## in the sem'checked AST. This is very bad for IDE-like tooling
-  ## ("find all usages of this template" would not work). We need special
-  ## logic to remember macro/template expansions. This is done here and
-  ## delegated to the "NIF" file mechanism.
+  ## Templates and macros are inlined and leave no trace in the
+  ## sem'checked AST, and generic procs do not leave enough information
+  ## referencing the generic definition for tools to use for definitions
+  ## and usages, since they are instantiated by the compiler.
+  ## This is pecial logic that helps remember macro/template/generic proc
+  ## expansions, saving the data for thethe "NIF" file mechanism to handle.
   ##
   ## We only bother when a NIF file is actually going to be written (IC / `nim m`,
   ## `--compress`, or a running suggestion engine); a plain `nim c` throws the

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -90,6 +90,8 @@ type
     newlyTypedOperands*: seq[int]
       ## indexes of arguments that are newly typechecked in this match
       ## used for type bound op additions
+    pendingGenericExpansions*:
+      seq[tuple[sym: PSym; info: TLineInfo]]
 
   TTypeRelFlag* = enum
     trDontBind
@@ -2772,6 +2774,12 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
       markUsed(m.c, arg.info, arg[best].sym)
       onUse(arg.info, arg[best].sym)
       result = paramTypesMatchAux(m, f, arg[best].typ, arg[best], argOrig)
+  if result != nil:
+    let chosen = result.skipConv
+    if chosen.kind == nkSym and
+        chosen.sym.instantiatedFrom != nil:
+      m.pendingGenericExpansions.add (
+        chosen.sym.instantiatedFrom, chosen.info)
   when false:
     if m.calleeSym != nil and m.calleeSym.name.s == "[]":
       echo m.c.config $ arg.info, " for ", m.calleeSym.name.s, " ", m.c.config $ m.calleeSym.info


### PR DESCRIPTION
Fixes #25999 where instantiations of generic procs do not provide tooling a way to reference the original proc. This commit fixes this by extending the expansion tag system for macros/templates to work for generic procs, while also adding line info in the generated NIF to make `findPos` in `idetools.nim` find the correct instantiation.

This fixes --usages and --def for all generic proc usecases:
- direct calls (tests `semResolvedCall` changes)
```nim
proc foo[T](x: T): T = x
discard foo(1)
discard foo[float](1)
```
- explicit instantiation (`explicitGenericInstantiation`)
```nim
proc foo[T](x: T): T = x
let baz = foo[int]
discard baz(3)
```
- explicit overloaded argument (handle a symChoice)
```nim
proc biz[T](x: int): int = x
proc biz[T](x: string): string = x
proc apply(f: proc(x: int): int) = discard f(1)
apply(biz[float])
```
- overloaded contextual assignment (`indexTypesMatch`)
```nim
proc bar[T](x: T): T = x
proc bar[T](x, y: T): T = x
let bee: proc(x: float): float = bar
discard bee(3.0)
```
- outer overloading
```nim
proc foo[T](x: T): T = x
proc foo[T](x, y: T): T = x
proc choose(f: proc(x: int): int; marker: int) = discard
proc choose(f: proc(x, y: int): int; marker: string) = discard
choose(foo, 1)
```
- `inferWithMetatype`
```nim
proc foo[T](x: T): int = 1
let f: proc(x: int): auto = foo
discard f(1)
```