### PR TITLE
fixes #26189; compiler SIGSEGV with --exceptions:setjmp in try/except/finally

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -824,7 +824,7 @@ proc raiseExit(p: BProc) =
         p.s(cpsStmts).addGoto("LA" & $p.nestedTryStmts[^1].label & "_")
 
 proc finallyActions(p: BProc) =
-  if p.config.exc != excGoto:
+  if p.config.exc == excCpp:
     # Walk past compiler-injected `nkHiddenTryStmt` wrappers (e.g. ARC's
     # destructor try/finally that wraps `except T as e:` bodies) to reach
     # the user's actual try.  We must NOT walk past a real user try whose
@@ -844,6 +844,10 @@ proc finallyActions(p: BProc) =
         if finallyBlock != nil:
           genSimpleBlock(p, finallyBlock.firstSon)
       return
+  elif p.config.exc != excGoto and p.nestedTryStmts.len > 0 and p.nestedTryStmts[^1].inExcept:
+    let finallyBlock = p.nestedTryStmts[^1].fin
+    if finallyBlock != nil:
+      genSimpleBlock(p, finallyBlock.firstSon)
 
 proc raiseInstr(p: BProc; result: var Builder) =
   if p.config.exc == excGoto:

--- a/tests/exception/t26189.nim
+++ b/tests/exception/t26189.nim
@@ -1,0 +1,20 @@
+discard """
+  cmd: "nim c --exceptions:setjmp $file"
+  exitcode: 1
+  output: '''
+t26189.nim(20)           t26189
+t26189.nim(18)           trigger
+Error: unhandled exception: rollback failed [CatchableError]
+'''
+"""
+
+# Regression test for compiler recursion while generating a raise in finally.
+proc trigger() =
+  try:
+    discard
+  except Exception as exc:
+    raise exc
+  finally:
+    raise newException(CatchableError, "rollback failed")
+
+trigger()


### PR DESCRIPTION
fixes #26189