### PR TITLE
parsecsv: reset parser state when reopening

### DIFF
--- a/lib/pure/parsecsv.nim
+++ b/lib/pure/parsecsv.nim
@@ -132,6 +132,9 @@ proc open*(self: var CsvParser, input: Stream, filename: string,
     strm.close()
 
   lexbase.open(self, input)
+  self.row.setLen(0)
+  self.headers.setLen(0)
+  self.currRow = 0
   self.filename = filename
   self.sep = separator
   self.quote = quote

--- a/tests/stdlib/tparsecsv.nim
+++ b/tests/stdlib/tparsecsv.nim
@@ -34,3 +34,24 @@ block: # Tests for reading the header row
 
   # Tidy up
   removeFile("temp.csv")
+
+block: # Reopening a parser resets its state
+  var p: CsvParser
+
+  var first = newStringStream("A,B\n1,2\n")
+  p.open(first, "first.csv")
+  p.readHeaderRow()
+  doAssert p.readRow()
+  doAssert p.processedRows() == 2
+  p.close()
+  first.close()
+
+  var second = newStringStream("")
+  p.open(second, "second.csv")
+  doAssert p.processedRows() == 0
+  doAssert p.row.len == 0
+  doAssert p.headers.len == 0
+  p.readHeaderRow()
+  doAssert p.headers.len == 0
+  p.close()
+  second.close()


### PR DESCRIPTION


`CsvParser.open` did not reset parser-specific state when reopening a parser.

After parsing one input and reusing the same parser for another input, the previous `row`, `headers`, and `processedRows()` value could remain visible. In particular, calling `readHeaderRow()` on an empty second input did not clear the previous headers.

Reset the parser state in `open`:

- clear `row`
- clear `headers`
- reset `currRow` to zero
