### PR TITLE
koch: build nifler/nifmake with --skipUserCfg --skipParentCfg

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -190,10 +190,16 @@ proc bundleChecksums(latest: bool) =
   let nimonyCommit = if latest: "HEAD" else: NimonyStableCommit
   cloneDependency(distDir, "https://github.com/nim-lang/nimony.git", nimonyCommit, allowBundled = true)
 
+  # These are host tools: their build must not be affected by whatever
+  # `nim.cfg`/`config.nims` happens to live above the Nim checkout. Projects that
+  # vendor Nim (nimbus-eth1/eth2, nimbos) do pass `--skipUserCfg --skipParentCfg`
+  # to `koch boot`, but `nimCompileFold` spawns a fresh `nim c` that would
+  # otherwise inherit the ambient configuration.
+  const nifOptions = "-d:release --noNimblePath --skipUserCfg --skipParentCfg"
   if not fileExists("bin/nifler".exe):
-    nimCompileFold("Compile nifler", "dist/nimony/src/nifler/nifler.nim", options = "-d:release")
+    nimCompileFold("Compile nifler", "dist/nimony/src/nifler/nifler.nim", options = nifOptions)
   if not fileExists("bin/nifmake".exe):
-    nimCompileFold("Compile nifmake", "dist/nimony/src/nifmake/nifmake.nim", options = "-d:release")
+    nimCompileFold("Compile nifmake", "dist/nimony/src/nifmake/nifmake.nim", options = nifOptions)
 
 proc bundleNimsuggest(args: string) =
   bundleChecksums(false)


### PR DESCRIPTION
`bundleChecksums` compiles the two NIF host tools through `nimCompileFold`, which spawns a fresh `nim c` with only the `options` string. Unlike the other `bundle*` procs it takes no `args`, so the `--skipUserCfg --skipParentCfg` that `koch boot` was invoked with never reached these two sub-builds.

For a Nim checked out inside another project (nimbus-eth1/eth2, nimbos vendor Nim under `vendor/nimbus-build-system/vendor/Nim`) Nim then walks the parent directories of `dist/nimony/src/nifler` and applies the host project's `config.nims` to the tool build: an injected `--import:libbacktrace`, plus `warningAsError[UnusedImport]`, `hintAsError[DuplicateModuleImport]` and `hintAsError[ConvFromXtoItselfNotNeeded]` all turn ordinary nimony code into hard errors and break `koch boot`.

Host tools must not be configurable by whatever directory Nim happens to sit under, so hardcode the skip flags (and `--noNimblePath`, matching the other bundlers) rather than threading `args` through all seven call sites.