### PR TITLE
fixes #26118; hoist nimPrepareStrMutationV2 out of loops

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1337,12 +1337,18 @@ proc genSeqElem(p: BProc, n, x, y: PNode, d: var TLoc) =
       putIntoDest(p, d, n,
         cCall(cgsymValue(p.module, "nimStrAtV3"), bra, rcb), a.storage)
   else:
+    let cached = if ty.kind == tyString: preparedStrPayload(p, x) else: ""
     if lfPrepareForMutation in d.flags and ty.kind == tyString and
-        optSeqDestructors in p.config.globalOptions:
+        optSeqDestructors in p.config.globalOptions and cached.len == 0:
       let bra = byRefLoc(p, a)
       p.s(cpsStmts).addCallStmt(cgsymValue(p.module, "nimPrepareStrMutationV2"), bra)
     let ra = rdLoc(a)
-    putIntoDest(p, d, n, subscript(dataField(p, ra), rcb), a.storage)
+    if cached.len > 0:
+      # `s.p` is loop-invariant here, and reading it through a local pointer is
+      # what lets the C compiler disambiguate the stores and vectorize (#26118)
+      putIntoDest(p, d, n, subscript(derefField(cached, "data"), rcb), a.storage)
+    else:
+      putIntoDest(p, d, n, subscript(dataField(p, ra), rcb), a.storage)
 
 proc genBracketExpr(p: BProc; n: PNode; d: var TLoc) =
   var ty = skipTypes(n.firstSon.typ, abstractVarRange + tyUserTypeClasses)

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -692,6 +692,88 @@ proc genComputedGoto(p: BProc; n: PNode) =
     genStmts(p, it)
 
 
+proc localStrBase(n: PNode): PSym =
+  ## The `s` of `s[i]`, if `s` is a plain local `string` variable.
+  result = nil
+  if n.kind == nkBracketExpr and n.len == 2 and n.firstSon.kind == nkSym:
+    let s = n.firstSon.sym
+    if s.kind in {skVar, skLet, skResult, skTemp, skForVar} and
+        sfGlobal notin s.flags and s.typ != nil and
+        s.typ.skipTypes(abstractInst).kind == tyString:
+      result = s
+
+proc scanStrMutations(n: PNode; mutated, disabled: var seq[PSym]) =
+  ## Collects the local strings that a loop mutates as `s[i] = v` and disables
+  ## every local string that turns up in *any* other position. Only when `s`
+  ## occurs exclusively as `s[...]` is it impossible for the loop to put a
+  ## string literal back into `s`, which is what makes hoisting the
+  ## `nimPrepareStrMutationV2` call out of the loop sound: whole assignments,
+  ## `addr s` and `var`/`sink` arguments all show up as a bare `nkSym` here.
+  if n == nil: return
+  if n.kind == nkSym:
+    if n.sym notin disabled: disabled.add n.sym
+    return
+  if n.safeLen == 0: return
+  case n.kind
+  of nkAsgn, nkFastAsgn, nkSinkAsgn:
+    let le = n.firstSon
+    let s = localStrBase(le)
+    if s != nil:
+      if s notin mutated: mutated.add s
+      scanStrMutations(le.secondSon, mutated, disabled)
+    else:
+      scanStrMutations(le, mutated, disabled)
+    scanStrMutations(n.secondSon, mutated, disabled)
+  of nkBracketExpr:
+    # a read of `s[i]` neither mutates nor disables `s`
+    if localStrBase(n) != nil:
+      scanStrMutations(n.secondSon, mutated, disabled)
+    else:
+      for it in n: scanStrMutations(it, mutated, disabled)
+  else:
+    for it in n: scanStrMutations(it, mutated, disabled)
+
+proc hoistStrPrepare(p: BProc; t: PNode): int =
+  ## Emits `nimPrepareStrMutationV2` in front of a `while` loop for every local
+  ## string the loop only ever touches as `s[i]`, and records it in
+  ## `p.preparedStrs` so that the per-element calls inside the body are dropped.
+  ## The call is a plain (non-vectorizable) call that GCC cannot hoist itself --
+  ## it writes `s.p`, so no `pure`/`const` attribute can describe it -- and one
+  ## such call in the body is enough to stop the loop from being vectorized.
+  ## See https://github.com/nim-lang/Nim/issues/26118.
+  result = 0
+  if optSeqDestructors notin p.config.globalOptions: return
+  if p.config.usesSso(): return
+  if p.prc == nil: return
+  # a closure iterator's loop can span a `yield`; the cached payload is a plain
+  # C local and would not survive the suspension
+  if p.prc.kind == skIterator and p.prc.typ != nil and
+      p.prc.typ.callConv == ccClosure: return
+  var mutated: seq[PSym] = @[]
+  var disabled: seq[PSym] = @[]
+  # the loop condition is re-evaluated on every iteration, so it counts too
+  scanStrMutations(t.firstSon, mutated, disabled)
+  scanStrMutations(t.secondSon, mutated, disabled)
+  for s in mutated:
+    if s in disabled or preparedStrPayload(p, newSymNode(s)).len > 0: continue
+    # the variable has to be one of *this* C function's locals and already
+    # materialized, otherwise there is nothing to prepare in front of the loop
+    if s.owner != p.prc or s.loc.k == locNone: continue
+    var a = initLocExpr(p, newSymNode(s))
+    p.s(cpsStmts).addCallStmt(cgsymValue(p.module, "nimPrepareStrMutationV2"),
+      byRefLoc(p, a))
+    # cache `s.p` for the whole loop: the stores go through `&s`, which escaped
+    # into the call above, so without this the C compiler has to reload the
+    # payload pointer on every iteration and gives up on vectorizing
+    cgsym(p.module, "NimStrPayload")
+    inc(p.labels)
+    let payload = "T" & rope(p.labels) & "_"
+    p.s(cpsLocals).addVar(kind = Local, name = payload,
+                          typ = ptrType("NimStrPayload"))
+    p.s(cpsStmts).addAssignment(payload, dataFieldAccessor(p, rdLoc(a)))
+    p.preparedStrs.add (s, payload)
+    inc result
+
 proc genWhileStmt(p: BProc, t: PNode) =
   # we don't generate labels here as for example GCC would produce
   # significantly worse code
@@ -710,6 +792,7 @@ proc genWhileStmt(p: BProc, t: PNode) =
         loopBody = loopBody.secondSon
       genComputedGoto(p, loopBody)
     else:
+      let hoisted = hoistStrPrepare(p, t)
       var stmt: WhileBuilder
       p.breakIdx = startBlockWith(p):
         stmt = initWhileStmt(p.s(cpsStmts), cIntValue(1))
@@ -728,6 +811,7 @@ proc genWhileStmt(p: BProc, t: PNode) =
         p.s(cpsStmts).addCallStmt(cgsymValue(p.module, "nimProfile"))
       endBlockWith(p):
         finishWhileStmt(p.s(cpsStmts), stmt)
+      p.preparedStrs.setLen(p.preparedStrs.len - hoisted)
 
   dec(p.withinLoop)
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -642,6 +642,15 @@ proc byRefLoc(p: BProc; a: TLoc): Rope =
   else:
     result = a.snippet
 
+proc preparedStrPayload(p: BProc; x: PNode): Rope =
+  ## The C temporary caching `x.p` if `x` is a local string that a hoisted
+  ## `nimPrepareStrMutationV2` in front of an enclosing loop already prepared;
+  ## "" otherwise. See `hoistStrPrepare`.
+  result = ""
+  if x.kind == nkSym:
+    for it in p.preparedStrs:
+      if it.s == x.sym: return it.payload
+
 proc rdCharLoc(a: TLoc): Rope =
   # read a location that may need a char-cast:
   result = rdLoc(a)

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -101,6 +101,13 @@ type
     withinBlockLeaveActions*: int # complex to explain
     sigConflicts*: CountTable[string]
     inUncheckedAssignSection*: int
+    preparedStrs*: seq[tuple[s: PSym, payload: Rope]]
+                              # local strings whose payload a hoisted
+                              # `nimPrepareStrMutationV2` in front of an
+                              # enclosing loop already made unique; `payload`
+                              # is the C temporary caching `s.p` for the whole
+                              # loop, so the body neither repeats the call nor
+                              # reloads the pointer
 
   TTypeSeq* = seq[PType]
   TypeCache* = Table[SigHash, Rope]

--- a/tests/ccgbugs/thoist_str_mutation.nim
+++ b/tests/ccgbugs/thoist_str_mutation.nim
@@ -1,0 +1,114 @@
+discard """
+  matrix: "--mm:orc; --mm:orc -d:release; --mm:refc; --mm:arc -d:release"
+  output: '''xxxx
+ABCD
+zzzz
+abxx
+LMxx
+abxx
+abcdef
+abcd
+394
+bbbb
+wxxx
+qqqq'''
+"""
+
+# The `nimPrepareStrMutationV2` call that guards `s[i] = v` is hoisted in front
+# of a loop when the loop only ever touches `s` as `s[...]`, so that the loop
+# body contains no call and the C compiler can vectorize it (#26118).
+# Everything below checks that the hoist does not fire when something in the
+# loop -- or in the loop condition -- can put a string literal back into `s`.
+
+proc setLit(s: var string) = s = "LMNO"
+
+proc plain(): string =
+  result = newString(4)
+  for i in 0..3: result[i] = 'x'
+
+proc fromLiteral(): string =
+  var s = "abcd"                  # literal payload: has to be copied once
+  for i in 0..3: s[i] = char(ord('A') + i)
+  result = s
+
+proc lenInBound(): string =
+  var s = "abcd"
+  for i in 0 ..< s.len: s[i] = 'z'
+  result = s
+
+proc reassignedInLoop(): string =
+  var s = newString(4)
+  for i in 0..3:
+    s[i] = 'x'
+    if i == 1: s = "abcd"         # whole assignment inside the loop
+  result = s
+
+proc varArgInLoop(): string =
+  var s = newString(4)
+  for i in 0..3:
+    s[i] = 'x'
+    if i == 1: setLit(s)          # `var` argument inside the loop
+  result = s
+
+proc addrInLoop(): string =
+  var s = newString(4)
+  for i in 0..3:
+    s[i] = 'x'
+    if i == 1:
+      let p = addr s
+      p[] = "abcd"
+  result = s
+
+proc nested(): string =
+  result = newString(6)
+  for i in 0..1:
+    for j in 0..2:
+      result[i*3 + j] = char(ord('a') + i*3 + j)
+
+proc zeroTrip(): string =
+  var s = "abcd"
+  for i in 0 ..< 0: s[i] = 'q'    # never runs; must not corrupt the literal
+  result = s
+
+proc readOnlyLiteral(): int =
+  let s = "abcd"
+  for i in 0..3: result += ord(s[i])   # only read: must not copy
+
+proc mixedReadWrite(): string =
+  var s = newString(4)
+  for i in 0..3:
+    s[i] = 'a'
+    if s[i] == 'a': s[i] = 'b'
+  result = s
+
+proc whileCondTouches(): string =
+  var s = newString(4)
+  var i = 0
+  while (if i == 2: (s = "wxyz"; true) else: i < 4):
+    s[i] = 'x'
+    inc i
+    if i >= 4: break
+  result = s
+
+iterator viaClosure(): char {.closure.} =
+  var s = "abcd"
+  for i in 0..3:
+    s[i] = 'q'
+    yield s[i]
+
+proc closureIter(): string =
+  result = ""
+  for c in viaClosure(): result.add c
+
+echo plain()
+echo fromLiteral()
+echo lenInBound()
+echo reassignedInLoop()
+echo varArgInLoop()
+echo addrInLoop()
+echo nested()
+echo zeroTrip()
+echo readOnlyLiteral()
+echo mixedReadWrite()
+echo whileCondTouches()
+echo closureIter()


### PR DESCRIPTION
`s[i] = v` emits a `nimPrepareStrMutationV2(&s)` call in front of every single element store. One call in the loop body is enough to stop GCC from vectorizing it, which is why the reporter's `toHex` runs at 0.45 GB/s while the same loop written against a `var openArray[char]` runs at 6.28 GB/s.

A `pure`/`const` attribute on the runtime proc cannot help here. GCC ignores both on a function returning `void` (`-Wattributes`: "'pure' attribute on function returning 'void'"), and even with a return value the semantics are exactly inverted: the one thing the function does when it fires is store a new payload into `s.p`, and `pure` promises GCC that no such store happens. It would be free to keep a stale `s.p` in a register across the call.

So do the hoisting in the code generator instead. In front of a `while` loop, collect the local strings that the loop mutates as `s[i] = v` and that occur *only* as `s[...]` anywhere in the loop -- condition included. For those, nothing in the loop can put a literal back into `s`: whole assignments, `addr s` and `var`/`sink` arguments all show up as a bare `nkSym` and disable the candidate, and a captured or lifted variable is not an `nkSym` at all. The call is then emitted once before the loop and dropped from the body.

That alone is not enough. `&s` escaped into the hoisted call, so the C compiler must assume `s.p->data[i] = ...` may clobber `s.p` itself and reloads the pointer every iteration. Cache `s.p` in a C local for the duration of the loop under the same precondition and index through that; only then does the loop vectorize. On the reporter's benchmark: 0.97 -> 14.17 GB/s, matching the hand-split `toHex2` at 14.30 GB/s.

Restricted to `optSeqDestructors` (refc has no COW literals), to the non-SSO string representation, and skipped in closure iterators, whose loops can span a `yield` that the cached payload would not survive.