### PR TITLE
IC: preserve shared CacheCounter state across modules

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -960,6 +960,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     # real entry point so that `isMainModule` and `when isMainModule:` resolve
     # correctly even though every module is compiled with `sfMainModule` set.
     conf.isMainModule = switchOn(arg)
+  of "icwholeproject":
+    # Internal frontend mode selected by the IC driver for global counters.
+    conf.icWholeProject = switchOn(arg)
   of "icgroup":
     # `nim m` only: register a module that belongs to the current strongly-
     # connected import group, so it is compiled from source (not loaded from a

--- a/compiler/deps.nim
+++ b/compiler/deps.nim
@@ -20,6 +20,7 @@ import "../dist/nimony/src/lib" / [bitabs, nifreader, nifbuilder]
 import icmodnames
 import icnifcore
 from ic/replayer import BackendActionsExt
+import ic/counterstate
 
 type
   FilePair = object
@@ -1022,7 +1023,7 @@ proc computeForwardedArgs(c: DepContext): seq[string] =
   const notForwarded = [
     "nimcache", "out", "o", "outdir", "usenimcache", "run", "r",
     "incremental", "ic", "symbolfiles", "genbif",
-    "icproject", "icpreparsedconfig", "icconfigout", "icgroup",
+    "icproject", "icpreparsedconfig", "icconfigout", "icgroup", "icwholeproject",
     "icbackendstage", "icbackendmodule", "ismainmodule",
     "help", "h", "fullhelp", "version", "v", "advanced"]
   for a in commandLineParams():
@@ -1078,7 +1079,10 @@ proc configSignatureFile(c: DepContext; forwardedArgs: seq[string]): string =
   if not fileExists(result) or readFile(result) != content:
     writeFile(result, content)
 
-proc generateFrontendBuildFile(c: DepContext; forwardedArgs: seq[string]): string =
+proc computeLiveBackendNodes(c: DepContext): seq[bool]
+
+proc generateFrontendBuildFile(c: DepContext; forwardedArgs: seq[string];
+                               wholeProject: bool): string =
   ## Frontend build file: the nifler (parse) and `nim m` (sem) rules only. The
   ## driver runs this to a discovery fixpoint; it produces every module's semmed
   ## NIF plus the cookie/edge sidecars that the backend build file then consumes.
@@ -1163,6 +1167,34 @@ proc generateFrontendBuildFile(c: DepContext; forwardedArgs: seq[string]): strin
   # inputs — intra-component edges are produced by this very rule and listing
   # them would reintroduce the cycle nifmake just rejected.
   let argsFile = configSignatureFile(c, forwardedArgs)
+  if wholeProject:
+    # Counter reads observe a program-wide history, not just an import closure.
+    # Compile from the root in one VM; backend rules still consume per-module
+    # artifacts and retain their ordinary incremental reuse.
+    b.addTree "do"
+    b.addIdent "nim_m"
+    b.withTree "args":
+      b.addStrLit "--isMainModule:on"
+      b.addStrLit "--icWholeProject:on"
+    b.withTree "input": b.addStrLit c.nodes[0].files[0].nimFile
+    b.withTree "input": b.addStrLit argsFile
+    b.withTree "input": b.addStrLit counterSessionFile(c.config)
+    for node in c.nodes:
+      for pair in node.files:
+        b.withTree "input": b.addStrLit c.parsedFile(pair)
+    # Use the real import closure: speculative scanner nodes may never be
+    # compiled. A first retry may know only the root; subsequent runs recover
+    # the full closure from the successful frontend's semantic dependency files.
+    let live = computeLiveBackendNodes(c)
+    for i, node in c.nodes:
+      if live[i]:
+        let pair = node.files[0]
+        for path in [c.semmedFile(pair), c.ifaceFile(pair), c.implFile(pair.modname),
+                     c.edgesFile(pair), c.semDepsFile(pair)]:
+          b.withTree "output": b.addStrLit path
+    b.endTree()
+    b.endTree() # stmts
+    return
   let sccs = computeSCCs(c)
   var sccOf = newSeq[int](c.nodes.len)
   for sccId, comp in sccs:
@@ -1862,8 +1894,9 @@ proc commandIc*(conf: ConfigRef; frontendOnly = false) =
     # Phase 1 — frontend (nifler + `nim m`), run to a discovery fixpoint.
     var rounds = 0
     var frontendOk = false
+    var wholeProject = fileExists(counterSessionFile(conf))
     while true:
-      let buildFile = generateFrontendBuildFile(c, forwardedArgs)
+      let buildFile = generateFrontendBuildFile(c, forwardedArgs, wholeProject)
       rawMessage(conf, hintSuccess, "generated: " & buildFile)
       if nifmake.len == 0:
         rawMessage(conf, hintSuccess, "run:" & " nifmake run" & parallel & " " & buildFile)
@@ -1878,9 +1911,30 @@ proc commandIc*(conf: ConfigRef; frontendOnly = false) =
       let cmd = quoteShell(nifmake) & " run" & parallel & " " & quoteShell(buildFile)
       rawMessage(conf, hintExecuting, cmd)
       let exitCode = execShellCmd(cmd)
+      if not wholeProject and fileExists(counterSessionFile(conf)):
+        wholeProject = true
+        # The previous root artifact must not satisfy the replacement rule,
+        # even on a filesystem whose timestamp resolution hides this request.
+        removeFile(c.semmedFile(rootPair))
+        rawMessage(conf, hintExecuting, "CacheCounter: retrying with a shared frontend session")
+        continue
+      if exitCode == 0 and wholeProject:
+        # The shared frontend can compile macro-generated imports immediately;
+        # add them to the graph before emitting their backend rules.
+        if deriveFromSemDeps(c): continue
+        # The first shared run may have started without the root's semantic
+        # dependency list. Publish the complete output set now so the first
+        # warm run has an identical build graph and checks every artifact.
+        discard generateFrontendBuildFile(c, forwardedArgs, wholeProject)
       if exitCode == 0:
         frontendOk = true
         break
+
+      if wholeProject:
+        # Dependencies may have written fresh outputs before the root failed.
+        # nifmake uses the newest output as its freshness proof, so keep this
+        # grouped rule incomplete until the entire session succeeds.
+        removeFile(c.semmedFile(rootPair))
 
       # Re-derive from the post-sem deps of every node compiled so far. Imports
       # the static scanner missed become new nodes; the importer->import edge

--- a/compiler/ic/counterstate.nim
+++ b/compiler/ic/counterstate.nim
@@ -1,0 +1,26 @@
+#
+#           The Nim Compiler
+#        (c) Copyright 2026 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## A CacheCounter read depends on the program's preceding compile-time actions,
+## including sibling modules. Until IC can track and replay that global history
+## incrementally, these programs require a single semantic compilation session.
+
+import std/[os, syncio]
+import ../[options, pathutils]
+
+proc counterSessionFile*(conf: ConfigRef): string =
+  getNimcacheDir(conf).string / "ic.counter-session"
+
+proc requireCounterSession*(conf: ConfigRef) =
+  if conf.cmd == cmdM and conf.icProject.len > 0 and
+      not conf.icWholeProject and not conf.ideActive:
+    # Stop before observing or allocating an invalid value. The driver waits
+    # for its children, detects this request even after a failed frontend run,
+    # and retries from the project root with all modules in the same process.
+    writeFile(counterSessionFile(conf), "")
+    quit(1)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -29,7 +29,8 @@ const
 
   nimEnableCovariance* = defined(nimEnableCovariance)
 
-  icFormatVersion* = "39"
+  icFormatVersion* = "40"
+    ## v40: CacheCounter projects use one semantic compilation session.
     ## Version of the IC cache format (the sem-NIF module layout written by
     ## ast2nif.nim plus the iface/impl/edges side files). Bump it whenever
     ## that layout changes: `commandIc` wipes a nimcache whose `ic.version`
@@ -443,6 +444,7 @@ type
                               # recursion resolves in-memory) and each gets its NIF
                               # written, instead of being loaded from a precompiled
                               # NIF. See `compiler/deps.nim` (SCC grouping).
+    icWholeProject*: bool     # under nim m: compile imports from source in one VM
     icProject*: string        # under `nim m`/`nim nifc`: absolute path of the
                               # ORIGINAL project file. The child's own project file
                               # is the module being compiled, which would make that

--- a/compiler/pipelines.nim
+++ b/compiler/pipelines.nim
@@ -247,8 +247,8 @@ proc processPipelineModuleImpl(graph: ModuleGraph; module: PSym; idgen: IdGenera
   when not defined(nimKochBootstrap):
     # For cmdM: only write NIF for the main module, not for imported modules
     # (imported modules should be loaded from existing NIF files). Members of the
-    # current strongly-connected import group (`--icGroup`) are the exception:
-    # they are compiled from source here, so each must write its own NIF.
+    # current import group (`--icGroup`), or every module in a shared counter
+    # session (`--icWholeProject`), are compiled from source and write their NIFs.
     let shouldWriteNif =
       if graph.config.errorCounter > 0:
         # Never persist an artifact built from erroneous AST. `nim m` does exit
@@ -268,7 +268,7 @@ proc processPipelineModuleImpl(graph: ModuleGraph; module: PSym; idgen: IdGenera
       else:
         ({optCompress, optGenBif} * graph.config.globalOptions != {}) or
         (graph.config.cmd == cmdM and
-         (sfMainModule in module.flags or
+         (sfMainModule in module.flags or graph.config.icWholeProject or
           (graph.config.icGroup.len > 0 and
            toFullPath(graph.config, module.position.FileIndex) in graph.config.icGroup)))
     if shouldWriteNif and not graph.config.isDefined("nimscript"):
@@ -451,14 +451,15 @@ proc compilePipelineModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymF
     discard processPipelineModule(graph, result, idGeneratorFromModule(result), s)
   if result == nil:
     when not defined(nimKochBootstrap):
-      # For cmdM: load imports from NIF files (but compile the main module from source)
+      # For cmdM: load imports from NIF files, except in a shared counter
+      # session, where source compilation must preserve the complete VM history.
       # Skip when withinSystem is true (compiling system.nim itself).
       # Also skip for members of the current strongly-connected import group
       # (`--icGroup`): those are mutually recursive with the main module and have
       # no precompiled NIF yet, so they must be compiled from source in this same
       # process (falling through below) — that resolves the cycle in-memory, the
       # same way the non-incremental compiler handles recursive module imports.
-      if graph.config.cmd == cmdM and
+      if graph.config.cmd == cmdM and not graph.config.icWholeProject and
          sfMainModule notin flags and
          not graph.withinSystem and
          not graph.config.isDefined("nimscript") and

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -607,8 +607,11 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         # Under `nim m` (IC) `sfMainModule` is set on every module that is being
         # compiled (so it writes its own NIF), so it cannot answer `isMainModule`;
         # the IC build file marks the real entry point with `--isMainModule:on`.
-        let isMain = if g.config.cmd == cmdM: g.config.isMainModule
-                     else: sfMainModule in m.flags
+        # A shared frontend compiles the real root plus its imports, so the
+        # ordinary per-module flags identify the entry point there.
+        let isMain =
+          if g.config.cmd == cmdM and not g.config.icWholeProject: g.config.isMainModule
+          else: sfMainModule in m.flags
         result = newIntNodeT(toInt128(ord(isMain)), n, idgen, g)
       of mCompileDate: result = newStrNodeT(getDateStr(), n, g)
       of mCompileTime: result = newStrNodeT(getClockStr(), n, g)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -11,6 +11,7 @@
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
 import semmacrosanity
+import ic/counterstate
 import
   std/[strutils, tables, intsets, parseutils],
   msgs, vmdef, vmgen, nimsets, types,
@@ -2279,10 +2280,12 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       regs[ra].node = newSymNode(sym)
       regs[ra].node.flags.incl nfIsRef
     of opcNccValue:
+      requireCounterSession(c.config)
       decodeB(rkInt)
       let destKey {.cursor.} = regs[rb].node.strVal
       regs[ra].intVal = getOrDefault(c.graph.cacheCounters, destKey)
     of opcNccInc:
+      requireCounterSession(c.config)
       let g = c.graph
       declBC()
       let destKey {.cursor.} = regs[rb].node.strVal

--- a/doc/ic.md
+++ b/doc/ic.md
@@ -101,6 +101,28 @@ backend:
   picks the single artifact allowed to embed each body (smallest claimant), which
   is the cross-process replacement for the old in-process single-writer machinery.
 
+Shared compile-time counters
+============================
+
+``CacheCounter`` reads and increments require a shared compile-time history.
+Separate semantic processes cannot allocate values independently: sibling modules
+would embed duplicate values even if their increments were replayed later in the
+importer. Compiling those processes sequentially alone does not fix this.
+
+On the first counter operation, an IC frontend requests a shared session and
+stops before evaluating the operation. The driver retries semantic checking from
+the real project root, compiling all imports from source in one process. This
+preserves normal counter order and generic-instance reuse. Only the real root
+sees ``isMainModule`` as true, and macro-generated imports join the backend graph
+through the ordinary semantic dependency records.
+
+The cache records this mode in ``ic.counter-session``. Subsequent no-change builds
+reuse the semantic artifacts; changing a source input reruns the whole frontend.
+Parsing and the backend retain their incremental rules. This is a conservative
+correctness fallback until IC can record global counter dependencies and reuse
+individual semantic modules safely. The mode persists until the cache is cleared;
+merely importing ``std/macrocache`` does not activate it.
+
 The driver: graph construction (`commandIc`)
 ============================================
 

--- a/tests/compiler/ticcachecounter.nim
+++ b/tests/compiler/ticcachecounter.nim
@@ -1,0 +1,94 @@
+discard """
+  joinable: false
+"""
+
+import std/[assertions, os, osproc, strutils, tempfiles]
+
+const nim = getCurrentCompilerExe()
+
+proc run(serial: bool) =
+  let dir = createTempDir("nim_ic_counter_", "")
+  try:
+    let source = dir / "main.nim"
+    let cache = dir / "nc"
+    let binary = dir / "prog".addFileExt(ExeExt)
+    let flags = if serial: @["-d:icNoParallel"] else: @[]
+
+    proc build(expected: string; fails = false) =
+      let compiled = execCmdEx(quoteShellCommand(@[nim, "ic", "--hints:off",
+        "--warnings:off", "--nimcache:" & cache, "--out:" & binary] & flags & @[source]))
+      if fails:
+        doAssert compiled.exitCode != 0, compiled.output
+        doAssert expected in compiled.output, compiled.output
+      else:
+        doAssert compiled.exitCode == 0, compiled.output
+        let executed = execCmdEx(quoteShell(binary))
+        doAssert executed.exitCode == 0, executed.output
+        doAssert executed.output.strip == expected, executed.output
+
+    # Merely importing macrocache must retain the ordinary per-module frontend.
+    writeFile(source, "import std/macrocache\necho \"ordinary\"\n")
+    build("ordinary")
+    doAssert not fileExists(cache / "ic.counter-session")
+
+    writeFile(dir / "allocator.nim", """
+import std/macrocache
+const ids* = CacheCounter"tests.ic.counter.edits"
+proc nextId*(): int {.compileTime.} =
+  ids.inc
+  ids.value
+""")
+    writeFile(dir / "first.nim", """
+import allocator
+when isMainModule:
+  {.error: "imported module treated as main".}
+const firstId* = nextId()
+""")
+    writeFile(dir / "view.nim", """
+import std/macrocache
+const snapshot* = CacheCounter"tests.ic.counter.edits".value
+const otherStart = CacheCounter"tests.ic.counter.other".value
+static:
+  doAssert otherStart == 0
+  CacheCounter"tests.ic.counter.other".inc(5)
+  CacheCounter"tests.ic.counter.other".inc(-2)
+const otherValue* = CacheCounter"tests.ic.counter.other".value
+""")
+    writeFile(dir / "second.nim", "import allocator\nconst secondId* = nextId()\n")
+    let main = """
+import first, view, second
+static: doAssert isMainModule
+echo firstId, ",", snapshot, ",", secondId, ",", otherValue
+"""
+    writeFile(source, main)
+    build("1,1,2,3")
+    build("1,1,2,3")
+    doAssert fileExists(cache / "ic.counter-session")
+
+    # A dependency-only edit shifts later allocations AND a read-only sibling.
+    let untouchedMain = getLastModificationTime(source)
+    writeFile(dir / "first.nim", readFile(dir / "first.nim") &
+      "const extraId* = nextId()\n")
+    build("1,2,3,3")
+    build("1,2,3,3")
+    doAssert getLastModificationTime(source) == untouchedMain
+
+    # Every live module remains a declared output, even in the shared session.
+    var removed = false
+    for path in walkFiles(cache / "vie*.s.bif"):
+      removeFile(path)
+      removed = true
+    doAssert removed
+    build("1,2,3,3")
+
+    # A rejected build cannot turn into a successful cached build on repetition.
+    writeFile(source, main & "static: doAssert false, \"counter rejection\"\n")
+    build("counter rejection", fails = true)
+    build("counter rejection", fails = true)
+    writeFile(source, main)
+    build("1,2,3,3")
+  finally:
+    removeDir(dir)
+
+run(serial = false)
+run(serial = true)

--- a/tests/ic/tcachecounter.nim
+++ b/tests/ic/tcachecounter.nim
@@ -1,0 +1,71 @@
+discard """
+  description: "CacheCounter shares one allocation history across sibling modules"
+"""
+
+#? metamorphic
+
+#!FILE counter.nim
+when isMainModule:
+  {.error: "an imported counter module is not the entry point".}
+import std/macrocache
+const ids* = CacheCounter"tests.ic.sharedCounter"
+proc nextId*(): int {.compileTime.} =
+  ids.inc
+  ids.value
+
+#!FILE first.nim
+import counter
+const firstId* = nextId()
+
+#!FILE second.nim
+import counter
+const secondId* = nextId()
+
+#!FILE main.nim
+import first, second, counter
+import std/macrocache
+const finalCount = ids.value
+echo firstId, ",", secondId, ",", finalCount
+
+#!STEP expect: 1,2,2
+#!STEP noop; expect: 1,2,2
+
+# Only this sibling changes; the later allocation and reader must update too.
+#!FILE first.nim
+import counter
+const firstId* = nextId()
+const extraId* = nextId()
+
+#!STEP expect: 1,3,3
+#!STEP noop; expect: 1,3,3
+
+#!FILE first.nim
+import counter
+const firstId* = nextId()
+
+#!STEP expect: 1,2,2
+
+# The allocation sequence follows source import order, even on a warm cache.
+#!FILE main.nim
+import second, first, counter
+import std/macrocache
+const finalCount = ids.value
+echo firstId, ",", secondId, ",", finalCount
+
+#!STEP expect: 2,1,2
+
+# The shared frontend can discover and compile a macro-generated import itself.
+#!FILE generated.nim
+import counter
+const generatedId* = nextId()
+
+#!FILE main.nim
+import second, first, counter
+import std/[macrocache, macros]
+macro importGenerated(): untyped = parseStmt("import generated")
+importGenerated()
+const finalCount = ids.value
+echo firstId, ",", secondId, ",", generatedId, ",", finalCount
+
+#!STEP expect: 2,1,3,3
+#!STEP noop; expect: 2,1,3,3

--- a/tests/ic/tcachecountergenerics.nim
+++ b/tests/ic/tcachecountergenerics.nim
@@ -1,0 +1,52 @@
+discard """
+  description: "CacheCounter type IDs reuse generic instances across modules"
+"""
+
+#? metamorphic
+
+#!FILE ids.nim
+import std/macrocache
+const ids = CacheCounter"tests.ic.genericCounter"
+proc nextId(): int {.compileTime.} =
+  ids.inc
+  ids.value
+proc typeIdAux[T](): int =
+  var id {.global.} = nextId()
+  id
+proc typeId*(T: typedesc): int = static(typeIdAux[T]())
+
+#!FILE first.nim
+import ids
+proc intId*(): int = typeId(int)
+proc sequenceId*(): int = typeId(seq[int])
+
+#!FILE second.nim
+import ids
+proc stringId*(): int = typeId(string)
+proc sequenceId*(): int = typeId(seq[int])
+
+#!FILE main.nim
+import first, second
+echo first.intId(), ",", second.stringId(), ",",
+  first.sequenceId(), ",", second.sequenceId()
+
+#!STEP expect: 1,3,2,2
+#!STEP noop; expect: 1,3,2,2
+
+# Adding a new instantiation shifts subsequent IDs; shared instances stay equal.
+#!FILE first.nim
+import ids
+proc intId*(): int = typeId(int)
+proc boolId*(): int = typeId(bool)
+proc sequenceId*(): int = typeId(seq[int])
+
+#!STEP expect: 1,4,3,3
+#!STEP noop; expect: 1,4,3,3
+
+#!FILE main.nim
+import second, first
+echo first.intId(), ",", second.stringId(), ",",
+  first.sequenceId(), ",", second.sequenceId()
+
+#!STEP expect: 3,1,2,2
+#!STEP noop; expect: 3,1,2,2


### PR DESCRIPTION
Automatically retry counter-using projects in one semantic session so sibling allocations and generic instances share their compile-time history. Preserve incremental parsing, backend compilation, and no-op reuse; invalidate failed grouped builds.

Cover cold and warm builds, dependency edits, import ordering, generated imports, generic type IDs, separate counters, and error recovery. Fixes #26201.