### PR TITLE
fixes #26123; Update PathKinds1 to include nkCast

### DIFF
--- a/compiler/aliasanalysis.nim
+++ b/compiler/aliasanalysis.nim
@@ -8,7 +8,7 @@ const
                  nkBracketExpr, nkDerefExpr, nkHiddenDeref,
                  nkAddr, nkHiddenAddr,
                  nkObjDownConv, nkObjUpConv}
-  PathKinds1* = {nkHiddenStdConv, nkHiddenSubConv}
+  PathKinds1* = {nkHiddenStdConv, nkHiddenSubConv, nkCast}
 
 proc skipConvDfa*(n: PNode): PNode =
   result = n
@@ -125,4 +125,3 @@ proc aliases*(obj, field: PNode): AliasKind =
       else:
         result = maybe
     else: assert false # unreachable
-

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -454,7 +454,7 @@ proc gen(c: var Con; n: PNode) =
   of nkPragmaBlock: gen(c, n.lastSon)
   of nkDiscardStmt, nkObjDownConv, nkObjUpConv, nkStringToCString, nkCStringToString:
     gen(c, n[0])
-  of nkConv, nkExprColonExpr, nkExprEqExpr, nkCast, PathKinds1:
+  of nkConv, nkExprColonExpr, nkExprEqExpr, PathKinds1:
     gen(c, n[1])
   of nkVarSection, nkLetSection: genVarSection(c, n)
   of nkDefer: raiseAssert "dfa construction pass requires the elimination of 'defer'"

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1931,7 +1931,7 @@ proc borrowCheck(c: PContext, n, le, ri: PNode) =
     PathKinds0 = {nkDotExpr, nkCheckedFieldExpr,
                   nkBracketExpr, nkAddr, nkHiddenAddr,
                   nkObjDownConv, nkObjUpConv}
-    PathKinds1 = {nkHiddenStdConv, nkHiddenSubConv}
+    PathKinds1 = {nkHiddenStdConv, nkHiddenSubConv, nkCast}
 
   proc getRoot(n: PNode; followDeref: bool): PNode =
     result = n

--- a/tests/destructor/t26123.nim
+++ b/tests/destructor/t26123.nim
@@ -1,0 +1,28 @@
+discard """
+  matrix: "--mm:orc"
+  output: "destroy b"
+"""
+
+# bug #26123
+
+type
+  A = ptr AObj
+
+  AObj = object
+    b: B
+
+  B = distinct ptr BObj
+
+  BObj = object
+    a: A
+
+proc `=destroy`(r: var B) =
+  echo "destroy b"
+
+proc main() =
+  var a = create(AObj)
+  var b = B(create(BObj))
+  a.b = b
+  cast[ptr BObj](b).a = a
+
+main()


### PR DESCRIPTION
fixes #26123

`cast[T](x)` is a transparent path expression for compiler analysis. Previously, move/alias analysis could fail to see a later use through a cast and incorrectly mark the source as moved, causing the issue’s segmentation fault.


for views, https://nim-lang.org/docs/manual_experimental.html#view-types-path-expressions: A cast expression cast[T](e) is a path expression.

It also affects skipConvDfa, isAnalysableFieldAccess, and aliases. And I might narrow it down for the two cases above mentioned if it causes problems

