### PR TITLE
Fix IC execution, linking, overload order, ownership, and cache reuse

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -145,11 +145,16 @@ proc transformedBody*(s: PSym): lent PNode {.inline.} =
   if s.state == Partial: loadSym(s)
   result = s.transformedBodyImpl
 
+proc nifBodyLoaded*(s: PSym): bool {.inline.} =
+  if s.state == Partial: loadSym(s)
+  result = s.nifBodyLoadedImpl
+
 proc `transformedBody=`*(s: PSym, val: PNode) {.inline.} =
   #assert s.state != Sealed
   # Make an exception here for this misfeature...
   if s.state == Partial: loadSym(s)
   s.transformedBodyImpl = val
+  s.nifBodyLoadedImpl = false
 
 proc guard*(s: PSym): lent PSym {.inline.} =
   if s.state == Partial: loadSym(s)
@@ -1458,6 +1463,7 @@ proc transitionRoutineSymKind*(s: PSym, kind: range[skProc..skTemplate]) =
   transitionSymKindCommon(kind)
   s.gcUnsafetyReasonImpl = obj.gcUnsafetyReasonImpl
   s.transformedBodyImpl = obj.transformedBodyImpl
+  s.nifBodyLoadedImpl = obj.nifBodyLoadedImpl
 
 proc transitionToLet*(s: PSym) =
   transitionSymKindCommon(skLet)

--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -1403,6 +1403,7 @@ var offerTag = registerTag("offer")
 var typeOfferTag = registerTag("toffer")
 var modulesrcTag = registerTag("modulesrc")
 var expansionTag = registerTag("expansion")
+var overloadsTag = registerTag("overloads")
 # `(sig <symUse @src>)*` — signature occurrences (parameter names and the symbols
 # in their type expressions). A semchecked routine's params are dropped from the
 # serialized AST (`skipParams`) and reconstructed from `s.typ`, which holds the
@@ -1480,6 +1481,7 @@ proc registerNifAstTags*() =
   typeOfferTag = registerTag("toffer")
   modulesrcTag = registerTag("modulesrc")
   expansionTag = registerTag("expansion")
+  overloadsTag = registerTag("overloads")
   sigTag = registerTag("sig")
 
 proc emitSigOccurrences(w: var Writer; n: PNode) =
@@ -2071,7 +2073,8 @@ proc scanStmtsForCookie(s: var Sha1State; c: var CookieCtx; flat: seq[CookieTok]
            tg == "repwasmoved" or tg == "repcopy" or tg == "repsink" or
            tg == "repdup" or tg == "reptrace" or tg == "repdeepcopy" or
            tg == "repenumtostr" or tg == "repmethod" or
-           tg == exportName or tg == exportExceptName or tg == "include":
+           tg == exportName or tg == exportExceptName or tg == "include" or
+           tg == "overloads":
         let e = nextTree(flat, i)
         hashRegion(s, c, flat, i, e)
         i = e
@@ -2214,7 +2217,8 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
                      firstUnusedId: int32 = 0;
                      expansions: seq[(PSym, TLineInfo)] = @[];
                      moduleFlags: int32 = 0;
-                     extraExports: seq[ItemId] = @[]) =
+                     extraExports: seq[ItemId] = @[];
+                     exportedOverloads: seq[seq[PSym]] = @[]) =
   var w = Writer(infos: newLineInfoWriter(config), currentModule: thisModule)
   for id in extraExports: w.extraExports.incl id
   w.deps = newIcBuilder(64)
@@ -2265,6 +2269,16 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
     w.deps.addParLe reexpModTag, NoLineInfo
     w.deps.addStrLit mname
     w.deps.addStrLit msuffix
+    w.deps.addParRi
+
+  # Generic alias lookup observes the first overload, including a template
+  # with default arguments used without a call. Preserve the actual interface
+  # order: neither index hash order nor symbol mint order reproduces it after
+  # the frontend's symbol table has grown and rehashed.
+  for overloads in exportedOverloads:
+    w.deps.addParLe overloadsTag, NoLineInfo
+    for candidate in overloads:
+      w.deps.addStrLit w.toNifSymName(candidate)
     w.deps.addParRi
 
   # Generic-instance OFFERS: every generic instance this module created
@@ -3383,6 +3397,8 @@ proc loadSymFromCursor(c: var DecodeContext; s: PSym; n: var Cursor; thisModule:
         let before = nodesDecoded
         s.transformedBodyImpl = loadNode(c, n, thisModule, localSyms)
         if loadStatsInit == 1: bodyNodes += nodesDecoded - before
+      s.nifBodyLoadedImpl = s.transformedBodyImpl != nil and
+        conf.icBackendStage in ["cg", "emit"]
     else:
       skip n
 
@@ -4087,6 +4103,7 @@ type
       ## `typeInstCache` from them so a consumer reuses the baked instance
       ## (e.g. a `mixin`/`compiles()`-dependent array bound) instead of
       ## re-instantiating it with a different bound in its own scope.
+    overloads*: seq[seq[string]] ## exported symbols in frontend lookup order
     moduleFlags*: int32 ## the module SYMBOL's backend-relevant flags; see
                         ## `(modflags)` / `ModFlagInjectDestructors`.
     includes*: seq[string] # resolved full paths of files this module `include`s;
@@ -4274,7 +4291,7 @@ type
     ttRepConverter, ttRepDestroy, ttRepWasMoved, ttRepCopy, ttRepSink, ttRepDup,
     ttRepTrace, ttRepDeepCopy, ttRepEnumToStr, ttRepMethod, ttRepPureEnum,
     ttRepCppMember, ttExport, ttInclude, ttImport, ttReexpMod, ttOffer, ttTOffer,
-    ttModuleSrc, ttExpansion, ttSig, ttImplementation,
+    ttModuleSrc, ttExpansion, ttOverloads, ttSig, ttImplementation,
     ttLetSection, ttVarSection, ttPragma
 
 const
@@ -4307,6 +4324,7 @@ proc classifyTopTag(name: string): TopTag =
   of "toffer": ttTOffer
   of "modulesrc": ttModuleSrc
   of "expansion": ttExpansion
+  of "overloads": ttOverloads
   of "sig": ttSig
   of "implementation": ttImplementation
   else:
@@ -4377,6 +4395,16 @@ proc processTopLevel(c: var DecodeContext; cur: var Cursor; flags: set[LoadFlag]
             result.moduleFlags = int32 intVal(cur)
             skip cur
           while cur.hasMore: skip cur
+      of ttOverloads:
+        if SkipInterfaceTables in flags:
+          skip cur
+        else:
+          var names: seq[string] = @[]
+          cur.into:
+            while cur.hasMore:
+              names.add strVal(cur)
+              skip cur
+          result.overloads.add move names
       of ttRepConverter:
         timed tTopLogOps:
           loadLogOp(c, result.logOps, cur, ConverterEntry, attachedTrace, module)
@@ -4578,6 +4606,27 @@ proc registerModuleSelfSym*(c: var DecodeContext; suffix: string; m: PSym) =
   if not c.syms.hasKey(key):
     c.syms[key] = (m, NifIndexEntry())
 
+proc restoreOverloadOrder(c: var DecodeContext; interf: var TStrTable;
+                          overloads: seq[seq[string]]) =
+  # Swap only slots with the same identifier, preserving the table's probe
+  # chains and all symbols added by export/enum handling.
+  for names in overloads:
+    var syms: seq[PSym] = @[]
+    for name in names:
+      if c.mainModuleSuffix.len > 0 and
+          parseSymName(name).module == c.mainModuleSuffix:
+        continue
+      let sym = resolveSym(c, name, false)
+      if sym != nil and strTableContains(interf, sym): syms.add sym
+    if syms.len < 2: continue
+    var h = syms[0].name.h and high(interf.data)
+    var i = 0
+    while interf.data[h] != nil:
+      if interf.data[h] in syms:
+        interf.data[h] = syms[i]
+        inc i
+      h = nextTry(h, high(interf.data))
+
 proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHidden: var TStrTable;
                     flags: set[LoadFlag] = {}): PrecompiledModule =
   # Ensure module index is loaded - moduleId returns the FileIndex for this suffix
@@ -4605,6 +4654,8 @@ proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHi
   if SkipInterfaceTables notin flags:
     icProfStart(tInterfTables)
     populateInterfaceTablesFromIndex(c, module, interf, interfHidden, string(suffix))
+    restoreOverloadOrder(c, interf, result.overloads)
+    restoreOverloadOrder(c, interfHidden, result.overloads)
     icProfStop(tInterfTables)
 
 proc loadNifModule*(c: var DecodeContext; f: FileIndex; interf, interfHidden: var TStrTable;

--- a/compiler/ast2nif.nim
+++ b/compiler/ast2nif.nim
@@ -33,8 +33,6 @@ import "../dist/nimony/src/lib" / [bitabs, lineinfos,
 import "../dist/nimony/src/lib/nifcore" except pool, symName, strVal, poolSym, poolStr, lineInfoFile
 from "../dist/nimony/src/lib" / bif import BifModule, IndexVis, ivHidden, IndexEntry
 import icbif
-import icmodnames
-import "../dist/nimony/src/models" / nifindex_tags
 import typekeys
 import icnifcore
 import ic / [enum2nif]
@@ -1092,30 +1090,15 @@ proc docOfSym(sym: PSym): string =
 proc writeSymDef(w: var Writer; dest: var IcBuilder; sym: PSym) =
   dest.addParLe sdefTag, nifLineInfoWithComment(w.infos, sym.infoImpl, docOfSym(sym))
   dest.addSymDef pool.syms.getOrIncl(w.toNifSymName(sym)), NoLineInfo
-  # The `x` marker means "importable as a bare identifier into an importer's
-  # scope". Object fields carry `sfExported` (so they are visible via `obj.field`
-  # across modules) but must NOT become bare-importable: otherwise an exported
-  # field name (e.g. `HSlice.a`, whose type is a generic param `T`) leaks into
-  # module scope and a template's open/mixin symbol of the same name resolves to
-  # the field instead of a local, producing "type mismatch: got 'T'". Fields are
-  # still indexed (for `obj.field` resolution via the loaded object type); they
-  # are merely not advertised as importable. Plain `skEnumField` stays importable
-  # — enum values are legitimately usable as bare identifiers — but a field of a
-  # `{.pure.}` enum is NOT: the source path keeps pure fields out of the importer
-  # scope (`declarePureEnumField`), reachable only qualified or via the restricted
-  # pure-enum mechanism (`importPureEnumFields`, fed by `ifaces[].pureEnums` which
-  # a loaded module rebuilds from its `PureEnumEntry` log ops). Marking them
-  # bare-importable made a loaded pure enum's fields leak into module scope
-  # (`populateInterfaceTablesFromIndex` adds every `x`/Exported sym to `interf`),
-  # e.g. nim-json-serialization's pure `JsonValueKind.Number` shadowing web3's
-  # `Number = distinct uint64` so `uint64(x).Number` failed under `nim ic`
-  # ("undeclared field 'Number'").
+  # The index visibility marker is still used by tooling and interface
+  # fingerprints. Membership and lookup order are serialized separately in
+  # the authoritative interface records, so fields and pure-enum members must
+  # not be advertised as bare exports here either.
   let isPureEnumField = sym.kindImpl == skEnumField and sym.typImpl != nil and
     sym.typImpl.symImpl != nil and sfPure in sym.typImpl.symImpl.flagsImpl
   # `sfExported` is the declaration's `*`. An explicit `export s` makes a symbol
   # importable WITHOUT it (semExport -> reexportSym -> the interface table only),
-  # so ask the interface as well or those symbols ship as non-importable and the
-  # importer reports "undeclared identifier".
+  # so include these symbols when fingerprinting exported declarations too.
   if sym.kindImpl != skField and not isPureEnumField and
       ({sfExported, sfFromGeneric} * sym.flagsImpl == {sfExported} or
        sym.itemId in w.extraExports):
@@ -1364,11 +1347,8 @@ proc trImport(w: var Writer; n: PNode) =
       w.depSuffixes.incl fp
 
 proc trExport(w: var Writer; n: PNode) =
-  # Collect export information for the index
-  # nkExportStmt children are nkSym nodes
-  # When exporting a module (export dollars), the module symbol is a child
-  # followed by all symbols from that module - we use empty set to mean "export all"
-  # When exporting specific symbols (export foo, bar), we collect their names
+  # Preserve the export statement for source tooling and fingerprints. The
+  # interface record, written from the completed symbol table, owns membership.
   w.deps.addParLe pool.tags.getOrIncl(toNifTag(n.kind)), trLineInfo(w, n.info)
   w.deps.addDotToken # flags
   w.deps.addDotToken # type
@@ -1403,7 +1383,8 @@ var offerTag = registerTag("offer")
 var typeOfferTag = registerTag("toffer")
 var modulesrcTag = registerTag("modulesrc")
 var expansionTag = registerTag("expansion")
-var overloadsTag = registerTag("overloads")
+var interfaceTag = registerTag("interface")
+var hiddenInterfaceTag = registerTag("hiddeninterface")
 # `(sig <symUse @src>)*` — signature occurrences (parameter names and the symbols
 # in their type expressions). A semchecked routine's params are dropped from the
 # serialized AST (`skipParams`) and reconstructed from `s.typ`, which holds the
@@ -1481,7 +1462,8 @@ proc registerNifAstTags*() =
   typeOfferTag = registerTag("toffer")
   modulesrcTag = registerTag("modulesrc")
   expansionTag = registerTag("expansion")
-  overloadsTag = registerTag("overloads")
+  interfaceTag = registerTag("interface")
+  hiddenInterfaceTag = registerTag("hiddeninterface")
   sigTag = registerTag("sig")
 
 proc emitSigOccurrences(w: var Writer; n: PNode) =
@@ -2074,7 +2056,7 @@ proc scanStmtsForCookie(s: var Sha1State; c: var CookieCtx; flat: seq[CookieTok]
            tg == "repdup" or tg == "reptrace" or tg == "repdeepcopy" or
            tg == "repenumtostr" or tg == "repmethod" or
            tg == exportName or tg == exportExceptName or tg == "include" or
-           tg == "overloads":
+           tg == "interface":
         let e = nextTree(flat, i)
         hashRegion(s, c, flat, i, e)
         i = e
@@ -2204,11 +2186,25 @@ proc writeSemDeps*(config: ConfigRef; thisModule: int32; importPaths: seq[string
   ## to the previous `nifstreams` writer.
   icnifcore.writeSemDeps(config, thisModule, importPaths)
 
+proc writeInterface(w: var Writer; dest: var IcBuilder; syms: openArray[PSym];
+                    hidden: bool) =
+  ## The sequence is authoritative; the definition index only supplies offsets.
+  dest.addParLe (if hidden: hiddenInterfaceTag else: interfaceTag), NoLineInfo
+  dest.addIntLit syms.len
+  for sym in syms:
+    if sym.kindImpl == skModule:
+      dest.addParLe reexpModTag, NoLineInfo
+      dest.addStrLit sym.name.s
+      dest.addStrLit cachedModuleSuffix(w.infos.config, FileIndex sym.positionImpl)
+      dest.addParRi()
+    else:
+      dest.addSymUse w.toNifSymName(sym)
+  dest.addParRi()
+
 proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
                      opsLog: seq[LogEntry];
                      replayActions: seq[PNode] = @[];
                      implDeps: seq[int] = @[];
-                     reexportedModules: seq[(string, string)] = @[];
                      genericOffers: seq[tuple[generic, inst: PSym;
                                               concreteTypes: seq[PType];
                                               genericParamsCount: int]] = @[];
@@ -2218,7 +2214,7 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
                      expansions: seq[(PSym, TLineInfo)] = @[];
                      moduleFlags: int32 = 0;
                      extraExports: seq[ItemId] = @[];
-                     exportedOverloads: seq[seq[PSym]] = @[]) =
+                     publicInterface: seq[PSym] = @[]; hiddenInterface: seq[PSym] = @[]) =
   var w = Writer(infos: newLineInfoWriter(config), currentModule: thisModule)
   for id in extraExports: w.extraExports.incl id
   w.deps = newIcBuilder(64)
@@ -2259,27 +2255,6 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
       w.deps.addDotToken # type
       w.deps.addStrLit fp
       w.deps.addParRi
-
-  # Re-exported MODULES (`import x; export x`): semExport puts only x's
-  # member syms into the nkExportStmt; the module sym itself reaches the
-  # exporter's interface via `reexportSym` and acts as a QUALIFIER there
-  # (`asmm.x86.nd`). Serialize (name, suffix) pairs so the loader can
-  # rebuild that part of the interface.
-  for (mname, msuffix) in reexportedModules:
-    w.deps.addParLe reexpModTag, NoLineInfo
-    w.deps.addStrLit mname
-    w.deps.addStrLit msuffix
-    w.deps.addParRi
-
-  # Generic alias lookup observes the first overload, including a template
-  # with default arguments used without a call. Preserve the actual interface
-  # order: neither index hash order nor symbol mint order reproduces it after
-  # the frontend's symbol table has grown and rehashed.
-  for overloads in exportedOverloads:
-    w.deps.addParLe overloadsTag, NoLineInfo
-    for candidate in overloads:
-      w.deps.addStrLit w.toNifSymName(candidate)
-    w.deps.addParRi
 
   # Generic-instance OFFERS: every generic instance this module created
   # (`getOrDefault[MultiCodec]`, …). A consumer that re-instantiates the same
@@ -2387,6 +2362,8 @@ proc writeNifModule*(config: ConfigRef; thisModule: int32; n: PNode;
   dest.addParLe modFlagsTag, NoLineInfo
   dest.addIntLit moduleFlags.int64
   dest.addParRi()
+  writeInterface(w, dest, publicInterface, hidden = false)
+  writeInterface(w, dest, hiddenInterface, hidden = true)
   addAll(dest, w.deps)
   # do not write the (stmts .. ) wrapper:
   addStmtsBody(dest, content)
@@ -2532,6 +2509,9 @@ type
       ## reuses freed cells promptly; not malloc, not ASan) could produce.
     when defined(icReleaseStrict):
       released: bool
+
+  ModuleResolver* = proc(name, suffix: string): PSym {.closure.}
+    ## Resolve a module qualifier and make its interface available to lookup.
 
   DecodeContext* = object
     infos: LineInfoWriter
@@ -3887,63 +3867,76 @@ proc extractBasename(nifName: string): string =
     if c == '.': break
     result.add c
 
-proc populateInterfaceTablesFromIndex(c: var DecodeContext; module: FileIndex;
-                                      interf, interfHidden: var TStrTable; thisModule: string) =
-  ## Populates interface tables from the NIF index structure.
-  ## Uses the simple embedded index for offsets, exports passed from processTopLevel.
+proc interfaceCursor(c: var DecodeContext; module: FileIndex; hidden: bool): Cursor =
+  let name = if hidden: "hiddeninterface" else: "interface"
+  var cur = c.mods[module].buf.beginRead()
+  cur.loopInto:
+    if cur.kind == TagLit and tagIs(cur, name):
+      return cur
+    skip cur
+  raiseAssert "missing " & name & " record in module " & c.mods[module].suffix
 
-  let m = c.mods[module]
-
-  # Only the EXPORTED half; `buildHiddenInterface` below does the rest, on
-  # demand. Exported symbols go into both tables, which costs little and leaves
-  # `interfHidden` a coherent view of a module with no hidden symbols rather
-  # than an empty one.
-  prof pIfaceModules
-  for nifName, entry in m.index.exportedPairs(m.buf):
-    if entry.vis == Exported:
-      prof pIfaceExported
-      let sym = loadSymFromIndexEntry(c, module, nifName, entry, thisModule)
+proc loadInterface(c: var DecodeContext; module: FileIndex; hidden: bool;
+                   resolveModule: ModuleResolver): TStrTable =
+  var cur = interfaceCursor(c, module, hidden)
+  if not hidden: prof pIfaceModules
+  cur.into:
+    expect cur, IntLit
+    let count = intVal(cur).int
+    skip cur
+    # Reserve before insertion. Rehashing enumerates physical slots and can
+    # change the lookup order of symbols sharing an identifier.
+    var capacity = StartSize
+    while capacity <= count or mustRehash(capacity, count):
+      capacity *= GrowthFactor
+    result = TStrTable(data: newSeq[PSym](capacity))
+    while cur.hasMore:
+      var sym: PSym = nil
+      if cur.kind == Symbol:
+        let name = symName(cur)
+        if c.mainModuleSuffix.len == 0 or parseSymName(name).module != c.mainModuleSuffix:
+          let owner = moduleId(c, parseSymName(name).module)
+          let entry = c.mods[owner].indexEntry(name)
+          if entry.offset != 0:
+            sym = loadSymFromIndexEntry(c, owner, name, entry, c.mods[owner].suffix)
+          else:
+            # Lowered artifacts omit unchanged type declarations. The backend
+            # resolves those through the semantic type buffer when demanded.
+            doAssert c.mods[owner].loweredPrimary, "missing interface symbol: " & name
+        skip cur
+      else:
+        expect cur, TagLit
+        doAssert tagIs(cur, "reexpmod")
+        var name, suffix = ""
+        cur.into:
+          expect cur, StrLit
+          name = strVal(cur)
+          skip cur
+          expect cur, StrLit
+          suffix = strVal(cur)
+          skip cur
+        doAssert resolveModule != nil
+        sym = resolveModule(name, suffix)
       if sym != nil:
-        strTableAdd(interf, sym)
-        strTableAdd(interfHidden, sym)
-
+        if hidden:
+          prof pIfaceHidden
+        else:
+          prof pIfaceExported
+        strTableAdd(result, sym)
 
 proc buildHiddenInterface*(c: var DecodeContext; suffix: string;
-                           interfHidden: var TStrTable): bool {.discardable.} =
-  ## The hidden-only half of a loaded module's interface, materialised on
-  ## demand. Deferred because almost nothing reads it: `interfHidden` is reached
-  ## exclusively through `modulegraphs.interfSelect`, which picks it only when
-  ## `optImportHidden` is in the module's options, and that flag is set in
-  ## exactly one place — an `import x {.all.}`. Building it eagerly was 1.05s of
-  ## a cold Atlas build: 1.70M hidden stubs against 0.29M exported ones, made by
-  ## every `nim m` for every module it imports and read by none of them.
-  ##
-  ## Takes the module SUFFIX, not a FileIndex, and that is the whole trick. A
-  ## module has TWO FileIndexes: `registerNifSuffix` keys
-  ## `filenameToIndexTbl` by the suffix string and mints a `fikNifModule` entry,
-  ## while the graph indexes `g.ifaces` by the module's `fikSource` file. `c.mods`
-  ## is keyed by the former. Asking it with the latter misses every single time,
-  ## silently, and an `import x {.all.}` then reports "undeclared identifier"
-  ## for a symbol that is right there.
-  ##
-  ## Returns false when the artifact is not on disk yet — an import the build
-  ## has not produced. The caller must leave the request PENDING then: writing
-  ## it off on that first miss costs the module its hidden symbols for the rest
-  ## of the process.
+                           interfHidden: var TStrTable;
+                           resolveModule: ModuleResolver): bool {.discardable.} =
+  ## Build the full interface independently, on demand. Appending private
+  ## symbols to the public table would lose the full interface's own order.
   let conf = c.infos.config
-  if not fileExists((getNimcacheDir(conf) / RelativeFile(suffix & ".s.bif")).string):
-    return false
-  let module = moduleId(c, suffix, {})
-  if not c.mods.hasKey(module): return false
-  let m = c.mods[module]
-  for nifName, entry in m.index.pairs(m.buf):
-    if entry.vis != Exported and not nifName.startsWith("`t"):
-      prof pIfaceHidden
-      # do not load types, they are not part of an interface but an implementation detail!
-      let sym = loadSymFromIndexEntry(c, module, nifName, entry, suffix)
-      if sym != nil:
-        strTableAdd(interfHidden, sym)
-  result = true
+  if fileExists((getNimcacheDir(conf) / RelativeFile(suffix & ".s.bif")).string):
+    let module = moduleId(c, suffix, {})
+    if not c.mods.hasKey(module): return false
+    interfHidden = loadInterface(c, module, true, resolveModule)
+    result = true
+  else:
+    result = false
 
 proc moduleSymbolStubs*(c: var DecodeContext; module: FileIndex): seq[PSym] =
   ## Stubs for every non-type symbol serialized in `module`'s NIF index. The
@@ -4091,8 +4084,6 @@ type
     deps*: seq[ModuleSuffix] # other modules we need to process the top level statements of
     logOps*: seq[LogEntry]
     module*: PSym # set by modulegraphs.nim!
-    reexportedModules*: seq[(string, string)] # (name, suffix) of re-exported MODULE syms;
-                                              # materialized by modulegraphs.nim
     genericOffers*: seq[tuple[generic, inst: PSym; concreteTypes: seq[PType];
                               genericParamsCount: int]]
       ## generic instances this module created; modulegraphs.nim rebuilds
@@ -4103,7 +4094,6 @@ type
       ## `typeInstCache` from them so a consumer reuses the baked instance
       ## (e.g. a `mixin`/`compiles()`-dependent array bound) instead of
       ## re-instantiating it with a different bound in its own scope.
-    overloads*: seq[seq[string]] ## exported symbols in frontend lookup order
     moduleFlags*: int32 ## the module SYMBOL's backend-relevant flags; see
                         ## `(modflags)` / `ModFlagInjectDestructors`.
     includes*: seq[string] # resolved full paths of files this module `include`s;
@@ -4167,7 +4157,7 @@ proc scanIncludeGraph*(config: ConfigRef): seq[tuple[includer: string; includes:
               else: includer = strVal(ic)
             skip ic
           skip c
-        elif tagIs(c, "import") or tagIs(c, "reexpmod"):
+        elif tagIs(c, "import") or tagIs(c, "interface") or tagIs(c, "hiddeninterface"):
           skip c
         else:
           done = true
@@ -4195,89 +4185,12 @@ proc nifModuleHasIncludes*(config: ConfigRef; fileIdx: FileIndex): bool =
         result = true
         done = true
         skip c
-      elif tagIs(c, "modulesrc") or tagIs(c, "import") or tagIs(c, "reexpmod"):
+      elif tagIs(c, "modulesrc") or tagIs(c, "import") or
+           tagIs(c, "interface") or tagIs(c, "hiddeninterface"):
         skip c
       else:
         done = true
         skip c
-
-proc peekSymKind(c: var DecodeContext; module: FileIndex;
-                 entry: NifIndexEntry): TSymKind =
-  ## The kind a symbol's `(sd …)` header records, WITHOUT decoding the symbol.
-  ##
-  ## The layout is `(sd <SymbolDef name> <marker: `x` | `.`> <kind> …)`, which is
-  ## exactly what `loadSymFromCursor` walks — that proc is the definition this
-  ## mirrors, so the two must be changed together. Anything unexpected answers
-  ## `skUnknown` and the caller falls back to a real load rather than guessing.
-  var n = cursorFromIndexEntry(c, module, entry)
-  if n.kind != TagLit or not tagIs(n, symDefTagName): return skUnknown
-  var k = childCursor(n)
-  if not k.hasMore or k.kind != SymbolDef: return skUnknown
-  skip k                     # the name
-  if not k.hasMore: return skUnknown
-  skip k                     # the `x` / `.` export marker
-  if not k.hasMore or k.kind != TagLit: return skUnknown
-  result = parse(TSymKind, cursorTag(k))
-
-proc symKindFast(c: var DecodeContext; sym: PSym; symAsStr: string): TSymKind =
-  ## `sym`'s kind, taken from its def header while it is still `Partial` rather
-  ## than by forcing the full decode. An already-loaded symbol answers from the
-  ## field, and anything the peek cannot read falls back to loading.
-  ##
-  ## `-d:icPeekKindCheck` grades the peek against the load it replaces, on every
-  ## call: the loaded kind is authoritative, so a disagreement is the peek's bug.
-  ## The oracle has to be run for the answer to mean anything — and broken on
-  ## purpose once, to confirm it fires.
-  if sym.state != Partial:
-    prof pPeekLoaded
-    return sym.kindImpl
-  let e = c.syms.getOrDefault(symAsStr)
-  if e[1].offset == 0:
-    prof pPeekFallback
-    loadSym(c, sym)
-    return sym.kindImpl
-  result = peekSymKind(c, sym.itemId.module.FileIndex, e[1])
-  if result == skUnknown:
-    # The peek could not read the header. Correct, but it is also how a walk
-    # that has drifted out of step with `loadSymFromCursor` would present, so
-    # the rate is counted rather than shrugged at: `-d:icBNodeProf` reports
-    # `PeekFallback` beside `PeekKind`, and it should stay at zero.
-    prof pPeekFallback
-    loadSym(c, sym)
-    return sym.kindImpl
-  prof pPeekKind
-  when defined(icPeekKindCheck):
-    let peeked = result
-    loadSym(c, sym)
-    doAssert peeked == sym.kindImpl,
-      "peekSymKind disagrees for " & symAsStr & ": peeked " & $peeked &
-      " but the load says " & $sym.kindImpl
-
-proc addReexportedEnumFields(c: var DecodeContext; sym: PSym; symAsStr: string;
-                             interf: var TStrTable) =
-  ## When a non-pure enum type is (re-)exported, its fields must also become
-  ## visible (unqualified) to importers. In a from-source build this happens via
-  ## `rawImportSymbol`'s enum handling when the type is imported; the lazy IC
-  ## importer never runs that, so we materialise the fields into the interface
-  ## here, when the export list is processed.
-  ##
-  ## Only a TYPE can contribute fields, and almost none of an export list is
-  ## types — so the kind is read off the def header first (`symKindFast`) rather
-  ## than by forcing every exported symbol through a full decode to find out.
-  ## That decode was 290ms of an 8.6s build over 34815 symbols.
-  if symKindFast(c, sym, symAsStr) != skType: return
-  loadSym(c, sym)
-  if sym.kindImpl != skType or sfPure in sym.flagsImpl: return
-  let et = sym.typImpl
-  if et == nil: return
-  loadType(c, et)
-  if et.kind notin {tyEnum, tyBool}: return
-  let fields = et.nImpl
-  if fields == nil: return
-  for i in 0 ..< fields.len:
-    let f = fields[i]
-    if f != nil and f.kind == nkSym and f.sym != nil:
-      strTableAdd(interf, f.sym)
 
 type
   TopTag = enum
@@ -4290,8 +4203,8 @@ type
     ttOther, ttReplay, ttUnusedId, ttModFlags,
     ttRepConverter, ttRepDestroy, ttRepWasMoved, ttRepCopy, ttRepSink, ttRepDup,
     ttRepTrace, ttRepDeepCopy, ttRepEnumToStr, ttRepMethod, ttRepPureEnum,
-    ttRepCppMember, ttExport, ttInclude, ttImport, ttReexpMod, ttOffer, ttTOffer,
-    ttModuleSrc, ttExpansion, ttOverloads, ttSig, ttImplementation,
+    ttRepCppMember, ttExport, ttInclude, ttImport, ttOffer, ttTOffer,
+    ttModuleSrc, ttExpansion, ttInterface, ttSig, ttImplementation,
     ttLetSection, ttVarSection, ttPragma
 
 const
@@ -4319,12 +4232,11 @@ proc classifyTopTag(name: string): TopTag =
   of "export": ttExport
   of "include": ttInclude
   of "import": ttImport
-  of "reexpmod": ttReexpMod
   of "offer": ttOffer
   of "toffer": ttTOffer
   of "modulesrc": ttModuleSrc
   of "expansion": ttExpansion
-  of "overloads": ttOverloads
+  of "interface", "hiddeninterface": ttInterface
   of "sig": ttSig
   of "implementation": ttImplementation
   else:
@@ -4355,7 +4267,7 @@ proc topTagAt(cur: Cursor): TopTag =
   result = TopTag(topTagCache[id])
 
 proc processTopLevel(c: var DecodeContext; cur: var Cursor; flags: set[LoadFlag];
-                     interf: var TStrTable; suffix: string; module: int): PrecompiledModule =
+                     suffix: string; module: int): PrecompiledModule =
   ## Step 2 phase 2: walk the module body directly over the resident `buf` cursor
   ## (was a `next(s)` stream walk). `cur` enters at the `(stmts` type dot. Lazy
   ## loads done here (resolveSym/loadType/…) read INDEPENDENT cursors into the
@@ -4395,16 +4307,8 @@ proc processTopLevel(c: var DecodeContext; cur: var Cursor; flags: set[LoadFlag]
             result.moduleFlags = int32 intVal(cur)
             skip cur
           while cur.hasMore: skip cur
-      of ttOverloads:
-        if SkipInterfaceTables in flags:
-          skip cur
-        else:
-          var names: seq[string] = @[]
-          cur.into:
-            while cur.hasMore:
-              names.add strVal(cur)
-              skip cur
-          result.overloads.add move names
+      of ttInterface:
+        skip cur # Loaded directly, in order, only when the interface is needed.
       of ttRepConverter:
         timed tTopLogOps:
           loadLogOp(c, result.logOps, cur, ConverterEntry, attachedTrace, module)
@@ -4442,48 +4346,9 @@ proc processTopLevel(c: var DecodeContext; cur: var Cursor; flags: set[LoadFlag]
         timed tTopLogOps:
           loadLogOp(c, result.logOps, cur, CppMemberEntry, attachedTrace, module)
       of ttExport:
-        if SkipInterfaceTables in flags:
-          # Same reason the interface tables are skipped: `interf` is a scratch
-          # table this caller throws away, so every `resolveSym` here (one per
-          # exported symbol, plus `addReexportedEnumFields`) only warms the
-          # name-keyed `c.syms` cache that `resolveSym` refills lazily on a miss.
-          skip cur
-          continue
-        icProfStart(tExportBranch)
-        cur.into:
-          while cur.hasMore and cur.kind == DotToken: skip cur  # flags / type
-          while cur.hasMore:
-            if cur.kind == Symbol:
-              prof pExportSyms
-              let symAsStr = symName(cur)
-              # Skip symbols re-exported by this dependency but owned by the module
-              # being compiled fresh (they would collide with the fresh originals).
-              if c.mainModuleSuffix.len == 0 or
-                 parseSymName(symAsStr).module != c.mainModuleSuffix:
-                icProfStart(tResolveSym)
-                let sym = resolveSym(c, symAsStr, false)
-                icProfStop(tResolveSym)
-                if sym != nil:
-                  strTableAdd(interf, sym)
-                  icProfStart(tEnumFields)
-                  addReexportedEnumFields(c, sym, symAsStr, interf)
-                  icProfStop(tEnumFields)
-              skip cur
-            else:
-              raiseAssert "expected Symbol or ParRi but got " & $cur.kind &
-                " in export list of module " & suffix
-        icProfStop(tExportBranch)
+        skip cur # Membership and order come exclusively from the interface record.
       of ttInclude: loadInclude(c, cur, result.includes)
       of ttImport:  loadImport(c, cur, result.deps)
-      of ttReexpMod:
-        # a re-exported MODULE: (reexpmod "name" "suffix"); the module sym is a
-        # qualifier in this module's interface — materialized by modulegraphs.
-        var mname, msuffix = ""
-        cur.into:
-          if cur.hasMore and cur.kind == StrLit: (mname = strVal(cur); skip cur)
-          if cur.hasMore and cur.kind == StrLit: (msuffix = strVal(cur); skip cur)
-        if mname.len > 0 and msuffix.len > 0:
-          result.reexportedModules.add (mname, msuffix)
       of ttOffer:
         # The offers exist to rebuild the FRONTEND's instantiation caches
         # (`procInstCache`/`typeInstCache`, see modulegraphs) so a later `nim m`
@@ -4606,36 +4471,16 @@ proc registerModuleSelfSym*(c: var DecodeContext; suffix: string; m: PSym) =
   if not c.syms.hasKey(key):
     c.syms[key] = (m, NifIndexEntry())
 
-proc restoreOverloadOrder(c: var DecodeContext; interf: var TStrTable;
-                          overloads: seq[seq[string]]) =
-  # Swap only slots with the same identifier, preserving the table's probe
-  # chains and all symbols added by export/enum handling.
-  for names in overloads:
-    var syms: seq[PSym] = @[]
-    for name in names:
-      if c.mainModuleSuffix.len > 0 and
-          parseSymName(name).module == c.mainModuleSuffix:
-        continue
-      let sym = resolveSym(c, name, false)
-      if sym != nil and strTableContains(interf, sym): syms.add sym
-    if syms.len < 2: continue
-    var h = syms[0].name.h and high(interf.data)
-    var i = 0
-    while interf.data[h] != nil:
-      if interf.data[h] in syms:
-        interf.data[h] = syms[i]
-        inc i
-      h = nextTry(h, high(interf.data))
-
 proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHidden: var TStrTable;
-                    flags: set[LoadFlag] = {}): PrecompiledModule =
+                    flags: set[LoadFlag] = {};
+                    resolveModule: ModuleResolver = nil): PrecompiledModule =
   # Ensure module index is loaded - moduleId returns the FileIndex for this suffix
   icProfStart(tModuleId)
   let module = moduleId(c, string(suffix), flags)
   icProfStop(tModuleId)
 
   # Load the module AST (or just replay actions if loadFullAst is false).
-  # processTopLevel also collects export instructions. Step 2 phase 2: read the
+  # Step 2 phase 2: read the
   # body straight from the resident `buf` cursor (no stream, no rewind — lazy
   # loads use independent cursors so they never disturb this one).
   var cur = beginRead(c.mods[module].buf)
@@ -4643,25 +4488,23 @@ proc loadNifModule*(c: var DecodeContext; suffix: ModuleSuffix; interf, interfHi
     inc cur        # enter (stmts (past the tag head, onto the flags dot)
     skip cur       # flags dot  (processTopLevel skips the type dot itself)
     icProfStart(tTopLevel)
-    result = processTopLevel(c, cur, flags, interf, string(suffix), module.int)
+    result = processTopLevel(c, cur, flags, string(suffix), module.int)
     icProfStop(tTopLevel)
   else:
     result = PrecompiledModule(topLevel: newNode(nkStmtList))
 
-  # Populate interface tables from the NIF index structure
-  # Symbols are created as stubs (Partial state) and will be loaded lazily via loadSym
-  # Use exports collected by processTopLevel
   if SkipInterfaceTables notin flags:
     icProfStart(tInterfTables)
-    populateInterfaceTablesFromIndex(c, module, interf, interfHidden, string(suffix))
-    restoreOverloadOrder(c, interf, result.overloads)
-    restoreOverloadOrder(c, interfHidden, result.overloads)
+    interf = loadInterface(c, module, false, resolveModule)
+    # The full interface is independent and stays lazy until an import {.all.}.
+    interfHidden = TStrTable(data: newSeq[PSym](StartSize))
     icProfStop(tInterfTables)
 
 proc loadNifModule*(c: var DecodeContext; f: FileIndex; interf, interfHidden: var TStrTable;
-                    flags: set[LoadFlag] = {}): PrecompiledModule =
+                    flags: set[LoadFlag] = {};
+                    resolveModule: ModuleResolver = nil): PrecompiledModule =
   let suffix = ModuleSuffix(moduleSuffix(c.infos.config, f))
-  result = loadNifModule(c, suffix, interf, interfHidden, flags)
+  result = loadNifModule(c, suffix, interf, interfHidden, flags, resolveModule)
 
 proc writeLoweredModule*(c: var DecodeContext; config: ConfigRef;
                          precomp: PrecompiledModule;
@@ -4746,11 +4589,6 @@ proc writeLoweredModule*(c: var DecodeContext; config: ConfigRef;
       w.deps.addDotToken
       w.deps.addStrLit dep.string
       w.deps.addParRi
-  for (mname, msuffix) in precomp.reexportedModules:
-    w.deps.addParLe reexpModTag, NoLineInfo
-    w.deps.addStrLit mname
-    w.deps.addStrLit msuffix
-    w.deps.addParRi
   for off in precomp.genericOffers:
     w.deps.addParLe offerTag, NoLineInfo
     w.deps.addSymUse pool.syms.getOrIncl(w.toNifSymName(off.generic)), NoLineInfo
@@ -4799,6 +4637,31 @@ proc writeLoweredModule*(c: var DecodeContext; config: ConfigRef;
   dest.addParLe modFlagsTag, NoLineInfo
   dest.addIntLit precomp.moduleFlags.int64
   dest.addParRi()
+  # Preserve interface references and order without loading their declarations.
+  for hidden in [false, true]:
+    var cur = interfaceCursor(c, FileIndex thisModule, hidden)
+    # Read names through icbif: nifcore.addSubtree reads pools directly, whose
+    # entries may still be empty under the mapped, lazy-name loader.
+    cur.into:
+      dest.addParLe (if hidden: hiddenInterfaceTag else: interfaceTag), NoLineInfo
+      expect cur, IntLit
+      dest.addIntLit intVal(cur)
+      skip cur
+      while cur.hasMore:
+        if cur.kind == Symbol:
+          dest.addSymUse pool.syms.getOrIncl(symName(cur)), NoLineInfo
+          skip cur
+        else:
+          expect cur, TagLit
+          doAssert tagIs(cur, "reexpmod")
+          dest.addParLe reexpModTag, NoLineInfo
+          cur.into:
+            while cur.hasMore:
+              expect cur, StrLit
+              dest.addStrLit strVal(cur)
+              skip cur
+          dest.addParRi()
+      dest.addParRi()
   addAll(dest, w.deps)
   addStmtsBody(dest, content)
   dest.addParRi()

--- a/compiler/astdef.nim
+++ b/compiler/astdef.nim
@@ -737,6 +737,7 @@ type
       #procInstCache*: seq[PInstantiation]
       gcUnsafetyReasonImpl*: PSym  # for better error messages regarding gcsafe
       transformedBodyImpl*: PNode  # cached body after transf pass
+      nifBodyLoadedImpl*: bool # body loaded from the fully lowered IC artifact
     of skLet, skVar, skField, skForVar:
       guardImpl*: PSym
       bitsizeImpl*: int
@@ -1175,6 +1176,7 @@ proc forcePartial*(s: PSym) =
   of routineKinds:
     s.gcUnsafetyReasonImpl = nil
     s.transformedBodyImpl = nil
+    s.nifBodyLoadedImpl = false
   of skLet, skVar, skField, skForVar:
     s.guardImpl = nil
     s.bitsizeImpl = 0

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3105,7 +3105,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       cgsym(p.module, $opr.loc.snippet)
       # make sure we have pointer-initialising code for hot code reloading
       if not wasDeclared and p.hcrOn:
-        let name = mangleDynLibProc(prc)
+        let name = mangleDynLibProc(p.module, prc)
         let rt = getTypeDesc(p.module, prc.loc.t)
         p.module.s[cfsDynLibInit].add('\t')
         p.module.s[cfsDynLibInit].addAssignmentWithValue(name):

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -859,7 +859,7 @@ proc fillObjectFields*(m: BModule; typ: PType) =
   if typ.baseClass != nil:
     fillObjectFields(m, typ.baseClass.skipTypes(skipPtrs))
 
-proc mangleDynLibProc(sym: PSym): Rope
+proc mangleDynLibProc(m: BModule; sym: PSym): Rope
 
 proc getRecordDesc(m: BModule; typ: PType, name: Rope,
                    check: var IntSet): Rope =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -982,7 +982,7 @@ proc assignGlobalVar(p: BProc; n: PNode; value: Rope) =
       varInDynamicLib(q, s)
     else:
       backendEnsureMutable s
-      s.locImpl.snippet = mangleDynLibProc(s)
+      s.locImpl.snippet = mangleDynLibProc(p.module, s)
     if value != "":
       internalError(p.config, n.info, ".dynlib variables cannot have a value")
     return
@@ -1225,12 +1225,24 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
 
   if lib.name == "": internalError(m.config, "loadDynamicLib")
 
-proc mangleDynLibProc(sym: PSym): Rope =
+proc isDeferredDynlib(sym: PSym): bool =
+  result = false
+  if sym.annex != nil and isGetProcAddr(sym.annex):
+    var index = sym.annex.path.lastSon
+    if index.kind == nkHiddenStdConv: index = index.secondSon
+    result = index.kind == nkStrLit and index.strVal.len == 1 and
+      index.strVal[0] in {'0'..'9'}
+
+proc mangleDynLibProc(m: BModule; sym: PSym): Rope =
   # we have to build this as a single rope in order not to trip the
   # optimization in genInfixCall, see test tests/cpp/t8241.nim
   if sfCompilerProc in sym.flags:
     # NOTE: sym.loc.snippet is the external name!
     result = rope(sym.name.s)
+  elif m.config.cmd == cmdNifC and isDeferredDynlib(sym):
+    # Process-local symbol IDs can alias unrelated imports in another TU.
+    # Deferred pointers need stable names and liveness marks just like procs.
+    result = markCName("Dl_" & sym.name.s.mangle & mangleProcNameExt(m.g.graph, sym))
   else:
     result = rope(strutils.`%`("Dl_$1_", $sym.id))
 
@@ -1263,7 +1275,8 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
   let isCall = isGetProcAddr(lib)
   var extname = sym.loc.snippet
   if not isCall: loadDynamicLib(m, lib)
-  var tmp = mangleDynLibProc(sym)
+  var tmp = mangleDynLibProc(m, sym)
+  let deferredIc = m.config.cmd == cmdNifC and isDeferredDynlib(sym)
   backendEnsureMutable sym
   sym.locImpl.snippet = tmp             # from now on we only need the internal name
   sym.typ.sym = nil           # generate a new name
@@ -1281,10 +1294,16 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
       params.add(rdLoc(a))
     params.add(makeCString($extname))
     template load(builder: var Builder) =
+      if deferredIc:
+        # A seeded but dead wrapper must not cause an unavailable extension to
+        # be resolved. The pointer and its assignment share liveness/ownership.
+        builder.add(cnifDefDirective(stripCnifMarks(tmp), "u", icNifName(m, sym)))
       builder.add('\t')
       builder.addAssignment(tmp,
         cCast(getTypeDesc(m, sym.typ, dkVar),
           cCall(callee, params)))
+      if deferredIc:
+        builder.add(cnifEndDefs())
     var last = lastSon(n)
     if last.kind == nkHiddenStdConv: last = last.secondSon
     internalAssert(m.config, last.kind == nkStrLit)
@@ -1304,14 +1323,23 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
         cCall(fn,
           lib.name,
           makeCString($extname))))
-  addDynLibVar(m, sym, getTypeDesc(m, sym.loc.t, dkVar))
+  let typ = getTypeDesc(m, sym.loc.t, dkVar)
+  if deferredIc:
+    let name = stripCnifMarks(tmp)
+    m.s[cfsVars].addDeclWithVisibility(Extern):
+      m.s[cfsVars].addVar(kind = Local, name = name, typ = typ)
+    m.s[cfsVars].add(cnifDefDirective(name, "u", icNifName(m, sym)))
+    m.s[cfsVars].addVar(name = tmp, typ = typ)
+    m.s[cfsVars].add(cnifEndDefs())
+  else:
+    addDynLibVar(m, sym, typ)
 
 proc varInDynamicLib(m: BModule, sym: PSym) =
   var lib = sym.annex
   var extname = sym.loc.snippet
   loadDynamicLib(m, lib)
   incl(sym, lfIndirect)
-  var tmp = mangleDynLibProc(sym)
+  var tmp = mangleDynLibProc(m, sym)
   backendEnsureMutable sym
   sym.locImpl.snippet = tmp             # from now on we only need the internal name
   inc(m.labels, 2)
@@ -1327,7 +1355,7 @@ proc varInDynamicLib(m: BModule, sym: PSym) =
 
 proc symInDynamicLibPartial(m: BModule, sym: PSym) =
   backendEnsureMutable sym
-  sym.locImpl.snippet = mangleDynLibProc(sym)
+  sym.locImpl.snippet = mangleDynLibProc(m, sym)
   sym.typ.sym = nil           # generate a new name
 
 proc cgsymImpl(m: BModule; sym: PSym) {.inline.} =
@@ -1879,7 +1907,7 @@ proc genProcPrototype(m: BModule, sym: PSym) =
     elif sym.itemId.module != m.module.position and
         not containsOrIncl(m.declaredThings, sym.id):
       let vis = if isReloadable(m, sym): StaticProc else: Extern
-      let name = mangleDynLibProc(sym)
+      let name = stripCnifMarks(mangleDynLibProc(m, sym))
       let t = getTypeDesc(m, sym.loc.t)
       m.s[cfsVars].addDeclWithVisibility(vis):
         m.s[cfsVars].addVar(kind = Local,
@@ -2577,7 +2605,7 @@ proc hcrGetProcLoadCode(builder: var Builder, m: BModule, sym, prefix, handle, g
   assert prc != nil
   fillProcLoc(m, son(prc.ast, namePos))
 
-  var tmp = mangleDynLibProc(prc)
+  var tmp = mangleDynLibProc(m, prc)
   backendEnsureMutable prc
   prc.locImpl.snippet = tmp
   prc.typ.sym = nil
@@ -2717,10 +2745,32 @@ proc genInitCode(m: BModule) =
   for i, el in pairs(m.extensionLoaders):
     if el.buf.len != 0:
       moduleInitRequired = true
+      var name = "nimLoadProcs" & $(i.ord - '0'.ord)
+      if m.config.cmd == cmdNifC and m.config.icBackendStage == "cg":
+        # Each IC translation unit has its own demanded dynlib pointers. Keep
+        # their deferred initializers separate; main provides the public entry
+        # point and calls every module's fragment, including cached modules.
+        name.add "__" & getSomeNameForModule(m)
+        if sfMainModule in m.module.flags:
+          m.g.icExtensionLoaders[i].add name
       procs.addDeclWithVisibility(ExternC):
-        procs.addProcHeader(ccNimCall, "nimLoadProcs" & $(i.ord - '0'.ord), CVoid, cProcParams())
+        procs.addProcHeader(ccNimCall, name, CVoid, cProcParams())
         procs.finishProcHeaderWithBody():
           procs.add(extract(el))
+
+  if m.config.cmd == cmdNifC and m.config.icBackendStage == "cg" and
+      sfMainModule in m.module.flags:
+    for i, names in pairs(m.g.icExtensionLoaders):
+      if names.len > 0:
+        for name in names:
+          procs.addDeclWithVisibility(ExternC):
+            procs.addProcHeader(ccNimCall, name, CVoid, cProcParams())
+            procs.finishProcHeaderAsProto()
+        procs.addDeclWithVisibility(ExternC):
+          procs.addProcHeader(ccNimCall, "nimLoadProcs" & $i, CVoid, cProcParams())
+          procs.finishProcHeaderWithBody():
+            for name in names:
+              procs.addCallStmt(name)
 
   if moduleInitRequired or sfMainModule in m.module.flags:
     m.s[cfsInitProc].add(extract(procs))
@@ -2828,12 +2878,16 @@ proc genModule(m: BModule, cfile: Cfile): Rope =
       if pos != m.module.position:
         implDeps.add modname(pos, m.config)
     sort implDeps
+    var extensionLoaders = ""
+    for i, el in pairs(m.extensionLoaders):
+      if el.buf.len > 0: extensionLoaders.add i
     writeCnifArtifact(result, artifact, initRequired, datInitRequired,
                       m.icDataDefs,
                       semmedNif = toNifFilename(m.config, FileIndex m.module.position),
                       moduleBase = getSomeNameForModule(m),
                       globalDtor = m.icGlobalDtorName,
-                      implDeps = implDeps)
+                      implDeps = implDeps,
+                      extensionLoaders = extensionLoaders)
     m.g.graph.icCnifFiles.add artifact
   # NB: under cmdNifC the returned text still carries the cnif marks; the
   # caller renders it (dropping dead definitions) or strips it.

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1685,7 +1685,10 @@ proc genProcLvl3*(m: BModule, prc: PSym) =
   # CT-evaluated or earlier-referenced routine), NOT a `.t.bif` load — gating on
   # it there would WRONGLY skip destructor injection and miscompile (orc
   # decref-on-freed). The `.t.bif`-loaded-body concept exists only under cmdNifC.
-  let wasLoaded = m.config.cmd == cmdNifC and prc.transformedBody != nil
+  # Lambda lifting can also populate this cache during IC codegen, especially
+  # for nested routines in generic instances. Those bodies still need ownership
+  # lowering; only the artifact loader can certify that it already happened.
+  let wasLoaded = m.config.cmd == cmdNifC and prc.nifBodyLoaded
   icProfStart(tTransform)
   var procBody = transformBody(m.g.graph, m.idgen, prc, {})
   if sfInjectDestructors in prc.flags and not wasLoaded:

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -119,6 +119,7 @@ type
 
   BModuleList* = ref object of RootObj
     mainModProcs*, mainModInit*, otherModsInit*, mainDatInit*: Builder
+    icExtensionLoaders*: array['0'..'9', seq[string]]
     mapping*: Rope             # the generated mapping file (if requested)
     mods*: seq[BModule]     # list of all compiled modules
     modulesClosed*: seq[BModule] # list of the same compiled modules, but in the order they were closed

--- a/compiler/cnif.nim
+++ b/compiler/cnif.nim
@@ -74,14 +74,15 @@ proc stripCnifMarks*(s: string): string =
       inc i
 
 const
-  CnifVersion* = "5"
+  CnifVersion* = "6"
     ## Artifact format version, stored in the meta head. Artifacts written
     ## by an older compiler lack the NIF names and the cref group the
     ## def-retention check needs (v2), the cdeps group the fine-grained
     ## reuse gate needs (v3), the type NIF names and cnif-marked extern
     ## RTTI references the typeinfo flavor of the def-retention check
     ## needs (v4), or the global-destructor name the main module's `cg`
-    ## calls at teardown (v5); `readCnifHeads` reports them as invalid so
+    ## calls at teardown (v5), or deferred dynlib loader indices (v6);
+    ## `readCnifHeads` reports them as invalid so
     ## their TUs simply regenerate once.
 
 proc cnifDefDirective*(name, flags, nifName: string): string =
@@ -94,11 +95,12 @@ proc writeCnifArtifact*(code: string; outfile: string;
                         initRequired = false; datInitRequired = false;
                         dataDefs: openArray[tuple[cname, nifname: string]] = [];
                         semmedNif = ""; moduleBase = ""; globalDtor = "";
-                        implDeps: openArray[string] = []) =
+                        implDeps: openArray[string] = [];
+                        extensionLoaders = "") =
   ## Splits the marked module text into the `.c.nif` artifact.
   ## The artifact starts with a `(meta <flags> "semmedNif" "moduleBase"
-  ## "version" "globalDtor")` head — whether the module has an init/datInit
-  ## proc ('i'/'d'), which semmed NIF it was generated from, the module's
+  ## "version" "globalDtor" "extensionLoaders")` head — whether the module has
+  ## an init/datInit proc ('i'/'d'), which semmed NIF it was generated from, the module's
   ## mangled base name (what `registerModuleToMain` and the reuse decision
   ## need when the TU is reused in a later run, possibly without the module
   ## ever being loaded again) and the C name of the module's global-destructor
@@ -158,6 +160,7 @@ proc writeCnifArtifact*(code: string; outfile: string;
       b.addStrLit moduleBase
       b.addStrLit CnifVersion
       b.addStrLit globalDtor
+      b.addStrLit extensionLoaders
     b.withTree "cdata":
       for d in dataDefs:
         b.addSymbolDef d.cname
@@ -268,6 +271,7 @@ type
     moduleBase*: string      ## the module's mangled base name
     globalDtor*: string      ## C name of the module's global-destructor proc
                              ## ("" when the module has no global destructors)
+    extensionLoaders*: string ## deferred dynlib loader indices ('0'..'9')
     cdefs*: seq[tuple[cname, nifname: string]] ## the proc definitions
     cdata*: seq[tuple[cname, nifname: string]] ## the data definitions
     crefs*: seq[string]      ## C names referenced but not defined here
@@ -337,6 +341,7 @@ proc readCnifHeads*(f: string): CnifHeads =
               elif strIdx == 1: result.moduleBase = v
               elif strIdx == 2: version = v
               elif strIdx == 3: result.globalDtor = v
+              elif strIdx == 4: result.extensionLoaders = v
               inc strIdx
           else: discard
       elif tok.data == "cdata":

--- a/compiler/deps.nim
+++ b/compiler/deps.nim
@@ -1025,7 +1025,12 @@ proc computeForwardedArgs(c: DepContext): seq[string] =
     "icproject", "icpreparsedconfig", "icconfigout", "icgroup",
     "icbackendstage", "icbackendmodule", "ismainmodule",
     "help", "h", "fullhelp", "version", "v", "advanced"]
+  var positionalArgs = 0
   for a in commandLineParams():
+    if a.len > 0 and a[0] != '-':
+      inc positionalArgs
+      if positionalArgs == 2 and c.config.cmd != cmdTrack:
+        break # program arguments must not become compiler switches in children
     if a.len < 2 or a[0] != '-': continue
     var i = 1
     if i < a.len and a[i] == '-': inc i

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -691,8 +691,11 @@ proc externalFileChanged(conf: ConfigRef; cfile: Cfile): bool =
 proc addExternalFileToCompile*(conf: ConfigRef; c: var Cfile) =
   # we want to generate the hash file unconditionally
   let extFileChanged = externalFileChanged(conf, c)
+  # A matching source hash does not prove that the object belongs to it. A
+  # classic build can overwrite IC's main object without updating its SHA1;
+  # after emit restores the IC source, that object is older than the source.
   if optForceFullMake notin conf.globalOptions and fileExists(c.obj) and
-      not extFileChanged:
+      not extFileChanged and os.fileNewer(c.obj.string, c.cname.string):
     c.flags.incl CfileFlag.Cached
   else:
     # make sure Nim keeps recompiling the external file on reruns

--- a/compiler/icconfig.nim
+++ b/compiler/icconfig.nim
@@ -264,10 +264,10 @@ proc ensureIcConfig*(conf: ConfigRef) =
     # and the explicit output path. Every switch must land BEFORE the project
     # file, because anything after the project is swallowed into
     # `config.arguments` by `cmdLineRest` (and a non-empty `arguments` without
-    # `--run` is a hard error). Callers may legitimately put switches after the
-    # project — `nim track PROJ --def:...` — so we re-order rather than replay
-    # verbatim: all `-`-prefixed switches first (in encounter order), then the
-    # non-switch project token(s). The producer re-reads `nim.cfg` itself.
+    # `--run` is a hard error). Program arguments must not reach the config
+    # producer, even when they look like compiler switches. Only `nim track`
+    # accepts compiler switches after the project; move those before it.
+    # The producer re-reads `nim.cfg` itself.
     var pargs = @["icconfig", "--icConfigOut:" & outPath]
     # The command token is dropped below, so `nim cpp --ic:on` would hand the
     # producer a C-backend config: name the backend explicitly. (`nim ic
@@ -293,7 +293,8 @@ proc ensureIcConfig*(conf: ConfigRef) =
       elif not droppedCmd:
         droppedCmd = true  # drop the original command token (`ic`/`track`)
       else:
-        rest.add a  # project file (and any further non-switch tokens) go last
+        rest.add a
+        if conf.cmd != cmdTrack: break # everything after the project is a program argument
     for a in rest: pargs.add a
     let p = startProcess(getAppFilename(), args = pargs,
                          options = {poStdErrToStdOut})

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -341,6 +341,20 @@ iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
     if s != nil:
       yield s
 
+proc exportedOverloads*(g: ModuleGraph; m: PSym): seq[seq[PSym]] =
+  ## Preserve lookup order for overloaded names across IC serialization.
+  result = @[]
+  var seen = initHashSet[int]()
+  for sym in items(semtab(g, m)):
+    if seen.containsOrIncl(sym.name.id): continue
+    var overloads: seq[PSym] = @[]
+    var it = default(TIdentIter)
+    var candidate = initIdentIter(it, semtab(g, m), sym.name)
+    while candidate != nil:
+      overloads.add candidate
+      candidate = nextIdentIter(it, semtab(g, m))
+    if overloads.len > 1: result.add move overloads
+
 proc reexportedModuleSyms*(g: ModuleGraph; m: PSym): seq[(string, string)] =
   ## (name, NIF module suffix) of MODULE syms in `m`'s interface — these are
   ## re-exports (`import x; export x`, added by `reexportSym`) acting as

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -11,7 +11,7 @@
 ## represents a complete Nim project. Single modules can either be kept in RAM
 ## or stored in a rod-file.
 
-import std/[intsets, tables, hashes, strtabs, os, strutils, parseutils, sets]
+import std/[algorithm, intsets, tables, hashes, strtabs, os, strutils, parseutils, sets]
 import ../dist/checksums/src/checksums/md5
 import ast, astalgo, options, lineinfos,idents, btrees, ropes, msgs, pathutils, packages, suggestsymdb
 
@@ -351,18 +351,26 @@ iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
       yield s
 
 proc orderedInterface*(g: ModuleGraph; m: PSym; hidden = false): seq[PSym] =
-  ## Each identifier's symbols appear in the frontend's lookup order.
+  ## Names are sorted; each identifier's symbols retain frontend lookup order.
+  ## Re-exporting must not depend on physical hash-table slots: a loaded table
+  ## can have a different layout while preserving every identifier's order.
   result = @[]
   if hidden: ensureHiddenIface(g, m.position)
   let tab = if hidden: addr semtabAll(g, m) else: addr semtab(g, m)
   var seen = initHashSet[int]()
+  var names: seq[PIdent] = @[]
   for sym in items(tab[]):
     if not seen.containsOrIncl(sym.name.id):
-      var it = default(TIdentIter)
-      var candidate = initIdentIter(it, tab[], sym.name)
-      while candidate != nil:
-        result.add candidate
-        candidate = nextIdentIter(it, tab[])
+      names.add sym.name
+  names.sort(proc(a, b: PIdent): int =
+    result = cmp(a.s[0], b.s[0])
+    if result == 0: result = cmpIgnoreStyle(a.s, b.s))
+  for name in names:
+    var it = default(TIdentIter)
+    var candidate = initIdentIter(it, tab[], name)
+    while candidate != nil:
+      result.add candidate
+      candidate = nextIdentIter(it, tab[])
 
 proc reexportedLocalSyms*(g: ModuleGraph; m: PSym): seq[ItemId] =
   ## Symbols DEFINED in `m` that reached `m`'s interface through an explicit

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -36,10 +36,8 @@ type
     pureEnums*: seq[PSym]
     interf: TStrTable
     interfHidden: TStrTable
-    hiddenPending: bool ## `interfHidden` holds only the exported half so far;
-                        ## `ensureHiddenIface` materialises the hidden-only
-                        ## symbols on first use. See
-                        ## `ast2nif.buildHiddenInterface`.
+    hiddenPending: bool ## The full interface is built from its ordered BIF
+                        ## record on first use by `ensureHiddenIface`.
     uniqueName*: Rope
 
   Operators* = object
@@ -274,10 +272,21 @@ proc toBase64a(s: cstring, len: int): string =
     result.add cb64[a shr 2]
     result.add cb64[(a and 3) shl 4]
 
+when not defined(nimKochBootstrap):
+  proc materializeReexportedModule(g: ModuleGraph; mname, msuffix: string): PSym
+
+  proc moduleResolver(g: ModuleGraph): ModuleResolver =
+    result = proc(name, suffix: string): PSym =
+      materializeReexportedModule(g, name, suffix)
+
 proc ensureHiddenIface(g: ModuleGraph; pos: int) =
-  ## Materialise a loaded module's hidden-only interface the first time anything
+  ## Materialise a loaded module's full interface the first time anything
   ## asks for it. Every READ of `interfHidden` goes through `interfSelect`, so
   ## guarding those sites is complete.
+  if g.config.cmd == cmdM:
+    # Private declarations and their order are outside the public fingerprint.
+    # Record every consumer, including those reusing an already-built table.
+    g.icImplDeps.incl pos
   if g.ifaces[pos].hiddenPending:
     when not defined(nimKochBootstrap):
       # By SUFFIX: `c.mods` and `g.ifaces` use different FileIndexes for the
@@ -287,7 +296,7 @@ proc ensureHiddenIface(g: ModuleGraph; pos: int) =
       # `.s.bif` does not exist yet is retried rather than written off.
       var tab = g.ifaces[pos].interfHidden
       if buildHiddenInterface(ast.program,
-                              cachedModuleSuffix(g.config, FileIndex pos), tab):
+                              cachedModuleSuffix(g.config, FileIndex pos), tab, moduleResolver(g)):
         g.ifaces[pos].interfHidden = tab
         g.ifaces[pos].hiddenPending = false
     else:
@@ -341,31 +350,19 @@ iterator allSyms*(g: ModuleGraph; m: PSym): PSym =
     if s != nil:
       yield s
 
-proc exportedOverloads*(g: ModuleGraph; m: PSym): seq[seq[PSym]] =
-  ## Preserve lookup order for overloaded names across IC serialization.
+proc orderedInterface*(g: ModuleGraph; m: PSym; hidden = false): seq[PSym] =
+  ## Each identifier's symbols appear in the frontend's lookup order.
   result = @[]
+  if hidden: ensureHiddenIface(g, m.position)
+  let tab = if hidden: addr semtabAll(g, m) else: addr semtab(g, m)
   var seen = initHashSet[int]()
-  for sym in items(semtab(g, m)):
-    if seen.containsOrIncl(sym.name.id): continue
-    var overloads: seq[PSym] = @[]
-    var it = default(TIdentIter)
-    var candidate = initIdentIter(it, semtab(g, m), sym.name)
-    while candidate != nil:
-      overloads.add candidate
-      candidate = nextIdentIter(it, semtab(g, m))
-    if overloads.len > 1: result.add move overloads
-
-proc reexportedModuleSyms*(g: ModuleGraph; m: PSym): seq[(string, string)] =
-  ## (name, NIF module suffix) of MODULE syms in `m`'s interface — these are
-  ## re-exports (`import x; export x`, added by `reexportSym`) acting as
-  ## qualifiers (`m.x.sym`). Consumed by the NIF writer; semExport does not
-  ## put them into the nkExportStmt children, so the AST walk cannot see them.
-  result = @[]
-  var seen = initIntSet()
-  for s in g.ifaces[m.position].interf.data:
-    if s != nil and s.kind == skModule and s.position != m.position and
-        not seen.containsOrIncl(s.position):
-      result.add (s.name.s, cachedModuleSuffix(g.config, FileIndex s.position))
+  for sym in items(tab[]):
+    if not seen.containsOrIncl(sym.name.id):
+      var it = default(TIdentIter)
+      var candidate = initIdentIter(it, tab[], sym.name)
+      while candidate != nil:
+        result.add candidate
+        candidate = nextIdentIter(it, tab[])
 
 proc reexportedLocalSyms*(g: ModuleGraph; m: PSym): seq[ItemId] =
   ## Symbols DEFINED in `m` that reached `m`'s interface through an explicit
@@ -1167,13 +1164,8 @@ when not defined(nimKochBootstrap):
         not g.icQualIfaces.containsOrIncl(fIdx.int):
       var interf = initStrTable()
       var interfHidden = initStrTable()
-      let precomp = loadNifModule(ast.program, ModuleSuffix(msuffix),
-                                  interf, interfHidden, {})
-      # chains: the re-exported module may itself re-export modules
-      for (n2, s2) in precomp.reexportedModules:
-        let inner = materializeReexportedModule(g, n2, s2)
-        if inner != nil:
-          strTableAdd(interf, inner)
+      discard loadNifModule(ast.program, ModuleSuffix(msuffix),
+                            interf, interfHidden, {}, moduleResolver(g))
       g.ifaces[fIdx.int].interf = interf
       g.ifaces[fIdx.int].interfHidden = interfHidden
       g.ifaces[fIdx.int].hiddenPending = true
@@ -1219,20 +1211,20 @@ when not defined(nimKochBootstrap):
     if g.config.cmd == cmdNifC:
       registerModuleSelfSym(ast.program, cachedModuleSuffix(g.config, fileIdx), m)
 
-    result = loadNifModule(ast.program, fileIdx,
-                           g.ifaces[fileIdx.int].interf,
-                           g.ifaces[fileIdx.int].interfHidden, flags)
-    # The hidden-only half was not built; `ensureHiddenIface` will, if asked.
+    # Resolving module aliases can grow g.ifaces. Keep the tables local until
+    # loading finishes so no var argument points into a reallocated sequence.
+    var interf = initStrTable()
+    var interfHidden = initStrTable()
+    result = loadNifModule(ast.program, fileIdx, interf, interfHidden, flags, moduleResolver(g))
+    g.ifaces[fileIdx.int].interf = move interf
+    g.ifaces[fileIdx.int].interfHidden = move interfHidden
+    # The full interface stays lazy until `ensureHiddenIface` is asked for it.
     g.ifaces[fileIdx.int].hiddenPending = true
     result.module = m
     # Restore the module symbol's persisted flags (see ast2nif `(modflags)`);
     # `cgen.genTopLevelStmt` gates the destructor pass on `sfInjectDestructors`.
     if (result.moduleFlags and ModFlagInjectDestructors) != 0:
       m.incl sfInjectDestructors
-    for (mname, msuffix) in result.reexportedModules:
-      let ms = materializeReexportedModule(g, mname, msuffix)
-      if ms != nil:
-        strTableAdd(g.ifaces[fileIdx.int].interf, ms)
     # Re-establish include->module mapping so nimsuggest's `parentModule` can map
     # a query in an included file back to this (NIF-loaded) module and recompile
     # it, exactly as it does for a from-source module. Without this the include

--- a/compiler/nifbackend.nim
+++ b/compiler/nifbackend.nim
@@ -747,6 +747,8 @@ proc cgFinishModule(g: ModuleGraph; target: PrecompiledModule;
       let heads = readCnifHeads(getCFile(m).string & ".nif")
       registerReusedModuleToMain(bl, m, heads.initRequired, heads.datInitRequired)
       if heads.globalDtor.len > 0: g.icModuleDtors.add heads.globalDtor
+      for i in heads.extensionLoaders:
+        bl.icExtensionLoaders[i].add "nimLoadProcs" & $i & "__" & heads.moduleBase
     # `ordered` is dependency (post-order) init order; teardown runs in reverse,
     # so an importer's globals are destroyed before the ones it may still point
     # at. This mirrors whole-program cgen, which walks its single accumulated

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -152,7 +152,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   if optRun in conf.globalOptions:
     let output = conf.absOutFile
     case conf.cmd
-    of cmdBackends, cmdTcc:
+    of cmdBackends, cmdTcc, cmdIc:
       let nimRunExe = getNimRunExe(conf)
       var cmdPrefix = ""
       if nimRunExe.len > 0: cmdPrefix.add nimRunExe.quoteShell

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -29,8 +29,8 @@ const
 
   nimEnableCovariance* = defined(nimEnableCovariance)
 
-  icFormatVersion* = "40"
-    ## v40: per-module deferred dynlib loaders and loader indices in C artifacts.
+  icFormatVersion* = "41"
+    ## v41: preserve exported overload order and regenerate ownership lowering.
     ## Version of the IC cache format (the sem-NIF module layout written by
     ## ast2nif.nim plus the iface/impl/edges side files). Bump it whenever
     ## that layout changes: `commandIc` wipes a nimcache whose `ic.version`

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -29,7 +29,8 @@ const
 
   nimEnableCovariance* = defined(nimEnableCovariance)
 
-  icFormatVersion* = "39"
+  icFormatVersion* = "40"
+    ## v40: per-module deferred dynlib loaders and loader indices in C artifacts.
     ## Version of the IC cache format (the sem-NIF module layout written by
     ## ast2nif.nim plus the iface/impl/edges side files). Bump it whenever
     ## that layout changes: `commandIc` wipes a nimcache whose `ic.version`

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -29,8 +29,8 @@ const
 
   nimEnableCovariance* = defined(nimEnableCovariance)
 
-  icFormatVersion* = "41"
-    ## v41: preserve exported overload order and regenerate ownership lowering.
+  icFormatVersion* = "42"
+    ## v42: authoritative ordered public and hidden interfaces.
     ## Version of the IC cache format (the sem-NIF module layout written by
     ## ast2nif.nim plus the iface/impl/edges side files). Bump it whenever
     ## that layout changes: `commandIc` wipes a nimcache whose `ic.version`

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -29,8 +29,8 @@ const
 
   nimEnableCovariance* = defined(nimEnableCovariance)
 
-  icFormatVersion* = "42"
-    ## v42: authoritative ordered public and hidden interfaces.
+  icFormatVersion* = "43"
+    ## v43: deterministic re-export traversal for ordered interfaces.
     ## Version of the IC cache format (the sem-NIF module layout written by
     ## ast2nif.nim plus the iface/impl/edges side files). Bump it whenever
     ## that layout changes: `commandIc` wipes a nimcache whose `ic.version`

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -342,7 +342,8 @@ proc processPipelineModuleImpl(graph: ModuleGraph; module: PSym; idgen: IdGenera
                        replayActions, implDeps, reexportedModuleSyms(graph, module),
                        genericOffers, typeOffers, resolvedImportDeps, firstUnusedId,
                        expansions, moduleFlags,
-                       reexportedLocalSyms(graph, module))
+                       reexportedLocalSyms(graph, module),
+                       exportedOverloads(graph, module))
       # The module's REAL direct imports (incl. macro-generated) for `nim ic`'s
       # graph re-derivation; see ast2nif.writeSemDeps / semdata.addImportFileDep.
       var semDepPaths: seq[string] = @[]

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -339,11 +339,12 @@ proc processPipelineModuleImpl(graph: ModuleGraph; module: PSym; idgen: IdGenera
         if sfInjectDestructors in module.flags: ModFlagInjectDestructors else: 0'i32
       timed tWriteNif:
         writeNifModule(graph.config, module.position.int32, topLevelStmts, graph.opsLog,
-                       replayActions, implDeps, reexportedModuleSyms(graph, module),
+                       replayActions, implDeps,
                        genericOffers, typeOffers, resolvedImportDeps, firstUnusedId,
                        expansions, moduleFlags,
                        reexportedLocalSyms(graph, module),
-                       exportedOverloads(graph, module))
+                       orderedInterface(graph, module),
+                       orderedInterface(graph, module, hidden = true))
       # The module's REAL direct imports (incl. macro-generated) for `nim ic`'s
       # graph re-derivation; see ast2nif.writeSemDeps / semdata.addImportFileDep.
       var semDepPaths: seq[string] = @[]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -3093,7 +3093,7 @@ proc semExportExcept(c: PContext, n: PNode): PNode =
   let exported = moduleName.sym
   result = newNodeI(nkExportStmt, n.info)
   reexportSym(c, exported)
-  for s in allSyms(c.graph, exported):
+  for s in orderedInterface(c.graph, exported, optImportHidden in exported.options):
     if s.kind in ExportableSymKinds+{skModule} and
        s.name.id notin exceptSet and sfError notin s.flags:
       reexportSym(c, s)
@@ -3116,7 +3116,7 @@ proc semExport(c: PContext, n: PNode): PNode =
     elif s.kind == skModule:
       # forward everything from that module:
       reexportSym(c, s)
-      for it in allSyms(c.graph, s):
+      for it in orderedInterface(c.graph, s, optImportHidden in s.options):
         if it.kind in ExportableSymKinds+{skModule}:
           reexportSym(c, it)
           result.add newSymNode(it, a.info)

--- a/doc/ic.md
+++ b/doc/ic.md
@@ -101,6 +101,32 @@ backend:
   picks the single artifact allowed to embed each body (smallest claimant), which
   is the cross-process replacement for the old in-process single-writer machinery.
 
+Ordered module interfaces
+=========================
+
+Each semantic BIF carries two authoritative interface records:
+
+* ``(interface <count> <symbol>...)`` lists public symbols, including re-exports.
+* ``(hiddeninterface <count> <symbol>...)`` lists the full interface used by
+  ``import module {.all.}``, including both public and private symbols.
+
+Symbols with the same identifier appear in the frontend's lookup order. A module
+qualifier is represented by ``(reexpmod "alias" "moduleSuffix")`` in the sequence.
+The definition index supplies symbol offsets; its hash-table iteration order does
+not determine interface membership or overload precedence.
+
+The loader reserves space for the complete record before inserting its symbols,
+so table growth cannot scramble the recorded order. It builds the public table
+on import and the full table independently on first hidden lookup. Module aliases
+are resolved during insertion, with no later appends or slot-reordering pass.
+Lowered BIFs carry these records forward without eagerly loading declarations.
+
+The public record contributes to the interface fingerprint, so changing overload
+order invalidates importers. The full record contributes to the implementation
+fingerprint, and hidden lookups record an implementation dependency so private
+edits invalidate their consumers too. These records expose candidate order to
+tooling; they are not a trace of call-site overload resolution.
+
 The driver: graph construction (`commandIc`)
 ============================================
 

--- a/doc/ic.md
+++ b/doc/ic.md
@@ -110,8 +110,11 @@ Each semantic BIF carries two authoritative interface records:
 * ``(hiddeninterface <count> <symbol>...)`` lists the full interface used by
   ``import module {.all.}``, including both public and private symbols.
 
-Symbols with the same identifier appear in the frontend's lookup order. A module
-qualifier is represented by ``(reexpmod "alias" "moduleSuffix")`` in the sequence.
+Identifier groups are sorted by name; symbols with the same identifier appear in
+the frontend's lookup order. Whole-module exports (including ``export except``)
+use this same traversal, so re-export chains do not depend on whether a source or
+cached hash table supplies the symbols. A module qualifier is represented by
+``(reexpmod "alias" "moduleSuffix")`` in the sequence.
 The definition index supplies symbol offsets; its hash-table iteration order does
 not determine interface membership or overload precedence.
 

--- a/tests/compiler/tichiddeninterface.nim
+++ b/tests/compiler/tichiddeninterface.nim
@@ -1,0 +1,41 @@
+discard """
+  joinable: false
+"""
+
+import std/[assertions, os, osproc, strutils, tempfiles]
+
+const nim = getCurrentCompilerExe()
+
+let dir = createTempDir("nim_ic_hidden_interface_", "")
+let source = dir / "main.nim"
+let dependency = dir / "hidden.nim"
+let binary = dir / "prog".addFileExt(ExeExt)
+
+proc build(expected: string) =
+  let compiled = execCmdEx(quoteShellCommand([nim, "ic", "--hints:off", "--warnings:off",
+    "--nimcache:" & dir / "nc", "--out:" & binary, source]))
+  doAssert compiled.exitCode == 0, compiled.output
+  let executed = execCmdEx(quoteShell(binary))
+  doAssert executed.exitCode == 0, executed.output
+  doAssert executed.output.strip == expected, executed.output
+
+try:
+  writeFile(source, """
+import hidden {.all.}
+when compiles(value(1)):
+  echo value(1)
+else:
+  echo value("text")
+""")
+  writeFile(dependency, "proc value(x: int): string = \"int\"\n")
+  build("int")
+  build("int")
+  let mainModified = getLastModificationTime(source)
+  # Keep main.nim untouched: rewriting it would force sem independently of
+  # whether the hidden interface correctly invalidates its importer.
+  writeFile(dependency, "proc value(x: string): string = \"string\"\n")
+  build("string")
+  build("string")
+  doAssert getLastModificationTime(source) == mainModified
+finally:
+  removeDir(dir)

--- a/tests/compiler/ticinterface.nim
+++ b/tests/compiler/ticinterface.nim
@@ -2,7 +2,7 @@ discard """
   joinable: false
 """
 
-import std/[assertions, os, tempfiles]
+import std/[algorithm, assertions, os, strutils, tempfiles]
 import compiler/[ast, astalgo, ast2nif, idents, lineinfos, modulegraphs, msgs, options, pathutils, typekeys]
 
 # Compare the actual lookup sequence, not just successful overload resolution.
@@ -14,7 +14,10 @@ proc ids(tab: TStrTable; name: PIdent): seq[int32] =
     result.add sym.disamb
     sym = nextIdentIter(it, tab)
 
-proc run(count: int) =
+type Visibility = enum
+  allPublic, allPrivate, mixed
+
+proc run(count: int; visibility: Visibility) =
   let dir = createTempDir("nim_ic_interface_", "")
   try:
     let conf = newConfigRef()
@@ -32,45 +35,64 @@ proc run(count: int) =
       itemId: itemId(file.int32, 0), positionImpl: file.int, infoImpl: info)
     graph.registerModule(module)
     let idgen = idGeneratorFromModule(module)
-    let name = getIdent(cache, "choose")
+    let names = [getIdent(cache, "choose"), getIdent(cache, "anotherChoice"),
+      getIdent(cache, "anotherAlternative"),
+      getIdent(cache, "longOverloadedNameThatCannotBeStoredInline")]
     let body = newNodeI(nkStmtList, info)
     var publicTable = initStrTable()
     for i in 0 ..< count:
-      let sym = newSym(skProc, name, idgen, module, info)
-      # Interleave private and public overloads under the SAME identifier.
-      if i mod 3 == 0:
-        sym.incl sfExported
-        graph.strTableAdds(module, sym)
-        strTableAdd(publicTable, sym)
-      else:
-        strTableAdd(semtabAll(graph, module), sym)
-      body.add newSymNode(sym)
+      for name in names:
+        # Style-equivalent spellings share a lookup group too.
+        let spelling = if i mod 2 == 0: name else:
+          getIdent(cache, name.s[0] & "_" & name.s[1..^1].toUpperAscii)
+        let sym = newSym(skProc, spelling, idgen, module, info)
+        # Interleave private and public overloads under the SAME identifiers.
+        if visibility == allPublic or (visibility == mixed and i mod 3 == 0):
+          sym.incl sfExported
+          graph.strTableAdds(module, sym)
+          strTableAdd(publicTable, sym)
+        else:
+          strTableAdd(semtabAll(graph, module), sym)
+        body.add newSymNode(sym)
       # Unrelated names force hash collisions and table growth too.
       let other = newSym(skProc, getIdent(cache, "other" & $i), idgen, module, info)
-      other.incl sfExported
-      graph.strTableAdds(module, other)
-      strTableAdd(publicTable, other)
+      if visibility != allPrivate:
+        other.incl sfExported
+        graph.strTableAdds(module, other)
+        strTableAdd(publicTable, other)
+      else:
+        strTableAdd(semtabAll(graph, module), other)
       body.add newSymNode(other)
-    let expectedPublic = ids(publicTable, name)
-    let expectedHidden = ids(semtabAll(graph, module), name)
+    var expectedPublic, expectedHidden: seq[seq[int32]]
+    for name in names:
+      expectedPublic.add ids(publicTable, name)
+      expectedHidden.add ids(semtabAll(graph, module), name)
+    # Definition/index order must not become the source of interface order.
+    body.sons.reverse()
     let publicSyms = orderedInterface(graph, module)
     let hiddenSyms = orderedInterface(graph, module, hidden = true)
     writeNifModule(conf, file.int32, body, @[],
       publicInterface = publicSyms, hiddenInterface = hiddenSyms)
 
-    var decoder = createDecodeContext(conf, cache)
-    var exported = initStrTable()
-    var hidden = initStrTable()
-    discard loadNifModule(decoder, file, exported, hidden)
-    doAssert ids(exported, name) == expectedPublic
-    doAssert hidden.counter == 0 # hidden symbols are still lazy
-    doAssert buildHiddenInterface(decoder, cachedModuleSuffix(conf, file), hidden, nil)
-    doAssert ids(hidden, name) == expectedHidden
-    doAssert ids(exported, name) == expectedPublic # loading hidden changes no public order
-    doAssert exported.counter == publicSyms.len
-    doAssert hidden.counter == hiddenSyms.len
+    # Each independent decoder must reconstruct the same order from disk.
+    for _ in 0..1:
+      var decoder = createDecodeContext(conf, cache)
+      var exported = initStrTable()
+      var hidden = initStrTable()
+      discard loadNifModule(decoder, file, exported, hidden)
+      for i, name in names:
+        doAssert ids(exported, name) == expectedPublic[i], $visibility & ": " & $count
+      doAssert hidden.counter == 0 # hidden symbols are still lazy
+      doAssert buildHiddenInterface(decoder, cachedModuleSuffix(conf, file), hidden, nil)
+      for i, name in names:
+        doAssert ids(hidden, name) == expectedHidden[i], $visibility & ": " & $count
+        doAssert ids(exported, name) == expectedPublic[i]
+      doAssert exported.counter == publicSyms.len
+      doAssert hidden.counter == hiddenSyms.len
   finally:
     removeDir(dir)
 
-for count in [2, 8, 32, 128]:
-  run(count)
+# Include empty/singleton tables and both sides of table-growth boundaries.
+for count in [0, 1, 2, 7, 8, 9, 31, 32, 33, 127, 128, 129]:
+  for visibility in Visibility:
+    run(count, visibility)

--- a/tests/compiler/ticinterface.nim
+++ b/tests/compiler/ticinterface.nim
@@ -1,0 +1,76 @@
+discard """
+  joinable: false
+"""
+
+import std/[assertions, os, tempfiles]
+import compiler/[ast, astalgo, ast2nif, idents, lineinfos, modulegraphs, msgs, options, pathutils, typekeys]
+
+# Compare the actual lookup sequence, not just successful overload resolution.
+# Enough symbols share each name to exercise multiple source-table rehashes.
+proc ids(tab: TStrTable; name: PIdent): seq[int32] =
+  var it: TIdentIter
+  var sym = initIdentIter(it, tab, name)
+  while sym != nil:
+    result.add sym.disamb
+    sym = nextIdentIter(it, tab)
+
+proc run(count: int) =
+  let dir = createTempDir("nim_ic_interface_", "")
+  try:
+    let conf = newConfigRef()
+    conf.cmd = cmdM
+    conf.backend = backendC
+    conf.projectPath = AbsoluteDir(dir)
+    conf.nimcacheDir = AbsoluteDir(dir)
+    conf.projectFull = AbsoluteFile(dir / "sample.nim")
+    writeFile(conf.projectFull.string, "")
+    let cache = newIdentCache()
+    let graph = newModuleGraph(cache, conf)
+    let file = fileInfoIdx(conf, conf.projectFull)
+    let info = newLineInfo(file, 1, 1)
+    let module = PSym(kindImpl: skModule, name: getIdent(cache, "sample"),
+      itemId: itemId(file.int32, 0), positionImpl: file.int, infoImpl: info)
+    graph.registerModule(module)
+    let idgen = idGeneratorFromModule(module)
+    let name = getIdent(cache, "choose")
+    let body = newNodeI(nkStmtList, info)
+    var publicTable = initStrTable()
+    for i in 0 ..< count:
+      let sym = newSym(skProc, name, idgen, module, info)
+      # Interleave private and public overloads under the SAME identifier.
+      if i mod 3 == 0:
+        sym.incl sfExported
+        graph.strTableAdds(module, sym)
+        strTableAdd(publicTable, sym)
+      else:
+        strTableAdd(semtabAll(graph, module), sym)
+      body.add newSymNode(sym)
+      # Unrelated names force hash collisions and table growth too.
+      let other = newSym(skProc, getIdent(cache, "other" & $i), idgen, module, info)
+      other.incl sfExported
+      graph.strTableAdds(module, other)
+      strTableAdd(publicTable, other)
+      body.add newSymNode(other)
+    let expectedPublic = ids(publicTable, name)
+    let expectedHidden = ids(semtabAll(graph, module), name)
+    let publicSyms = orderedInterface(graph, module)
+    let hiddenSyms = orderedInterface(graph, module, hidden = true)
+    writeNifModule(conf, file.int32, body, @[],
+      publicInterface = publicSyms, hiddenInterface = hiddenSyms)
+
+    var decoder = createDecodeContext(conf, cache)
+    var exported = initStrTable()
+    var hidden = initStrTable()
+    discard loadNifModule(decoder, file, exported, hidden)
+    doAssert ids(exported, name) == expectedPublic
+    doAssert hidden.counter == 0 # hidden symbols are still lazy
+    doAssert buildHiddenInterface(decoder, cachedModuleSuffix(conf, file), hidden, nil)
+    doAssert ids(hidden, name) == expectedHidden
+    doAssert ids(exported, name) == expectedPublic # loading hidden changes no public order
+    doAssert exported.counter == publicSyms.len
+    doAssert hidden.counter == hiddenSyms.len
+  finally:
+    removeDir(dir)
+
+for count in [2, 8, 32, 128]:
+  run(count)

--- a/tests/compiler/ticloweredinterface.nim
+++ b/tests/compiler/ticloweredinterface.nim
@@ -1,0 +1,101 @@
+discard """
+  joinable: false
+"""
+
+import std/[assertions, os, osproc, strutils, tempfiles]
+import "../../dist/nimony/src/lib/nifcore"
+from "../../dist/nimony/src/lib/bif" import load
+
+type Interface = object
+  present: bool
+  count: int
+  entries: seq[string]
+
+proc tagIs(cur: Cursor; name: string): bool =
+  cur.tags.tagName(cursorTagId(cur)) == name
+
+proc interfaces(path: string): array[bool, Interface] =
+  var artifact = load(path)
+  var cur = beginRead(artifact.buf)
+  cur.loopInto:
+    if cur.kind == TagLit and
+        (tagIs(cur, "interface") or tagIs(cur, "hiddeninterface")):
+      let hidden = tagIs(cur, "hiddeninterface")
+      doAssert not result[hidden].present
+      result[hidden].present = true
+      cur.into:
+        doAssert cur.kind == IntLit
+        result[hidden].count = intVal(cur).int
+        skip cur
+        while cur.hasMore:
+          if cur.kind == Symbol:
+            result[hidden].entries.add symName(cur)
+            skip cur
+          else:
+            doAssert cur.kind == TagLit and tagIs(cur, "reexpmod")
+            var alias, suffix: string
+            cur.into:
+              doAssert cur.kind == StrLit
+              alias = strVal(cur)
+              skip cur
+              doAssert cur.kind == StrLit
+              suffix = strVal(cur)
+              skip cur
+            doAssert alias.len > 0 and suffix.len > 0
+            result[hidden].entries.add "alias:" & alias & ":" & suffix
+      doAssert result[hidden].entries.len == result[hidden].count
+    else:
+      skip cur
+  doAssert result[false].present and result[true].present
+
+let dir = createTempDir("nim_ic_lowered_interface_", "")
+try:
+  writeFile(dir / "definitions.nim", """
+import std/macros
+macro declarations(): untyped =
+  result = newStmtList()
+  for i in 0..<40:
+    result.add parseStmt("type Tag" & $i & "* = distinct int")
+    result.add parseStmt("proc choose*(x: Tag" & $i & "): int = " & $i)
+    result.add parseStmt("proc privateOverloadedNameNeverUsed(x: Tag" & $i & "): int = " & $i)
+declarations()
+""")
+  writeFile(dir / "facade.nim", """
+import definitions as longReexportedModuleAlias
+import definitions as secondReexportedModuleAlias
+export longReexportedModuleAlias, secondReexportedModuleAlias
+""")
+  let source = dir / "main.nim"
+  writeFile(source, """
+import facade
+echo longReexportedModuleAlias.choose(Tag12(0))
+""")
+  let cache = dir / "nc"
+  let binary = dir / "prog".addFileExt(ExeExt)
+  let built = execCmdEx(quoteShellCommand([getCurrentCompilerExe(), "ic",
+    "--hints:off", "--warnings:off", "--nimcache:" & cache, "--out:" & binary, source]))
+  doAssert built.exitCode == 0, built.output
+  let executed = execCmdEx(quoteShell(binary))
+  doAssert executed.exitCode == 0 and executed.output.strip == "12", executed.output
+
+  var checked, privateOverloads, aliases: int
+  for semantic in walkFiles(cache / "*.s.bif"):
+    let lowered = semantic[0 ..< semantic.len - ".s.bif".len] & ".t.bif"
+    if fileExists(lowered):
+      let original = interfaces(semantic)
+      # Compare the actual on-disk sequences, including symbols never demanded
+      # by codegen. Reading these names through an eager-only pool accessor can
+      # silently copy empty names from the new lazy BIF pools.
+      doAssert interfaces(lowered) == original, semantic
+      inc checked
+      for entry in original[true].entries:
+        if entry.startsWith("privateOverloadedNameNeverUsed."): inc privateOverloads
+      for entry in original[false].entries:
+        if entry.startsWith("alias:longReexportedModuleAlias:") or
+            entry.startsWith("alias:secondReexportedModuleAlias:"):
+          inc aliases
+  doAssert checked >= 3
+  doAssert privateOverloads == 40
+  doAssert aliases == 2
+finally:
+  removeDir(dir)

--- a/tests/compiler/ticsharedcache.nim
+++ b/tests/compiler/ticsharedcache.nim
@@ -1,0 +1,36 @@
+discard """
+  joinable: false
+"""
+
+# IC recompiles objects overwritten by a classic build before an edit.
+import std/[assertions, os, osproc, strutils, tempfiles]
+
+const nim = getCurrentCompilerExe()
+
+let dir = createTempDir("nim_ic_shared_cache_", "")
+let source = dir / "main.nim"
+let dependency = dir / "dep.nim"
+let binary = dir / "prog".addFileExt(ExeExt)
+
+proc build(command: string) =
+  let args = [nim, command, "--hints:off", "--warnings:off",
+    "--nimcache:" & dir / "nc", "--out:" & binary, source]
+  let compiled = execCmdEx(quoteShellCommand(args))
+  doAssert compiled.exitCode == 0, compiled.output
+  let executed = execCmdEx(quoteShell(binary))
+  doAssert executed.exitCode == 0, executed.output
+  doAssert executed.output.strip == "42", executed.output
+
+try:
+  writeFile(source, "import dep\necho value()\n")
+  writeFile(dependency, "proc value*(): int = 42\n")
+  build("ic")
+  # Classic codegen overwrites the main C/object pair without updating IC's
+  # SHA1. The next edit restores the original IC C text and its matching hash,
+  # but the object still belongs to the classic build.
+  build("c")
+  writeFile(dependency, "\n\nproc value*(): int = 42\n")
+  build("ic")
+  build("ic")
+finally:
+  removeDir(dir)

--- a/tests/ic/mselectordefaults.nim
+++ b/tests/ic/mselectordefaults.nim
@@ -1,0 +1,8 @@
+type Selector*[A, R] = object
+  value*: int
+
+template restoreState*(self: untyped = (), state: untyped = ()): untyped =
+  Selector[int, string](value: 42)
+
+proc restoreState*(self: int, state: string) =
+  discard

--- a/tests/ic/textensionloader.nim
+++ b/tests/ic/textensionloader.nim
@@ -1,0 +1,101 @@
+discard """
+  description: "Deferred dynlib loaders from multiple IC modules share one entry point"
+"""
+
+#? metamorphic
+
+#!FILE mextensionloader.nim
+var loads*: int
+
+proc implementation(): cint {.cdecl.} =
+  42
+
+proc otherImplementation(): cint {.cdecl.} =
+  73
+
+proc resolve*(name: cstring): pointer =
+  if $name == "unavailable":
+    quit("loaded an unused extension", 1)
+  inc loads
+  if $name == "other":
+    cast[pointer](otherImplementation)
+  else:
+    cast[pointer](implementation)
+
+proc imported*(): cint {.importc, dynlib: resolve("0").}
+proc other*(): cint {.importc, dynlib: resolve("9").}
+proc unavailable(): cint {.importc, dynlib: resolve("0").}
+
+proc unusedWrapper*(): cint =
+  unavailable()
+
+proc callImported*(): cint =
+  imported()
+
+proc callOther*(): cint =
+  other()
+
+#!FILE mextensioncaller.nim
+import mextensionloader
+
+proc callFromAnotherModule*(): cint =
+  imported()
+
+#!FILE main.nim
+import mextensionloader, mextensioncaller
+
+proc load0() {.importc: "nimLoadProcs0".}
+proc load9() {.importc: "nimLoadProcs9".}
+
+doAssert loads == 0
+load0()
+let firstLoads = loads
+doAssert firstLoads == 1
+doAssert callImported() == 42
+doAssert callFromAnotherModule() == 42
+doAssert imported() == 42
+doAssert loads == firstLoads
+load9()
+doAssert loads == 2
+doAssert callOther() == 73
+doAssert other() == 73
+let allLoads = loads
+load0()
+doAssert loads == allLoads + firstLoads
+echo "loaded"
+#!STEP expect: loaded
+
+# Reuse every module's loader metadata on an unchanged build.
+#!STEP expect: loaded
+
+# Regenerate one fragment while retaining the other modules from the cache.
+#!FILE mextensioncaller.nim
+import mextensionloader
+
+proc callFromAnotherModule*(): cint =
+  imported() + 0
+
+#!STEP expect: loaded
+
+# Removing the caller's fragment must remove it from the shared entry point.
+#!FILE mextensioncaller.nim
+proc callFromAnotherModule*(): cint =
+  42
+
+#!STEP expect: loaded
+
+# Main need not have a fragment of its own to provide the shared entry points.
+#!FILE main.nim
+import mextensionloader, mextensioncaller
+
+proc load0() {.importc: "nimLoadProcs0".}
+proc load9() {.importc: "nimLoadProcs9".}
+
+doAssert loads == 0
+load0()
+load9()
+doAssert callImported() == 42
+doAssert callOther() == 73
+doAssert callFromAnotherModule() == 42
+echo "loaded"
+#!STEP expect: loaded

--- a/tests/ic/tgenericclosureownership.nim
+++ b/tests/ic/tgenericclosureownership.nim
@@ -1,0 +1,38 @@
+discard """
+  description: "IC injects ownership hooks into nested bodies cached during generic codegen"
+"""
+
+#? metamorphic
+
+#!FILE factory.nim
+proc factory*[T](data: seq[T]): proc(): seq[T] =
+  result = proc(): seq[T] =
+    data
+
+#!FILE main.nim
+import factory
+
+proc main() =
+  let f = factory(@[11, 22, 33])
+  for i in 0 .. 3:
+    var first = f()
+    first[0] = 99
+    doAssert f() == @[11, 22, 33]
+    echo first
+
+main()
+#!FLAGS --mm:arc
+#!STEP
+#!STEP
+
+# Exercise another ownership mode and a nested named routine.
+#!FILE factory.nim
+proc factory*[T](data: seq[T]): proc(): seq[T] =
+  proc getData(): seq[T] =
+    data
+
+  result = proc(): seq[T] =
+    getData()
+
+#!FLAGS --mm:orc
+#!STEP

--- a/tests/ic/tinterface_order.nim
+++ b/tests/ic/tinterface_order.nim
@@ -1,0 +1,52 @@
+discard """
+  description: "Ordered interfaces preserve public, private, and re-exported overloads"
+"""
+
+#? metamorphic
+
+#!FILE definitions.nim
+import std/macros
+
+macro declareOverloads(): untyped =
+  result = newStmtList()
+  for i in 0 ..< 64:
+    result.add parseStmt("type Tag" & $i & "* = distinct int")
+    result.add parseStmt("proc select*(x: Tag" & $i & "): int = " & $i)
+    result.add parseStmt("proc secret(x: Tag" & $i & "): int = " & $i)
+
+declareOverloads()
+
+#!FILE reexports.nim
+import definitions as renamed
+import definitions as second
+export renamed, second
+
+#!FILE main.nim
+import std/macros
+import definitions {.all.}
+import reexports
+
+macro order(symbols: typed): untyped =
+  var names = ""
+  doAssert symbols.len == 64
+  for candidate in symbols:
+    names.add candidate.getImpl.params[1][^2].repr & " "
+  result = newLit(names)
+
+echo order(bindSym("select", brForceOpen))
+echo order(bindSym("secret", brForceOpen))
+doAssert reexports.renamed.select(Tag12(0)) == 12
+doAssert reexports.second.select(Tag13(0)) == 13
+
+# The first warm build records newly discovered compile-time body dependencies.
+#!STEP
+#!STEP
+#!STEP noop
+
+#!FILE reexports.nim
+import definitions as renamed
+import definitions as second
+export renamed, second
+proc another*(): int = 42
+
+#!STEP

--- a/tests/ic/tinterface_order.nim
+++ b/tests/ic/tinterface_order.nim
@@ -4,37 +4,54 @@ discard """
 
 #? metamorphic
 
-#!FILE definitions.nim
+#!FILE overloads.nim
 import std/macros
 
-macro declareOverloads(): untyped =
+macro declareOverloads*(count: static[int]; backwards: static[bool]): untyped =
   result = newStmtList()
-  for i in 0 ..< 64:
+  for index in 0 ..< count:
+    let i = if backwards: count - index - 1 else: index
     result.add parseStmt("type Tag" & $i & "* = distinct int")
     result.add parseStmt("proc select*(x: Tag" & $i & "): int = " & $i)
     result.add parseStmt("proc secret(x: Tag" & $i & "): int = " & $i)
 
-declareOverloads()
+#!FILE definitions.nim
+import overloads
+declareOverloads(64, false)
 
 #!FILE reexports.nim
 import definitions as renamed
 import definitions as second
 export renamed, second
 
-#!FILE main.nim
-import std/macros
-import definitions {.all.}
+#!FILE chain.nim
 import reexports
+export reexports
 
-macro order(symbols: typed): untyped =
+#!FILE inspectorder.nim
+import std/macros
+
+macro order*(symbols: typed): untyped =
   var names = ""
-  doAssert symbols.len == 64
+  doAssert symbols.len in [33, 64, 65]
   for candidate in symbols:
     names.add candidate.getImpl.params[1][^2].repr & " "
   result = newLit(names)
 
-echo order(bindSym("select", brForceOpen))
+#!FILE hiddenconsumer.nim
+import std/macros
+import definitions {.all.}
+import inspectorder
 echo order(bindSym("secret", brForceOpen))
+
+#!FILE main.nim
+import std/macros
+import chain
+import inspectorder
+import hiddenconsumer
+
+# Public lookup is reached solely through the re-exported interface.
+echo order(bindSym("select", brForceOpen))
 doAssert reexports.renamed.select(Tag12(0)) == 12
 doAssert reexports.second.select(Tag13(0)) == 13
 
@@ -47,6 +64,35 @@ doAssert reexports.second.select(Tag13(0)) == 13
 import definitions as renamed
 import definitions as second
 export renamed, second
+proc another*(): int = 42
+
+#!STEP
+
+# Reorder the definitions without changing membership, then grow and shrink it.
+#!FILE definitions.nim
+import overloads
+declareOverloads(64, true)
+
+#!STEP
+
+#!FILE definitions.nim
+import overloads
+declareOverloads(65, true)
+
+#!STEP
+
+#!FILE definitions.nim
+import overloads
+declareOverloads(33, false)
+
+#!STEP
+
+# Export/except follows the same ordered traversal, including through a chain.
+#!FILE reexports.nim
+import definitions as renamed
+import definitions as second
+export renamed except Tag0
+export second except Tag0
 proc another*(): int = 42
 
 #!STEP

--- a/tests/ic/tselectordefaults.nim
+++ b/tests/ic/tselectordefaults.nim
@@ -1,0 +1,15 @@
+discard """
+  description: "Imported nullary templates retain precedence in generic alias lookup"
+  output: "42"
+"""
+
+import mselectordefaults
+
+proc useSelector[A, R](s: Selector[A, R]) =
+  doAssert s.value == 42
+  echo s.value
+
+proc init[T]() =
+  useSelector(restoreState)
+
+init[int]()

--- a/tests/misc/ticrun.nim
+++ b/tests/misc/ticrun.nim
@@ -1,0 +1,11 @@
+discard """
+  cmd: "nim ic --run $options $file argument --program-option"
+  action: compile
+  nimout: "IC argument: argument"
+"""
+
+import std/os
+
+doAssert paramCount() == 2
+doAssert paramStr(2) == "--program-option"
+echo "IC argument: ", paramStr(1)


### PR DESCRIPTION
Fixes #26195.

`nim ic` could fail to link FigDraw's deferred extension loaders, reject Merenda's imported selectors, and miscompile nested generic closures by skipping ownership lowering. IC run mode also omitted execution and could forward program arguments into child compiler invocations. Sharing a nimcache with a classic build could leave a stale main object that IC reused after a whitespace edit, causing undefined symbols at link time.

- Execute IC outputs for `--run` and keep program arguments out of config/frontend switches, preserving `nim track` handling.
- Give deferred dynlib pointers stable names and liveness metadata. Emit per-module loader fragments and aggregate them into one public entry point, including fragments from cached modules.
- Serialize exported overloads in frontend lookup order and restore that order when loading interfaces; include the order in interface fingerprints.
- Distinguish fully lowered artifact bodies from bodies cached during transformation, so nested generic routines still receive ownership hooks.
- Require a cached C object to be newer than its source as well as match the source/command hash. A classic build can replace IC's main object without updating the hash; restoring identical IC C text after an edit must still recompile that older object.

Bump IC cache format to 40 and C-NIF format to 6 to invalidate incompatible artifacts. Add run-argument, loader, selector, ARC/ORC closure, and shared-cache regressions, including cold/warm and dependency-edit scenarios where applicable. The shared-cache regression builds with IC, builds classically into the same cache, adds two blank lines to a dependency, then checks IC rebuild and no-op execution.

Validation on macOS arm64 with Clang:

- IC test category: **45 passed, 0 failed**; separate `tests/misc/ticrun.nim` regression passed before the object-freshness change.
- Object-freshness change: `tests/compiler/ticsharedcache.nim` reproduced the linker failure before the fix and passes afterward; `tests/ic/tmeta_smoke.nim` passes.
- FigDraw: five selected test runners passed with IC; three examples compiled with IC.
- Merenda hello: cold/warm builds and GUI interaction passed; AddressSanitizer run clean.
- Kosmo: built with IC and opened a sample Nim file after applying the separate variant type-ID fix in https://github.com/yglukhov/variant/pull/13.
- Kosmo edit reproduction: a fresh build and two-line whitespace rebuild passed. The object-freshness fix also repaired the original shared cache without clearing it; the exact `../Nim/bin/nim ic -r src/merenda/kosmo/kosmo.nim` command built and initialized the native window without a reported runtime crash during a 15-second smoke check.

The variant compile-time counter defect is outside this compiler patch. Rebuilding an edited dependency body in that dependency's regression still exposes a `symbol has no offset` assertion; this PR does not claim to fix it. The full compiler corpus and other platforms have not been validated locally.
