### PR TITLE
Fix globalSymbols support on POSIX

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -73,11 +73,18 @@ when defined(posix):
   #
 
   # c stuff:
-  when defined(linux) or defined(macosx):
-    const RTLD_NOW = cint(2)
+  when defined(linux):
+    const
+      RTLD_NOW = cint(2)
+      RTLD_GLOBAL = cint(0x100)
+  elif defined(macosx):
+    const
+      RTLD_NOW = cint(2)
+      RTLD_GLOBAL = cint(0x8)
   else:
     var
       RTLD_NOW {.importc: "RTLD_NOW", header: "<dlfcn.h>".}: cint
+      RTLD_GLOBAL {.importc: "RTLD_GLOBAL", header: "<dlfcn.h>".}: cint
 
   proc dlclose(lib: LibHandle) {.importc, header: "<dlfcn.h>".}
   proc dlopen(path: cstring, mode: cint): LibHandle {.


### PR DESCRIPTION
## Fix `globalSymbols` support on POSIX

### Summary

Fix `-d:globalSymbols` on POSIX platforms by defining `RTLD_GLOBAL` alongside `RTLD_NOW` in `system/dyncalls.nim`.

On Linux and macOS, `RTLD_NOW` is defined locally in `dyncalls.nim`, but `RTLD_GLOBAL` was not. As a result, enabling `-d:globalSymbols` could fail because `RTLD_GLOBAL` was undeclared.

This change:

* defines `RTLD_GLOBAL` as `0x100` on Linux,
* defines `RTLD_GLOBAL` as `0x8` on macOS,
* imports `RTLD_GLOBAL` from `<dlfcn.h>` on other POSIX platforms.

These values are consistent with the existing POSIX constants already used elsewhere in the Nim source tree.

### Motivation

`globalSymbols` is intended to load dynamic libraries with `RTLD_GLOBAL` so that their exported symbols are available to subsequently loaded shared libraries.

This is needed, for example, when a dynamically loaded library later loads a plugin or provider that depends on symbols from the first library.

Without this fix, `-d:globalSymbols` cannot be used reliably for that purpose on POSIX systems.

### Testing

Tested on Linux with an AArch64 target.

A program using dynamically loaded OpenSSL libraries and a subsequently loaded OpenSSL provider failed when the OpenSSL libraries were loaded with the default local symbol visibility.

Using `RTLD_GLOBAL` made the same program work correctly.

After this change, building the original Nim program with:

```text
-d:globalSymbols
```

successfully loads the OpenSSL libraries with global symbol visibility, and the provider-based TLS 1.2 and TLS 1.3 tests both pass.

The same behavior was also independently reproduced using direct `dlopen()` / `dlsym()` calls:

```text
RTLD_LOCAL   -> TLS 1.2 failed
RTLD_GLOBAL  -> TLS 1.2 passed
```
