### PR TITLE
std/xmltree/constructor macro: fix quoting in output (#26039)

### DIFF
--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -913,17 +913,14 @@ proc findAll*(n: XmlNode, tag: string, caseInsensitive = false): seq[XmlNode] =
 
 proc xmlConstructor(a: NimNode): NimNode =
   if a.kind == nnkCall:
-    result = newCall("newXmlTree", toStrLit(a[0]))
+    result = newCall("newXmlTree", newStrLitNode($a[0]))
     var attrs = newNimNode(nnkBracket, a)
     var newStringTabCall = newCall(bindSym"newStringTable", attrs,
                                     bindSym"modeCaseSensitive")
     var elements = newNimNode(nnkBracket, a)
     for i in 1..a.len-1:
       if a[i].kind == nnkExprEqExpr:
-        # In order to support attributes like `data-lang` we have to
-        # replace whitespace because `toStrLit` gives `data - lang`.
-        let attrName = toStrLit(a[i][0]).strVal.replace(" ", "")
-        attrs.add(newStrLitNode(attrName))
+        attrs.add(newStrLitNode($a[i][0]))
         attrs.add(a[i][1])
         #echo repr(attrs)
       else:

--- a/tests/stdlib/txmltree.nim
+++ b/tests/stdlib/txmltree.nim
@@ -118,3 +118,14 @@ block: #21541
   doAssert temp.text == "Hello!"
   temp.text = "Hola!"
   doAssert temp.text == "Hola!"
+
+block: #26039
+  let tree = <>rss(
+    "xmlns:atom" = "http://www.w3.org/2005/Atom",
+    <>"atom:link"(
+      `data-dummy` = "test",
+    ),
+  )
+  doAssert $tree == """<rss xmlns:atom="http://www.w3.org/2005/Atom">
+  <atom:link data-dummy="test" />
+</rss>"""


### PR DESCRIPTION
`toStrLit()` uses `repr()` internally, which forwards quotes and messes with dashes in the output. Let's use `newStrLitNode()` directly instead.

GitHub: fixes https://github.com/nim-lang/Nim/issues/26039