### PR TITLE
Fix #26069: nested type tests in generic object when conditions

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -268,6 +268,17 @@ proc hasValuelessStatics(n: PNode): bool =
       if hasValuelessStatics(x):
         return true
 
+proc resetTypeTestPath(n: PNode): bool =
+  # `mIs` is resolved during semantic checking. Reset cached types along the
+  # path so nested type tests are checked again after generic substitution.
+  result = n.kind in nkCallKinds and n[0].kind == nkSym and
+    n[0].sym.magic == mIs
+  for i in ord(n.kind in nkCallKinds)..<n.safeLen:
+    result = resetTypeTestPath(n[i]) or result
+  if result:
+    n.typ = nil
+    n.flags.excl nfSem
+
 proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0; expectedType: PType = nil): PNode =
   if n == nil: return
   result = copyNode(n)
@@ -324,6 +335,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0; expectedType: PT
         checkSonsLen(it, 2, cl.c.config)
         var cond = prepareNode(cl, it[0])
         if not cond.hasValuelessStatics:
+          discard resetTypeTestPath(cond)
           var e = cl.c.semConstExpr(cl.c, cond)
           if e.kind != nkIntLit:
             internalError(cl.c.config, e.info, "ReplaceTypeVarsN: when condition not a bool")

--- a/tests/generics/t26069.nim
+++ b/tests/generics/t26069.nim
@@ -1,0 +1,16 @@
+block: # bug #26069
+  type
+    ConditionalField[T] = object
+      when not (T is object):
+        value: int
+      else:
+        value: string
+
+    Obj = object
+      value: int
+
+  var objectField: ConditionalField[Obj]
+  var nonObjectField: ConditionalField[int]
+
+  doAssert typeof(objectField.value) is string
+  doAssert typeof(nonObjectField.value) is int


### PR DESCRIPTION
Fixes #26069.

  Reset cached semantic state along paths to nested `is` expressions after generic type substitution, allowing regular `is` semantics to evaluate the concrete condition.

  Add regression coverage for both object and non-object instantiations