### PR TITLE
Limit use of `long` checked integer ops to arm-none-eabi

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -17,6 +17,7 @@ __AVR__
 __arm__
 __riscv
 __EMSCRIPTEN__
+__unix__
 */
 
 
@@ -597,7 +598,7 @@ NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, "P
   #define nimMulInt64(a, b, res) __builtin_smulll_overflow(a, b, (long long int*)res)
 
   #if NIM_INTBITS == 32
-    #if (defined(__arm__) || defined(__riscv)) && defined(__GNUC__)
+    #if ((defined(__arm__) && !defined(__unix__)) || defined(__riscv)) && defined(__GNUC__)
       /* arm-none-eabi-gcc and riscv32-unknown-elf-gcc targets define int32_t as long int */
       #define nimAddInt(a, b, res) __builtin_saddl_overflow(a, b, res)
       #define nimSubInt(a, b, res) __builtin_ssubl_overflow(a, b, res)


### PR DESCRIPTION
#23835 tried to do this, but it also switched to `long int` on the GNU ABI, where it's actually just `int`.

Fixes #26111