### PR TITLE
fixes #26165; Destructors not called during Defect unwinding

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1823,6 +1823,13 @@ proc canRaise*(fn: PNode): bool =
     markCanRaiseBranch 0
     result = false
 
+proc canRaiseDefect*(fn: PNode): bool =
+  ## Defects are not represented in a routine's regular raises effect list.
+  ## Sempass2 records this separate fact on the callee so ownership lowering
+  ## can install `finally` sections for defect unwinding without treating every
+  ## routine with an empty raises list as potentially raising.
+  result = fn.kind != nkSym or sfRaisesDefect in fn.sym.flags
+
 proc toHumanStrImpl[T](kind: T, num: static int): string =
   result = $kind
   result = result[num..^1]

--- a/compiler/astdef.nim
+++ b/compiler/astdef.nim
@@ -118,6 +118,7 @@ type
     sfInjectDestructors # whether the proc needs the 'injectdestructors' transformation
     sfNeverRaises     # proc can never raise an exception, not even OverflowDefect
                       # or out-of-memory
+    sfRaisesDefect    # proc may raise a Defect (defects are omitted from effects)
     sfSystemRaisesDefect # proc in the system can raise defects
     sfUsedInFinallyOrExcept  # symbol is used inside an 'except' or 'finally'
     sfSingleUsedTemp  # For temporaries that we know will only be used once

--- a/compiler/ic/enum2nif.nim
+++ b/compiler/ic/enum2nif.nim
@@ -1247,6 +1247,7 @@ proc genFlags*(s: set[TSymFlag]; dest: var string) =
     of sfCursor: dest.add "c4"
     of sfInjectDestructors: dest.add "i1"
     of sfNeverRaises: dest.add "n3"
+    of sfRaisesDefect: dest.add "n5"
     of sfSystemRaisesDefect: dest.add "s2"
     of sfUsedInFinallyOrExcept: dest.add "u0"
     of sfSingleUsedTemp: dest.add "s3"
@@ -1394,6 +1395,9 @@ proc parse*(t: typedesc[TSymFlag]; s: string): set[TSymFlag] =
         inc i
       elif i+1 < s.len and s[i+1] == '4':
         result.incl sfNoalias
+        inc i
+      elif i+1 < s.len and s[i+1] == '5':
+        result.incl sfRaisesDefect
         inc i
       else: result.incl sfNoSideEffect
     of 'o': result.incl sfOverridden
@@ -1863,4 +1867,3 @@ proc parse*(t: typedesc[TOption]; s: string): set[TOption] =
     of 'w': result.incl optWarns
     else: discard
     inc i
-

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -978,7 +978,7 @@ proc p(n: PNode; c: var Con; s: var Scope; mode: ProcessMode; tmpFlags = {sfSing
           result = newTree(nkStmtList, destroyOld, result)
       else:
         result[0] = p(n[0], c, s, normal)
-      if canRaise(n[0]): s.needsTry = true
+      if canRaise(n[0]) or canRaiseDefect(n[0]): s.needsTry = true
       # A raising call needs owned storage even when its value is consumed: the
       # callee can partially initialize the result before control unwinds.
       if mode == normal or (canRaise(n[0]) and inSpawn == 0):

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -97,6 +97,10 @@ type
     inNimvmBranch: int
   PEffects = var TEffects
 
+proc markRaisesDefect(tracked: PEffects) {.inline.} =
+  tracked.canRaiseDefect = true
+  tracked.owner.incl sfRaisesDefect
+
 const
   errXCannotBeAssignedTo = "'$1' cannot be assigned to"
   errLetNeedsInit = "'let' symbol requires an initialization"
@@ -519,7 +523,7 @@ proc addRaiseEffect(a: PEffects, e, comesFrom: PNode) =
 
   if e.typ != nil:
     if isDefectException(e.typ):
-      a.canRaiseDefect = true
+      markRaisesDefect(a)
     else:
       throws(a.exc, e, comesFrom)
 
@@ -1136,30 +1140,32 @@ proc trackCall(tracked: PEffects; n: PNode) =
   var a = n[0]
   if a.kind == nkSym:
     let s = a.sym
+    if sfRaisesDefect in s.flags:
+      markRaisesDefect(tracked)
     case s.magic
     of mNone:
       if {sfNeverRaises, sfImportc, sfCompilerProc} * s.flags == {} and
           (sfSystemModule notin getModule(s).flags or
            sfSystemRaisesDefect in s.flags):
-        tracked.canRaiseDefect = true
+        markRaisesDefect(tracked)
     of mUnaryMinusI..mAbsI, mAddI..mPred:
       if optOverflowCheck in tracked.currOptions:
-        tracked.canRaiseDefect = true
+        markRaisesDefect(tracked)
     of mInc, mDec:
       let typ = n[1].typ.skipTypes({tyGenericInst, tyAlias, tySink,
                                     tyVar, tyLent, tyRange, tyDistinct})
       if optOverflowCheck in tracked.currOptions and
           typ.kind notin {tyUInt..tyUInt64}:
-        tracked.canRaiseDefect = true
+        markRaisesDefect(tracked)
     of mDivU, mModU:
-      tracked.canRaiseDefect = true
+      markRaisesDefect(tracked)
     of mAddF64..mDivF64:
       if {optNaNCheck, optInfCheck} * tracked.currOptions != {}:
-        tracked.canRaiseDefect = true
+        markRaisesDefect(tracked)
     else:
       discard
   else:
-    tracked.canRaiseDefect = true
+    markRaisesDefect(tracked)
   #if canRaise(a):
   #  echo "this can raise ", tracked.config $ n.info
   let op = a.typ
@@ -1460,7 +1466,7 @@ proc track(tracked: PEffects, n: PNode) =
     else:
       track(tracked, n[0])
   of nkRaiseStmt:
-    tracked.canRaiseDefect = true
+    markRaisesDefect(tracked)
     if n[0].kind != nkEmpty:
       n[0].info = n.info
       #throws(tracked.exc, n[0])
@@ -1490,7 +1496,7 @@ proc track(tracked: PEffects, n: PNode) =
     tracked.leftPartOfAsgn = oldLeftPartOfAsgn
   of nkCheckedFieldExpr:
     if optFieldCheck in tracked.currOptions:
-      tracked.canRaiseDefect = true
+      markRaisesDefect(tracked)
     track(tracked, n[0])
     if tracked.config.hasWarn(warnProveField) or strictCaseObjects in tracked.c.features:
       checkFieldAccess(tracked.guards, n, tracked.config, strictCaseObjects in tracked.c.features)
@@ -1691,7 +1697,7 @@ proc track(tracked: PEffects, n: PNode) =
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     if optRangeCheck in tracked.currOptions and
         conversionCanRaiseDefect(tracked.config, n.typ, n[1].typ):
-      tracked.canRaiseDefect = true
+      markRaisesDefect(tracked)
     if n.kind in {nkHiddenStdConv, nkHiddenSubConv} and
         n.typ.skipTypes(abstractInst).kind == tyCstring and
         not allowCStringConv(n[1]):
@@ -1731,9 +1737,9 @@ proc track(tracked: PEffects, n: PNode) =
   of nkObjUpConv, nkObjDownConv, nkChckRange, nkChckRangeF, nkChckRange64:
     if n.kind in {nkObjUpConv, nkObjDownConv}:
       if optObjCheck in tracked.currOptions:
-        tracked.canRaiseDefect = true
+        markRaisesDefect(tracked)
     elif optRangeCheck in tracked.currOptions:
-      tracked.canRaiseDefect = true
+      markRaisesDefect(tracked)
     if n.len == 1:
       track(tracked, n[0])
       if tracked.owner.kind != skMacro:
@@ -1749,7 +1755,7 @@ proc track(tracked: PEffects, n: PNode) =
       createTypeBoundOps(tracked, n.typ, n.info)
   of nkBracketExpr:
     if optBoundsCheck in tracked.currOptions:
-      tracked.canRaiseDefect = true
+      markRaisesDefect(tracked)
     if optStaticBoundsCheck in tracked.currOptions and n.len == 2:
       if n[0].typ != nil and skipTypes(n[0].typ, abstractVar).kind != tyTuple:
         checkBounds(tracked, n[0], n[1])

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -8,19 +8,21 @@ var
   splat
   :tmp
   :tmp_1
-splat = splitDrive do:
-  let blitTmp = path
-  blitTmp
-:tmp = splat.drive
-`=wasMoved`(splat.drive)
-:tmp_1 = splat.path_1
-`=wasMoved`(splat.path_1)
-result = (
-  let blitTmp_1 = :tmp
-  blitTmp_1,
-  let blitTmp_2 = :tmp_1
-  blitTmp_2)
-`=destroy`(splat)
+try:
+  splat = splitDrive do:
+    let blitTmp = path
+    blitTmp
+  :tmp = splat.drive
+  `=wasMoved`(splat.drive)
+  :tmp_1 = splat.path_1
+  `=wasMoved`(splat.path_1)
+  result = (
+    let blitTmp_1 = :tmp
+    blitTmp_1,
+    let blitTmp_2 = :tmp_1
+    blitTmp_2)
+finally:
+  `=destroy`(splat)
 -- end of expandArc ------------------------
 --expandArc: delete
 
@@ -103,51 +105,57 @@ finally:
 --expandArc: mergeShadowScope
 
 var shadowScope
-`=copy`(shadowScope, c.currentScope)
-rawCloseScope(c)
-block :tmp:
-  var sym
-  var i = 0
-  let L = len(shadowScope.symbols)
-  block :tmp_1:
-    while i < L:
-      var :tmpD
-      sym = shadowScope.symbols[i]
-      addInterfaceDecl(c):
-        :tmpD = `=dup`(sym)
-        :tmpD
-      {.push, overflowChecks: false.}
-      inc(i, 1)
-      {.pop.}
-`=destroy`(shadowScope)
+try:
+  `=copy`(shadowScope, c.currentScope)
+  rawCloseScope(c)
+  block :tmp:
+    var sym
+    var i = 0
+    let L = len(shadowScope.symbols)
+    block :tmp_1:
+      while i < L:
+        var :tmpD
+        sym = shadowScope.symbols[i]
+        addInterfaceDecl(c):
+          :tmpD = `=dup`(sym)
+          :tmpD
+        {.push, overflowChecks: false.}
+        inc(i, 1)
+        {.pop.}
+finally:
+  `=destroy`(shadowScope)
 -- end of expandArc ------------------------
 --expandArc: check
 
 var par
-this.isValid = fileExists(this.value)
-if dirExists(this.value):
-  var :tmpD
-  par = (dir:
-    :tmpD = `=dup`(this.value)
-    :tmpD, front: "")
-else:
-  var
-    :tmpD_1
-    :tmpD_2
-    :tmpD_3
-  par = (dir_1: parentDir(this.value), front_1:
-    :tmpD_1 = `=dup`(
-      :tmpD_3 = splitDrive do:
-        :tmpD_2 = `=dup`(this.value)
-        :tmpD_2
-      :tmpD_3.path)
-    :tmpD_1)
-  `=destroy`(:tmpD_3)
-if dirExists(par.dir):
-  `=sink`(this.matchDirs, getSubDirs(par.dir, par.front))
-else:
-  `=sink`(this.matchDirs, [])
-`=destroy`(par)
+try:
+  this.isValid = fileExists(this.value)
+  if dirExists(this.value):
+    var :tmpD
+    par = (dir:
+      :tmpD = `=dup`(this.value)
+      :tmpD, front: "")
+  else:
+    var
+      :tmpD_1
+      :tmpD_2
+      :tmpD_3
+    try:
+      par = (dir_1: parentDir(this.value), front_1:
+        :tmpD_1 = `=dup`(
+          :tmpD_3 = splitDrive do:
+            :tmpD_2 = `=dup`(this.value)
+            :tmpD_2
+          :tmpD_3.path)
+        :tmpD_1)
+    finally:
+      `=destroy`(:tmpD_3)
+  if dirExists(par.dir):
+    `=sink`(this.matchDirs, getSubDirs(par.dir, par.front))
+  else:
+    `=sink`(this.matchDirs, [])
+finally:
+  `=destroy`(par)
 -- end of expandArc ------------------------
 --expandArc: check
 

--- a/tests/destructor/t26165.nim
+++ b/tests/destructor/t26165.nim
@@ -1,0 +1,28 @@
+discard """
+  cmd: "nim c -r --gc:arc --exceptions:goto --panics:off $file"
+  output: '''
+In test
+destroy
+in defect
+'''
+"""
+
+type MyObject = object
+
+proc `=destroy`(a: var MyObject) =
+  debugEcho "destroy"
+
+proc test(): int8 =
+  debugEcho "In test"
+  raiseAssert "a defect"
+
+proc noex() =
+  try:
+    let x = block:
+      var v = MyObject()
+      test()
+    echo x
+  except AssertionDefect:
+    debugEcho "in defect"
+
+noex()


### PR DESCRIPTION
fixes #26165

Raises effects intentionally omit Defect exceptions, so destructor
injection could mistakenly treat defect-raising calls as non-raising and place
cleanup after the call. During semantic analysis, the fix records a dedicated
sfRaisesDefect flag on routines and propagates it to callers. Destructor
lowering then uses that flag to add try/finally only where cleanup could be
skipped by defect unwinding.