### PR TITLE
deprecate hotCodeReloading

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -843,6 +843,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "hotcodereloading":
     processOnOffSwitchG(conf, {optHotCodeReloading}, arg, pass, info)
     if conf.hcrOn:
+      warningDeprecated(conf, info, "hotCodeReloading is deprecated, see https://github.com/nim-lang/RFCs/issues/573 for further information")
       defineSymbol(conf.symbols, "hotcodereloading")
       defineSymbol(conf.symbols, "useNimRtl")
       # hardcoded linking with dynamic runtime for MSVC for smaller binaries


### PR DESCRIPTION
See https://github.com/nim-lang/RFCs/issues/573 - deprecating for visibility in 2.4, in case a maintainer wants to step up - else it can be binned for 2.6