### PR TITLE
fix #25870 #25846: var return type in C++ backend

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -146,7 +146,11 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
           else:
             if d.k == locNone: d = getTemp(p, typ.returnType)
             var list = initLoc(locCall, d.lode, OnUnknown)
-            list.snippet = extract(result)
+            var rval = extract(result)
+            # the function returns T& but the temp is T*, so we need &
+            if tfVarIsPtr in typ.returnType.flags:
+              rval = cAddr(rval)
+            list.snippet = rval
             genAssignment(p, d, list, {needAssignCall}) # no need for deep copying
             if canRaise: raiseExit(p)
 
@@ -589,6 +593,8 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         list.snippet = callIter(rp, pars)
       else:
         list.snippet = callProc(rp, pars, rawProc)
+      if tfVarIsPtr in typ.returnType.flags:
+        list.snippet = cAddr(list.snippet)
       genAssignment(p, d, list, {}) # no need for deep copying
       if canRaise: raiseExit(p)
     else:
@@ -601,6 +607,8 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         list.snippet = callIter(rp, pars)
       else:
         list.snippet = callProc(rp, pars, rawProc)
+      if tfVarIsPtr in typ.returnType.flags:
+        list.snippet = cAddr(list.snippet)
       genAssignment(p, tmp, list, {})
       if canRaise: raiseExit(p)
       genAssignment(p, d, tmp, {})
@@ -872,11 +880,18 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
         genAssignment(p, d, tmp, {}) # no need for deep copying
     else:
       pl.add("]")
-      if d.k == locNone: d = getTemp(p, typ.returnType)
-      assert(d.t != nil)        # generate an assignment to d:
-      var list: TLoc = initLoc(locCall, ri, OnUnknown)
-      list.snippet = extract(pl)
-      genAssignment(p, d, list, {}) # no need for deep copying
+      if p.module.compileToCpp and typ.returnType != nil and
+          typ.returnType.skipTypes(abstractInst).kind == tyVar:
+        d = getTempCpp(p, typ.returnType, extract(pl))
+      else:
+        if d.k == locNone: d = getTemp(p, typ.returnType)
+        assert(d.t != nil)        # generate an assignment to d:
+        var list: TLoc = initLoc(locCall, ri, OnUnknown)
+        var rval = extract(pl)
+        if tfVarIsPtr in typ.returnType.flags:
+          rval = cAddr(rval)
+        list.snippet = rval
+        genAssignment(p, d, list, {}) # no need for deep copying
   else:
     pl.add("]")
     p.s(cpsStmts).addStmt():

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -880,18 +880,11 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
         genAssignment(p, d, tmp, {}) # no need for deep copying
     else:
       pl.add("]")
-      if p.module.compileToCpp and typ.returnType != nil and
-          typ.returnType.skipTypes(abstractInst).kind == tyVar:
-        d = getTempCpp(p, typ.returnType, extract(pl))
-      else:
-        if d.k == locNone: d = getTemp(p, typ.returnType)
-        assert(d.t != nil)        # generate an assignment to d:
-        var list: TLoc = initLoc(locCall, ri, OnUnknown)
-        var rval = extract(pl)
-        if tfVarIsPtr in typ.returnType.flags:
-          rval = cAddr(rval)
-        list.snippet = rval
-        genAssignment(p, d, list, {}) # no need for deep copying
+      if d.k == locNone: d = getTemp(p, typ.returnType)
+      assert(d.t != nil)        # generate an assignment to d:
+      var list: TLoc = initLoc(locCall, ri, OnUnknown)
+      list.snippet = extract(pl)
+      genAssignment(p, d, list, {}) # no need for deep copying
   else:
     pl.add("]")
     p.s(cpsStmts).addStmt():

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -929,6 +929,13 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
     # bug #23453 #25265
     if e.typ != nil and e.typ.skipTypes(abstractInst).kind == tyObject:
       discard getTypeDesc(p.module, e.typ)
+    # C++: genProcParams strips tfVarIsPtr from the signature, so a var T
+    # return is T&. When used directly (lfSingleUse, a.k == locCall) it's a
+    # reference and must not be dereferenced. Temps hold T* (via cAddr) and
+    # still need '*'. The AST type keeps tfVarIsPtr (markResultVarIsPtr),
+    # so we check a.k to tell the two paths apart.
+    let isCppCallRef = p.module.compileToCpp and typ.kind in {tyVar} and
+        tfVarIsPtr in typ.flags and a.k == locCall
     if d.k == locNone:
       # dest = *a;  <-- We do not know that 'dest' is on the heap!
       # It is completely wrong to set 'd.storage' here, unless it's not yet
@@ -938,7 +945,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
         d.storage = OnHeap
       of tyVar, tyLent:
         d.storage = OnUnknown
-        if tfVarIsPtr notin typ.flags and p.module.compileToCpp and
+        if (tfVarIsPtr notin typ.flags or isCppCallRef) and p.module.compileToCpp and
             e.kind == nkHiddenDeref:
           putIntoDest(p, d, e, rdLoc(a), a.storage)
           return
@@ -947,7 +954,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc) =
       else:
         internalError(p.config, e.info, "genDeref " & $typ.kind)
     elif p.module.compileToCpp:
-      if typ.kind in {tyVar} and tfVarIsPtr notin typ.flags and
+      if typ.kind in {tyVar} and (tfVarIsPtr notin typ.flags or isCppCallRef) and
            e.kind == nkHiddenDeref:
         putIntoDest(p, d, e, rdLoc(a), a.storage)
         return

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -665,7 +665,13 @@ proc genProcParams(m: BModule; t: PType, rettype: var Rope, params: var Builder,
   if t.returnType == nil or isInvalidReturnType(m.config, t):
     rettype = CVoid
   else:
-    rettype = getTypeDescWeak(m, t.returnType, check, dkResult)
+    var rt = t.returnType
+    if m.config.backend == backendCpp and
+        tfVarIsPtr in rt.flags and
+        rt.skipTypes(abstractInst).kind == tyVar:
+      rt = rt.exactReplica(m.idgen)
+      rt.excl(tfVarIsPtr)
+    rettype = getTypeDescWeak(m, rt, check, dkResult)
   var paramBuilder: ProcParamBuilder
   params.addProcParams(paramBuilder):
     for i in 1..<t.n.len:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1525,8 +1525,14 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
           initLocalVar(p, res, immediateAsgn=false)
       var returnBuilder = newBuilder("\t")
       var rres = rdLoc(res.loc)
-      if m.compileToCpp and res.typ.skipTypes(abstractInst).kind == tyVar and
-          tfVarIsPtr in res.typ.flags:
+      # Match genProcParams: it checks prc.typ.returnType.flags (not res.typ.flags)
+      # because markResultVarIsPtr sets tfVarIsPtr on the result sym's type, which
+      # can be a different object than prc.typ.returnType for generic instances.
+      # Checking the same type ensures the body ('*result' vs 'result') matches the
+      # signature ('T&' vs 'T*').
+      let rt = prc.typ.returnType
+      if m.compileToCpp and rt.skipTypes(abstractInst).kind == tyVar and
+          tfVarIsPtr in rt.flags:
         rres = cDeref(rres)
       returnBuilder.addReturn(rres)
       returnStmt = extract(returnBuilder)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1528,11 +1528,13 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
       # Match genProcParams: it checks prc.typ.returnType.flags (not res.typ.flags)
       # because markResultVarIsPtr sets tfVarIsPtr on the result sym's type, which
       # can be a different object than prc.typ.returnType for generic instances.
-      # Checking the same type ensures the body ('*result' vs 'result') matches the
-      # signature ('T&' vs 'T*').
+      # For tyVar of tyArray, genProcParams forces '*' (ctPtrToArray path in
+      # getTypeDescAux overwrites '&' with '*'), so the signature is T* and we
+      # must return 'result' (the pointer), not '*result' (the element).
       let rt = prc.typ.returnType
       if m.compileToCpp and rt.skipTypes(abstractInst).kind == tyVar and
-          tfVarIsPtr in rt.flags:
+          tfVarIsPtr in rt.flags and
+          mapType(m.config, rt, false) != ctPtrToArray:
         rres = cDeref(rres)
       returnBuilder.addReturn(rres)
       returnStmt = extract(returnBuilder)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -746,10 +746,14 @@ proc getTempCpp(p: BProc, t: PType, value: Rope): TLoc =
   inc(p.labels)
   result = TLoc(snippet: "T" & rope(p.labels) & "_", k: locTemp, lode: lodeTyp t,
                 storage: OnStack, flags: {})
+  let isVarRet = p.module.compileToCpp and
+                 t.skipTypes(abstractInst).kind == tyVar
+  let tmpTyp = if isVarRet: getTypeDesc(p.module, t, dkVar) else: "auto"
+  let initVal = if isVarRet and tfVarIsPtr in t.flags: cAddr(value) else: value
   p.s(cpsStmts).addVar(kind = Local,
     name = result.snippet,
-    typ = "auto",
-    initializer = value)
+    typ = tmpTyp,
+    initializer = initVal)
 
 proc getIntTemp(p: BProc): TLoc =
   inc(p.labels)
@@ -1520,7 +1524,10 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
         else:
           initLocalVar(p, res, immediateAsgn=false)
       var returnBuilder = newBuilder("\t")
-      let rres = rdLoc(res.loc)
+      var rres = rdLoc(res.loc)
+      if m.compileToCpp and res.typ.skipTypes(abstractInst).kind == tyVar and
+          tfVarIsPtr in res.typ.flags:
+        rres = cDeref(rres)
       returnBuilder.addReturn(rres)
       returnStmt = extract(returnBuilder)
     elif sfConstructor in prc.flags:

--- a/tests/cpp_var_typical.nim
+++ b/tests/cpp_var_typical.nim
@@ -1,0 +1,35 @@
+discard """
+  targets: "c cpp"
+  matrix: "--mm:refc; --mm:arc"
+  output: "ok"
+"""
+
+# lfSingleUse path: a var T call result used directly is T& in C++,
+# genDeref must not emit '*' for it.
+block: # bug: C++ genDeref wrongly emitted '*' for a T& reference
+  type Obj = object
+    field: tuple[a, b: int]
+  func get(v: var Obj): var tuple[a, b: int] = v.field
+  var v = Obj(field: (1, 2))
+  doAssert get(v).a == 1
+  doAssert get(v).b == 2
+  get(v).a = 99
+  doAssert v.field.a == 99
+  # tuple unpacking also takes the lfSingleUse path
+  var (xa, xb) = get(v)
+  doAssert xa == 99
+  doAssert xb == 2
+
+# temp path: cAddr turns T& into T*, so '*' must still be emitted.
+block: # ensure the temp path still generates '*' dereference
+  proc id(x: var int): var int = x
+  var n = 42
+  doAssert id(n) == 42
+  id(n) = 99
+  doAssert n == 99
+  # nested call: inner result goes to a temp, outer takes lfSingleUse
+  doAssert id(id(n)) == 99
+  id(id(n)) = 100
+  doAssert n == 100
+
+echo "ok"

--- a/tests/proc/tprocvar_var_ret.nim
+++ b/tests/proc/tprocvar_var_ret.nim
@@ -1,0 +1,54 @@
+discard """
+  targets: "c cpp"
+"""
+
+proc testVarRet(x: var int): var int = x
+
+proc testProcTypeParam(prc: proc (x: var int): var int {.nimcall.}) =
+  var x = 123
+  prc(x) = 321
+  doAssert x == 321
+
+testProcTypeParam(testVarRet)
+
+var v = 42
+doAssert testVarRet(v) == 42
+testVarRet(v) = 99
+doAssert v == 99
+
+var pVarRet = testVarRet
+var testVar = 1234
+pVarRet(testVar) = 5678
+doAssert testVar == 5678
+
+proc testVarRetStr(x: var string): var string = x
+
+proc testProcTypeParamStr(prc: proc (x: var string): var string {.nimcall.}) =
+  var x = "foo"
+  prc(x) = "bar"
+  doAssert x == "bar"
+
+testProcTypeParamStr(testVarRetStr)
+
+type
+  FooObj = object
+    x, y: int
+
+proc testVarRetObj(x: var FooObj): var FooObj = x
+
+proc testProcTypeParamObj(prc: proc (x: var FooObj): var FooObj {.nimcall.}) =
+  var x = FooObj(x: 111, y: 222)
+  prc(x) = FooObj(x: 333, y: 444)
+  doAssert x == FooObj(x: 333, y: 444)
+
+testProcTypeParamObj(testVarRetObj)
+
+proc testProcTypeParamChain(prc: proc (x: var int): var int {.nimcall.}) =
+  var x = 100
+  var y = 200
+  prc(x) = prc(y)
+  doAssert x == 200
+
+testProcTypeParamChain(testVarRet)
+
+echo "ok"


### PR DESCRIPTION
fix #25870 #25846: C++ codegen for proc returning var T

The C++ codegen was generating conflicting types for procs with ar T return:
the signature said T& but the internal result variable was T*, and callers
expected T& back. This caused link errors on some platforms (undefined symbols)
and clang errors on macOS.

The problem was that 	fVarIsPtr was being set too early (in semexprs) and leaked
into the proc type, so every place that looked at the return type saw T* instead
of T&. The fix moves the flag application into cgen where it belongs: we make a
shallow copy of the return type, set 	fVarIsPtr on the copy, and keep the
original clean for the signature.

There were also a few call sites that weren't updated when the signature changed
from T* to T&. Stuff like s[^1] in an nd expression would hit the
splitDecls path and try to store a T& into a T* variable, which clang rightfully
refuses to compile. These now get the missing & operator.

Tested with 
im c and 
im cpp on the new test case, plus --threads:on.