### PR TITLE
Docs: clarify isMainModule for library builds

### DIFF
--- a/doc/tut1.md
+++ b/doc/tut1.md
@@ -1829,7 +1829,9 @@ This can be used to initialize complex data structures for example.
 
 Each module has a special magic constant `isMainModule` that is true if the
 module is compiled as the main file. This is very useful to embed tests within
-the module as shown by the above example.
+the module as shown by the above example. When compiling a module as a library,
+`isMainModule` is also true and `appType` is `"lib"`. To avoid running embedded
+tests when the library is loaded, use `when isMainModule and appType != "lib"`.
 
 A symbol of a module *can* be *qualified* with the `module.symbol` syntax. And if
 a symbol is ambiguous, it *must* be qualified. A symbol is ambiguous


### PR DESCRIPTION
Fixes #17496.

Documents on the `isMainModule` constant itself (`lib/system/compilation.nim`, included by `system.nim`, so it shows up in the `system` module docs) that it is also true when a module is compiled as a library with `--app:lib`, and that `when isMainModule and appType != "lib"` keeps embedded tests out of library builds.

Following review, the earlier addition to Tutorial 1 has been reverted; the tutorial is unchanged from `devel`.

Testing:
- The guard itself was checked earlier by building and loading dynamic libraries: an unguarded embedded test emitted output, while the guarded one did not.
- The follow-up is a `##` doc comment change only (no code or `runnableExamples` touched); it was checked by inspection for indentation and whitespace, not by rebuilding the docs locally.
