### PR TITLE
fixes #26104; prevent compile-time-only `typeof` from being treated a…

### DIFF
--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -25,6 +25,11 @@ type
     pfStructural    ## use structural prefix-chain detection and tree-walk
     pfBidirectional ## also check reverse direction per field in nkObjConstr
 
+proc isCompileTimeOnlyNode(n: PNode): bool {.inline.} =
+  ## `typeof` and typedesc/static values describe types at compile time; they
+  ## do not read the runtime location that alias analysis is protecting.
+  n.kind == nkTypeOfExpr or (n.typ != nil and n.typ.containsCompileTimeOnly)
+
 func sameLocation(a, b: PNode): bool =
   template sameConstIndex(a, b: PNode): bool =
     a.kind in nkLiterals and b.kind in nkLiterals and a.intVal == b.intVal
@@ -157,6 +162,9 @@ proc isPartOf*(a, b: PNode; flags: set[PartFlag] = {}): TAnalysisResult =
   ##
   ##  x[]  ?<| y  depending on type
   ##  ```
+  if a.isCompileTimeOnlyNode or b.isCompileTimeOnlyNode:
+    return arNo
+
   if a.kind == b.kind:
     case a.kind
     of nkSym:
@@ -271,6 +279,11 @@ proc isPartOf*(a, b: PNode; flags: set[PartFlag] = {}): TAnalysisResult =
     of nkCallKinds:
       result = arNo
       for i in 1..<b.len:
+        # A call such as `fill(typeof(result.f))` has a compile-time-only
+        # argument. It must not make the object constructor look aliased with
+        # `result.f`; runtime arguments remain subject to the normal analysis.
+        if b[i].isCompileTimeOnlyNode:
+          continue
         let res = isPartOf(a, b[i], flags)
         if res != arNo:
           result = res

--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -28,7 +28,7 @@ type
 proc isCompileTimeOnlyNode(n: PNode): bool {.inline.} =
   ## `typeof` and typedesc/static values describe types at compile time; they
   ## do not read the runtime location that alias analysis is protecting.
-  n.kind == nkTypeOfExpr or (n.typ != nil and n.typ.containsCompileTimeOnly)
+  n.kind == nkTypeOfExpr or (n.typ != nil and n.typ.isCompileTimeOnly)
 
 func sameLocation(a, b: PNode): bool =
   template sameConstIndex(a, b: PNode): bool =

--- a/tests/ccgbugs/t26104.nim
+++ b/tests/ccgbugs/t26104.nim
@@ -1,0 +1,16 @@
+discard """
+  action: compile
+  ccodeCheck: "@'f_.*((*Result).f)' .*"
+"""
+
+# bug #26104: a compile-time-only `typeof` argument was treated as a runtime
+# alias of the result field, forcing an unnecessarily large temporary and copy.
+type
+  B = array[131072, byte]
+  Y = object
+    f: B
+
+proc fill(_: type B): B = discard
+proc make(): Y = result.f = fill(typeof(result.f))
+
+discard make()

--- a/tests/ccgbugs/t26104.nim
+++ b/tests/ccgbugs/t26104.nim
@@ -1,6 +1,6 @@
 discard """
   action: compile
-  ccodeCheck: "@'f_.*((*Result).f)' .*"
+  ccodeCheck: "@'((*Result).f);' .*"
 """
 
 # bug #26104: a compile-time-only `typeof` argument was treated as a runtime


### PR DESCRIPTION
…s a runtime alias

fixes #26104

Follows up https://github.com/nim-lang/Nim/pull/25994