### PR TITLE
Alloc: Pool MemRegion, split foreign queues, queues as chunk owners

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2437,7 +2437,7 @@ when notJSnotNims and hasAlloc:
   {.push profiler: off.}
   include "system/mmdisp"
   {.pop.}
-  when hasThreadLocalAllocator and not defined(createNimRtl):
+  when hasThreadLocalAllocator:
     initThreadAllocator()
   {.push stackTrace: off, profiler: off.}
   when not defined(nimSeqsV2):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1154,7 +1154,19 @@ template sysAssert(cond: bool, msg: string) =
       cstderr.rawWrite "\n"
       rawQuit 1
 
-const hasAlloc = (hostOS != "standalone" or not defined(nogc)) and not defined(nimscript)
+const
+  hasAlloc = (hostOS != "standalone" or not defined(nogc)) and not defined(nimscript)
+  hasDefaultAllocator =
+    hasAlloc and
+    not (defined(useNimRtl) or defined(useMalloc) or defined(gcRegions) or
+         defined(nogc) or defined(boehmgc) or defined(gogc))
+  hasThreadLocalAllocator =
+    hasDefaultAllocator and hasThreadSupport and defined(gcDestructors)
+
+when hasThreadLocalAllocator:
+  # threadimpl is included before mmdisp provides these implementations.
+  proc initThreadAllocator() {.gcsafe, raises: [].}
+  proc releaseThreadAllocator() {.gcsafe, raises: [].}
 
 when notJSnotNims and hasAlloc and not defined(nimSeqsV2):
   proc addChar(s: NimString, c: char): NimString {.compilerproc, gcsafe.}
@@ -2425,6 +2437,8 @@ when notJSnotNims and hasAlloc:
   {.push profiler: off.}
   include "system/mmdisp"
   {.pop.}
+  when hasThreadLocalAllocator and not defined(createNimRtl):
+    initThreadAllocator()
   {.push stackTrace: off, profiler: off.}
   when not defined(nimSeqsV2):
     include "system/sysstr"

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -182,7 +182,7 @@ type
       allocCounter, deallocCounter: int
     when usesRegionHandles:
       # Keep this off the front: a leading pointer shifts freeSmallChunks and
-      # the TLSF bitmaps and regresses 2-4 KiB allocations.
+      # the TLSF bitmaps by 8 bytes and regresses 2-4 KiB allocations.
       regionHandle: ptr RegionHandle
 
   RegionHandle = object
@@ -979,19 +979,13 @@ proc bigChunkAlignOffset(alignment: int): int {.inline.} =
   else:
     result = align(sizeof(BigChunk) + sizeof(FreeCell), alignment) - sizeof(BigChunk) - sizeof(FreeCell)
 
-template rawAllocAux(aligned: static bool) {.dirty.} =
+proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer =
   when defined(nimTypeNames):
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
   sysAssert(roundup(65, 8) == 72, "rawAlloc: roundup broken")
-  when aligned:
-    var size = roundup(requestedSize, max(MemAlign, alignment))
-    let alignOff = smallChunkAlignOffset(alignment)
-  else:
-    # Common `alloc` path: no custom alignment. Keep this a separate
-    # instantiation so clang does not emit `smallChunkAlignOffset(0)`.
-    var size = (requestedSize + (MemAlign - 1)) and not (MemAlign - 1)
-    const alignOff = 0
+  var size = roundup(requestedSize, max(MemAlign, alignment))
+  let alignOff = smallChunkAlignOffset(alignment)
   sysAssert(size >= sizeof(FreeCell), "rawAlloc: requested size too small")
   sysAssert(size >= requestedSize, "insufficient allocated size!")
   #c_fprintf(stdout, "alloc; size: %ld; %ld\n", requestedSize, size)
@@ -1010,10 +1004,9 @@ template rawAllocAux(aligned: static bool) {.dirty.} =
           else:
             tc.freeList = sharedHead[]
             sharedHead[] = nil
-          # Empty peeks are the common local case; skip the walk and the
-          # `free += 0` / `occ -= 0` stores clang would otherwise keep.
-          if tc.freeList != nil:
-            compensateCounters(a, tc, size)
+          # If `tc.freeList` isn't nil, `tc` gains capacity. Calculate how
+          # much it gained and how many foreign cells are included.
+          compensateCounters(a, tc, size)
 
     # allocate a small block: for small chunks, we use only its next pointer
     let s = size div MemAlign
@@ -1097,7 +1090,7 @@ template rawAllocAux(aligned: static bool) {.dirty.} =
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time
     # deterministic value rather than a worst-case estimate.
-    let alignPad = when aligned: bigChunkAlignOffset(alignment) else: 0
+    let alignPad = bigChunkAlignOffset(alignment)
     size = requestedSize + bigChunkOverhead() + alignPad
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
@@ -1121,12 +1114,6 @@ template rawAllocAux(aligned: static bool) {.dirty.} =
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
-
-proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
-  rawAllocAux(false)
-
-proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int): pointer =
-  rawAllocAux(true)
 
 proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
   result = rawAlloc(a, requestedSize)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -40,7 +40,7 @@ template track(op, address, size) =
 #
 # A deallocation of a small pointer then looks like this
 #[
-  dealloc -> rawDealloc -> chunk.owner == addr(a) --------------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
+  dealloc -> rawDealloc -> chunk.owner == regionOwner(a) -------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
                                       |                                       |                   (Add cell into the current chunk)                 |                  Return the current chunk back to tlsf
                                       |                                       |                                   |                                 |
                                       v                                       v                                   v                                 v
@@ -63,6 +63,7 @@ const
   # size of chunks in last matrix bin
   MaxBigChunkSize = int(1'i32 shl MaxFli - 1'i32 shl (MaxFli-MaxLog2Sli-1))
   HugeChunkSize = MaxBigChunkSize + 1
+  usesRegionHandles = hasThreadSupport and defined(gcDestructors)
 
 type
   PTrunk = ptr Trunk
@@ -112,11 +113,19 @@ type
   PChunk = ptr BaseChunk
   PBigChunk = ptr BigChunk
   PSmallChunk = ptr SmallChunk
+  SharedFreeLists = array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
+  RegionHandle = object
+    # Permanent chunk-owner identity and home of the remote-free queues.
+    sharedFreeLists: SharedFreeLists
+    sharedFreeListBigChunks: PBigChunk
   BaseChunk {.pure, inheritable.} = object
     prevSize: int        # size of previous chunk; for coalescing
                          # 0th bit == 1 if 'used
     size: int            # if < PageSize it is a small chunk
-    owner: ptr MemRegion
+    when usesRegionHandles:
+      owner: ptr RegionHandle
+    else:
+      owner: ptr MemRegion
 
   SmallChunk = object of BaseChunk
     next, prev: PSmallChunk  # chunks of the same size
@@ -145,14 +154,16 @@ type
     next: ptr HeapLinks
 
   MemRegion = object
+    when usesRegionHandles:
+      regionHandle: ptr RegionHandle
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
     when defined(gcDestructors):
-      sharedFreeLists: array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
-        # When a thread frees a pointer it did not create, it must not adjust the counters.
-        # Instead, the cell is placed here and deferred until the next allocation.
+      sharedFreeLists: SharedFreeLists
+        # Used directly without threads. Threaded builds use RegionHandle but
+        # retain this 2 KiB spacer: removing it regresses 2-4 KiB allocations.
     flBitmap: uint32
     slBitmap: array[RealFli, uint32]
     matrix: array[RealFli, array[MaxSli, PBigChunk]]
@@ -160,7 +171,7 @@ type
     currMem, maxMem, freeMem, occ: int # memory sizes (allocated from OS)
     lastSize: int # needed for the case that OS gives us pages linearly
     when defined(gcDestructors):
-      sharedFreeListBigChunks: PBigChunk # make no attempt at avoiding false sharing for now for this object field
+      sharedFreeListBigChunks: PBigChunk # private pending list with threads; shared queue otherwise
 
     chunkStarts: IntSet
     when not defined(gcDestructors):
@@ -173,8 +184,18 @@ type
     when defined(nimTypeNames):
       allocCounter, deallocCounter: int
 
+  PooledRegion = object
+    region: MemRegion
+    next: ptr PooledRegion
+
 template smallChunkOverhead(): untyped = sizeof(SmallChunk)
 template bigChunkOverhead(): untyped = sizeof(BigChunk)
+
+template regionOwner(a: var MemRegion): untyped =
+  when usesRegionHandles:
+    a.regionHandle
+  else:
+    addr a
 
 when hasThreadSupport:
   template loada(x: untyped): untyped = atomicLoadN(unsafeAddr x, ATOMIC_RELAXED)
@@ -502,6 +523,51 @@ proc pageAddr(p: pointer): PChunk {.inline.} =
   result = cast[PChunk](cast[int](p) and not PageMask)
   #sysAssert(Contains(allocator.chunkStarts, pageIndex(result)))
 
+when hasThreadLocalAllocator:
+  var
+    regionPool: ptr PooledRegion
+    regionPoolLock: SysLock
+  initSysLock(regionPoolLock)
+
+  proc moveMemRegion(dest, source: ptr MemRegion) {.inline.} =
+    # MemRegion owns only raw allocator state, so transfer it bitwise and
+    # clear the source to leave exactly one owner.
+    copyMem(dest, source, sizeof(MemRegion))
+    zeroMem(source, sizeof(MemRegion))
+
+  proc acquireMemRegion(a: var MemRegion) {.raises: [], gcsafe.} =
+    if a.regionHandle != nil:
+      return
+
+    acquireSys(regionPoolLock)
+    let pooled = regionPool
+    if pooled != nil:
+      regionPool = pooled.next
+    releaseSys(regionPoolLock)
+
+    if pooled == nil:
+      let handle = cast[ptr RegionHandle](c_malloc(csize_t sizeof(RegionHandle)))
+      if handle == nil:
+        raiseOutOfMem()
+      zeroMem(handle, sizeof(RegionHandle))
+      a.regionHandle = handle
+    else:
+      moveMemRegion(addr a, addr pooled.region)
+      c_free(pooled)
+
+  proc releaseMemRegion(a: var MemRegion) {.raises: [], gcsafe.} =
+    if a.regionHandle == nil:
+      return
+    let pooled = cast[ptr PooledRegion](c_malloc(csize_t sizeof(PooledRegion)))
+    if pooled == nil:
+      raiseOutOfMem()
+    moveMemRegion(addr pooled.region, addr a)
+
+    acquireSys(regionPoolLock)
+    pooled.next = regionPool
+    regionPool = pooled
+    releaseSys(regionPoolLock)
+
 when false:
   proc writeFreeList(a: MemRegion) =
     var it = a.freeChunksList
@@ -618,7 +684,7 @@ proc splitChunk2(a: var MemRegion, c: PBigChunk, size: int): PBigChunk =
     result.prev = nil
   # size and not used:
   result.prevSize = size
-  result.owner = addr a
+  result.owner = regionOwner(a)
   sysAssert((size and 1) == 0, "splitChunk 2")
   sysAssert((size and PageMask) == 0,
       "splitChunk: size is not a multiple of the PageSize")
@@ -686,7 +752,7 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
       # if we over allocated split the chunk:
       if result.size > size:
         splitChunk(a, result, size)
-    result.owner = addr a
+    result.owner = regionOwner(a)
   else:
     removeChunkFromMatrix2(a, result, fl, sl)
     if result.size >= size + PageSize:
@@ -694,7 +760,7 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
   # set 'used' to true:
   result.prevSize = 1
   track("setUsedToFalse", addr result.size, sizeof(int))
-  sysAssert result.owner == addr a, "getBigChunk: No owner set!"
+  sysAssert result.owner == regionOwner(a), "getBigChunk: No owner set!"
 
   incl(a, a.chunkStarts, pageIndex(result))
   dec(a.freeMem, size)
@@ -710,7 +776,7 @@ proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
   result.size = size
   # set 'used' to true:
   result.prevSize = 1
-  result.owner = addr a
+  result.owner = regionOwner(a)
   incl(a, a.chunkStarts, pageIndex(result))
 
 proc freeHugeChunk(a: var MemRegion; c: PBigChunk) =
@@ -791,7 +857,7 @@ proc deallocBigChunk(a: var MemRegion, c: PBigChunk) =
 when defined(gcDestructors):
   template atomicPrepend(head, elem: untyped) =
     # see also https://en.cppreference.com/w/cpp/atomic/atomic_compare_exchange
-    when hasThreadSupport:
+    when usesRegionHandles:
       while true:
         elem.next.storea head.loada
         if atomicCompareExchangeN(addr head, addr elem.next, elem, weak = true, ATOMIC_RELEASE, ATOMIC_RELAXED):
@@ -800,30 +866,39 @@ when defined(gcDestructors):
       elem.next.storea head.loada
       head.storea elem
 
-  proc addToSharedFreeListBigChunks(a: var MemRegion; c: PBigChunk) {.inline.} =
-    sysAssert c.next == nil, "c.next pointer must be nil"
-    atomicPrepend a.sharedFreeListBigChunks, c
+  when usesRegionHandles:
+    proc addToSharedFreeListBigChunks(handle: ptr RegionHandle;
+                                      c: PBigChunk) {.inline.} =
+      sysAssert c.next == nil, "c.next pointer must be nil"
+      atomicPrepend handle.sharedFreeListBigChunks, c
+  else:
+    proc addToSharedFreeListBigChunks(a: var MemRegion;
+                                      c: PBigChunk) {.inline.} =
+      sysAssert c.next == nil, "c.next pointer must be nil"
+      atomicPrepend a.sharedFreeListBigChunks, c
 
   proc takeFromSharedFreeListBigChunks(a: var MemRegion): PBigChunk {.inline.} =
-    when hasThreadSupport:
-      while true:
-        result = atomicLoadN(addr a.sharedFreeListBigChunks, ATOMIC_ACQUIRE)
-        if result == nil:
-          break
-        let next = result.next.loada
-        var expected = result
-        if atomicCompareExchangeN(addr a.sharedFreeListBigChunks, addr expected, next,
-                                  weak = true, ATOMIC_ACQUIRE, ATOMIC_RELAXED):
-          result.next.storea nil
-          break
-    else:
-      result = a.sharedFreeListBigChunks
-      if result != nil:
-        a.sharedFreeListBigChunks = result.next
-        result.next = nil
+    when usesRegionHandles:
+      if a.sharedFreeListBigChunks == nil:
+        let sharedHead = addr a.regionHandle.sharedFreeListBigChunks
+        # Detach a batch from the stable remote inbox. The embedded MemRegion
+        # field is now a private pending list and moves with the region.
+        if atomicLoadN(sharedHead, ATOMIC_RELAXED) != nil:
+          a.sharedFreeListBigChunks = atomicExchangeN(sharedHead, nil,
+                                                       ATOMIC_ACQUIRE)
+    result = a.sharedFreeListBigChunks
+    if result != nil:
+      a.sharedFreeListBigChunks = result.next
+      result.next = nil
 
-  proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell; size: int) {.inline.} =
-    atomicPrepend c.owner.sharedFreeLists[size], f
+  when usesRegionHandles:
+    proc addToSharedFreeList(handle: ptr RegionHandle; f: ptr FreeCell;
+                             size: int) {.inline.} =
+      atomicPrepend handle.sharedFreeLists[size], f
+  else:
+    proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell;
+                             size: int) {.inline.} =
+      atomicPrepend c.owner.sharedFreeLists[size], f
 
   const MaxSteps = 20
 
@@ -846,9 +921,8 @@ when defined(gcDestructors):
     dec(a.occ, total)
 
   proc freeDeferredObjects(a: var MemRegion) =
-    # Pop only as many nodes as we can process. Detaching the entire list and
-    # re-enqueuing its unprocessed tail through atomicPrepend would overwrite
-    # that tail's next pointer and lose the rest of the list.
+    # Bound the work per allocation. With threads, takeFromSharedFreeListBigChunks
+    # detaches the shared stack into the region's private pending list first.
     for _ in 0..MaxSteps:
       let it = takeFromSharedFreeListBigChunks(a)
       if it == nil: break
@@ -892,17 +966,20 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
 
   if size + alignOff <= SmallChunkSize-smallChunkOverhead():
     template fetchSharedCells(tc: PSmallChunk) =
-      # Consumes cells from (potentially) foreign threads from `a.sharedFreeLists[s]`
+      # Consume cells freed by potentially foreign threads.
       when defined(gcDestructors):
         if tc.freeList == nil:
-          when hasThreadSupport:
-            # Steal the entire list from `sharedFreeList`:
-            tc.freeList = atomicExchangeN(addr a.sharedFreeLists[s], nil, ATOMIC_RELAXED)
+          when usesRegionHandles:
+            let sharedHead = addr tc.owner.sharedFreeLists[s]
+            # The owner is the only consumer, so once it observes a non-empty
+            # stack no other thread can make it empty before the exchange.
+            if atomicLoadN(sharedHead, ATOMIC_RELAXED) != nil:
+              tc.freeList = atomicExchangeN(sharedHead, nil, ATOMIC_ACQUIRE)
           else:
             tc.freeList = a.sharedFreeLists[s]
             a.sharedFreeLists[s] = nil
-          # if `tc.freeList` isn't nil, `tc` will gain capacity.
-          # We must calculate how much it gained and how many foreign cells are included.
+          # If `tc.freeList` isn't nil, `tc` gains capacity. Calculate how
+          # much it gained and how many foreign cells are included.
           compensateCounters(a, tc, size)
 
     # allocate a small block: for small chunks, we use only its next pointer
@@ -921,11 +998,11 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       c.size = size
       c.acc = (alignOff + size).uint32
       c.free = SmallChunkSize - smallChunkOverhead() - alignOff.int32 - size.int32
-      sysAssert c.owner == addr(a), "rawAlloc: No owner set!"
+      sysAssert c.owner == regionOwner(a), "rawAlloc: No owner set!"
       c.next = nil
       c.prev = nil
-      # Shared cells are fetched here in case `c.size * 2 >= SmallChunkSize - smallChunkOverhead()`.
-      # For those single cell chunks, we would otherwise have to allocate a new one almost every time.
+      # Fetch deferred cells here for single-cell chunks; otherwise every
+      # allocation of that size would tend to allocate a new chunk.
       fetchSharedCells(c)
       if c.free >= size:
         # Because removals from `a.freeSmallChunks[s]` only happen in the other alloc branch and during dealloc,
@@ -963,9 +1040,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       dec(c.free, size)
       sysAssert((cast[int](result) and (MemAlign-1)) == 0, "rawAlloc 9")
       sysAssert(allocInv(a), "rawAlloc: end c != nil")
-      # We fetch deferred cells *after* advancing `c.freeList`/`acc` to adjust `c.free`.
-      # If after the adjustment it turns out there's free cells available,
-      #  the chunk stays in `a.freeSmallChunks[s]` and the need for a new chunk is delayed.
+      # Fetch after advancing `freeList`/`acc` so `c.free` can be adjusted. If
+      # cells arrived, keep this chunk active instead of allocating another.
       fetchSharedCells(c)
       sysAssert(allocInv(a), "rawAlloc: before c.free < size")
       if c.free < size:
@@ -1030,7 +1106,8 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     #       ^ We might access thread foreign storage here.
     # The other thread cannot possibly free this block as it's still alive.
     var f = cast[ptr FreeCell](p)
-    if c.owner == addr(a):
+    let owner = c.owner
+    if owner == regionOwner(a):
       # We own the block, there is no foreign thread involved.
       dec a.occ, s
       untrackSize(s)
@@ -1093,7 +1170,10 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
       when logAlloc: cprintf("dealloc(pointer_%p) # SMALL FROM %p CALLER %p\n", p, c.owner, addr(a))
 
       when defined(gcDestructors):
-        addToSharedFreeList(c, f, s div MemAlign)
+        when usesRegionHandles:
+          addToSharedFreeList(owner, f, s div MemAlign)
+        else:
+          addToSharedFreeList(c, f, s div MemAlign)
     sysAssert(((cast[int](p) and PageMask) - smallChunkOverhead() - c.chunkAlignOff) %%
                s == 0, "rawDealloc 2")
   else:
@@ -1101,10 +1181,14 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     when overwriteFree: nimSetMem(p, -1'i32, c.size -% bigChunkOverhead())
     when logAlloc: cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.owner)
     when defined(gcDestructors):
-      if c.owner == addr(a):
+      let owner = c.owner
+      if owner == regionOwner(a):
         deallocBigChunk(a, cast[PBigChunk](c))
       else:
-        addToSharedFreeListBigChunks(c.owner[], cast[PBigChunk](c))
+        when usesRegionHandles:
+          addToSharedFreeListBigChunks(owner, cast[PBigChunk](c))
+        else:
+          addToSharedFreeListBigChunks(owner[], cast[PBigChunk](c))
     else:
       deallocBigChunk(a, cast[PBigChunk](c))
 
@@ -1262,6 +1346,13 @@ when defined(nimTypeNames):
 
 template instantiateForRegion(allocator: untyped) {.dirty.} =
   {.push stackTrace: off.}
+
+  when hasThreadLocalAllocator:
+    proc initThreadAllocator() {.gcsafe, raises: [].} =
+      acquireMemRegion(allocator)
+
+    proc releaseThreadAllocator() {.gcsafe, raises: [].} =
+      releaseMemRegion(allocator)
 
   when defined(nimFulldebug):
     proc interiorAllocatedPtr*(p: pointer): pointer =

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -221,10 +221,9 @@ when defined(gcDestructors):
     else:
       false
 
-when usesRegionHandles:
-  static:
-    doAssert sizeof(SharedFreeLists) + sizeof(PBigChunk) <= PageSize,
-             "remote-free queues must fit on the RegionHandle's first page"
+  when usesRegionHandles:
+    sysAssert sizeof(SharedFreeLists) + sizeof(PBigChunk) <= PageSize,
+              "remote-free queues must fit on the RegionHandle's first page"
 
 template setBigForeignQueue(c: untyped; a: var MemRegion) =
   when defined(gcDestructors):

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -221,9 +221,10 @@ when defined(gcDestructors):
     else:
       false
 
-  when usesRegionHandles:
-    sysAssert sizeof(SharedFreeLists) + sizeof(PBigChunk) <= PageSize,
-              "remote-free queues must fit on the RegionHandle's first page"
+when usesRegionHandles:
+  static:
+    doAssert sizeof(SharedFreeLists) + sizeof(PBigChunk) <= PageSize,
+             "remote-free queues must fit on the RegionHandle's first page"
 
 template setBigForeignQueue(c: untyped; a: var MemRegion) =
   when defined(gcDestructors):

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -40,12 +40,12 @@ template track(op, address, size) =
 #
 # A deallocation of a small pointer then looks like this
 #[
-  dealloc -> rawDealloc -> chunk.owner == regionOwner(a) -------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
+  dealloc -> rawDealloc -> chunk.foreignQueue is local -------> This thread owns the chunk ------> The current chunk is active    -> Chunk is completely unused -----> Chunk references no foreign cells
                                       |                                       |                   (Add cell into the current chunk)                 |                  Return the current chunk back to tlsf
                                       |                                       |                                   |                                 |
                                       v                                       v                                   v                                 v
                       A different thread owns this chunk.     The current chunk is not active.          chunk.free was < size      Chunk references foreign cells, noop
-                      Add the cell to a.sharedFreeLists      Add the cell into the active chunk          Activate the chunk                       (end)
+                      Push the cell onto chunk.foreignQueue  Add the cell into the active chunk          Activate the chunk                       (end)
                                     (end)                                    (end)                              (end)
 ]#
 # So "true" deallocation is delayed for as long as possible in favor of reusing cells.
@@ -118,8 +118,11 @@ type
     prevSize: int        # size of previous chunk; for coalescing
                          # 0th bit == 1 if 'used
     size: int            # if < PageSize it is a small chunk
-    when usesRegionHandles:
-      owner: ptr RegionHandle
+    when defined(gcDestructors):
+      foreignQueue: pointer
+        # Remote-free list this chunk publishes to. Small chunks store the
+        # size-class bucket (`ptr ptr FreeCell`); big chunks store the
+        # region's deferred list (`ptr PBigChunk`).
     else:
       owner: ptr MemRegion
 
@@ -181,10 +184,13 @@ type
       allocCounter, deallocCounter: int
 
   RegionHandle = object
-    # Permanent chunk-owner identity and home of the remote-free queues.
+    # Stable home of the remote-free queues. Chunks point at these lists
+    # rather than at the handle, so a foreign free does not need the owner.
+    # Both queues must remain on the handle's first page: dealloc recovers
+    # the owner by masking the queue pointer with PageMask.
     sharedFreeLists: SharedFreeLists
     sharedFreeListBigChunks: PBigChunk
-    # Keep the movable allocator state with its permanent owner while the
+    # Keep the movable allocator state with its permanent queues while the
     # owning thread is retired.
     region: MemRegion
     next: ptr RegionHandle
@@ -192,11 +198,36 @@ type
 template smallChunkOverhead(): untyped = sizeof(SmallChunk)
 template bigChunkOverhead(): untyped = sizeof(BigChunk)
 
-template regionOwner(a: var MemRegion): untyped =
+when defined(gcDestructors):
+  template smallCellQueue(a: var MemRegion; bucket: int): pointer =
+    when usesRegionHandles:
+      cast[pointer](addr a.regionHandle.sharedFreeLists[bucket])
+    else:
+      cast[pointer](addr a.sharedFreeLists[bucket])
+
+  template bigChunkQueue(a: var MemRegion): pointer =
+    when usesRegionHandles:
+      cast[pointer](addr a.regionHandle.sharedFreeListBigChunks)
+    else:
+      cast[pointer](addr a.sharedFreeListBigChunks)
+
+  template ownsLocalQueue(a: var MemRegion; q: pointer): bool =
+    when usesRegionHandles:
+      # RegionHandle is page-aligned and both remote-free queues live on its
+      # first page, so masking the queue pointer recovers the owning handle.
+      (cast[int](q) and not PageMask) == cast[int](a.regionHandle)
+    else:
+      false
+
   when usesRegionHandles:
-    a.regionHandle
+    sysAssert sizeof(SharedFreeLists) + sizeof(PBigChunk) <= PageSize,
+              "remote-free queues must fit on the RegionHandle's first page"
+
+template setBigForeignQueue(c: untyped; a: var MemRegion) =
+  when defined(gcDestructors):
+    c.foreignQueue = bigChunkQueue(a)
   else:
-    addr a
+    c.owner = addr a
 
 when hasThreadSupport:
   template loada(x: untyped): untyped = atomicLoadN(unsafeAddr x, ATOMIC_RELAXED)
@@ -552,6 +583,8 @@ when hasThreadLocalAllocator:
       let handleSize = roundup(sizeof(RegionHandle), PageSize)
       let newHandle = cast[ptr RegionHandle](osAllocPages(handleSize))
       zeroMem(newHandle, sizeof(RegionHandle))
+      sysAssert (cast[int](newHandle) and PageMask) == 0,
+                "RegionHandle must be page-aligned"
       a.regionHandle = newHandle
     else:
       moveMemRegion(addr a, addr handle.region)
@@ -683,7 +716,7 @@ proc splitChunk2(a: var MemRegion, c: PBigChunk, size: int): PBigChunk =
     result.prev = nil
   # size and not used:
   result.prevSize = size
-  result.owner = regionOwner(a)
+  setBigForeignQueue(result, a)
   sysAssert((size and 1) == 0, "splitChunk 2")
   sysAssert((size and PageMask) == 0,
       "splitChunk: size is not a multiple of the PageSize")
@@ -751,15 +784,18 @@ proc getBigChunk(a: var MemRegion, size: int): PBigChunk =
       # if we over allocated split the chunk:
       if result.size > size:
         splitChunk(a, result, size)
-    result.owner = regionOwner(a)
   else:
     removeChunkFromMatrix2(a, result, fl, sl)
     if result.size >= size + PageSize:
       splitChunk(a, result, size)
+  setBigForeignQueue(result, a)
   # set 'used' to true:
   result.prevSize = 1
   track("setUsedToFalse", addr result.size, sizeof(int))
-  sysAssert result.owner == regionOwner(a), "getBigChunk: No owner set!"
+  when defined(gcDestructors):
+    sysAssert result.foreignQueue == bigChunkQueue(a), "getBigChunk: No foreign queue set!"
+  else:
+    sysAssert result.owner == addr a, "getBigChunk: No owner set!"
 
   incl(a, a.chunkStarts, pageIndex(result))
   dec(a.freeMem, size)
@@ -775,7 +811,7 @@ proc getHugeChunk(a: var MemRegion; size: int): PBigChunk =
   result.size = size
   # set 'used' to true:
   result.prevSize = 1
-  result.owner = regionOwner(a)
+  setBigForeignQueue(result, a)
   incl(a, a.chunkStarts, pageIndex(result))
 
 proc freeHugeChunk(a: var MemRegion; c: PBigChunk) =
@@ -865,16 +901,10 @@ when defined(gcDestructors):
       elem.next.storea head.loada
       head.storea elem
 
-  when usesRegionHandles:
-    proc addToSharedFreeListBigChunks(handle: ptr RegionHandle;
-                                      c: PBigChunk) {.inline.} =
-      sysAssert c.next == nil, "c.next pointer must be nil"
-      atomicPrepend handle.sharedFreeListBigChunks, c
-  else:
-    proc addToSharedFreeListBigChunks(a: var MemRegion;
-                                      c: PBigChunk) {.inline.} =
-      sysAssert c.next == nil, "c.next pointer must be nil"
-      atomicPrepend a.sharedFreeListBigChunks, c
+  proc addToSharedFreeListBigChunks(queue: pointer;
+                                    c: PBigChunk) {.inline.} =
+    sysAssert c.next == nil, "c.next pointer must be nil"
+    atomicPrepend cast[ptr PBigChunk](queue)[], c
 
   proc takeFromSharedFreeListBigChunks(a: var MemRegion): PBigChunk {.inline.} =
     when usesRegionHandles:
@@ -890,14 +920,8 @@ when defined(gcDestructors):
       a.sharedFreeListBigChunks = result.next
       result.next = nil
 
-  when usesRegionHandles:
-    proc addToSharedFreeList(handle: ptr RegionHandle; f: ptr FreeCell;
-                             size: int) {.inline.} =
-      atomicPrepend handle.sharedFreeLists[size], f
-  else:
-    proc addToSharedFreeList(c: PSmallChunk; f: ptr FreeCell;
-                             size: int) {.inline.} =
-      atomicPrepend c.owner.sharedFreeLists[size], f
+  proc addToSharedFreeList(queue: pointer; f: ptr FreeCell) {.inline.} =
+    atomicPrepend cast[ptr ptr FreeCell](queue)[], f
 
   const MaxSteps = 20
 
@@ -968,15 +992,15 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       # Consume cells freed by potentially foreign threads.
       when defined(gcDestructors):
         if tc.freeList == nil:
+          let sharedHead = cast[ptr ptr FreeCell](tc.foreignQueue)
           when usesRegionHandles:
-            let sharedHead = addr tc.owner.sharedFreeLists[s]
             # The owner is the only consumer, so once it observes a non-empty
             # stack no other thread can make it empty before the exchange.
             if atomicLoadN(sharedHead, ATOMIC_RELAXED) != nil:
               tc.freeList = atomicExchangeN(sharedHead, nil, ATOMIC_ACQUIRE)
           else:
-            tc.freeList = a.sharedFreeLists[s]
-            a.sharedFreeLists[s] = nil
+            tc.freeList = sharedHead[]
+            sharedHead[] = nil
           # If `tc.freeList` isn't nil, `tc` gains capacity. Calculate how
           # much it gained and how many foreign cells are included.
           compensateCounters(a, tc, size)
@@ -995,9 +1019,12 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
       c.chunkAlignOff = alignOff.int32
       sysAssert c.size == PageSize, "rawAlloc 3"
       c.size = size
+      when defined(gcDestructors):
+        c.foreignQueue = smallCellQueue(a, s)
       c.acc = (alignOff + size).uint32
       c.free = SmallChunkSize - smallChunkOverhead() - alignOff.int32 - size.int32
-      sysAssert c.owner == regionOwner(a), "rawAlloc: No owner set!"
+      when defined(gcDestructors):
+        sysAssert c.foreignQueue == smallCellQueue(a, s), "rawAlloc: No foreign queue set!"
       c.next = nil
       c.prev = nil
       # Fetch deferred cells here for single-cell chunks; otherwise every
@@ -1105,8 +1132,15 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
     #       ^ We might access thread foreign storage here.
     # The other thread cannot possibly free this block as it's still alive.
     var f = cast[ptr FreeCell](p)
-    let owner = c.owner
-    if owner == regionOwner(a):
+    when defined(gcDestructors):
+      let q = c.foreignQueue
+      let local = when usesRegionHandles:
+                    ownsLocalQueue(a, q)
+                  else:
+                    q == smallCellQueue(a, s div MemAlign)
+    else:
+      let local = c.owner == addr a
+    if local:
       # We own the block, there is no foreign thread involved.
       dec a.occ, s
       untrackSize(s)
@@ -1121,13 +1155,14 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
         # set to 0xff to check for usage after free bugs:
         nimSetMem(cast[pointer](cast[int](p) +% sizeof(FreeCell)), -1'i32,
                 s -% sizeof(FreeCell))
-      let activeChunk = a.freeSmallChunks[s div MemAlign]
+      let bucket = s div MemAlign
+      let activeChunk = a.freeSmallChunks[bucket]
       if activeChunk != nil and c != activeChunk and
           activeChunk.chunkAlignOff == c.chunkAlignOff:
         # This pointer is not part of the active chunk, lend it out
         #  and do not adjust the current chunk (same logic as compensateCounters.)
         # Put the cell into the active chunk,
-        #  may prevent a queue of available chunks from forming in a.freeSmallChunks[s div MemAlign].
+        #  may prevent a queue of available chunks from forming in a.freeSmallChunks[bucket].
         #  This queue would otherwise waste memory in the form of free cells until we return to those chunks.
         f.next = activeChunk.freeList
         activeChunk.freeList = f # lend the cell
@@ -1138,15 +1173,15 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
         c.freeList = f
         if c.free < s:
           # The chunk could not have been active as it didn't have enough space to give
-          listAdd(a.freeSmallChunks[s div MemAlign], c)
+          listAdd(a.freeSmallChunks[bucket], c)
           inc(c.free, s)
         else:
           inc(c.free, s)
           # FIX: Don't free small chunks to avoid race condition with sharedFreeLists.
           #
           # RACE CONDITION: Between checking foreignCells==0 and calling freeBigChunk,
-          # another thread may read chunk.owner and decide to add a cell to our
-          # sharedFreeLists. If we free the chunk, that cell becomes orphaned.
+          # another thread may read chunk.foreignQueue and decide to add a cell
+          # to our remote-free list. If we free the chunk, that cell becomes orphaned.
           #
           # SOLUTION: Never free small chunks. They remain in freeSmallChunks[s] and
           # are reused on next allocation. This maintains the invariant that chunks
@@ -1162,32 +1197,33 @@ proc rawDealloc(a: var MemRegion, p: pointer) =
           sysAssert(c.free >= s, "Invariant violated: chunk in freeSmallChunks has insufficient space")
           when false:
             if c.free == SmallChunkSize-smallChunkOverhead() and c.foreignCells == 0:
-              listRemove(a.freeSmallChunks[s div MemAlign], c)
+              listRemove(a.freeSmallChunks[bucket], c)
               c.size = SmallChunkSize
               freeBigChunk(a, cast[PBigChunk](c))
     else:
-      when logAlloc: cprintf("dealloc(pointer_%p) # SMALL FROM %p CALLER %p\n", p, c.owner, addr(a))
-
-      when defined(gcDestructors):
-        when usesRegionHandles:
-          addToSharedFreeList(owner, f, s div MemAlign)
+      when logAlloc:
+        when defined(gcDestructors):
+          cprintf("dealloc(pointer_%p) # SMALL FROM %p CALLER %p\n", p, c.foreignQueue, addr(a))
         else:
-          addToSharedFreeList(c, f, s div MemAlign)
+          cprintf("dealloc(pointer_%p) # SMALL FROM %p CALLER %p\n", p, c.owner, addr(a))
+      when defined(gcDestructors):
+        addToSharedFreeList(q, f)
     sysAssert(((cast[int](p) and PageMask) - smallChunkOverhead() - c.chunkAlignOff) %%
                s == 0, "rawDealloc 2")
   else:
     # set to 0xff to check for usage after free bugs:
     when overwriteFree: nimSetMem(p, -1'i32, c.size -% bigChunkOverhead())
-    when logAlloc: cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.owner)
+    when logAlloc:
+      when defined(gcDestructors):
+        cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.foreignQueue)
+      else:
+        cprintf("dealloc(pointer_%p) # BIG %p\n", p, c.owner)
     when defined(gcDestructors):
-      let owner = c.owner
-      if owner == regionOwner(a):
+      let q = c.foreignQueue
+      if q == bigChunkQueue(a):
         deallocBigChunk(a, cast[PBigChunk](c))
       else:
-        when usesRegionHandles:
-          addToSharedFreeListBigChunks(owner, cast[PBigChunk](c))
-        else:
-          addToSharedFreeListBigChunks(owner[], cast[PBigChunk](c))
+        addToSharedFreeListBigChunks(q, cast[PBigChunk](c))
     else:
       deallocBigChunk(a, cast[PBigChunk](c))
 

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -114,10 +114,6 @@ type
   PBigChunk = ptr BigChunk
   PSmallChunk = ptr SmallChunk
   SharedFreeLists = array[0..max(1, SmallChunkSize div MemAlign-1), ptr FreeCell]
-  RegionHandle = object
-    # Permanent chunk-owner identity and home of the remote-free queues.
-    sharedFreeLists: SharedFreeLists
-    sharedFreeListBigChunks: PBigChunk
   BaseChunk {.pure, inheritable.} = object
     prevSize: int        # size of previous chunk; for coalescing
                          # 0th bit == 1 if 'used
@@ -184,9 +180,14 @@ type
     when defined(nimTypeNames):
       allocCounter, deallocCounter: int
 
-  PooledRegion = object
+  RegionHandle = object
+    # Permanent chunk-owner identity and home of the remote-free queues.
+    sharedFreeLists: SharedFreeLists
+    sharedFreeListBigChunks: PBigChunk
+    # Keep the movable allocator state with its permanent owner while the
+    # owning thread is retired.
     region: MemRegion
-    next: ptr PooledRegion
+    next: ptr RegionHandle
 
 template smallChunkOverhead(): untyped = sizeof(SmallChunk)
 template bigChunkOverhead(): untyped = sizeof(BigChunk)
@@ -525,7 +526,7 @@ proc pageAddr(p: pointer): PChunk {.inline.} =
 
 when hasThreadLocalAllocator:
   var
-    regionPool: ptr PooledRegion
+    regionPool: ptr RegionHandle
     regionPoolLock: SysLock
   initSysLock(regionPoolLock)
 
@@ -540,32 +541,29 @@ when hasThreadLocalAllocator:
       return
 
     acquireSys(regionPoolLock)
-    let pooled = regionPool
-    if pooled != nil:
-      regionPool = pooled.next
+    let handle = regionPool
+    if handle != nil:
+      regionPool = handle.next
     releaseSys(regionPoolLock)
 
-    if pooled == nil:
-      let handle = cast[ptr RegionHandle](c_malloc(csize_t sizeof(RegionHandle)))
-      if handle == nil:
+    if handle == nil:
+      let newHandle = cast[ptr RegionHandle](c_malloc(csize_t sizeof(RegionHandle)))
+      if newHandle == nil:
         raiseOutOfMem()
-      zeroMem(handle, sizeof(RegionHandle))
-      a.regionHandle = handle
+      zeroMem(newHandle, sizeof(RegionHandle))
+      a.regionHandle = newHandle
     else:
-      moveMemRegion(addr a, addr pooled.region)
-      c_free(pooled)
+      moveMemRegion(addr a, addr handle.region)
 
   proc releaseMemRegion(a: var MemRegion) {.raises: [], gcsafe.} =
     if a.regionHandle == nil:
       return
-    let pooled = cast[ptr PooledRegion](c_malloc(csize_t sizeof(PooledRegion)))
-    if pooled == nil:
-      raiseOutOfMem()
-    moveMemRegion(addr pooled.region, addr a)
+    let handle = a.regionHandle
+    moveMemRegion(addr handle.region, addr a)
 
     acquireSys(regionPoolLock)
-    pooled.next = regionPool
-    regionPool = pooled
+    handle.next = regionPool
+    regionPool = handle
     releaseSys(regionPoolLock)
 
 when false:

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -182,7 +182,7 @@ type
       allocCounter, deallocCounter: int
     when usesRegionHandles:
       # Keep this off the front: a leading pointer shifts freeSmallChunks and
-      # the TLSF bitmaps by 8 bytes and regresses 2-4 KiB allocations.
+      # the TLSF bitmaps and regresses 2-4 KiB allocations.
       regionHandle: ptr RegionHandle
 
   RegionHandle = object
@@ -978,13 +978,19 @@ proc bigChunkAlignOffset(alignment: int): int {.inline.} =
   else:
     result = align(sizeof(BigChunk) + sizeof(FreeCell), alignment) - sizeof(BigChunk) - sizeof(FreeCell)
 
-proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer =
+template rawAllocAux(aligned: static bool) {.dirty.} =
   when defined(nimTypeNames):
     inc(a.allocCounter)
   sysAssert(allocInv(a), "rawAlloc: begin")
   sysAssert(roundup(65, 8) == 72, "rawAlloc: roundup broken")
-  var size = roundup(requestedSize, max(MemAlign, alignment))
-  let alignOff = smallChunkAlignOffset(alignment)
+  when aligned:
+    var size = roundup(requestedSize, max(MemAlign, alignment))
+    let alignOff = smallChunkAlignOffset(alignment)
+  else:
+    # Common `alloc` path: no custom alignment. Keep this a separate
+    # instantiation so clang does not emit `smallChunkAlignOffset(0)`.
+    var size = (requestedSize + (MemAlign - 1)) and not (MemAlign - 1)
+    const alignOff = 0
   sysAssert(size >= sizeof(FreeCell), "rawAlloc: requested size too small")
   sysAssert(size >= requestedSize, "insufficient allocated size!")
   #c_fprintf(stdout, "alloc; size: %ld; %ld\n", requestedSize, size)
@@ -1003,9 +1009,10 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
           else:
             tc.freeList = sharedHead[]
             sharedHead[] = nil
-          # If `tc.freeList` isn't nil, `tc` gains capacity. Calculate how
-          # much it gained and how many foreign cells are included.
-          compensateCounters(a, tc, size)
+          # Empty peeks are the common local case; skip the walk and the
+          # `free += 0` / `occ -= 0` stores clang would otherwise keep.
+          if tc.freeList != nil:
+            compensateCounters(a, tc, size)
 
     # allocate a small block: for small chunks, we use only its next pointer
     let s = size div MemAlign
@@ -1089,7 +1096,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
     # For big chunks with custom alignment, allocate extra space.
     # Since chunks are page-aligned, the needed padding is a compile-time
     # deterministic value rather than a worst-case estimate.
-    let alignPad = bigChunkAlignOffset(alignment)
+    let alignPad = when aligned: bigChunkAlignOffset(alignment) else: 0
     size = requestedSize + bigChunkOverhead() + alignPad
     # allocate a large block
     var c = if size >= HugeChunkSize: getHugeChunk(a, size)
@@ -1113,6 +1120,12 @@ proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int = 0): pointer
   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
   when defined(heaptrack):
     heaptrack_malloc(result, requestedSize)
+
+proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
+  rawAllocAux(false)
+
+proc rawAlloc(a: var MemRegion, requestedSize: int, alignment: int): pointer =
+  rawAllocAux(true)
 
 proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
   result = rawAlloc(a, requestedSize)

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -547,9 +547,10 @@ when hasThreadLocalAllocator:
     releaseSys(regionPoolLock)
 
     if handle == nil:
-      let newHandle = cast[ptr RegionHandle](c_malloc(csize_t sizeof(RegionHandle)))
-      if newHandle == nil:
-        raiseOutOfMem()
+      # RegionHandle is larger than llAlloc's one-page metadata slabs and is
+      # retained independently of any checked-out MemRegion.
+      let handleSize = roundup(sizeof(RegionHandle), PageSize)
+      let newHandle = cast[ptr RegionHandle](osAllocPages(handleSize))
       zeroMem(newHandle, sizeof(RegionHandle))
       a.regionHandle = newHandle
     else:

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -153,16 +153,14 @@ type
     next: ptr HeapLinks
 
   MemRegion = object
-    when usesRegionHandles:
-      regionHandle: ptr RegionHandle
     when not defined(gcDestructors):
       minLargeObj, maxLargeObj: int
     freeSmallChunks: array[0..max(1, SmallChunkSize div MemAlign-1), PSmallChunk]
       # List of available chunks per size class. Only one is expected to be active per class.
-    when defined(gcDestructors):
+    when defined(gcDestructors) and not usesRegionHandles:
       sharedFreeLists: SharedFreeLists
-        # Used directly without threads. Threaded builds use RegionHandle but
-        # retain this 2 KiB spacer: removing it regresses 2-4 KiB allocations.
+        # Remote-free buckets live on the MemRegion when there is no
+        # RegionHandle. Threaded ORC keeps them on the handle instead.
     flBitmap: uint32
     slBitmap: array[RealFli, uint32]
     matrix: array[RealFli, array[MaxSli, PBigChunk]]
@@ -182,6 +180,10 @@ type
     heapLinks: HeapLinks
     when defined(nimTypeNames):
       allocCounter, deallocCounter: int
+    when usesRegionHandles:
+      # Keep this off the front: a leading pointer shifts freeSmallChunks and
+      # the TLSF bitmaps by 8 bytes and regresses 2-4 KiB allocations.
+      regionHandle: ptr RegionHandle
 
   RegionHandle = object
     # Stable home of the remote-free queues. Chunks point at these lists

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -283,13 +283,17 @@ when not (defined(gcOrc) or defined(gcYrc)):
     ## Forces a full garbage collection pass. With `--mm:arc` a nop.
     discard
 
-template setupForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
-
-template tearDownForeignThreadGc* =
-  ## With `--mm:arc` a nop.
-  discard
+when not hasThreadSupport:
+  template setupForeignThreadGc* = discard
+  template tearDownForeignThreadGc* = discard
+elif emulatedThreadVars:
+  template setupForeignThreadGc* =
+    {.error: "setupForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+  template tearDownForeignThreadGc* =
+    {.error: "tearDownForeignThreadGc is available only when ``--threads:on`` and ``--tlsEmulation:off`` are used".}
+elif not hasThreadLocalAllocator:
+  template setupForeignThreadGc* = discard
+  template tearDownForeignThreadGc* = discard
 
 proc isObjDisplayCheck(source: PNimTypeV2, targetDepth: int16, token: uint32): bool {.compilerRtl, inl.} =
   result = targetDepth <= source.depth and source.display[targetDepth] == token

--- a/lib/system/threadimpl.nim
+++ b/lib/system/threadimpl.nim
@@ -19,6 +19,13 @@ when not defined(useNimRtl):
 
       threadType = ThreadType.NimThread
 
+when hasThreadLocalAllocator and not emulatedThreadVars:
+  proc setupForeignThreadGc*() {.gcsafe, raises: [].} =
+    initThreadAllocator()
+
+  proc tearDownForeignThreadGc*() {.gcsafe, raises: [].} =
+    releaseThreadAllocator()
+
 when defined(gcDestructors):
   proc deallocThreadStorage(p: pointer) = c_free(p)
 else:
@@ -83,6 +90,8 @@ else:
         deallocThreadStorage(thrd.rawStack)
 
 proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
+  when hasThreadLocalAllocator:
+    initThreadAllocator()
   when defined(boehmgc):
     boehmGC_call_with_stack_base(threadProcWrapDispatch[TArg], thrd)
   elif not defined(nogc) and not defined(gogc) and not defined(gcRegions) and not usesDestructors:
@@ -97,6 +106,8 @@ proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
     when declared(deallocOsPages): deallocOsPages()
   else:
     threadProcWrapDispatch(thrd)
+    when hasThreadLocalAllocator:
+      releaseThreadAllocator()
 
 template nimThreadProcWrapperBody*(closure: untyped): untyped =
   var thrd = cast[ptr Thread[TArg]](closure)

--- a/tests/threads/tthreadallocatorforeignpool.nim
+++ b/tests/threads/tthreadallocatorforeignpool.nim
@@ -1,0 +1,59 @@
+discard """
+  matrix: "--mm:arc --threads:on --tlsEmulation:off; --mm:orc --threads:on --tlsEmulation:off"
+  disabled: "windows"
+  output: "ok"
+  timeout: "30"
+"""
+
+import std/posix
+
+var
+  escaped: pointer
+  reused: pointer
+
+proc allocateOnForeignThread(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  escaped = allocShared(96)
+  cast[ptr int](escaped)[] = 73
+  tearDownForeignThreadGc()
+  result = nil
+
+proc reuseOnForeignThread(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  doAssert cast[ptr int](escaped)[] == 73
+  deallocShared(escaped)
+  reused = allocShared(96)
+  doAssert reused == escaped
+  deallocShared(reused)
+  tearDownForeignThreadGc()
+  result = nil
+
+proc consumeDeferredFree(_: pointer): pointer {.noconv.} =
+  setupForeignThreadGc()
+  let first = allocShared(96)
+  let second = allocShared(96)
+  # The first allocation advances the active chunk and collects its deferred
+  # foreign frees. The next allocation reuses the remotely returned cell.
+  doAssert second == escaped
+  deallocShared(first)
+  deallocShared(second)
+  tearDownForeignThreadGc()
+  result = nil
+
+proc run(worker: proc(_: pointer): pointer {.noconv.}) =
+  var thread: Pthread
+  doAssert pthread_create(addr thread, nil, worker, nil) == 0
+  doAssert pthread_join(thread, nil) == 0
+
+# setup/teardown is the checkout/return boundary. A distinct native thread can
+# safely inherit the allocator even while one of its allocations is still live.
+run(allocateOnForeignThread)
+run(reuseOnForeignThread)
+
+# A free that arrives while the allocator is idle is queued on its handle and
+# consumed after that allocator is handed to another foreign thread.
+run(allocateOnForeignThread)
+deallocShared(escaped)
+run(consumeDeferredFree)
+
+echo "ok"

--- a/tests/threads/tthreadallocatorhandoffrace.nim
+++ b/tests/threads/tthreadallocatorhandoffrace.nim
@@ -1,0 +1,64 @@
+discard """
+  matrix: "--mm:arc --threads:on; --mm:orc --threads:on"
+  output: "ok"
+  timeout: "30"
+"""
+
+import std/[atomics, typedthreads]
+
+const
+  pointerCount = 512
+  drainCount = 2048
+  iterations {.intdefine.} = 200
+  sizes = [16, 64, 4000, 4096, 8192]
+
+var
+  pointers: array[pointerCount, pointer]
+  mayExit: Atomic[bool]
+
+proc owner() {.thread.} =
+  for i in 0..<pointers.len:
+    let size = sizes[i mod sizes.len]
+    pointers[i] = allocShared(size)
+    cast[ptr byte](pointers[i])[] = byte(i)
+
+proc borrower() {.thread.} =
+  while not mayExit.load(moAcquire):
+    discard
+
+proc drain() {.thread.} =
+  var drained: array[drainCount, pointer]
+  for i in 0..<drained.len:
+    drained[i] = allocShared(sizes[i mod sizes.len])
+  for p in drained:
+    deallocShared(p)
+  let occupied = getOccupiedMem()
+  doAssert occupied == 0, "allocator retained " & $occupied & " bytes"
+
+for _ in 0..<iterations:
+  # The owner retires with live small and big allocations. The borrower checks
+  # out that region while this already-running main thread returns the cells.
+  # This races foreign queue publication against both directions of the
+  # MemRegion handoff without creating an unbounded number of regions.
+  block:
+    var thread: Thread[void]
+    createThread(thread, owner)
+    joinThread(thread)
+
+  mayExit.store(false, moRelaxed)
+  var borrowerThread: Thread[void]
+  createThread(borrowerThread, borrower)
+  for i, p in pointers:
+    if i == pointers.len div 2:
+      # Let the borrower tear the allocator down while the second half of the
+      # foreign publications are still in flight.
+      mayExit.store(true, moRelease)
+    deallocShared(p)
+  joinThread(borrowerThread)
+
+  block:
+    var thread: Thread[void]
+    createThread(thread, drain)
+    joinThread(thread)
+
+echo "ok"

--- a/tests/threads/tthreadallocatorpool.nim
+++ b/tests/threads/tthreadallocatorpool.nim
@@ -1,0 +1,92 @@
+discard """
+  matrix: "--mm:arc --threads:on; --mm:orc --threads:on"
+  output: "ok"
+  timeout: "30"
+"""
+
+import std/[atomics, typedthreads]
+
+const concurrentThreads = 4
+
+var
+  escaped: pointer
+  reused: pointer
+  bigEscaped: pointer
+  roundAddresses: array[2, array[concurrentThreads, pointer]]
+  ready: Atomic[int]
+  mayExit: Atomic[bool]
+
+proc allocateEscaped() {.thread.} =
+  escaped = allocShared(64)
+  cast[ptr int](escaped)[] = 42
+
+proc consumeAfterHandoff() {.thread.} =
+  doAssert cast[ptr int](escaped)[] == 42
+  deallocShared(escaped)
+  reused = allocShared(64)
+  doAssert reused == escaped
+  deallocShared(reused)
+
+# A live allocation can outlast its original thread. The next thread receives
+# the same allocator and its stable handle makes the deallocation local again.
+block:
+  var thread: Thread[void]
+  createThread(thread, allocateEscaped)
+  joinThread(thread)
+  createThread(thread, consumeAfterHandoff)
+  joinThread(thread)
+
+proc allocateBigEscaped() {.thread.} =
+  bigEscaped = allocShared(8192)
+  cast[ptr int](bigEscaped)[] = 91
+
+proc consumeBigAfterHandoff() {.thread.} =
+  doAssert cast[ptr int](bigEscaped)[] == 91
+  deallocShared(bigEscaped)
+  let p = allocShared(8192)
+  doAssert p == bigEscaped
+  deallocShared(p)
+
+# Big chunks use a separate deferred-free queue on the stable handle.
+block:
+  var thread: Thread[void]
+  createThread(thread, allocateBigEscaped)
+  joinThread(thread)
+  createThread(thread, consumeBigAfterHandoff)
+  joinThread(thread)
+
+proc allocateConcurrently(arg: tuple[round, index: int]) {.thread.} =
+  let p = allocShared(80)
+  roundAddresses[arg.round][arg.index] = p
+  deallocShared(p)
+  discard ready.fetchAdd(1, moRelease)
+  while not mayExit.load(moAcquire):
+    discard
+
+proc runConcurrentRound(round: int) =
+  var threads: array[concurrentThreads, Thread[tuple[round, index: int]]]
+  ready.store(0, moRelaxed)
+  mayExit.store(false, moRelaxed)
+  for i in 0..<threads.len:
+    createThread(threads[i], allocateConcurrently, (round, i))
+  while ready.load(moAcquire) != concurrentThreads:
+    discard
+  mayExit.store(true, moRelease)
+  for thread in threads.mitems:
+    joinThread(thread)
+
+# The first round establishes the peak number of simultaneous allocators. The
+# following rounds must reuse those regions instead of reserving one region per
+# new thread.
+runConcurrentRound(0)
+for _ in 0..<32:
+  runConcurrentRound(1)
+  for p in roundAddresses[1]:
+    var found = false
+    for old in roundAddresses[0]:
+      if p == old:
+        found = true
+        break
+    doAssert found
+
+echo "ok"

--- a/tests/threads/tthreadallocatorpoolrace.nim
+++ b/tests/threads/tthreadallocatorpoolrace.nim
@@ -1,0 +1,56 @@
+discard """
+  matrix: "--mm:arc --threads:on; --mm:orc --threads:on"
+  output: "ok"
+  timeout: "30"
+"""
+
+import std/[atomics, typedthreads]
+
+const
+  pointerCount = 1024
+  iterations = 100
+
+var
+  pointers: array[pointerCount, pointer]
+  drainPointers: array[pointerCount, pointer]
+  ready: Atomic[bool]
+  start: Atomic[bool]
+  remoteDone: Atomic[bool]
+
+proc owner() {.thread.} =
+  for i in 0..<pointers.len:
+    pointers[i] = allocShared(16 + (i mod 8) * 16)
+  ready.store(true, moRelease)
+  while not start.load(moAcquire):
+    discard
+
+  # Race allocator activity against remote frees. The owner can consume cells
+  # while the remote thread is still publishing entries to its handle.
+  while not remoteDone.load(moAcquire):
+    for i in 0..<8:
+      let p = allocShared(16 + i * 16)
+      deallocShared(p)
+
+  # Exhaust local free lists so all remaining remote lists are consumed before
+  # this allocator is returned to the pool.
+  for i in 0..<drainPointers.len:
+    drainPointers[i] = allocShared(16 + (i mod 8) * 16)
+  for p in drainPointers:
+    deallocShared(p)
+  doAssert getOccupiedMem() == 0
+
+for _ in 0..<iterations:
+  ready.store(false, moRelaxed)
+  start.store(false, moRelaxed)
+  remoteDone.store(false, moRelaxed)
+  var thread: Thread[void]
+  createThread(thread, owner)
+  while not ready.load(moAcquire):
+    discard
+  start.store(true, moRelease)
+  for p in pointers:
+    deallocShared(p)
+  remoteDone.store(true, moRelease)
+  joinThread(thread)
+
+echo "ok"


### PR DESCRIPTION
replace #26020 
replace #26035

As before, all clean (no leaks, no issues reported by ASan). We split `MemRegion` into two separate pieces, one that is primarily used as a stable access path (`RegionHandle`) and the local internal state (`MemRegion`).
Chunks now point to their corresponding foreign free queues instead of owners and owner identity is checked based on page alignment.

The unrelated `rawAllocAux` template is here because it erases the performance lost from hitting a cold page over and over in the single-cell-per-chunk case.

Additionally, we waste a bit of time and memory at thread creation because the region+handle is initialized at thread creation. Lazy initialization caused more widespread performance regressions. #26043 (virtual threads) would eat that cost and should still be up for consideration.

close #23361
close #20542
close #24988
close #26014