### PR TITLE
make two-argument `withValues` `untyped`

### DIFF
--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -95,7 +95,7 @@ template withValue*[A, B](t: var SharedTable[A, B], key: A,
     release(t.lock)
 
 template withValue*[A, B](t: var SharedTable[A, B], key: A,
-                          value, body1, body2: untyped) =
+                          value, body1, body2: untyped): untyped =
   ## Retrieves the value at `t[key]`.
   ## `value` can be modified in the scope of the `withValue` call.
   runnableExamples:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -636,7 +636,7 @@ template withValue*[A, B](t: var Table[A, B], key: A, value, body: untyped) =
     body
 
 template withValue*[A, B](t: var Table[A, B], key: A,
-                          value, body1, body2: untyped) =
+                          value, body1, body2: untyped): untyped =
   ## Retrieves the value at `t[key]`.
   ##
   ## `value` can be modified in the scope of the `withValue` call.
@@ -677,7 +677,7 @@ template withValue*[A, B](t: var Table[A, B], key: A,
     body2
 
 template withValue*[A, B](t: Table[A, B], key: A,
-                          value, body1, body2: untyped) =
+                          value, body1, body2: untyped): untyped =
   ## Retrieves the value at `t[key]` if it exists, assigns
   ## it to the variable `value` and executes `body`
   runnableExamples:

--- a/tests/stdlib/ttables.nim
+++ b/tests/stdlib/ttables.nim
@@ -33,6 +33,22 @@ s2[p2] = 45_000
 s3[p1] = 30_000
 s3[p2] = 45_000
 
+block: # two-argument form of withValue forms expression
+  block: # Present
+    let sal = salaries.withValue(p1, sal):
+      sal[]
+    do:
+      0
+    doAssert sal == 30_000
+  block: # Missing
+    let sal = salaries.withValue(Person(), sal):
+      sal[]
+    do:
+      0
+    doAssert sal == 0
+  block: # Short form
+    doAssert salaries.withValue(p1, sal, sal[], 0) == 30_000
+
 block: # Ordered table should preserve order after deletion
   var
     s4 = initOrderedTable[int, int]()


### PR DESCRIPTION
The twp-argument form of `withValue` are expression when the branches themselves are expressions.