### PR TITLE
tests(effects): pin `.forbids` behaviour on indirect calls

### DIFF
--- a/tests/effects/tforbids_indirect_call.nim
+++ b/tests/effects/tforbids_indirect_call.nim
@@ -1,0 +1,32 @@
+discard """
+  action: run
+  output: "callback ran"
+"""
+
+# Pins the current behaviour of `.forbids` on a proc *body* whose own body makes
+# an indirect call with unknown effects (refs #25978).
+#
+# The callee is widened to RootEffect by `assumeTheWorst`. A whitelist (`tags`)
+# rejects that, since RootEffect is not among the listed tags. A blacklist
+# (`forbids`) accepts it, because the check asks whether RootEffect is a subtype
+# of the forbidden effect, while it is an ancestor of it instead.
+#
+# Replacing `{.forbids: [MyEffect].}` below with `{.tags: [].}` is rejected at
+# compile time, so the two pragmas disagree on identical input. This test only
+# records the current state; it takes no position on which side is correct.
+#
+# Unrelated to the diagnostic wording covered by #26005: here no message is
+# produced at all.
+#
+# If the behaviour is changed deliberately, this test is expected to fail and
+# should be updated to the new expectation.
+
+type MyEffect = object of RootEffect
+
+proc viaCallback(p: proc(i: int)) {.forbids: [MyEffect].} =
+  p(1)
+
+proc hasEffect(i: int) {.tags: [MyEffect].} =
+  echo "callback ran"
+
+viaCallback(hasEffect)


### PR DESCRIPTION
While looking at #25978 I ran into a case that currently has no test coverage, and this
adds one for it.

`.forbids` on a proc body does not reject an indirect call whose effects are unknown. The
callee is widened to `RootEffect` by `assumeTheWorst`, and `checkRaisesSpec` then asks
whether that is a *subtype* of the forbidden effect — but `RootEffect` is an ancestor of
it, so the test never fires. The same code with `{.tags: [].}` in place of
`{.forbids: [MyEffect].}` is rejected at compile time, so the whitelist and the blacklist
disagree on identical input.

The test records the current behaviour and takes no position on which side is correct. If
the behaviour is ever changed deliberately, it fails and gets updated to the new
expectation; until then it keeps the case from drifting unnoticed.

This is separate from #26005, which improves the diagnostic for an already detected
violation. Here no diagnostic is produced at all, so the two do not overlap — this touches
only `tests/`, no compiler code.

Verified with `testament --nim:<clean devel build>`: the new test passes, and the whole
`effects` category is 50/50 with it added. I also confirmed it is sensitive rather than
vacuous by running it against a locally patched compiler that makes the blacklist check
symmetric — there it fails, as intended.

refs #25978

Disclosure: I work with an AI assistant (Claude Code, Anthropic). It wrote the test file
and ran the compiler builds and testament runs under my direction; I reviewed the reasoning
about `assumeTheWorst` against `sempass2.nim` and checked the results before opening this.
