### PR TITLE
fix #560: allow templates/macros producing '..' in range[...] types

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -463,8 +463,15 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
 proc semRange(c: PContext, n: PNode, prev: PType): PType =
   result = nil
   if n.len == 2:
-    if isRange(n[1]):
-      result = semRangeAux(c, n[1], prev)
+    var rangeSpec = n[1]
+    if not isRange(rangeSpec):
+      # bug #560: the argument may only expand to a '..' expression during
+      # semantic analysis, for example through a template or macro call.
+      let ex = semExprWithType(c, rangeSpec, {efDetermineType})
+      if isRange(ex):
+        rangeSpec = ex
+    if isRange(rangeSpec):
+      result = semRangeAux(c, rangeSpec, prev)
       if not isDefined(c.config, "nimPreviewRangeDefault"):
         let n = result.n
         if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
@@ -478,7 +485,7 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
             n[1].floatVal < 0.0:
           incl(result, tfRequiresInit)
     else:
-      if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
+      if rangeSpec.kind == nkInfix and considerQuotedIdent(c, rangeSpec[0]).s == "..<":
         localError(c.config, n[0].info, "range types need to be constructed with '..', '..<' is not supported")
       else:
         localError(c.config, n[0].info, "expected range")

--- a/tests/range/ttemplate.nim
+++ b/tests/range/ttemplate.nim
@@ -1,0 +1,16 @@
+discard """
+  output: '''
+4
+2
+6
+'''
+"""
+
+# bug #560
+template test(): untyped =
+  2 .. 6
+
+var x: range[test()] = 4
+echo x
+echo low(typeof(x))
+echo high(typeof(x))


### PR DESCRIPTION
Hi!

Starting an experimental project of vibefixing old issues.

The idea is that maybe in the age of AI focusing on priority is a waste of tokens- if the AI is going to analyze the task it might as well fix it.

But what I think makes sense is a human assessment- in this case, I feel this is basically convenient syntactic sugar worth adding.

Of course this might create a rather large load of PRs for the team to handle so let us stay in communication to whether you even like this idea and also to keep a managemeble pace. 

I think it would be a worthy goal for Nim to have open issues to 0 at least occasionally- but no point having no issues and 2000 open stale PRs.

So here's the start! Dom thinks in 2013 that stuff like range() should work in []. I agree with 2013 Dom, thanks to his past self!

All vibefixes are manually somewhat reviewed for basic sensibleness.

If these initial fixes are received well by you, the team, we can look into picking up the pace. Happy to hear your feedback!

Reproduction: Run with system vs. patched nim

```nim
# Issue #560 (2013): template call in range[...] type
template test(): untyped =
  2 .. 6

var x: range[test()] = 5
echo x
```

