### PR TITLE
lib/wrappers/pcre: select .dylib instead of .so when targeting iOS

### DIFF
--- a/lib/wrappers/pcre.nim
+++ b/lib/wrappers/pcre.nim
@@ -318,7 +318,7 @@ when not defined(usePcreHeader):
       const pcreDll = "pcre64.dll"
     else:
       const pcreDll = "pcre32.dll"
-  elif hostOS == "macosx":
+  elif defined(macosx):
     const pcreDll = "libpcre(.3|.1|).dylib"
   else:
     const pcreDll = "libpcre.so(.3|.1|)"


### PR DESCRIPTION
When targeting iOS (`--os:ios`), `lib/wrappers/pcre.nim` currently selects an ELF `.so` name rather than `.dylib`:

```nim
when not defined(usePcreHeader):
  when hostOS == "windows":
    when defined(nimOldDlls):
      const pcreDll = "pcre.dll"
    elif defined(cpu64):
      const pcreDll = "pcre64.dll"
    else:
      const pcreDll = "pcre32.dll"
  elif hostOS == "macosx":
    const pcreDll = "libpcre(.3|.1|).dylib"
  else:
    const pcreDll = "libpcre.so(.3|.1|)"
  {.push dynlib: pcreDll.}
```

`hostOS` evaluates to the target OS string (`"ios"` under `--os:ios`), so the `elif hostOS == "macosx"` branch is not taken and the wrapper falls through to the ELF pattern. A binary compiled with `--os:ios` that imports `re`, `nre`, or `pcre` directly fails at load time with:

```console
could not load: libpcre.so(.3|.1|)
```

iOS is Darwin: its shared libraries are Mach-O `.dylib` loaded by dyld, just as on macOS. In `compiler/options.nim`, `isDefined` treats `macosx` as the Darwin family by answering both `"osx"` and `"macosx"` with `conf.target.targetOS in {osMacosx, osIos}`. As a result, `defined(macosx)` evaluates to true for `--os:ios`, whereas the string equality `hostOS == "macosx"` does not.

Other Darwin-specific logic in the compiler and standard library already relies on this define; for instance, the `@if macosx:` section in `config/nim.cfg` applies to `--os:ios` builds for this reason. In a full `devel` checkout, `hostOS == "macosx"` appears only once in the source tree, at `lib/wrappers/pcre.nim:321` (with `doc/tut1.md:531` carrying one in prose example code; for contrast, `hostOS == "windows"` occurs four times).

An alternative would be `elif hostOS == "macosx" or hostOS == "ios":` to match the surrounding `hostOS` style. While that would work, it duplicates by hand a mapping the compiler already provides. Selecting Darwin `.dylib` names under `when defined(macosx):` is already the pattern used by `lib/wrappers/openssl.nim` (lines 50 and 93 on `devel`) and `lib/nimhcr.nim` (`dllExt = when defined(windows): "dll" elif defined(macosx): "dylib" else: "so"`). Furthermore, `defined(windows)` and `hostOS == "windows"` are equivalent, so the Windows branch in this file is not wrong and can be left alone. `defined(macosx)` and `hostOS == "macosx"` are not equivalent because the compiler answers the define for the whole Darwin family; that asymmetry is why only this branch is changed.

Switching the condition to `elif defined(macosx):` selects `libpcre(.3|.1|).dylib` for `--os:ios`. Tested on a physical iPhone 8 (iOS 16.7.14, arm64) using `nimgrep` built with Nim 2.2.12 for `--os:ios --cpu:arm64`. The device is jailbroken (palera1n, rootless), and the `libpcre.1.dylib` that resolved came from a package manager on that device. The unpatched binary failed at load time with `could not load: libpcre.so(.3|.1|)`. With the patched wrapper, the binary successfully resolved `libpcre.1.dylib` and ran because that build links an `-rpath` entry pointing at its directory. Without such an entry the bare name does not resolve on that device.

To be precise about the impact: `pcreDll` is expanded by `libCandidates` in `compiler/cgen.nim` into the concrete names to try (`libpcre.so.3`, `libpcre.so.1`, `libpcre.so`, and after this change `libpcre.3.dylib`, `libpcre.1.dylib`, `libpcre.dylib`), and `nimLoadLibrary` in `lib/system/dyncalls.nim` calls `dlopen` on each in turn. dyld does not reject a name by extension, but looks for the name it is given; because the Darwin build of PCRE is `libpcre.1.dylib`, none of the `.so` candidates match it. iOS does not ship a public `libpcre`, so on a stock device the library must travel with the application (for example inside `App.app/Frameworks` resolved via an `@rpath` entry, an arrangement we did not test). Shipping the library was always possible; what changes is the name passed to `dlopen`. This fix is necessary but not sufficient, as it does not by itself make `re` work on a device with no `libpcre` present. On `--os:macosx`, `defined(macosx)` remains true, so the selected library name is unchanged.

No changelog entry is included: this does not change documented behavior or a default that worked before. It replaces a name that does not match the library as it is built for Darwin. Nothing under `tests/` or in the CI workflows exercises `--os:ios`, and the failure is a runtime `dlopen` on an Apple device.
