### PR TITLE
fix SIGSEGV on refc: genGenericAsgn must deep-copy from static data

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -251,7 +251,7 @@ proc genGenericAsgn(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
   # (for objects, etc.):
   if optSeqDestructors in p.config.globalOptions:
     simpleAsgn(p.s(cpsStmts), dest, src)
-  elif needToCopy notin flags or
+  elif (needToCopy notin flags and src.storage != OnStatic) or
       tfShallow in skipTypes(dest.t, abstractVarRange).flags:
     if (dest.storage == OnStack and p.config.selectedGC != gcGo) or not usesWriteBarrier(p.config):
       let rad = addrLoc(p.config, dest)

--- a/tests/async/tawait_in_array_literal_loop.nim
+++ b/tests/async/tawait_in_array_literal_loop.nim
@@ -1,0 +1,28 @@
+discard """
+  matrix: "--mm:refc; --mm:orc"
+  output: "ok"
+"""
+
+# the loop temp lifted into the env must be deep-copied: a shallow assign from the static const array made refc incRef string literals in static memory
+
+import std/asyncdispatch
+
+const ips = ["::1", "2001:db8::", "::"]
+
+proc overLiteral(): Future[int] {.async.} =
+  var n = 0
+  for ip in ["::1", "2001:db8::", "::"]:
+    await sleepAsync(1)
+    n += ip.len
+  return n
+
+proc overConst(): Future[int] {.async.} =
+  var n = 0
+  for ip in ips:
+    await sleepAsync(1)
+    n += ip.len
+  return n
+
+doAssert waitFor(overLiteral()) == 15
+doAssert waitFor(overConst()) == 15
+echo "ok"


### PR DESCRIPTION
There is no upstream issue for this yet. The crash showed up in the nim-libp2p daily CI against Nim devel (vacp2p/nim-libp2p#2959).

`await` (or any suspend point) inside a `for` over an array literal of strings crashes with SIGSEGV under `--mm:refc`:

```nim
import std/asyncdispatch

proc f() {.async.} =
  for ip in ["::1", "2001:db8::", "::"]:
    await sleepAsync(1)

waitFor f()
```

```
lib/system/assign.nim(151) genericShallowAssign
lib/system/assign.nim(140) genericAssignAux
lib/system/assign.nim(78)  genericAssignAux
lib/system/gc.nim(301)     unsureAsgnRef
lib/system/gc.nim(234)     incRef
SIGSEGV: Illegal storage access.
```

Regression from #25860, verified by builds of the compiler at that commit and at its parent. Since #25860, `items(arrayLiteral)` materializes the literal into a temp so a `lent` result keeps valid backing storage. In an async proc that temp is lifted into the closure env, and the codegen emits `genericShallowAssign(env.tmp, <static const array>, ...)`. The shallow assign of each `tyString` element calls `unsureAsgnRef`, which calls `incRef` on a string literal. A literal has no GC cell header, so `incRef` writes into static memory and crashes. A named const (`const a = [...]`) as the loop expression triggers the same crash.

`genGenericAsgn` took the shallow path whenever `needToCopy` was absent, without a check of the source storage. The other assignment helpers in `ccgexprs.nim` (`genOptAsgnTuple`, `genOptAsgnObject`, the `tySequence` and `tyString` branches of `genAssignment`) already force a deep copy when `src.storage == OnStatic`. This PR applies the same check in `genGenericAsgn`, so the assignment falls through to `genericAssign`, which copies each string element properly.

Tested locally: the new test fails on devel and passes with the fix under refc and orc; the `gc`, `iter`, `array`, `assign`, `closure`, `refc` and `async` categories pass.
