### PR TITLE
fix std/atomics on MSVC: fetchAdd, fetchSub, exchange and compareExchange

### DIFF
--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -222,6 +222,11 @@ else:
     proc interlockedCompareExchange(location: pointer; desired, expected: int32): int32 {.importc: "_InterlockedCompareExchange".}
     proc interlockedCompareExchange(location: pointer; desired, expected: int64): int64 {.importc: "_InterlockedCompareExchange64".}
 
+    proc interlockedExchangeAdd(location: pointer; value: int8): int8 {.importc: "_InterlockedExchangeAdd8".}
+    proc interlockedExchangeAdd(location: pointer; value: int16): int16 {.importc: "_InterlockedExchangeAdd16".}
+    proc interlockedExchangeAdd(location: pointer; value: int32): int32 {.importc: "_InterlockedExchangeAdd".}
+    proc interlockedExchangeAdd(location: pointer; value: int64): int64 {.importc: "_InterlockedExchangeAdd64".}
+
     proc interlockedAnd(location: pointer; value: int8): int8 {.importc: "_InterlockedAnd8".}
     proc interlockedAnd(location: pointer; value: int16): int16 {.importc: "_InterlockedAnd16".}
     proc interlockedAnd(location: pointer; value: int32): int32 {.importc: "_InterlockedAnd".}
@@ -253,17 +258,30 @@ else:
       discard interlockedExchange(addr(location.value), cast[nonAtomicType(T)](desired))
 
     proc exchange*[T: Trivial](location: var Atomic[T]; desired: T; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =
-      cast[T](interlockedExchange(addr(location.value), cast[int64](desired)))
+      cast[T](interlockedExchange(addr(location.value), cast[nonAtomicType(T)](desired)))
     proc compareExchange*[T: Trivial](location: var Atomic[T]; expected: var T; desired: T; success, failure: MemoryOrder): bool {.inline.} =
-      cast[T](interlockedCompareExchange(addr(location.value), cast[nonAtomicType(T)](desired), cast[nonAtomicType(T)](expected))) == expected
+      # `_InterlockedCompareExchange` returns the initial value of `location`,
+      # so the exchange happened exactly when that equals `expected`. Comparing
+      # the integer representations rather than the `T` values keeps float and
+      # enum payloads bit-exact.
+      let expectedValue = cast[nonAtomicType(T)](expected)
+      let previousValue = interlockedCompareExchange(addr(location.value), cast[nonAtomicType(T)](desired), expectedValue)
+      result = previousValue == expectedValue
+      if not result:
+        # On failure the observed value is reported back through `expected`.
+        expected = cast[T](previousValue)
     proc compareExchangeWeak*[T: Trivial](location: var Atomic[T]; expected: var T; desired: T; success, failure: MemoryOrder): bool {.inline.} =
       compareExchange(location, expected, desired, success, failure)
 
     proc fetchAdd*[T: SomeInteger](location: var Atomic[T]; value: T; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =
-      var currentValue = location.load()
-      while not compareExchangeWeak(location, currentValue, currentValue + value): discard
+      cast[T](interlockedExchangeAdd(addr(location.value), cast[nonAtomicType(T)](value)))
+    # MSVC has no interlocked subtract, so subtracting is adding the two's
+    # complement. Overflow checks are disabled so that negating `low(T)` wraps,
+    # matching the modular semantics of C11 `atomic_fetch_sub_explicit`.
+    {.push overflowChecks: off.}
     proc fetchSub*[T: SomeInteger](location: var Atomic[T]; value: T; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =
-      fetchAdd(location, -value, order)
+      cast[T](interlockedExchangeAdd(addr(location.value), -cast[nonAtomicType(T)](value)))
+    {.pop.}
     proc fetchAnd*[T: SomeInteger](location: var Atomic[T]; value: T; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =
       cast[T](interlockedAnd(addr(location.value), cast[nonAtomicType(T)](value)))
     proc fetchOr*[T: SomeInteger](location: var Atomic[T]; value: T; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =


### PR DESCRIPTION
## Problem

`Atomic[T].fetchAdd` no longer compiles with `--cc:vcc`. Any use of `fetchAdd`, `fetchSub`, `atomicInc`, `atomicDec`, `+=` or `-=` on an `Atomic[T]` fails:

```
lib/pure/concurrency/atomics.nim(264, 36) Error: type mismatch
Expression: compareExchangeWeak(location, currentValue, currentValue + value)
  [1] location: Atomic[system.int]
  [2] currentValue: int
  [3] currentValue + value: int

Expected one of (first mismatch at [position]):
[4] proc compareExchangeWeak[T: Trivial](location: var Atomic[T]; expected: var T;
                                     desired: T; success, failure: MemoryOrder): bool
  missing parameter: success
```

Reproducer (`nim c --cc:vcc` fails, `nim c` with gcc passes):

```nim
import std/atomics

var a: Atomic[int]
a.store(5)
doAssert a.fetchAdd(3) == 5
doAssert a.load() == 8
a.atomicInc()
doAssert a.load() == 9
```

### Cause

#26066 hoisted the single-order `compareExchange`/`compareExchangeWeak` convenience overloads out of both backend branches into shared code placed *below* them. The MSVC `fetchAdd` is written as a CAS retry loop and calls the three-argument `compareExchangeWeak` from inside the `when defined(vcc)` block, about 110 lines before the shared overload is declared, so the call resolves against the five-argument overload only.

The C11 branch is unaffected because its `fetchAdd` calls `atomic_fetch_add_explicit` directly. No CI job builds with `vcc`, which is why this was not caught.

## Fix

Implement `fetchAdd`/`fetchSub` with the `_InterlockedExchangeAdd` intrinsics instead of repairing the CAS loop. This matches how `fetchAnd`/`fetchOr`/`fetchXor` are already implemented immediately below, follows the branch's own stated intent ("Since MSVC does not implement C11, we fall back to MS intrinsics where available"), and mirrors `lib/std/sysatomics.nim`, which already binds `_InterlockedExchangeAdd`/`_InterlockedExchangeAdd64` this way.

It also removes two latent defects in the loop that would have remained had it merely been made to compile: it never returned the previous value (control fell off the end of a `while`, so it returned zero), and it could not have terminated, because the MSVC `compareExchange` never refreshed `expected`.

Two further MSVC-only defects surfaced while getting `tests/stdlib/concurrency/tatomics.nim` to pass. Both are already covered by that test, and neither is reachable without the first fix, so they are included here rather than split out:

- **`compareExchange` never reported the observed value back through `expected` on failure.** This breaks the documented contract and hangs any user-written CAS retry loop. `tatomics.nim:82` (`block trivialCompareExchangeDoesNotExchange`) asserts exactly this. It now returns the previous value through `expected`, and compares integer representations rather than `T` values so float and enum payloads stay bit-exact.
- **`exchange` cast `desired` to `int64` instead of `nonAtomicType(T)`**, selecting `_InterlockedExchange64` for every `T` and writing eight bytes into atomics of one, two or four bytes. `store` directly above it already used `nonAtomicType(T)`.

`fetchSub` disables overflow checks around the negation so that `low(T)` wraps, matching the modular semantics of `atomic_fetch_sub_explicit`.

## Testing

MSVC 14.51, Windows. All of these previously failed to compile:

| test | `--mm:refc` | `--mm:orc` |
| --- | --- | --- |
| `tests/stdlib/concurrency/tatomics.nim` | pass | pass |
| `tests/stdlib/concurrency/tatomics_size.nim` | pass | pass |
| `tests/stdlib/concurrency/tatomic_import.nim` | pass | pass |
| `tests/system/tatomics1.nim` | pass | pass |
| `tests/destructor/tatomicptrs.nim` | pass | pass |

No new test is added because `tatomics.nim` already covers all of this, including the previous-value return semantics of `fetchAdd`/`fetchSub` and the `expected` write-back of `compareExchange`. The gap is that CI never runs it under `vcc`.

The C11 path is untouched (the change is entirely inside `when defined(vcc)`) and `tatomics.nim` still passes across all eight combinations of `c`/`cpp` x `--mm:refc`/`--mm:orc` x with/without `-d:nimUseCppAtomics`.

## Known issue left out of scope

`--cc:vcc` with the `cpp` target and *without* `-d:nimUseCppAtomics` still fails to compile, unrelated to this change: the intrinsics are declared as `location: pointer`, and C++ will not implicitly convert `void*` to `volatile __int64*`. This reproduces on unmodified `devel` with a program that only calls `store`/`load`:

```
error C2664: '__int64 _InterlockedExchange64(volatile __int64 *,__int64)':
cannot convert argument 1 from 'void *' to 'volatile __int64 *'
```

Fixing it means giving all ~20 intrinsic declarations typed pointer parameters, which seemed better as a separate PR. `--cc:vcc --cpp -d:nimUseCppAtomics` works, as it uses `std::atomic`.
