### PR TITLE
Clean thread's allocators at some point after death

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -147,6 +147,8 @@ type
   MemRegion = object
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
+    else:
+      references: int # owning thread plus allocations whose deallocation has not finished
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
     when defined(gcDestructors):
@@ -1006,6 +1008,11 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     trackSize(c.size)
   sysAssert(isAccessible(a, result), "rawAlloc 14")
   sysAssert(allocInv(a), "rawAlloc: end")
+  when defined(gcDestructors):
+    when hasThreadSupport:
+      discard atomicAddFetch(addr a.references, 1, ATOMIC_RELAXED)
+    else:
+      inc a.references
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
@@ -1013,6 +1020,9 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
 proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
   result = rawAlloc(a, requestedSize)
   zeroMem(result, requestedSize)
+
+when defined(gcDestructors):
+  proc releaseRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].}
 
 proc rawDealloc(a: var MemRegion, p: pointer) =
   when defined(nimTypeNames):
@@ -1023,6 +1033,8 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
   sysAssert(allocInv(a), "rawDealloc: begin")
   var c = pageAddr(p)
   sysAssert(c != nil, "rawDealloc: begin")
+  when defined(gcDestructors):
+    let owner = c.owner
   if isSmallChunk(c):
     # `p` is within a small chunk:
     var c = cast[PSmallChunk](c)
@@ -1109,6 +1121,10 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
       deallocBigChunk(a, cast[PBigChunk](c))
 
   sysAssert(allocInv(a), "rawDealloc: end")
+  when defined(gcDestructors):
+    # This must be the final access through the chunk's owner. Reaching zero
+    # can release every page belonging to the region and the region itself.
+    releaseRegion(owner)
   #when logAlloc: cprintf("dealloc(pointer_%p)\n", p)
 
 when not defined(gcDestructors):
@@ -1247,6 +1263,19 @@ proc deallocOsPages(a: var MemRegion) =
     if it == nil: break
   # And then we free the pages that are in use for the page bits:
   llDeallocAll(a)
+
+when defined(gcDestructors):
+  proc releaseRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
+    let references =
+      when hasThreadSupport:
+        atomicSubFetch(addr a.references, 1, ATOMIC_ACQ_REL)
+      else:
+        dec a.references
+        a.references
+    sysAssert references >= 0, "releaseRegion: negative reference count"
+    if references == 0:
+      deallocOsPages(a[])
+      c_free(a)
 
 proc getFreeMem(a: MemRegion): int {.inline.} = result = a.freeMem
 proc getTotalMem(a: MemRegion): int {.inline.} = result = a.currMem

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -931,7 +931,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
         if tc.freeList == nil:
           when hasThreadSupport:
             # Steal the entire list from `sharedFreeList`:
-            tc.freeList = atomicExchangeN(addr a.handle.sharedFreeLists[s], nil, ATOMIC_RELAXED)
+            tc.freeList = atomicExchangeN(addr a.handle.sharedFreeLists[s], nil, ATOMIC_ACQUIRE)
           else:
             tc.freeList = a.handle.sharedFreeLists[s]
             a.handle.sharedFreeLists[s] = nil

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -1010,6 +1010,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
   sysAssert(allocInv(a), "rawAlloc: end")
   when defined(gcDestructors):
     when hasThreadSupport:
+      # The pointer cannot be published before rawAlloc returns, so this only
+      # participates in lifetime accounting and needs no ordering.
       discard atomicAddFetch(addr a.references, 1, ATOMIC_RELAXED)
     else:
       inc a.references

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -1332,7 +1332,7 @@ when defined(gcDestructors):
   proc finishRemoteDeallocation(h: ptr RegionHandle) {.raises: [], gcsafe, tags: [].} =
     let balance =
       when hasThreadSupport:
-        atomicAddFetch(addr h.remoteDeallocationBalance, 1, ATOMIC_ACQ_REL)
+        atomicInc(h.remoteDeallocationBalance)
       else:
         inc h.remoteDeallocationBalance
         h.remoteDeallocationBalance
@@ -1359,8 +1359,7 @@ when defined(gcDestructors):
 
     let balance =
       when hasThreadSupport:
-        atomicSubFetch(addr h.remoteDeallocationBalance,
-                       expectedRemoteDeallocations, ATOMIC_ACQ_REL)
+        atomicDec(h.remoteDeallocationBalance, expectedRemoteDeallocations)
       else:
         dec h.remoteDeallocationBalance, expectedRemoteDeallocations
         h.remoteDeallocationBalance

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -40,12 +40,12 @@ template track(op, address, size) =
 #
 # A deallocation of a small pointer then looks like this
 #[
-  dealloc -> rawDealloc -> chunk.owner == addr(a) --------------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
+  dealloc -> rawDealloc -> chunk.owner == a.handle -----------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
                                       |                                       |                   (Add cell into the current chunk)                 |                  Return the current chunk back to tlsf
                                       |                                       |                                   |                                 |
                                       v                                       v                                   v                                 v
                       A different thread owns this chunk.     The current chunk is not active.          chunk.free was < size      Chunk references foreign cells, noop
-                      Add the cell to a.sharedFreeLists      Add the cell into the active chunk          Activate the chunk                       (end)
+                      Add the cell to owner.sharedFreeLists  Add the cell into the active chunk          Activate the chunk                       (end)
                                     (end)                                    (end)                              (end)
 ]#
 # So "true" deallocation is delayed for as long as possible in favor of reusing cells.
@@ -116,7 +116,10 @@ type
     prevSize: int        # size of previous chunk; for coalescing
                          # 0th bit == 1 if 'used
     size: int            # if < PageSize it is a small chunk
-    owner: ptr MemRegion
+    when defined(gcDestructors):
+      owner: ptr RegionHandle
+    else:
+      owner: ptr MemRegion
 
   SmallChunk = object of BaseChunk
     next, prev: PSmallChunk  # chunks of the same size
@@ -144,33 +147,40 @@ type
     chunks: array[30, (PBigChunk, int)]
     next: ptr HeapLinks
 
+  RegionHandle = object
+    ## Stable identity and remotely-accessed state for a thread's allocator.
+    ## Chunks can outlive the owning thread, so they point here rather than
+    ## at the thread-local MemRegion.
+    remoteDeallocationBalance: int
+      # Before abandonment this is the number of completed remote
+      # deallocations. Abandonment subtracts the expected total, turning it
+      # into the negative number of allocations that remain alive.
+    sharedFreeLists: array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
+    sharedFreeListBigChunks: PBigChunk
+
+    # The owner copies these fields here before abandoning its TLS region.
+    # Together with the deferred big-chunk list they are sufficient to
+    # release all remaining OS allocations without retaining MemRegion.
+    orphanHeapLinks: HeapLinks
+    orphanLlmem: PLLChunk
+
   MemRegion = object
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
     else:
+      handle: ptr RegionHandle
       remoteDeallocationTarget: int
         # Written only by the owning thread: incremented on allocation and
         # decremented on local deallocation. At abandonment it is the total
         # number of remote deallocations expected over the region's lifetime.
-      remoteDeallocationBalance: int
-        # Before abandonment this is the number of completed remote
-        # deallocations. Abandonment subtracts the expected total, turning it
-        # into the negative number of allocations that remain alive.
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
-    when defined(gcDestructors):
-      sharedFreeLists: array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
-        # When a thread frees a pointer it did not create, it must not adjust the counters.
-        # Instead, the cell is placed here and deferred until the next allocation.
     flBitmap: uint32
     slBitmap: array[RealFli, uint32]
     matrix: array[RealFli, array[MaxSli, PBigChunk]]
     llmem: PLLChunk
     currMem, maxMem, freeMem, occ: int # memory sizes (allocated from OS)
     lastSize: int # needed for the case that OS gives us pages linearly
-    when defined(gcDestructors):
-      sharedFreeListBigChunks: PBigChunk # make no attempt at avoiding false sharing for now for this object field
-
     chunkStarts: IntSet
     when not defined(gcDestructors):
       root, deleted, last, freeAvlNodes: PAvlNode
@@ -184,6 +194,10 @@ type
 
 template smallChunkOverhead(): untyped = sizeof(SmallChunk)
 template bigChunkOverhead(): untyped = sizeof(BigChunk)
+
+template regionOwner(a: MemRegion): untyped =
+  when defined(gcDestructors): a.handle
+  else: unsafeAddr a
 
 when hasThreadSupport:
   template loada(x: untyped): untyped = atomicLoadN(unsafeAddr x, ATOMIC_RELAXED)
@@ -501,6 +515,13 @@ when not defined(gcDestructors):
     result = cast[ptr FreeCell](p).zeroField >% 1
 
 # ------------- chunk management ----------------------------------------------
+when defined(gcDestructors):
+  proc ensureRegionHandle(a: var MemRegion) {.inline.} =
+    if a.handle == nil:
+      a.handle = cast[ptr RegionHandle](c_calloc(1, csize_t(sizeof(RegionHandle))))
+      if a.handle == nil:
+        raiseOutOfMem()
+
 proc pageIndex(c: PChunk): int {.inline.} =
   result = cast[int](c) shr PageShift
 
@@ -521,6 +542,8 @@ when false:
       it = it.next
 
 proc requestOsChunks(a: var MemRegion, size: int): PBigChunk =
+  when defined(gcDestructors):
+    ensureRegionHandle(a)
   when not defined(emscripten):
     if not a.blockChunkSizeIncrease:
       let usedMem = a.occ #a.currMem # - a.freeMem
@@ -627,7 +650,7 @@ proc splitChunk2(a: var MemRegion, c: PBigChunk, size: int): PBigChunk =
     result.prev = nil
   # size and not used:
   result.prevSize = size
-  result.owner = addr a
+  result.owner = regionOwner(a)
   sysAssert((size and 1) == 0, "splitChunk 2")
   sysAssert((size and PageMask) == 0,
       "splitChunk: size is not a multiple of the PageSize")
@@ -695,7 +718,7 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
       # if we over allocated split the chunk:
       if result.size > size:
         splitChunk(a, result, size)
-    result.owner = addr a
+    result.owner = regionOwner(a)
   else:
     removeChunkFromMatrix2(a, result, fl, sl)
     if result.size >= size + PageSize:
@@ -703,12 +726,14 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
   # set 'used' to true:
   result.prevSize = 1
   track("setUsedToFalse", addr result.size, sizeof(int))
-  sysAssert result.owner == addr a, "getBigChunk: No owner set!"
+  sysAssert result.owner == regionOwner(a), "getBigChunk: No owner set!"
 
   incl(a, a.chunkStarts, pageIndex(result))
   dec(a.freeMem, size)
 
 proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
+  when defined(gcDestructors):
+    ensureRegionHandle(a)
   result = cast[PBigChunk](allocPages(a, size))
   incCurrMem(a, size)
   # XXX add this to the heap links. But also remove it from it later.
@@ -719,7 +744,7 @@ proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
   result.size = size
   # set 'used' to true:
   result.prevSize = 1
-  result.owner = addr a
+  result.owner = regionOwner(a)
   incl(a, a.chunkStarts, pageIndex(result))
 
 proc freeHugeChunk(a: var MemRegion; c: PBigChunk) =
@@ -809,26 +834,26 @@ when defined(gcDestructors):
       elem.next.storea head.loada
       head.storea elem
 
-  proc addToSharedFreeListBigChunks(a: var MemRegion; c: PBigChunk) {.inline.} =
+  proc addToSharedFreeListBigChunks(h: var RegionHandle; c: PBigChunk) {.inline.} =
     sysAssert c.next == nil, "c.next pointer must be nil"
-    atomicPrepend a.sharedFreeListBigChunks, c
+    atomicPrepend h.sharedFreeListBigChunks, c
 
-  proc takeFromSharedFreeListBigChunks(a: var MemRegion): PBigChunk {.inline.} =
+  proc takeFromSharedFreeListBigChunks(h: var RegionHandle): PBigChunk {.inline.} =
     when hasThreadSupport:
       while true:
-        result = atomicLoadN(addr a.sharedFreeListBigChunks, ATOMIC_ACQUIRE)
+        result = atomicLoadN(addr h.sharedFreeListBigChunks, ATOMIC_ACQUIRE)
         if result == nil:
           break
         let next = result.next.loada
         var expected = result
-        if atomicCompareExchangeN(addr a.sharedFreeListBigChunks, addr expected, next,
+        if atomicCompareExchangeN(addr h.sharedFreeListBigChunks, addr expected, next,
                                   weak = true, ATOMIC_ACQUIRE, ATOMIC_RELAXED):
           result.next.storea nil
           break
     else:
-      result = a.sharedFreeListBigChunks
+      result = h.sharedFreeListBigChunks
       if result != nil:
-        a.sharedFreeListBigChunks = result.next
+        h.sharedFreeListBigChunks = result.next
         result.next = nil
 
   proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell; size: int) {.inline.} =
@@ -859,20 +884,9 @@ when defined(gcDestructors):
     # re-enqueuing its unprocessed tail through atomicPrepend would overwrite
     # that tail's next pointer and lose the rest of the list.
     for _ in 0..MaxSteps:
-      let it = takeFromSharedFreeListBigChunks(a)
+      let it = takeFromSharedFreeListBigChunks(a.handle[])
       if it == nil: break
       deallocBigChunk(a, it)
-
-  proc freeAllDeferredObjects(a: var MemRegion) =
-    # Final region reclamation has exclusive access and must also process huge
-    # chunks, which are returned directly to the OS and are not in heapLinks.
-    var it = a.sharedFreeListBigChunks
-    a.sharedFreeListBigChunks = nil
-    while it != nil:
-      let next = it.next
-      it.next = nil
-      deallocBigChunk(a, it)
-      it = next
 
 when defined(heaptrack):
   const heaptrackLib =
@@ -912,15 +926,15 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
 
   if size + alignOff <= SmallChunkSize-smallChunkOverhead():
     template fetchSharedCells(tc: PSmallChunk) =
-      # Consumes cells from (potentially) foreign threads from `a.sharedFreeLists[s]`
+      # Consumes cells from (potentially) foreign threads from the stable handle.
       when defined(gcDestructors):
         if tc.freeList == nil:
           when hasThreadSupport:
             # Steal the entire list from `sharedFreeList`:
-            tc.freeList = atomicExchangeN(addr a.sharedFreeLists[s], nil, ATOMIC_RELAXED)
+            tc.freeList = atomicExchangeN(addr a.handle.sharedFreeLists[s], nil, ATOMIC_RELAXED)
           else:
-            tc.freeList = a.sharedFreeLists[s]
-            a.sharedFreeLists[s] = nil
+            tc.freeList = a.handle.sharedFreeLists[s]
+            a.handle.sharedFreeLists[s] = nil
           # if `tc.freeList` isn't nil, `tc` will gain capacity.
           # We must calculate how much it gained and how many foreign cells are included.
           compensateCounters(a, tc, size)
@@ -941,7 +955,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       c.size = size
       c.acc = (alignOff + size).uint32
       c.free = SmallChunkSize - smallChunkOverhead() - alignOff.int32 - size.int32
-      sysAssert c.owner == addr(a), "rawAlloc: No owner set!"
+      sysAssert c.owner == regionOwner(a), "rawAlloc: No owner set!"
       c.next = nil
       c.prev = nil
       # Shared cells are fetched here in case `c.size * 2 >= SmallChunkSize - smallChunkOverhead()`.
@@ -1000,7 +1014,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     trackSize(c.size)
   else:
     when defined(gcDestructors):
-      freeDeferredObjects(a)
+      if a.handle != nil:
+        freeDeferredObjects(a)
 
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time
@@ -1039,7 +1054,7 @@ proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
   zeroMem(result, requestedSize)
 
 when defined(gcDestructors):
-  proc finishRemoteDeallocation(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].}
+  proc finishRemoteDeallocation(h: ptr RegionHandle) {.raises: [], gcsafe, tags: [].}
 
 proc rawDealloc(a: var MemRegion, p: pointer) =
   when defined(nimTypeNames):
@@ -1052,7 +1067,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
   sysAssert(c != nil, "rawDealloc: begin")
   when defined(gcDestructors):
     let owner = c.owner
-    let isLocal = owner == addr(a)
+    let isLocal = owner == a.handle
   if isSmallChunk(c):
     # `p` is within a small chunk:
     var c = cast[PSmallChunk](c)
@@ -1060,7 +1075,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     #       ^ We might access thread foreign storage here.
     # The other thread cannot possibly free this block as it's still alive.
     var f = cast[ptr FreeCell](p)
-    if c.owner == addr(a):
+    if c.owner == regionOwner(a):
       # We own the block, there is no foreign thread involved.
       dec a.occ, s
       untrackSize(s)
@@ -1131,7 +1146,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     when overwriteFree: nimSetMem(p, -1'i32, c.size -% bigChunkOverhead())
     when logAlloc: cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.owner)
     when defined(gcDestructors):
-      if c.owner == addr(a):
+      if c.owner == regionOwner(a):
         deallocBigChunk(a, cast[PBigChunk](c))
       else:
         addToSharedFreeListBigChunks(c.owner[], cast[PBigChunk](c))
@@ -1141,8 +1156,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
   sysAssert(allocInv(a), "rawDealloc: end")
   when defined(gcDestructors):
     if isLocal:
-      # Only the owning thread reaches this path.
-      dec owner.remoteDeallocationTarget
+      dec a.remoteDeallocationTarget
     else:
       # This must be the final access through the chunk's owner unless this is
       # the deallocation that reclaims the abandoned region.
@@ -1287,39 +1301,75 @@ proc deallocOsPages(a: var MemRegion) =
   llDeallocAll(a)
 
 when defined(gcDestructors):
-  proc reclaimRegion(a: ptr MemRegion) {.inline, raises: [], gcsafe, tags: [].} =
-    freeAllDeferredObjects(a[])
-    deallocOsPages(a[])
-    c_free(a)
+  proc reclaimRegion(h: ptr RegionHandle) {.raises: [], gcsafe, tags: [].} =
+    # Huge chunks bypass heapLinks, so release the remotely-freed huge chunks
+    # individually before the ordinary backing pages are unmapped. Non-huge
+    # chunks are already covered by orphanHeapLinks.
+    var deferred = h.sharedFreeListBigChunks
+    while deferred != nil:
+      let next = deferred.next
+      if deferred.size >= HugeChunkSize:
+        osDeallocPages(deferred, deferred.size)
+      deferred = next
 
-  proc finishRemoteDeallocation(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
+    var links = addr(h.orphanHeapLinks)
+    while true:
+      let next = links.next
+      for i in 0..<links.len:
+        let (p, size) = links.chunks[i]
+        sysAssert size >= PageSize, "reclaimRegion: invalid heap link size"
+        osDeallocPages(p, size)
+      links = next
+      if links == nil: break
+
+    var llmem = h.orphanLlmem
+    while llmem != nil:
+      let next = llmem.next
+      osDeallocPages(llmem, PageSize)
+      llmem = next
+    c_free(h)
+
+  proc finishRemoteDeallocation(h: ptr RegionHandle) {.raises: [], gcsafe, tags: [].} =
     let balance =
       when hasThreadSupport:
-        atomicAddFetch(addr a.remoteDeallocationBalance, 1, ATOMIC_ACQ_REL)
+        atomicAddFetch(addr h.remoteDeallocationBalance, 1, ATOMIC_ACQ_REL)
       else:
-        inc a.remoteDeallocationBalance
-        a.remoteDeallocationBalance
+        inc h.remoteDeallocationBalance
+        h.remoteDeallocationBalance
     # Before abandonment the balance is positive. Afterwards it approaches
     # zero, and the remote deallocation that reaches zero is the only thread
     # allowed to reclaim the region.
     if balance == 0:
-      reclaimRegion(a)
+      reclaimRegion(h)
 
-  proc abandonRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
+  proc abandonRegion(a: var MemRegion) {.raises: [], gcsafe, tags: [].} =
+    let h = a.handle
+    if h == nil:
+      return
+
+    # Remote threads only touch RegionHandle. Publish the page bookkeeping
+    # needed for final reclamation before changing the lifetime balance.
+    h.orphanHeapLinks = a.heapLinks
+    h.orphanLlmem = a.llmem
     let expectedRemoteDeallocations = a.remoteDeallocationTarget
+
+    # The TLS storage may be reused after this thread exits. Chunks retain only
+    # the stable handle, so no pointer into this reset region can escape.
+    a = default(MemRegion)
+
     let balance =
       when hasThreadSupport:
-        atomicSubFetch(addr a.remoteDeallocationBalance,
+        atomicSubFetch(addr h.remoteDeallocationBalance,
                        expectedRemoteDeallocations, ATOMIC_ACQ_REL)
       else:
-        dec a.remoteDeallocationBalance, expectedRemoteDeallocations
-        a.remoteDeallocationBalance
+        dec h.remoteDeallocationBalance, expectedRemoteDeallocations
+        h.remoteDeallocationBalance
     # Every completed remote deallocation is part of the expected total.
     sysAssert balance <= 0, "abandonRegion: invalid remote deallocation balance"
     # If all allocations were already released, the owner performs the
     # reclamation. Otherwise the final remote deallocation does it.
     if balance == 0:
-      reclaimRegion(a)
+      reclaimRegion(h)
 
 proc getFreeMem(a: MemRegion): int {.inline.} = result = a.freeMem
 proc getTotalMem(a: MemRegion): int {.inline.} = result = a.currMem

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -856,6 +856,17 @@ when defined(gcDestructors):
       if it == nil: break
       deallocBigChunk(a, it)
 
+  proc freeAllDeferredObjects(a: var MemRegion) =
+    # Final region reclamation has exclusive access and must also process huge
+    # chunks, which are returned directly to the OS and are not in heapLinks.
+    var it = a.sharedFreeListBigChunks
+    a.sharedFreeListBigChunks = nil
+    while it != nil:
+      let next = it.next
+      it.next = nil
+      deallocBigChunk(a, it)
+      it = next
+
 when defined(heaptrack):
   const heaptrackLib =
     when defined(heaptrack_inject):
@@ -1276,6 +1287,7 @@ when defined(gcDestructors):
         a.references
     sysAssert references >= 0, "releaseRegion: negative reference count"
     if references == 0:
+      freeAllDeferredObjects(a[])
       deallocOsPages(a[])
       c_free(a)
 

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -148,7 +148,14 @@ type
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
     else:
-      references: int # owning thread plus allocations whose deallocation has not finished
+      remoteDeallocationTarget: int
+        # Written only by the owning thread: incremented on allocation and
+        # decremented on local deallocation. At abandonment it is the total
+        # number of remote deallocations expected over the region's lifetime.
+      remoteDeallocationBalance: int
+        # Before abandonment this is the number of completed remote
+        # deallocations. Abandonment subtracts the expected total, turning it
+        # into the negative number of allocations that remain alive.
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
     when defined(gcDestructors):
@@ -1020,12 +1027,9 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
   sysAssert(isAccessible(a, result), "rawAlloc 14")
   sysAssert(allocInv(a), "rawAlloc: end")
   when defined(gcDestructors):
-    when hasThreadSupport:
-      # The pointer cannot be published before rawAlloc returns, so this only
-      # participates in lifetime accounting and needs no ordering.
-      discard atomicAddFetch(addr a.references, 1, ATOMIC_RELAXED)
-    else:
-      inc a.references
+    # Only the owning thread allocates from a region, so lifetime accounting
+    # on this hot path does not need an atomic operation.
+    inc a.remoteDeallocationTarget
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
@@ -1035,7 +1039,7 @@ proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
   zeroMem(result, requestedSize)
 
 when defined(gcDestructors):
-  proc releaseRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].}
+  proc finishRemoteDeallocation(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].}
 
 proc rawDealloc(a: var MemRegion, p: pointer) =
   when defined(nimTypeNames):
@@ -1048,6 +1052,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
   sysAssert(c != nil, "rawDealloc: begin")
   when defined(gcDestructors):
     let owner = c.owner
+    let isLocal = owner == addr(a)
   if isSmallChunk(c):
     # `p` is within a small chunk:
     var c = cast[PSmallChunk](c)
@@ -1135,9 +1140,13 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
 
   sysAssert(allocInv(a), "rawDealloc: end")
   when defined(gcDestructors):
-    # This must be the final access through the chunk's owner. Reaching zero
-    # can release every page belonging to the region and the region itself.
-    releaseRegion(owner)
+    if isLocal:
+      # Only the owning thread reaches this path.
+      dec owner.remoteDeallocationTarget
+    else:
+      # This must be the final access through the chunk's owner unless this is
+      # the deallocation that reclaims the abandoned region.
+      finishRemoteDeallocation(owner)
   #when logAlloc: cprintf("dealloc(pointer_%p)\n", p)
 
 when not defined(gcDestructors):
@@ -1278,18 +1287,39 @@ proc deallocOsPages(a: var MemRegion) =
   llDeallocAll(a)
 
 when defined(gcDestructors):
-  proc releaseRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
-    let references =
+  proc reclaimRegion(a: ptr MemRegion) {.inline, raises: [], gcsafe, tags: [].} =
+    freeAllDeferredObjects(a[])
+    deallocOsPages(a[])
+    c_free(a)
+
+  proc finishRemoteDeallocation(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
+    let balance =
       when hasThreadSupport:
-        atomicSubFetch(addr a.references, 1, ATOMIC_ACQ_REL)
+        atomicAddFetch(addr a.remoteDeallocationBalance, 1, ATOMIC_ACQ_REL)
       else:
-        dec a.references
-        a.references
-    sysAssert references >= 0, "releaseRegion: negative reference count"
-    if references == 0:
-      freeAllDeferredObjects(a[])
-      deallocOsPages(a[])
-      c_free(a)
+        inc a.remoteDeallocationBalance
+        a.remoteDeallocationBalance
+    # Before abandonment the balance is positive. Afterwards it approaches
+    # zero, and the remote deallocation that reaches zero is the only thread
+    # allowed to reclaim the region.
+    if balance == 0:
+      reclaimRegion(a)
+
+  proc abandonRegion(a: ptr MemRegion) {.raises: [], gcsafe, tags: [].} =
+    let expectedRemoteDeallocations = a.remoteDeallocationTarget
+    let balance =
+      when hasThreadSupport:
+        atomicSubFetch(addr a.remoteDeallocationBalance,
+                       expectedRemoteDeallocations, ATOMIC_ACQ_REL)
+      else:
+        dec a.remoteDeallocationBalance, expectedRemoteDeallocations
+        a.remoteDeallocationBalance
+    # Every completed remote deallocation is part of the expected total.
+    sysAssert balance <= 0, "abandonRegion: invalid remote deallocation balance"
+    # If all allocations were already released, the owner performs the
+    # reclamation. Otherwise the final remote deallocation does it.
+    if balance == 0:
+      reclaimRegion(a)
 
 proc getFreeMem(a: MemRegion): int {.inline.} = result = a.freeMem
 proc getTotalMem(a: MemRegion): int {.inline.} = result = a.currMem

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -282,13 +282,20 @@ const hasForeignThreadAllocatorTeardown =
   when hasThreadSupport: not emulatedThreadVars
   else: false
 
-when not hasForeignThreadAllocatorTeardown:
+when hasThreadSupport and emulatedThreadVars:
   template setupForeignThreadGc* =
-    ## With `--mm:arc` a nop unless native thread-local allocator teardown is available.
+    {.error: "setupForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+
+  template tearDownForeignThreadGc* =
+    {.error: "tearDownForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+
+elif not hasForeignThreadAllocatorTeardown:
+  template setupForeignThreadGc* =
+    ## With `--mm:arc` a nop when thread support is disabled.
     discard
 
   template tearDownForeignThreadGc* =
-    ## With `--mm:arc` a nop unless native thread-local allocator teardown is available.
+    ## With `--mm:arc` a nop when thread support is disabled.
     discard
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -278,18 +278,14 @@ when not (defined(gcOrc) or defined(gcYrc)):
     ## Forces a full garbage collection pass. With `--mm:arc` a nop.
     discard
 
-const hasForeignThreadAllocatorTeardown =
-  when hasThreadSupport: not emulatedThreadVars
-  else: false
+when hasThreadSupport:
+  when emulatedThreadVars:
+    template setupForeignThreadGc* =
+      {.error: "setupForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
 
-when hasThreadSupport and emulatedThreadVars:
-  template setupForeignThreadGc* =
-    {.error: "setupForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
-
-  template tearDownForeignThreadGc* =
-    {.error: "tearDownForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
-
-elif not hasForeignThreadAllocatorTeardown:
+    template tearDownForeignThreadGc* =
+      {.error: "tearDownForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+else:
   template setupForeignThreadGc* =
     ## With `--mm:arc` a nop when thread support is disabled.
     discard

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -278,13 +278,18 @@ when not (defined(gcOrc) or defined(gcYrc)):
     ## Forces a full garbage collection pass. With `--mm:arc` a nop.
     discard
 
-template setupForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
+const hasForeignThreadAllocatorTeardown =
+  when hasThreadSupport: not emulatedThreadVars
+  else: false
 
-template tearDownForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
+when not hasForeignThreadAllocatorTeardown:
+  template setupForeignThreadGc* =
+    ## With `--mm:arc` a nop unless native thread-local allocator teardown is available.
+    discard
+
+  template tearDownForeignThreadGc* =
+    ## With `--mm:arc` a nop unless native thread-local allocator teardown is available.
+    discard
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -84,8 +84,24 @@ else:
     include "system/gc_regions"
   elif defined(nimV2) or usesDestructors:
     when not defined(useNimRtl):
-      var allocator {.rtlThreadVar.}: MemRegion
-      instantiateForRegion(allocator)
+      # The region is intentionally retained after thread exit. Its address is
+      # part of the ownership metadata stored in every chunk and must remain a
+      # stable identity until a later reclamation step can prove it is unused.
+      var allocator {.rtlThreadVar.}: ptr MemRegion
+
+      proc getAllocator(): ptr MemRegion {.inline.} =
+        if allocator == nil:
+          # Chunks can outlive the thread that allocated them and retain their
+          # owner pointer so that another thread can return them later. Keeping
+          # the MemRegion itself in TLS would let a later thread reuse the same
+          # address and be mistaken for that owner.
+          allocator = cast[ptr MemRegion](c_calloc(1, csize_t(sizeof(MemRegion))))
+          if allocator == nil:
+            raiseOutOfMem()
+        result = allocator
+
+      template threadAllocator: untyped = getAllocator()[]
+      instantiateForRegion(threadAllocator)
     when defined(gcHooks):
       include "system/gc_hooks"
   elif defined(gcMarkAndSweep):

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -84,9 +84,8 @@ else:
     include "system/gc_regions"
   elif defined(nimV2) or usesDestructors:
     when not defined(useNimRtl):
-      # The region is intentionally retained after thread exit. Its address is
-      # part of the ownership metadata stored in every chunk and must remain a
-      # stable identity until a later reclamation step can prove it is unused.
+      # Keep the region itself outside TLS: chunks retain its address as their
+      # stable owner identity after the allocating thread exits.
       var allocator {.rtlThreadVar.}: ptr MemRegion
 
       proc getAllocator(): ptr MemRegion {.inline.} =
@@ -98,10 +97,17 @@ else:
           allocator = cast[ptr MemRegion](c_calloc(1, csize_t(sizeof(MemRegion))))
           if allocator == nil:
             raiseOutOfMem()
+          allocator.references = 1 # owning thread
         result = allocator
 
       template threadAllocator: untyped = getAllocator()[]
       instantiateForRegion(threadAllocator)
+
+      proc abandonThreadAllocator() {.rtl, raises: [].} =
+        let a = allocator
+        allocator = nil
+        if a != nil:
+          releaseRegion(a)
     when defined(gcHooks):
       include "system/gc_hooks"
   elif defined(gcMarkAndSweep):

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -97,7 +97,6 @@ else:
           allocator = cast[ptr MemRegion](c_calloc(1, csize_t(sizeof(MemRegion))))
           if allocator == nil:
             raiseOutOfMem()
-          allocator.references = 1 # owning thread
         result = allocator
 
       template threadAllocator: untyped = getAllocator()[]
@@ -107,7 +106,7 @@ else:
         let a = allocator
         allocator = nil
         if a != nil:
-          releaseRegion(a)
+          abandonRegion(a)
     when defined(gcHooks):
       include "system/gc_hooks"
   elif defined(gcMarkAndSweep):

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -84,29 +84,15 @@ else:
     include "system/gc_regions"
   elif defined(nimV2) or usesDestructors:
     when not defined(useNimRtl):
-      # Keep the region itself outside TLS: chunks retain its address as their
-      # stable owner identity after the allocating thread exits.
-      var allocator {.rtlThreadVar.}: ptr MemRegion
+      # Keep hot allocator state directly in TLS. Chunks point to the stable,
+      # heap-allocated RegionHandle stored inside the region, never to the TLS
+      # MemRegion itself.
+      var allocator {.rtlThreadVar.}: MemRegion
+      instantiateForRegion(allocator)
 
-      proc getAllocator(): ptr MemRegion {.inline.} =
-        if allocator == nil:
-          # Chunks can outlive the thread that allocated them and retain their
-          # owner pointer so that another thread can return them later. Keeping
-          # the MemRegion itself in TLS would let a later thread reuse the same
-          # address and be mistaken for that owner.
-          allocator = cast[ptr MemRegion](c_calloc(1, csize_t(sizeof(MemRegion))))
-          if allocator == nil:
-            raiseOutOfMem()
-        result = allocator
-
-      template threadAllocator: untyped = getAllocator()[]
-      instantiateForRegion(threadAllocator)
-
-      proc abandonThreadAllocator() {.rtl, raises: [].} =
-        let a = allocator
-        allocator = nil
-        if a != nil:
-          abandonRegion(a)
+      when defined(gcDestructors) and not defined(useMalloc):
+        proc abandonThreadAllocator() {.rtl, raises: [].} =
+          abandonRegion(allocator)
     when defined(gcHooks):
       include "system/gc_hooks"
   elif defined(gcMarkAndSweep):

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -2,6 +2,8 @@ var
   nimThreadDestructionHandlers* {.rtlThreadVar.}: seq[proc () {.closure, gcsafe, raises: [].}]
 when not defined(boehmgc) and not hasSharedHeap and not defined(gogc) and not defined(gcRegions):
   proc deallocOsPages() {.rtl, raises: [].}
+when defined(gcDestructors) and not defined(useMalloc):
+  proc abandonThreadAllocator() {.rtl, raises: [].}
 
 # create for the main thread. Note: do not insert this data into the list
 # of all threads; it's not to be stopped etc.
@@ -93,6 +95,8 @@ proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
     when declared(deallocOsPages): deallocOsPages()
   else:
     threadProcWrapDispatch(thrd)
+    when defined(gcDestructors) and not defined(useMalloc):
+      abandonThreadAllocator()
 
 template nimThreadProcWrapperBody*(closure: untyped): untyped =
   var thrd = cast[ptr Thread[TArg]](closure)

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -5,21 +5,37 @@ when not defined(boehmgc) and not hasSharedHeap and not defined(gogc) and not de
 when defined(gcDestructors) and not defined(useMalloc):
   proc abandonThreadAllocator() {.rtl, raises: [].}
 
+when not emulatedThreadVars:
+  type ThreadType {.pure.} = enum
+    None = 0,
+    NimThread = 1,
+    ForeignThread = 2
+  var threadType {.rtlThreadVar.}: ThreadType
+
 # create for the main thread. Note: do not insert this data into the list
 # of all threads; it's not to be stopped etc.
 when not defined(useNimRtl):
   #when not defined(createNimRtl): initStackBottom()
   when declared(initGC):
     initGC()
-    when not emulatedThreadVars:
-      type ThreadType {.pure.} = enum
-        None = 0,
-        NimThread = 1,
-        ForeignThread = 2
-      var
-        threadType {.rtlThreadVar.}: ThreadType
+when declared(threadType):
+  threadType = ThreadType.NimThread
 
-      threadType = ThreadType.NimThread
+when defined(gcDestructors) and declared(threadType):
+  proc setupForeignThreadGc*() {.gcsafe, raises: [].} =
+    ## Marks a foreign thread so its native thread-local allocator can be
+    ## abandoned by `tearDownForeignThreadGc`. This is a no-op on Nim threads.
+    if threadType == ThreadType.None:
+      threadType = ThreadType.ForeignThread
+
+  proc tearDownForeignThreadGc*() {.gcsafe, raises: [].} =
+    ## Abandons a foreign thread's native thread-local allocator. Repeated
+    ## teardown calls and calls from Nim threads are no-ops.
+    if threadType != ThreadType.ForeignThread:
+      return
+    when not defined(useMalloc):
+      abandonThreadAllocator()
+    threadType = ThreadType.None
 
 when defined(gcDestructors):
   proc deallocThreadStorage(p: pointer) = c_free(p)
@@ -82,6 +98,8 @@ else:
         deallocThreadStorage(thrd.rawStack)
 
 proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
+  when declared(threadType):
+    threadType = ThreadType.NimThread
   when defined(boehmgc):
     boehmGC_call_with_stack_base(threadProcWrapDispatch[TArg], thrd)
   elif not defined(nogc) and not defined(gogc) and not defined(gcRegions) and not usesDestructors:
@@ -90,8 +108,6 @@ proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
     nimGC_setStackBottom(addr(p))
     when declared(initGC):
       initGC()
-    when declared(threadType):
-      threadType = ThreadType.NimThread
     threadProcWrapDispatch[TArg](thrd)
     when declared(deallocOsPages): deallocOsPages()
   else:

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -29,6 +29,7 @@ else:
 template afterThreadRuns() =
   for i in countdown(nimThreadDestructionHandlers.len-1, 0):
     nimThreadDestructionHandlers[i]()
+  reset(nimThreadDestructionHandlers)
 
 proc onThreadDestruction*(handler: proc () {.closure, gcsafe, raises: [].}) =
   ## Registers a *thread local* handler that is called at the thread's

--- a/tests/threads/mincoreutils.nim
+++ b/tests/threads/mincoreutils.nim
@@ -1,0 +1,19 @@
+when defined(posix):
+  # Linux libcs and Android bionic use unsigned char*. Darwin, the BSDs that
+  # expose mincore, AIX, and Solaris use char* for the residency vector.
+  when defined(linux) or defined(android):
+    type MincoreResidency = uint8
+  else:
+    type MincoreResidency = char
+
+  proc getpagesize(): cint {.importc, header: "<unistd.h>".}
+  proc mincore(p: pointer, length: csize_t,
+               residency: ptr MincoreResidency): cint {.
+    importc, header: "<sys/mman.h>".}
+
+  proc isResident*(p: pointer): bool =
+    let pageSize = uint(getpagesize())
+    let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
+    var residency: MincoreResidency
+    result = mincore(page, csize_t(pageSize), addr residency) == 0 and
+      (ord(residency) and 1) != 0

--- a/tests/threads/tthreadallocatorcleanup.nim
+++ b/tests/threads/tthreadallocatorcleanup.nim
@@ -4,7 +4,7 @@ discard """
   output: "ok"
 """
 
-import std/typedthreads
+import std/[atomics, typedthreads]
 
 var escaped: pointer
 
@@ -38,8 +38,38 @@ for _ in 0..<32:
     let allocationPage = escaped
   deallocShared(escaped)
   when defined(posix):
-    # The final reference releases the abandoned region and all of its pages.
+    # The final remote deallocation releases the abandoned region and its pages.
     doAssert not isResident(allocationPage)
   escaped = nil
+
+# Exercise the opposite finalization order: the allocation is remotely freed
+# while its owner is still running, so the owner must reclaim the region when
+# it subsequently exits.
+var
+  allocationReady: Atomic[bool]
+  ownerMayExit: Atomic[bool]
+
+proc allocateAndWait() {.thread.} =
+  escaped = allocShared(sizeof(int))
+  cast[ptr int](escaped)[] = 42
+  allocationReady.store(true, moRelease)
+  while not ownerMayExit.load(moAcquire):
+    discard
+
+var waitingThread: Thread[void]
+createThread(waitingThread, allocateAndWait)
+while not allocationReady.load(moAcquire):
+  discard
+
+when defined(posix):
+  let remotelyFreedPage = escaped
+deallocShared(escaped)
+when defined(posix):
+  doAssert isResident(remotelyFreedPage)
+escaped = nil
+ownerMayExit.store(true, moRelease)
+joinThread(waitingThread)
+when defined(posix):
+  doAssert not isResident(remotelyFreedPage)
 
 echo "ok"

--- a/tests/threads/tthreadallocatorcleanup.nim
+++ b/tests/threads/tthreadallocatorcleanup.nim
@@ -5,20 +5,10 @@ discard """
 """
 
 import std/[atomics, typedthreads]
+when defined(posix):
+  import ./mincoreutils
 
 var escaped: pointer
-
-when defined(posix):
-  proc getpagesize(): cint {.importc, header: "<unistd.h>".}
-  proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
-    importc, header: "<sys/mman.h>".}
-
-  proc isResident(p: pointer): bool =
-    let pageSize = uint(getpagesize())
-    let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
-    var residency: uint8
-    result = mincore(page, csize_t(pageSize), addr residency) == 0 and
-      (residency and 1) != 0
 
 proc allocateInThread() {.thread.} =
   escaped = allocShared(sizeof(int))

--- a/tests/threads/tthreadallocatorcleanup.nim
+++ b/tests/threads/tthreadallocatorcleanup.nim
@@ -24,7 +24,7 @@ proc allocateInThread() {.thread.} =
   escaped = allocShared(sizeof(int))
   cast[ptr int](escaped)[] = 42
 
-# The allocation keeps the worker's MemRegion alive after the worker exits.
+# The allocation keeps the worker's RegionHandle alive after the worker exits.
 # Deallocating it from this thread must release both the allocation and the
 # abandoned region. Repetition also exercises reuse of the worker's TLS slot.
 for _ in 0..<32:
@@ -71,5 +71,50 @@ ownerMayExit.store(true, moRelease)
 joinThread(waitingThread)
 when defined(posix):
   doAssert not isResident(remotelyFreedPage)
+
+# Exercise remote frees that the owner consumes before it exits. Lifetime
+# accounting remains matched even after the cells re-enter the local allocator.
+const remotePointerCount = 257
+var
+  remotePointers: array[remotePointerCount, pointer]
+  remotePointersReady: Atomic[bool]
+  ownerMayConsume: Atomic[bool]
+
+proc allocateConsumeAndExit() {.thread.} =
+  for i in 0..<remotePointers.len:
+    remotePointers[i] = allocShared(16 + (i mod 8) * 16)
+  remotePointersReady.store(true, moRelease)
+  while not ownerMayConsume.load(moAcquire):
+    discard
+
+  for i in 0..<8:
+    let p = allocShared(16 + i * 16)
+    deallocShared(p)
+  doAssert getOccupiedMem() == 0
+
+var consumingThread: Thread[void]
+createThread(consumingThread, allocateConsumeAndExit)
+while not remotePointersReady.load(moAcquire):
+  discard
+for p in remotePointers:
+  deallocShared(p)
+ownerMayConsume.store(true, moRelease)
+joinThread(consumingThread)
+
+# A region whose allocations were all freed locally has a zero lifetime balance;
+# its handle and backing pages are reclaimed directly by the exiting owner.
+var locallyFreedPage: pointer
+
+proc allocateAndFreeLocally() {.thread.} =
+  let p = allocShared(sizeof(int))
+  cast[ptr int](p)[] = 23
+  locallyFreedPage = p
+  deallocShared(p)
+
+var locallyFreeingThread: Thread[void]
+createThread(locallyFreeingThread, allocateAndFreeLocally)
+joinThread(locallyFreeingThread)
+when defined(posix):
+  doAssert not isResident(locallyFreedPage)
 
 echo "ok"

--- a/tests/threads/tthreadallocatorcleanup.nim
+++ b/tests/threads/tthreadallocatorcleanup.nim
@@ -1,0 +1,45 @@
+discard """
+  matrix: "--mm:arc; --mm:orc"
+  valgrind: true
+  output: "ok"
+"""
+
+import std/typedthreads
+
+var escaped: pointer
+
+when defined(posix):
+  proc getpagesize(): cint {.importc, header: "<unistd.h>".}
+  proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
+    importc, header: "<sys/mman.h>".}
+
+  proc isResident(p: pointer): bool =
+    let pageSize = uint(getpagesize())
+    let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
+    var residency: uint8
+    result = mincore(page, csize_t(pageSize), addr residency) == 0 and
+      (residency and 1) != 0
+
+proc allocateInThread() {.thread.} =
+  escaped = allocShared(sizeof(int))
+  cast[ptr int](escaped)[] = 42
+
+# The allocation keeps the worker's MemRegion alive after the worker exits.
+# Deallocating it from this thread must release both the allocation and the
+# abandoned region. Repetition also exercises reuse of the worker's TLS slot.
+for _ in 0..<32:
+  var thread: Thread[void]
+  createThread(thread, allocateInThread)
+  joinThread(thread)
+
+  doAssert cast[ptr int](escaped)[] == 42
+  when defined(posix):
+    doAssert isResident(escaped)
+    let allocationPage = escaped
+  deallocShared(escaped)
+  when defined(posix):
+    # The final reference releases the abandoned region and all of its pages.
+    doAssert not isResident(allocationPage)
+  escaped = nil
+
+echo "ok"

--- a/tests/threads/tthreadallocatorforeigncleanup.nim
+++ b/tests/threads/tthreadallocatorforeigncleanup.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--mm:arc; --mm:orc"
+  matrix: "--mm:arc --tlsEmulation:off; --mm:orc --tlsEmulation:off"
   disabled: "windows"
   output: "ok"
 """

--- a/tests/threads/tthreadallocatorforeigncleanup.nim
+++ b/tests/threads/tthreadallocatorforeigncleanup.nim
@@ -1,0 +1,54 @@
+discard """
+  matrix: "--mm:arc; --mm:orc"
+  disabled: "windows"
+  output: "ok"
+"""
+
+import std/posix
+
+var
+  escaped: array[2, pointer]
+  locallyFreedPage: pointer
+
+proc worker(_: pointer): pointer {.noconv.} =
+  # Repeated setup/teardown on one foreign thread must create independent
+  # allocator lifetimes without affecting Nim-managed threads.
+  for i in 0..<escaped.len:
+    setupForeignThreadGc()
+    escaped[i] = allocShared(sizeof(int))
+    cast[ptr int](escaped[i])[] = i
+    tearDownForeignThreadGc()
+
+  setupForeignThreadGc()
+  let p = allocShared(sizeof(int))
+  cast[ptr int](p)[] = 42
+  locallyFreedPage = p
+  deallocShared(p)
+  tearDownForeignThreadGc()
+  result = nil
+
+proc getpagesize(): cint {.importc, header: "<unistd.h>".}
+proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
+  importc, header: "<sys/mman.h>".}
+
+proc isResident(p: pointer): bool =
+  let pageSize = uint(getpagesize())
+  let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
+  var residency: uint8
+  result = mincore(page, csize_t(pageSize), addr residency) == 0 and
+    (residency and 1) != 0
+
+var thread: Pthread
+doAssert pthread_create(addr thread, nil, worker, nil) == 0
+doAssert pthread_join(thread, nil) == 0
+
+for i, p in escaped:
+  doAssert cast[ptr int](p)[] == i
+  doAssert isResident(p)
+  deallocShared(p)
+  doAssert not isResident(p)
+
+# With no escaped allocations, foreign teardown performs reclamation itself.
+doAssert not isResident(locallyFreedPage)
+
+echo "ok"

--- a/tests/threads/tthreadallocatorforeigncleanup.nim
+++ b/tests/threads/tthreadallocatorforeigncleanup.nim
@@ -5,6 +5,7 @@ discard """
 """
 
 import std/posix
+import ./mincoreutils
 
 var
   escaped: array[2, pointer]
@@ -26,17 +27,6 @@ proc worker(_: pointer): pointer {.noconv.} =
   deallocShared(p)
   tearDownForeignThreadGc()
   result = nil
-
-proc getpagesize(): cint {.importc, header: "<unistd.h>".}
-proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
-  importc, header: "<sys/mman.h>".}
-
-proc isResident(p: pointer): bool =
-  let pageSize = uint(getpagesize())
-  let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
-  var residency: uint8
-  result = mincore(page, csize_t(pageSize), addr residency) == 0 and
-    (residency and 1) != 0
 
 var thread: Pthread
 doAssert pthread_create(addr thread, nil, worker, nil) == 0

--- a/tests/threads/tthreadallocatorhugecleanup.nim
+++ b/tests/threads/tthreadallocatorhugecleanup.nim
@@ -1,0 +1,47 @@
+discard """
+  matrix: "--mm:arc; --mm:orc"
+  disabled: "windows"
+  output: "ok"
+"""
+
+import std/typedthreads
+
+const hugeAllocationSize =
+  # These are the allocator's MaxFli boundaries. The 64-bit POSIX mapping is
+  # virtual; this test only commits the page touched below.
+  when sizeof(int) == 8: 1 shl 30
+  else: 16 * 1024
+
+var escaped: pointer
+
+when defined(posix):
+  proc getpagesize(): cint {.importc, header: "<unistd.h>".}
+  proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
+    importc, header: "<sys/mman.h>".}
+
+  proc isResident(p: pointer): bool =
+    let pageSize = uint(getpagesize())
+    let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
+    var residency: uint8
+    result = mincore(page, csize_t(pageSize), addr residency) == 0 and
+      (residency and 1) != 0
+
+proc allocateHugeChunk() {.thread.} =
+  escaped = allocShared(hugeAllocationSize)
+  cast[ptr byte](escaped)[] = 42
+
+var thread: Thread[void]
+createThread(thread, allocateHugeChunk)
+joinThread(thread)
+
+doAssert cast[ptr byte](escaped)[] == 42
+when defined(posix):
+  doAssert isResident(escaped)
+  let allocationPage = escaped
+deallocShared(escaped)
+when defined(posix):
+  # Huge chunks bypass heapLinks and must be drained from the abandoned
+  # region's deferred big-chunk list before the region itself is released.
+  doAssert not isResident(allocationPage)
+
+echo "ok"

--- a/tests/threads/tthreadallocatorhugecleanup.nim
+++ b/tests/threads/tthreadallocatorhugecleanup.nim
@@ -12,7 +12,9 @@ const hugeAllocationSize =
   when sizeof(int) == 8: 1 shl 30
   else: 16 * 1024
 
-var escaped: pointer
+var
+  escaped: pointer
+  ordinaryEscaped: pointer
 
 when defined(posix):
   proc getpagesize(): cint {.importc, header: "<unistd.h>".}
@@ -27,6 +29,8 @@ when defined(posix):
       (residency and 1) != 0
 
 proc allocateHugeChunk() {.thread.} =
+  ordinaryEscaped = allocShared(sizeof(int))
+  cast[ptr int](ordinaryEscaped)[] = 17
   escaped = allocShared(hugeAllocationSize)
   cast[ptr byte](escaped)[] = 42
 
@@ -35,13 +39,25 @@ createThread(thread, allocateHugeChunk)
 joinThread(thread)
 
 doAssert cast[ptr byte](escaped)[] == 42
+doAssert cast[ptr int](ordinaryEscaped)[] == 17
 when defined(posix):
   doAssert isResident(escaped)
-  let allocationPage = escaped
+  doAssert isResident(ordinaryEscaped)
+  let
+    allocationPage = escaped
+    ordinaryAllocationPage = ordinaryEscaped
+
+# The ordinary chunk is covered by the handle's orphaned heap links. Its page
+# stays mapped until the huge allocation performs the final remote release.
+deallocShared(ordinaryEscaped)
+when defined(posix):
+  doAssert isResident(allocationPage)
+  doAssert isResident(ordinaryAllocationPage)
 deallocShared(escaped)
 when defined(posix):
   # Huge chunks bypass heapLinks and must be drained from the abandoned
-  # region's deferred big-chunk list before the region itself is released.
+  # handle's deferred big-chunk list before the ordinary pages are released.
   doAssert not isResident(allocationPage)
+  doAssert not isResident(ordinaryAllocationPage)
 
 echo "ok"

--- a/tests/threads/tthreadallocatorhugecleanup.nim
+++ b/tests/threads/tthreadallocatorhugecleanup.nim
@@ -5,6 +5,8 @@ discard """
 """
 
 import std/typedthreads
+when defined(posix):
+  import ./mincoreutils
 
 const hugeAllocationSize =
   # These are the allocator's MaxFli boundaries. The 64-bit POSIX mapping is
@@ -15,18 +17,6 @@ const hugeAllocationSize =
 var
   escaped: pointer
   ordinaryEscaped: pointer
-
-when defined(posix):
-  proc getpagesize(): cint {.importc, header: "<unistd.h>".}
-  proc mincore(p: pointer, length: csize_t, residency: ptr uint8): cint {.
-    importc, header: "<sys/mman.h>".}
-
-  proc isResident(p: pointer): bool =
-    let pageSize = uint(getpagesize())
-    let page = cast[pointer](cast[uint](p) - cast[uint](p) mod pageSize)
-    var residency: uint8
-    result = mincore(page, csize_t(pageSize), addr residency) == 0 and
-      (residency and 1) != 0
 
 proc allocateHugeChunk() {.thread.} =
   ordinaryEscaped = allocShared(sizeof(int))

--- a/tests/threads/tthreadallocatorracecleanup.nim
+++ b/tests/threads/tthreadallocatorracecleanup.nim
@@ -1,0 +1,55 @@
+discard """
+  matrix: "--mm:arc; --mm:orc"
+  output: "ok"
+"""
+
+import std/[atomics, typedthreads]
+
+const
+  pointerCount = 1024
+  iterations = 100
+
+var
+  pointers: array[pointerCount, pointer]
+  drainPointers: array[pointerCount, pointer]
+  ready: Atomic[bool]
+  start: Atomic[bool]
+  remoteDone: Atomic[bool]
+
+proc owner() {.thread.} =
+  for i in 0..<pointers.len:
+    pointers[i] = allocShared(16 + (i mod 8) * 16)
+  ready.store(true, moRelease)
+  while not start.load(moAcquire):
+    discard
+
+  # Race allocator activity against remote frees. The owner can consume cells
+  # while the remote thread is still publishing more queue entries.
+  while not remoteDone.load(moAcquire):
+    for i in 0..<8:
+      let p = allocShared(16 + i * 16)
+      deallocShared(p)
+
+  # Exhaust local free lists so all remaining remote lists are consumed before
+  # abandonment.
+  for i in 0..<drainPointers.len:
+    drainPointers[i] = allocShared(16 + (i mod 8) * 16)
+  for p in drainPointers:
+    deallocShared(p)
+  doAssert getOccupiedMem() == 0
+
+for iteration in 0..<iterations:
+  ready.store(false, moRelaxed)
+  start.store(false, moRelaxed)
+  remoteDone.store(false, moRelaxed)
+  var thread: Thread[void]
+  createThread(thread, owner)
+  while not ready.load(moAcquire):
+    discard
+  start.store(true, moRelease)
+  for p in pointers:
+    deallocShared(p)
+  remoteDone.store(true, moRelease)
+  joinThread(thread)
+
+echo "ok"


### PR DESCRIPTION
Cleans up the `MemRegion` of a dead thread once all allocations from it are freed, so it may still hold memory for longer than expected if threads are used badly.
MemRegion got split into MemRegion and RegionHandle, the reason for this is that we need some stable way to access a region after the thread died (see segfault issues, previously a new thread could occupy the same allocator address.)
The local path uses MemRegion to avoid indirection, for cleanup we use the stable RegionHandle that keeps track of chunks freed by foreign threads. RegionHandle receives the region's data on thread death.

Once again, fix by GPT 5.6 Sol and reviewed by me.

close #23361
close #20542
close #24988
close #26014