### PR TITLE
fixes #26049; don't track effects from `when nimvm` branches at run time

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -332,12 +332,20 @@ proc warnAboutGcUnsafe(n: PNode; conf: ConfigRef) =
   #assert false
   message(conf, n.info, warnGcUnsafe, renderTree(n))
 
+proc skipVmOnlyEffect(a: PEffects): bool {.inline.} =
+  ## Effects raised inside a `when nimvm` branch do not exist in the code that
+  ## is actually generated, so they must not be attributed to the routine.
+  ## Under `nim e` that branch *is* the code being run, so it still counts.
+  a.inNimvmBranch > 0 and a.config.cmd != cmdNimscript
+
 proc markGcUnsafe(a: PEffects; reason: PSym) =
+  if skipVmOnlyEffect(a): return
   if not a.inEnforcedGcSafe:
     a.gcUnsafe = true
     if a.owner.kind in routineKinds: a.owner.gcUnsafetyReason = reason
 
 proc markGcUnsafe(a: PEffects; reason: PNode) =
+  if skipVmOnlyEffect(a): return
   if not a.inEnforcedGcSafe:
     a.gcUnsafe = true
     if a.owner.kind in routineKinds:
@@ -511,6 +519,7 @@ proc createTag(g: ModuleGraph; n: PNode): PNode =
 
 proc addRaiseEffect(a: PEffects, e, comesFrom: PNode) =
   #assert e.kind != nkRaiseStmt
+  if skipVmOnlyEffect(a): return
   var aa = a.exc
   for i in a.bottom..<aa.len:
     # we only track the first node that can have the effect E in order
@@ -551,6 +560,7 @@ proc addRaiseEffectsFromExpr(a: PEffects, e, comesFrom: PNode) =
     addRaiseEffect(a, e, comesFrom)
 
 proc addTag(a: PEffects, e, comesFrom: PNode) =
+  if skipVmOnlyEffect(a): return
   var aa = a.tags
   for i in 0..<aa.len:
     # we only track the first node that can have the effect E in order

--- a/tests/effects/tnimvm_branch_effects.nim
+++ b/tests/effects/tnimvm_branch_effects.nim
@@ -1,0 +1,36 @@
+discard """
+  action: run
+  output: "ok"
+"""
+
+# Effects raised inside a `when nimvm` branch must not be attributed to the
+# routine when compiling for run time: that branch is not part of the generated
+# code. refs #26049
+
+var global: string
+
+proc gcSafety(): string {.gcsafe.} =
+  when nimvm:
+    result = global
+  else:
+    result = "ok"
+
+type VmEffect = object of RootEffect
+
+proc vmOnly() {.tags: [VmEffect].} = discard
+
+proc tagsTracking() {.tags: [].} =
+  when nimvm:
+    vmOnly()
+  else:
+    discard
+
+proc raisesTracking() {.raises: [].} =
+  when nimvm:
+    raise newException(ValueError, "vm only")
+  else:
+    discard
+
+tagsTracking()
+raisesTracking()
+echo gcSafety()


### PR DESCRIPTION
A `when nimvm` branch only runs in the VM, but the effect tracker attributed its
effects to the surrounding routine unconditionally. The example from the issue is
rejected even though the generated code never touches the global:

```nim
var b: string
proc p(): string {.gcsafe.} =
  when nimvm:
    doAssert false
    result = b
discard p()
```

The same leak affects `raises` and `tags`, not just GC safety — a `when nimvm`
branch that raises, or that calls a tagged proc, is enough to reject a
`{.raises: [].}` or `{.tags: [].}` routine.

`inNimvmBranch` already recorded when the walker is inside such a branch; it just
was not consulted where an effect is attributed. This skips attribution in
`markGcUnsafe`, `addRaiseEffect` and `addTag` while inside the branch — except
under `nim e`, where the `nimvm` branch *is* the code being run.

The added test covers all three effect kinds. Checks outside the branch are
unaffected: I verified that the plain cases (global access, unlisted raise,
unlisted tag) are still rejected, and specifically that the `else` branch of the
same `when nimvm` is still checked, since that is the code that actually runs.

Test runs on this branch: `effects` 51/51, `exception` 47/47, `whenstmt` 6/6, plus
`vm`, `gc`, `stdlib`, `arc`, `destructor` and `async` clean against a pre-change
build of the same commit. The handful of failures I do see (`std/re`/`nre`/`regex`,
`ssl`, `tempfiles`, `tjoinable`) reproduce identically without this change on my
machine — the regex ones are #26070, this box has libpcre2 but no libpcre1.

One judgement call worth flagging rather than burying: this treats VM-only effects
as not applying to *any* ordinary compilation, including when the routine is also
called at compile time via `static`/`const`, where the branch really does execute.
That seems right to me — GC safety is about threads, which the VM does not have,
and the VM catches exceptions itself — but it is a design decision for the project,
so please say if you would rather scope it more narrowly (e.g. only when the routine
is not used at compile time).

fixes #26049

Disclosure: I work with an AI assistant (Claude Code, Anthropic). It wrote the patch
and the test and ran the builds and testament runs under my direction; I reviewed the
mechanism against `sempass2.nim` and checked the negative cases before opening this.
