### PR TITLE
fixes #26176; nim js: explicit {.closure.} on a lambda with parameter…

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1220,7 +1220,7 @@ proc generateHeader(p: PProc, prc: PSym): Rope =
   result = ""
   let typ = prc.typ
   if jsNoLambdaLifting notin p.config.legacyFeatures:
-    if typ.callConv == ccClosure:
+    if typ.callConv == ccClosure and tfCapturesEnv in typ.flags:
       # we treat Env as the `this` parameter of the function
       # to keep it simple
       let env = prc.ast[paramsPos].lastSon

--- a/tests/js/tclosures.nim
+++ b/tests/js/tclosures.nim
@@ -50,6 +50,11 @@ let results = runCallbacks()
 
 doAssert(expected == $results)
 
+block issue26176:
+  let g = proc(x: int): int {.closure.} =
+    result = x + 1
+  doAssert g(1) == 2
+
 block issue7048:
   block:
     proc foo(x: seq[int]): auto =


### PR DESCRIPTION
…s crashes codegen

fixes #26176

It follows the same method of the C backend. Don't insert "this" in JavaScript backend If no variables are captured by closure functions.