### PR TITLE
fixes #26015; Multiple definition error when using codegenDecl regression

### DIFF
--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -634,7 +634,6 @@ type VarInitializerKind = enum
 
 proc addVar(builder: var Builder, m: BModule, s: PSym, name: string, typ: Snippet, kind = Local, visibility: DeclVisibility = None, initializer: Snippet = "", initializerKind: VarInitializerKind = Assignment) =
   if sfCodegenDecl in s.flags:
-    builder.addVisibilityPrefix(visibility)
     builder.add(runtimeFormat(s.cgDeclFrmt, [typ, name]))
     if initializer.len != 0:
       if initializerKind == Assignment:

--- a/compiler/cbuilderdecls.nim
+++ b/compiler/cbuilderdecls.nim
@@ -634,6 +634,7 @@ type VarInitializerKind = enum
 
 proc addVar(builder: var Builder, m: BModule, s: PSym, name: string, typ: Snippet, kind = Local, visibility: DeclVisibility = None, initializer: Snippet = "", initializerKind: VarInitializerKind = Assignment) =
   if sfCodegenDecl in s.flags:
+    builder.addVisibilityPrefix(visibility)
     builder.add(runtimeFormat(s.cgDeclFrmt, [typ, name]))
     if initializer.len != 0:
       if initializerKind == Assignment:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1854,20 +1854,10 @@ proc genVarPrototype(m: BModule, n: PNode) =
         typ = ptrType(typ)
       if lfDynamicLib in sym.loc.flags:
         typ = ptrType(typ)
-      if sfCodegenDecl in sym.flags:
-        # `codegenDecl` customizes the definition, but a reference from a
-        # different module still needs a plain declaration. Applying the
-        # custom format here can turn the declaration into a tentative
-        # definition (and thus cause duplicate symbols at link time).
-        m.s[cfsVars].addDeclWithVisibility(vis):
-          m.s[cfsVars].addVar(kind = Local,
-            name = sym.loc.snippet,
-            typ = typ)
-      else:
-        m.s[cfsVars].addVar(m, sym,
-          name = sym.loc.snippet,
-          typ = typ,
-          visibility = vis)
+      m.s[cfsVars].addVar(m, sym,
+        name = sym.loc.snippet,
+        typ = typ,
+        visibility = vis)
       if m.hcrOn:
         m.initProc.procSec(cpsLocals).add('\t')
         m.initProc.procSec(cpsLocals).addAssignment(sym.loc.snippet,

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1854,10 +1854,20 @@ proc genVarPrototype(m: BModule, n: PNode) =
         typ = ptrType(typ)
       if lfDynamicLib in sym.loc.flags:
         typ = ptrType(typ)
-      m.s[cfsVars].addVar(m, sym,
-        name = sym.loc.snippet,
-        typ = typ,
-        visibility = vis)
+      if sfCodegenDecl in sym.flags:
+        # `codegenDecl` customizes the definition, but a reference from a
+        # different module still needs a plain declaration. Applying the
+        # custom format here can turn the declaration into a tentative
+        # definition (and thus cause duplicate symbols at link time).
+        m.s[cfsVars].addDeclWithVisibility(vis):
+          m.s[cfsVars].addVar(kind = Local,
+            name = sym.loc.snippet,
+            typ = typ)
+      else:
+        m.s[cfsVars].addVar(m, sym,
+          name = sym.loc.snippet,
+          typ = typ,
+          visibility = vis)
       if m.hcrOn:
         m.initProc.procSec(cpsLocals).add('\t')
         m.initProc.procSec(cpsLocals).addAssignment(sym.loc.snippet,

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1854,10 +1854,16 @@ proc genVarPrototype(m: BModule, n: PNode) =
         typ = ptrType(typ)
       if lfDynamicLib in sym.loc.flags:
         typ = ptrType(typ)
-      m.s[cfsVars].addVar(m, sym,
-        name = sym.loc.snippet,
-        typ = typ,
-        visibility = vis)
+      if sfCodegenDecl in sym.flags:
+        m.s[cfsVars].addDeclWithVisibility(vis):
+          m.s[cfsVars].addVar(m, sym,
+            name = sym.loc.snippet,
+            typ = typ)
+      else:
+        m.s[cfsVars].addVar(m, sym,
+          name = sym.loc.snippet,
+          typ = typ,
+          visibility = vis)
       if m.hcrOn:
         m.initProc.procSec(cpsLocals).add('\t')
         m.initProc.procSec(cpsLocals).addAssignment(sym.loc.snippet,

--- a/tests/ccgbugs/mcodegendeclglobal.nim
+++ b/tests/ccgbugs/mcodegendeclglobal.nim
@@ -1,0 +1,4 @@
+var codegenDeclGlobal* {.codegenDecl: "$# /* custom declaration */ $#".} = 123
+
+proc readCodegenDeclGlobal*(): int {.inline.} =
+  codegenDeclGlobal

--- a/tests/ccgbugs/tcodegendeclglobal.nim
+++ b/tests/ccgbugs/tcodegendeclglobal.nim
@@ -3,6 +3,7 @@ discard """
 123
 123
 '''
+  ccodecheck: "'extern NI /* custom declaration */ codegenDeclGlobal'"
   targets: "c cpp"
 """
 

--- a/tests/ccgbugs/tcodegendeclglobal.nim
+++ b/tests/ccgbugs/tcodegendeclglobal.nim
@@ -1,0 +1,12 @@
+discard """
+  output: '''
+123
+123
+'''
+  targets: "c cpp"
+"""
+
+import ./mcodegendeclglobal
+
+echo codegenDeclGlobal
+echo readCodegenDeclGlobal()


### PR DESCRIPTION
fixes #26015

Fixes imported global variables with codegenDecl being emitted as definitions instead of extern declarations.

A variable’s codegenDecl format should customize its definition in the owning module. Other modules referencing the variable must emit a normal declaration:

```c
extern NI variable;
```

After the variable-declaration builder refactor, genVarPrototype passed Extern visibility to addVar. However, the sfCodegenDecl branch returned before applying that visibility. This caused importing modules to emit another tentative definition, resulting in duplicate-symbol linker errors.

The fix restores the previous distinction between the custom definition and cross-module prototypes. It also adds C and C++ regression coverage for both direct access and access through an inline procedure.

follows up https://github.com/nim-lang/Nim/pull/24423