### PR TITLE
Use .dylib for the iOS dynamic library extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -164,6 +164,9 @@ parameter and result types, not just their source-level shape. Use
   arrays slice via a `{base, off, len}` view. This also covers seq/non-numeric-array
   write-through, pass-through, re-slicing and `@` (openArray-to-seq) of such views.
 
+- On `--os:ios`, the default file name for `--app:lib` is now `libfoo.dylib`
+  instead of `libfoo.so`, matching `--os:macosx` and the Darwin convention.
+
 ## Tool changes
 
 - Added `--raw` flag when generating JSON docs to not render markup.

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -148,7 +148,7 @@ const
       objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
       scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
       props: {ospNeedsPIC, ospPosix, ospLacksThreadVars}),
-     (name: "iOS", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
+     (name: "iOS", parDir: "..", dllFrmt: "lib$1.dylib", altDirSep: "/",
       objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
       scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
       props: {ospNeedsPIC, ospPosix}),


### PR DESCRIPTION
`--app:lib` currently produces an ELF-style name when targeting iOS:

```console
$ nim c --app:lib --os:macosx --cpu:arm64 mylib.nim   # -> libmylib.dylib
$ nim c --app:lib --os:ios    --cpu:arm64 mylib.nim   # -> libmylib.so
```

iOS is Darwin: its shared libraries are Mach-O `.dylib`, loaded by the same dyld as on macOS. `compiler/platform.nim` already encodes this for the `MacOSX` entry (`lib$1.dylib`); the `iOS` entry is the only Darwin row still carrying the ELF name, so the same source yields a differently named artifact depending on which Apple platform it is built for.

`dllFrmt` is read in three places:

* `compiler/main.nim` — the default output name for `--app:lib`; this is the one users see.
* `compiler/cgen.nim` (`getModuleDllPath`) and `compiler/extccomp.nim` (`hcrLinkTargetName`) — hot code reloading.

To be precise about the impact: dyld does not key off the extension, so `dlopen` with an explicit path works either way. What the name does feed is everything built on the Darwin convention around it — `install_name`/`@rpath`, embedding under `App.app/Frameworks/`, and the codesign/Xcode packaging steps that expect `.dylib`.

This does change the default output file name for existing `--os:ios --app:lib` builds, so a changelog entry is included; `--out:` overrides it as before. Nothing under `tests/` or in the CI workflows exercises `--os:ios`.
