### PR TITLE
fixes #26134; del(seq) performs self-assignment and =destroy for del(…

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1254,7 +1254,9 @@ proc del*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
     a.del(2)
     assert a == @[10, 11, 14, 13]
   let xl = x.len - 1
-  movingCopy(x[i], x[xl])
+  # Avoid moving the element onto itself when deleting the last item.
+  if i != xl:
+    movingCopy(x[i], x[xl])
   setLen(x, xl)
 
 proc insert*[T](x: var seq[T], item: sink T, i = 0.Natural) {.noSideEffect.} =

--- a/tests/stdlib/t26134.nim
+++ b/tests/stdlib/t26134.nim
@@ -1,0 +1,24 @@
+discard """
+  matrix: "--mm:orc --undef:nimPreviewNonVarDestructor"
+  output: "hello"
+"""
+
+# bug #26134
+
+type MyObject = object
+
+proc `=destroy`(v: var MyObject) =
+  echo "hello"
+
+proc remove(v: var seq[MyObject]) =
+  v.del(0)
+
+proc aaa(v: var seq[MyObject], i: sink MyObject) =
+  v.add(i)
+
+proc main =
+  var v: seq[MyObject]
+  v.aaa(MyObject())
+  v.remove()
+
+main()


### PR DESCRIPTION
…0) of 1-length seq


fixes #26134