### PR TITLE
fixes #26124; internal error: expr: param not init with nested generic procs

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -129,7 +129,12 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
           result.typ = nil
     onUse(n.info, s)
   of skParam:
-    if s.owner == c.p.owner:
+    if s.typ != nil and s.typ.kind == tyStatic and s.typ.n != nil:
+      # The enclosing routine gives this static parameter a concrete value.
+      # Keep that value so the nested generic can fold it as a compile-time
+      # expression instead of generating a runtime parameter reference.
+      result = s.typ.n
+    elif s.owner == c.p.owner:
       # Parameters of the routine currently being semchecked stay as local
       # identifiers
       result = n
@@ -681,4 +686,3 @@ proc semConceptBody(c: PContext, n: PNode): PNode =
   )
   result = semGenericStmt(c, n, {withinConcept}, ctx)
   semIdeForTemplateOrGeneric(c, result, ctx.cursorInBody)
-

--- a/tests/generics/t26124.nim
+++ b/tests/generics/t26124.nim
@@ -1,0 +1,7 @@
+proc u(k: static int) =
+  proc r(_: static int) =
+    while k > 0:
+      discard
+  r(0)
+
+u(0)


### PR DESCRIPTION
fixes #26124

The fix preserves the resolved static value, allowing constant folding.