### PR TITLE
Alloc: Pooled MemRegions

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -893,7 +893,8 @@ when defined(gcDestructors):
         result.next = nil
 
   proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell; size: int) {.inline.} =
-    atomicPrepend c.owner.sharedFreeLists[size], f
+    let h = c.owner
+    atomicPrepend h.sharedFreeLists[size], f
 
   const MaxSteps = 20
 

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -968,8 +968,13 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       when defined(gcDestructors):
         if tc.freeList == nil:
           when hasThreadSupport:
-            # Steal the entire list from `sharedFreeList`:
-            tc.freeList = atomicExchangeN(addr a.handle.sharedFreeLists[s], nil, ATOMIC_ACQUIRE)
+            # Avoid an atomic RMW in the common case where no remote free was
+            # published since the last allocation. A concurrent publication
+            # after this probe can safely wait until the next allocation.
+            let shared = addr tc.owner.sharedFreeLists[s]
+            if atomicLoadN(shared, ATOMIC_RELAXED) != nil:
+              # Steal the entire list from `sharedFreeList`:
+              tc.freeList = atomicExchangeN(shared, nil, ATOMIC_ACQUIRE)
           else:
             tc.freeList = a.handle.sharedFreeLists[s]
             a.handle.sharedFreeLists[s] = nil

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -40,12 +40,12 @@ template track(op, address, size) =
 #
 # A deallocation of a small pointer then looks like this
 #[
-  dealloc -> rawDealloc -> chunk.owner == addr(a) --------------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
+  dealloc -> rawDealloc -> chunk.owner == a.handle ------------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
                                       |                                       |                   (Add cell into the current chunk)                 |                  Return the current chunk back to tlsf
                                       |                                       |                                   |                                 |
                                       v                                       v                                   v                                 v
                       A different thread owns this chunk.     The current chunk is not active.          chunk.free was < size      Chunk references foreign cells, noop
-                      Add the cell to a.sharedFreeLists      Add the cell into the active chunk          Activate the chunk                       (end)
+                      Add the cell to owner.sharedFreeLists  Add the cell into the active chunk          Activate the chunk                       (end)
                                     (end)                                    (end)                              (end)
 ]#
 # So "true" deallocation is delayed for as long as possible in favor of reusing cells.
@@ -116,7 +116,10 @@ type
     prevSize: int        # size of previous chunk; for coalescing
                          # 0th bit == 1 if 'used
     size: int            # if < PageSize it is a small chunk
-    owner: ptr MemRegion
+    when defined(gcDestructors):
+      owner: ptr RegionHandle
+    else:
+      owner: ptr MemRegion
 
   SmallChunk = object of BaseChunk
     next, prev: PSmallChunk  # chunks of the same size
@@ -147,21 +150,16 @@ type
   MemRegion = object
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
+    else:
+      handle: ptr RegionHandle
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
-    when defined(gcDestructors):
-      sharedFreeLists: array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
-        # When a thread frees a pointer it did not create, it must not adjust the counters.
-        # Instead, the cell is placed here and deferred until the next allocation.
     flBitmap: uint32
     slBitmap: array[RealFli, uint32]
     matrix: array[RealFli, array[MaxSli, PBigChunk]]
     llmem: PLLChunk
     currMem, maxMem, freeMem, occ: int # memory sizes (allocated from OS)
     lastSize: int # needed for the case that OS gives us pages linearly
-    when defined(gcDestructors):
-      sharedFreeListBigChunks: PBigChunk # make no attempt at avoiding false sharing for now for this object field
-
     chunkStarts: IntSet
     when not defined(gcDestructors):
       root, deleted, last, freeAvlNodes: PAvlNode
@@ -173,8 +171,24 @@ type
     when defined(nimTypeNames):
       allocCounter, deallocCounter: int
 
+  RegionHandle = object
+    ## Stable chunk ownership and remotely accessed allocator state. The
+    ## MemRegion itself moves between this handle and the current thread's TLS.
+    when defined(gcDestructors):
+      region: MemRegion
+      next: ptr RegionHandle
+      sharedFreeLists: array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
+        # Foreign frees are deferred here until the handle is checked out and
+        # its MemRegion allocates from the corresponding size class.
+      sharedFreeListBigChunks: PBigChunk
+        # Make no attempt at avoiding false sharing for this field for now.
+
 template smallChunkOverhead(): untyped = sizeof(SmallChunk)
 template bigChunkOverhead(): untyped = sizeof(BigChunk)
+
+template regionOwner(a: MemRegion): untyped =
+  when defined(gcDestructors): a.handle
+  else: unsafeAddr a
 
 when hasThreadSupport:
   template loada(x: untyped): untyped = atomicLoadN(unsafeAddr x, ATOMIC_RELAXED)
@@ -502,6 +516,58 @@ proc pageAddr(p: pointer): PChunk {.inline.} =
   result = cast[PChunk](cast[int](p) and not PageMask)
   #sysAssert(Contains(allocator.chunkStarts, pageIndex(result)))
 
+when defined(gcDestructors):
+  # Process-wide state. Keep both declarations at module scope: putting either
+  # into TLS or instantiateForRegion would create pools that are not mutually
+  # protected by the same lock.
+  var regionPool: ptr RegionHandle
+  when hasThreadSupport:
+    var regionPoolLock: SysLock
+    initSysLock(regionPoolLock)
+
+  proc acquireMemRegion(a: var MemRegion) {.raises: [], gcsafe.} =
+    ## Move an idle allocator into this thread's TLS, or create one if every
+    ## pooled allocator is currently in use.
+    if a.handle != nil:
+      return
+    var h: ptr RegionHandle
+    when hasThreadSupport:
+      acquireSys(regionPoolLock)
+    h = regionPool
+    if h != nil:
+      regionPool = h.next
+      h.next = nil
+    when hasThreadSupport:
+      releaseSys(regionPoolLock)
+    if h == nil:
+      h = cast[ptr RegionHandle](c_calloc(1, csize_t(sizeof(RegionHandle))))
+      if h == nil:
+        raiseOutOfMem()
+      a.handle = h
+    else:
+      a = h.region
+      h.region = default(MemRegion)
+      a.handle = h
+
+  proc releaseMemRegion(a: var MemRegion) {.raises: [], gcsafe.} =
+    ## Move this thread's allocator back into the process-wide pool. Handles
+    ## are never relocated, so chunks and concurrent foreign frees stay valid.
+    let h = a.handle
+    if h == nil:
+      return
+    h.region = a
+    a = default(MemRegion)
+    when hasThreadSupport:
+      acquireSys(regionPoolLock)
+    h.next = regionPool
+    regionPool = h
+    when hasThreadSupport:
+      releaseSys(regionPoolLock)
+
+  proc ensureRegionHandle(a: var MemRegion) {.inline.} =
+    if a.handle == nil:
+      acquireMemRegion(a)
+
 when false:
   proc writeFreeList(a: MemRegion) =
     var it = a.freeChunksList
@@ -512,6 +578,8 @@ when false:
       it = it.next
 
 proc requestOsChunks(a: var MemRegion, size: int): PBigChunk =
+  when defined(gcDestructors):
+    ensureRegionHandle(a)
   when not defined(emscripten):
     if not a.blockChunkSizeIncrease:
       let usedMem = a.occ #a.currMem # - a.freeMem
@@ -618,7 +686,7 @@ proc splitChunk2(a: var MemRegion, c: PBigChunk, size: int): PBigChunk =
     result.prev = nil
   # size and not used:
   result.prevSize = size
-  result.owner = addr a
+  result.owner = regionOwner(a)
   sysAssert((size and 1) == 0, "splitChunk 2")
   sysAssert((size and PageMask) == 0,
       "splitChunk: size is not a multiple of the PageSize")
@@ -686,7 +754,7 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
       # if we over allocated split the chunk:
       if result.size > size:
         splitChunk(a, result, size)
-    result.owner = addr a
+    result.owner = regionOwner(a)
   else:
     removeChunkFromMatrix2(a, result, fl, sl)
     if result.size >= size + PageSize:
@@ -694,12 +762,14 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
   # set 'used' to true:
   result.prevSize = 1
   track("setUsedToFalse", addr result.size, sizeof(int))
-  sysAssert result.owner == addr a, "getBigChunk: No owner set!"
+  sysAssert result.owner == regionOwner(a), "getBigChunk: No owner set!"
 
   incl(a, a.chunkStarts, pageIndex(result))
   dec(a.freeMem, size)
 
 proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
+  when defined(gcDestructors):
+    ensureRegionHandle(a)
   result = cast[PBigChunk](allocPages(a, size))
   incCurrMem(a, size)
   # XXX add this to the heap links. But also remove it from it later.
@@ -710,7 +780,7 @@ proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
   result.size = size
   # set 'used' to true:
   result.prevSize = 1
-  result.owner = addr a
+  result.owner = regionOwner(a)
   incl(a, a.chunkStarts, pageIndex(result))
 
 proc freeHugeChunk(a: var MemRegion; c: PBigChunk) =
@@ -800,26 +870,26 @@ when defined(gcDestructors):
       elem.next.storea head.loada
       head.storea elem
 
-  proc addToSharedFreeListBigChunks(a: var MemRegion; c: PBigChunk) {.inline.} =
+  proc addToSharedFreeListBigChunks(h: var RegionHandle; c: PBigChunk) {.inline.} =
     sysAssert c.next == nil, "c.next pointer must be nil"
-    atomicPrepend a.sharedFreeListBigChunks, c
+    atomicPrepend h.sharedFreeListBigChunks, c
 
-  proc takeFromSharedFreeListBigChunks(a: var MemRegion): PBigChunk {.inline.} =
+  proc takeFromSharedFreeListBigChunks(h: var RegionHandle): PBigChunk {.inline.} =
     when hasThreadSupport:
       while true:
-        result = atomicLoadN(addr a.sharedFreeListBigChunks, ATOMIC_ACQUIRE)
+        result = atomicLoadN(addr h.sharedFreeListBigChunks, ATOMIC_ACQUIRE)
         if result == nil:
           break
         let next = result.next.loada
         var expected = result
-        if atomicCompareExchangeN(addr a.sharedFreeListBigChunks, addr expected, next,
+        if atomicCompareExchangeN(addr h.sharedFreeListBigChunks, addr expected, next,
                                   weak = true, ATOMIC_ACQUIRE, ATOMIC_RELAXED):
           result.next.storea nil
           break
     else:
-      result = a.sharedFreeListBigChunks
+      result = h.sharedFreeListBigChunks
       if result != nil:
-        a.sharedFreeListBigChunks = result.next
+        h.sharedFreeListBigChunks = result.next
         result.next = nil
 
   proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell; size: int) {.inline.} =
@@ -850,7 +920,7 @@ when defined(gcDestructors):
     # re-enqueuing its unprocessed tail through atomicPrepend would overwrite
     # that tail's next pointer and lose the rest of the list.
     for _ in 0..MaxSteps:
-      let it = takeFromSharedFreeListBigChunks(a)
+      let it = takeFromSharedFreeListBigChunks(a.handle[])
       if it == nil: break
       deallocBigChunk(a, it)
 
@@ -892,15 +962,15 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
 
   if size + alignOff <= SmallChunkSize-smallChunkOverhead():
     template fetchSharedCells(tc: PSmallChunk) =
-      # Consumes cells from (potentially) foreign threads from `a.sharedFreeLists[s]`
+      # Consumes cells from (potentially) foreign threads from the stable handle.
       when defined(gcDestructors):
         if tc.freeList == nil:
           when hasThreadSupport:
             # Steal the entire list from `sharedFreeList`:
-            tc.freeList = atomicExchangeN(addr a.sharedFreeLists[s], nil, ATOMIC_RELAXED)
+            tc.freeList = atomicExchangeN(addr a.handle.sharedFreeLists[s], nil, ATOMIC_ACQUIRE)
           else:
-            tc.freeList = a.sharedFreeLists[s]
-            a.sharedFreeLists[s] = nil
+            tc.freeList = a.handle.sharedFreeLists[s]
+            a.handle.sharedFreeLists[s] = nil
           # if `tc.freeList` isn't nil, `tc` will gain capacity.
           # We must calculate how much it gained and how many foreign cells are included.
           compensateCounters(a, tc, size)
@@ -921,7 +991,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       c.size = size
       c.acc = (alignOff + size).uint32
       c.free = SmallChunkSize - smallChunkOverhead() - alignOff.int32 - size.int32
-      sysAssert c.owner == addr(a), "rawAlloc: No owner set!"
+      sysAssert c.owner == regionOwner(a), "rawAlloc: No owner set!"
       c.next = nil
       c.prev = nil
       # Shared cells are fetched here in case `c.size * 2 >= SmallChunkSize - smallChunkOverhead()`.
@@ -980,7 +1050,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     trackSize(c.size)
   else:
     when defined(gcDestructors):
-      freeDeferredObjects(a)
+      if a.handle != nil:
+        freeDeferredObjects(a)
 
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time
@@ -1030,7 +1101,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     #       ^ We might access thread foreign storage here.
     # The other thread cannot possibly free this block as it's still alive.
     var f = cast[ptr FreeCell](p)
-    if c.owner == addr(a):
+    if c.owner == regionOwner(a):
       # We own the block, there is no foreign thread involved.
       dec a.occ, s
       untrackSize(s)
@@ -1101,7 +1172,7 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     when overwriteFree: nimSetMem(p, -1'i32, c.size -% bigChunkOverhead())
     when logAlloc: cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.owner)
     when defined(gcDestructors):
-      if c.owner == addr(a):
+      if c.owner == regionOwner(a):
         deallocBigChunk(a, cast[PBigChunk](c))
       else:
         addToSharedFreeListBigChunks(c.owner[], cast[PBigChunk](c))
@@ -1272,6 +1343,13 @@ template instantiateForRegion(allocator: untyped) {.dirty.} =
       result = isAllocatedPtr(allocator, p)
 
   proc deallocOsPages = deallocOsPages(allocator)
+
+  when defined(gcDestructors) and not defined(useMalloc):
+    proc acquireThreadAllocator() {.rtl, raises: [], gcsafe.} =
+      acquireMemRegion(allocator)
+
+    proc releaseThreadAllocator() {.rtl, raises: [], gcsafe.} =
+      releaseMemRegion(allocator)
 
   proc allocImpl(size: Natural): pointer =
     result = alloc(allocator, size)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -919,8 +919,9 @@ when defined(gcDestructors):
     # Pop only as many nodes as we can process. Detaching the entire list and
     # re-enqueuing its unprocessed tail through atomicPrepend would overwrite
     # that tail's next pointer and lose the rest of the list.
+    let h = a.handle
     for _ in 0..MaxSteps:
-      let it = takeFromSharedFreeListBigChunks(a.handle[])
+      let it = takeFromSharedFreeListBigChunks(h[])
       if it == nil: break
       deallocBigChunk(a, it)
 

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -967,7 +967,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     template fetchSharedCells(tc: PSmallChunk) =
       # Consumes cells from (potentially) foreign threads from the stable handle.
       when defined(gcDestructors):
-        if tc.freeList == nil:
+        if tc.freeList == nil and tc.free < size:
           when hasThreadSupport:
             # Avoid an atomic RMW in the common case where no remote free was
             # published since the last allocation. A concurrent publication
@@ -1034,6 +1034,21 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
           dec(c.foreignCells)
         else:
           sysAssert(c == cast[PSmallChunk](pageAddr(result)), "rawAlloc: Bad cell")
+        if c.freeList != nil:
+          # With another reusable cell immediately available, the chunk cannot
+          # be exhausted and no deferred-list synchronization is needed.
+          sysAssert(c.free >= size, "rawAlloc: free-list capacity mismatch")
+          dec c.free, size
+          sysAssert((cast[int](result) and (MemAlign-1)) == 0, "rawAlloc 9(fast)")
+          sysAssert(allocInv(a), "rawAlloc: end c != nil")
+          sysAssert(((cast[int](result) and PageMask) - smallChunkOverhead() - c.chunkAlignOff) %%
+                    size == 0, "rawAlloc 21(fast)")
+          inc a.occ, size
+          trackSize(c.size)
+          sysAssert(isAccessible(a, result), "rawAlloc 14(fast)")
+          sysAssert(allocInv(a), "rawAlloc: end")
+          # early exit
+          return
       # Even if the cell we return is foreign, the local chunk's capacity decreases.
       # The capacity was previously reserved in the source chunk (when it first got allocated),
       #  then added into the current chunk during dealloc,
@@ -1110,7 +1125,14 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     #       ^ We might access thread foreign storage here.
     # The other thread cannot possibly free this block as it's still alive.
     var f = cast[ptr FreeCell](p)
-    if c.owner == regionOwner(a):
+    when defined(gcDestructors):
+      # A region's active chunk cannot belong to another allocator.
+      # Check the active chunk before going through the handle
+      let activeChunk = a.freeSmallChunks[s div MemAlign]
+      let locallyOwned = c == activeChunk or c.owner == a.handle
+    else:
+      let locallyOwned = c.owner == regionOwner(a)
+    if locallyOwned:
       # We own the block, there is no foreign thread involved.
       dec a.occ, s
       untrackSize(s)
@@ -1125,7 +1147,8 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
         # set to 0xff to check for usage after free bugs:
         nimSetMem(cast[pointer](cast[int](p) +% sizeof(FreeCell)), -1'i32,
                 s -% sizeof(FreeCell))
-      let activeChunk = a.freeSmallChunks[s div MemAlign]
+      when not defined(gcDestructors):
+        let activeChunk = a.freeSmallChunks[s div MemAlign]
       if activeChunk != nil and c != activeChunk and
           activeChunk.chunkAlignOff == c.chunkAlignOff:
         # This pointer is not part of the active chunk, lend it out

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -150,8 +150,6 @@ type
   MemRegion = object
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
-    else:
-      handle: ptr RegionHandle
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
     flBitmap: uint32
@@ -170,6 +168,10 @@ type
     heapLinks: HeapLinks
     when defined(nimTypeNames):
       allocCounter, deallocCounter: int
+    when defined(gcDestructors):
+      # Keep the allocator's hot size-class table at offset zero. The handle is
+      # only needed for ownership and remote-free paths.
+      handle: ptr RegionHandle
 
   RegionHandle = object
     ## Stable chunk ownership and remotely accessed allocator state. The
@@ -916,11 +918,10 @@ when defined(gcDestructors):
     inc(c.free, total)
     dec(a.occ, total)
 
-  proc freeDeferredObjects(a: var MemRegion) =
+  proc freeDeferredObjects(a: var MemRegion; h: ptr RegionHandle) =
     # Pop only as many nodes as we can process. Detaching the entire list and
     # re-enqueuing its unprocessed tail through atomicPrepend would overwrite
     # that tail's next pointer and lose the rest of the list.
-    let h = a.handle
     for _ in 0..MaxSteps:
       let it = takeFromSharedFreeListBigChunks(h[])
       if it == nil: break
@@ -1057,8 +1058,9 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     trackSize(c.size)
   else:
     when defined(gcDestructors):
-      if a.handle != nil:
-        freeDeferredObjects(a)
+      let h = a.handle
+      if h != nil:
+        freeDeferredObjects(a, h)
 
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -283,13 +283,20 @@ when not (defined(gcOrc) or defined(gcYrc)):
     ## Forces a full garbage collection pass. With `--mm:arc` a nop.
     discard
 
-template setupForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
+when not hasThreadSupport:
+  template setupForeignThreadGc* =
+    ## With `--mm:arc` and thread support disabled, a nop.
+    discard
 
-template tearDownForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
+  template tearDownForeignThreadGc* =
+    ## With `--mm:arc` and thread support disabled, a nop.
+    discard
+elif emulatedThreadVars:
+  template setupForeignThreadGc* =
+    {.error: "setupForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+
+  template tearDownForeignThreadGc* =
+    {.error: "tearDownForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -2,6 +2,16 @@ var
   nimThreadDestructionHandlers* {.rtlThreadVar.}: seq[proc () {.closure, gcsafe, raises: [].}]
 when not defined(boehmgc) and not hasSharedHeap and not defined(gogc) and not defined(gcRegions):
   proc deallocOsPages() {.rtl, raises: [].}
+when defined(gcDestructors) and not defined(useMalloc):
+  proc acquireThreadAllocator() {.rtl, raises: [], gcsafe.}
+  proc releaseThreadAllocator() {.rtl, raises: [], gcsafe.}
+
+when not emulatedThreadVars:
+  type ThreadType {.pure.} = enum
+    None = 0,
+    NimThread = 1,
+    ForeignThread = 2
+  var threadType {.rtlThreadVar.}: ThreadType
 
 # create for the main thread. Note: do not insert this data into the list
 # of all threads; it's not to be stopped etc.
@@ -9,15 +19,26 @@ when not defined(useNimRtl):
   #when not defined(createNimRtl): initStackBottom()
   when declared(initGC):
     initGC()
-    when not emulatedThreadVars:
-      type ThreadType {.pure.} = enum
-        None = 0,
-        NimThread = 1,
-        ForeignThread = 2
-      var
-        threadType {.rtlThreadVar.}: ThreadType
+when declared(threadType):
+  threadType = ThreadType.NimThread
 
-      threadType = ThreadType.NimThread
+when defined(gcDestructors) and declared(threadType):
+  proc setupForeignThreadGc*() {.gcsafe, raises: [].} =
+    ## Check out a pooled allocator for a foreign thread. Calls made from a
+    ## Nim-managed thread, or repeated calls on one foreign thread, are no-ops.
+    if threadType == ThreadType.None:
+      when not defined(useMalloc):
+        acquireThreadAllocator()
+      threadType = ThreadType.ForeignThread
+
+  proc tearDownForeignThreadGc*() {.gcsafe, raises: [].} =
+    ## Return a foreign thread's allocator to the pool. Its pages remain
+    ## resident for reuse by another thread.
+    if threadType != ThreadType.ForeignThread:
+      return
+    when not defined(useMalloc):
+      releaseThreadAllocator()
+    threadType = ThreadType.None
 
 when defined(gcDestructors):
   proc deallocThreadStorage(p: pointer) = c_free(p)
@@ -31,6 +52,7 @@ template afterThreadRuns() =
     # YRC: spill this thread's candidate roots so its garbage remains
     # collectible after the thread is gone
     nimYrcThreadTeardown()
+  reset(nimThreadDestructionHandlers)
 
 proc onThreadDestruction*(handler: proc () {.closure, gcsafe, raises: [].}) =
   ## Registers a *thread local* handler that is called at the thread's
@@ -83,6 +105,10 @@ else:
         deallocThreadStorage(thrd.rawStack)
 
 proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
+  when declared(threadType):
+    threadType = ThreadType.NimThread
+  when defined(gcDestructors) and not defined(useMalloc):
+    acquireThreadAllocator()
   when defined(boehmgc):
     boehmGC_call_with_stack_base(threadProcWrapDispatch[TArg], thrd)
   elif not defined(nogc) and not defined(gogc) and not defined(gcRegions) and not usesDestructors:
@@ -91,12 +117,12 @@ proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
     nimGC_setStackBottom(addr(p))
     when declared(initGC):
       initGC()
-    when declared(threadType):
-      threadType = ThreadType.NimThread
     threadProcWrapDispatch[TArg](thrd)
     when declared(deallocOsPages): deallocOsPages()
   else:
     threadProcWrapDispatch(thrd)
+    when defined(gcDestructors) and not defined(useMalloc):
+      releaseThreadAllocator()
 
 template nimThreadProcWrapperBody*(closure: untyped): untyped =
   var thrd = cast[ptr Thread[TArg]](closure)

--- a/tests/threads/tthreadallocatorforeignpool.nim
+++ b/tests/threads/tthreadallocatorforeignpool.nim
@@ -1,0 +1,58 @@
+discard """
+  matrix: "--mm:arc --threads:on --tlsEmulation:off; --mm:orc --threads:on --tlsEmulation:off"
+  disabled: "windows"
+  output: "ok"
+"""
+
+import std/posix
+
+var
+  escaped: pointer
+  reused: pointer
+
+proc allocateOnForeignThread(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  escaped = allocShared(96)
+  cast[ptr int](escaped)[] = 73
+  tearDownForeignThreadGc()
+  result = nil
+
+proc reuseOnForeignThread(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  doAssert cast[ptr int](escaped)[] == 73
+  deallocShared(escaped)
+  reused = allocShared(96)
+  doAssert reused == escaped
+  deallocShared(reused)
+  tearDownForeignThreadGc()
+  result = nil
+
+proc consumeDeferredFree(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  let first = allocShared(96)
+  let second = allocShared(96)
+  # The first allocation advances the active chunk and collects its deferred
+  # foreign frees. The next allocation reuses the remotely returned cell.
+  doAssert second == escaped
+  deallocShared(first)
+  deallocShared(second)
+  tearDownForeignThreadGc()
+  result = nil
+
+proc run(worker: proc(_: pointer): pointer {.noconv.}) =
+  var thread: Pthread
+  doAssert pthread_create(addr thread, nil, worker, nil) == 0
+  doAssert pthread_join(thread, nil) == 0
+
+# setup/teardown is the checkout/return boundary. A distinct native thread can
+# safely inherit the allocator even while one of its allocations is still live.
+run(allocateOnForeignThread)
+run(reuseOnForeignThread)
+
+# A free that arrives while the allocator is idle is queued on its handle and
+# consumed after that allocator is handed to another foreign thread.
+run(allocateOnForeignThread)
+deallocShared(escaped)
+run(consumeDeferredFree)
+
+echo "ok"

--- a/tests/threads/tthreadallocatorpool.nim
+++ b/tests/threads/tthreadallocatorpool.nim
@@ -1,0 +1,91 @@
+discard """
+  matrix: "--mm:arc --threads:on; --mm:orc --threads:on"
+  output: "ok"
+"""
+
+import std/[atomics, typedthreads]
+
+const concurrentThreads = 4
+
+var
+  escaped: pointer
+  reused: pointer
+  bigEscaped: pointer
+  roundAddresses: array[2, array[concurrentThreads, pointer]]
+  ready: Atomic[int]
+  mayExit: Atomic[bool]
+
+proc allocateEscaped() {.thread.} =
+  escaped = allocShared(64)
+  cast[ptr int](escaped)[] = 42
+
+proc consumeAfterHandoff() {.thread.} =
+  doAssert cast[ptr int](escaped)[] == 42
+  deallocShared(escaped)
+  reused = allocShared(64)
+  doAssert reused == escaped
+  deallocShared(reused)
+
+# A live allocation can outlast its original thread. The next thread receives
+# the same allocator and its stable handle makes the deallocation local again.
+block:
+  var thread: Thread[void]
+  createThread(thread, allocateEscaped)
+  joinThread(thread)
+  createThread(thread, consumeAfterHandoff)
+  joinThread(thread)
+
+proc allocateBigEscaped() {.thread.} =
+  bigEscaped = allocShared(8192)
+  cast[ptr int](bigEscaped)[] = 91
+
+proc consumeBigAfterHandoff() {.thread.} =
+  doAssert cast[ptr int](bigEscaped)[] == 91
+  deallocShared(bigEscaped)
+  let p = allocShared(8192)
+  doAssert p == bigEscaped
+  deallocShared(p)
+
+# Big chunks use a separate deferred-free queue on the stable handle.
+block:
+  var thread: Thread[void]
+  createThread(thread, allocateBigEscaped)
+  joinThread(thread)
+  createThread(thread, consumeBigAfterHandoff)
+  joinThread(thread)
+
+proc allocateConcurrently(arg: tuple[round, index: int]) {.thread.} =
+  let p = allocShared(80)
+  roundAddresses[arg.round][arg.index] = p
+  deallocShared(p)
+  discard ready.fetchAdd(1, moRelease)
+  while not mayExit.load(moAcquire):
+    discard
+
+proc runConcurrentRound(round: int) =
+  var threads: array[concurrentThreads, Thread[tuple[round, index: int]]]
+  ready.store(0, moRelaxed)
+  mayExit.store(false, moRelaxed)
+  for i in 0..<threads.len:
+    createThread(threads[i], allocateConcurrently, (round, i))
+  while ready.load(moAcquire) != concurrentThreads:
+    discard
+  mayExit.store(true, moRelease)
+  for thread in threads.mitems:
+    joinThread(thread)
+
+# The first round establishes the peak number of simultaneous allocators. The
+# following rounds must reuse those regions instead of reserving one region per
+# new thread.
+runConcurrentRound(0)
+for _ in 0..<32:
+  runConcurrentRound(1)
+  for p in roundAddresses[1]:
+    var found = false
+    for old in roundAddresses[0]:
+      if p == old:
+        found = true
+        break
+    doAssert found
+
+echo "ok"

--- a/tests/threads/tthreadallocatorpoolrace.nim
+++ b/tests/threads/tthreadallocatorpoolrace.nim
@@ -1,0 +1,55 @@
+discard """
+  matrix: "--mm:arc --threads:on; --mm:orc --threads:on"
+  output: "ok"
+"""
+
+import std/[atomics, typedthreads]
+
+const
+  pointerCount = 1024
+  iterations = 100
+
+var
+  pointers: array[pointerCount, pointer]
+  drainPointers: array[pointerCount, pointer]
+  ready: Atomic[bool]
+  start: Atomic[bool]
+  remoteDone: Atomic[bool]
+
+proc owner() {.thread.} =
+  for i in 0..<pointers.len:
+    pointers[i] = allocShared(16 + (i mod 8) * 16)
+  ready.store(true, moRelease)
+  while not start.load(moAcquire):
+    discard
+
+  # Race allocator activity against remote frees. The owner can consume cells
+  # while the remote thread is still publishing entries to its handle.
+  while not remoteDone.load(moAcquire):
+    for i in 0..<8:
+      let p = allocShared(16 + i * 16)
+      deallocShared(p)
+
+  # Exhaust local free lists so all remaining remote lists are consumed before
+  # this allocator is returned to the pool.
+  for i in 0..<drainPointers.len:
+    drainPointers[i] = allocShared(16 + (i mod 8) * 16)
+  for p in drainPointers:
+    deallocShared(p)
+  doAssert getOccupiedMem() == 0
+
+for _ in 0..<iterations:
+  ready.store(false, moRelaxed)
+  start.store(false, moRelaxed)
+  remoteDone.store(false, moRelaxed)
+  var thread: Thread[void]
+  createThread(thread, owner)
+  while not ready.load(moAcquire):
+    discard
+  start.store(true, moRelease)
+  for p in pointers:
+    deallocShared(p)
+  remoteDone.store(true, moRelease)
+  joinThread(thread)
+
+echo "ok"


### PR DESCRIPTION
replace #26020 

ASan and watching memory usage for the linked issues all seem clean, compared to devel where ASan reports issues and memory usage for the leak issues climbs.

The split of MemRegion into MemRegion and RegionHandle from the previous PR is still here, it is required to preserve a stable path towards foreign frees without introducing a cost for the local path.

close #23361
close #20542
close #24988
close #26014