### PR TITLE
fixes #26088; StringStream.write regression

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -1276,7 +1276,7 @@ else: # after 1.3 or JS not defined
         raise newException(Defect, "could not write to string stream, " &
           "did you use a non-string buffer pointer?", getCurrentException())
     elif not defined(nimscript):
-      copyMem(beginStore(s.data, s.pos + bufLen, s.pos), buffer, bufLen)
+      copyMem(beginStore(s.data, max(s.data.len, s.pos + bufLen), s.pos), buffer, bufLen)
       endStore(s.data)
     inc(s.pos, bufLen)
 

--- a/tests/js/tstreams.nim
+++ b/tests/js/tstreams.nim
@@ -20,3 +20,11 @@ doAssert s2.readAll == "abc"
 s2.write("def")
 doAssert s2.data == "abcdef"
 s2.close
+
+# bug #26088
+var s3 = newStringStream("0123456789ABCDEF")
+s3.setPosition(0)
+s3.write("XX")
+doAssert s3.data == "XX23456789ABCDEF"
+doAssert not s3.atEnd
+s3.close

--- a/tests/stdlib/tstreams.nim
+++ b/tests/stdlib/tstreams.nim
@@ -87,6 +87,20 @@ block:
   ss.setPosition(0)
   doAssert(ss.peekStr(5) == "hello")
 
+# bug #26088 - Overwriting a string stream must not truncate it
+block:
+  var short = newStringStream("0123456789ABCDEF")
+  short.setPosition(0)
+  short.write("XX")
+  doAssert short.data == "XX23456789ABCDEF"
+  doAssert not short.atEnd
+
+  var long = newStringStream("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+  long.setPosition(0)
+  long.write("XX")
+  doAssert long.data == "XX23456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  doAssert not long.atEnd
+
 # bug #19716
 static: # Ensure streams it doesnt break with nimscript on arc/orc #19716
   let s = newStringStream("a")


### PR DESCRIPTION
fixes #26088
 
in https://github.com/nim-lang/Nim/pull/25772, `beginStores` requires `newLen` to be passed for setting up the new length. So `streams.nim` must make the string length exactly newLen.
